### PR TITLE
Filter out swiftnav* and tests* modules for now

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ setup(name='libsbp',
                    'Topic :: Software Development :: Libraries :: Python Modules',
                    'Programming Language :: Python :: 2.7'
                    ],
-      packages=find_packages(),
+      packages=find_packages(exclude=['swiftnav*', 'tests*']),
       platforms="Linux,Windows,Mac",
       py_modules=['libsbp'],
       use_2to3=False,


### PR DESCRIPTION
Filter out `swiftnav` and `tests` in builds.

/cc @fnoble @mookerji 
