### PR TITLE
Examples for Python client library

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,21 @@ pip install libsbp
 ```python
 ```
 
+## Examples
+
+### Sending SBP messages over UDP
+
+Receives SBP messages over a serial port and sends all incoming messages to a
+UDP socket.
+
+See the [`source code`](sbp/client/examples/udp.py)
+
+Run the example:
+
+```shell
+$ python -m sbp.client.examples.udp -s /path/to/serial/port
+```
+
 ## LICENSE
 
 Copyright © 2015 Swift Navigation

--- a/python/README.md
+++ b/python/README.md
@@ -18,6 +18,19 @@ pip install libsbp
 
 ## Examples
 
+### Simple example
+
+Receives SBP messages over a serial port, decodes `MSG_BASELINE` messages and
+prints them out.
+
+See the [`source code`](sbp/client/examples/simple.py)
+
+Run the example:
+
+```shell
+$ python -m sbp.client.examples.simple -p /path/to/serial/port
+```
+
 ### Sending SBP messages over UDP
 
 Receives SBP messages over a serial port and sends all incoming messages to a

--- a/python/README.md
+++ b/python/README.md
@@ -23,9 +23,9 @@ pip install libsbp
 Receives SBP messages over a serial port, decodes `MSG_BASELINE` messages and
 prints them out.
 
-See the [`source code`](sbp/client/examples/simple.py)
+See the [`source code`](sbp/client/examples/simple.py).
 
-Run the example:
+Run this example with:
 
 ```shell
 $ python -m sbp.client.examples.simple -p /path/to/serial/port
@@ -36,9 +36,9 @@ $ python -m sbp.client.examples.simple -p /path/to/serial/port
 Receives SBP messages over a serial port and sends all incoming messages to a
 UDP socket.
 
-See the [`source code`](sbp/client/examples/udp.py)
+See the [`source code`](sbp/client/examples/udp.py).
 
-Run the example:
+Run this example with:
 
 ```shell
 $ python -m sbp.client.examples.udp -s /path/to/serial/port

--- a/python/sbp/client/examples/simple.py
+++ b/python/sbp/client/examples/simple.py
@@ -14,9 +14,9 @@ reading SBP messages from a serial port, decoding BASELINE_NED messages and
 printing them out.
 """
 
-from ..drivers.pyserial_driver import PySerialDriver
-from ..handler                 import Handler
-from ...navigation             import SBP_MSG_BASELINE_NED, MsgBaselineNED
+from sbp.client.drivers.pyserial_driver import PySerialDriver
+from sbp.client.handler import Handler
+from sbp.navigation import SBP_MSG_BASELINE_NED, MsgBaselineNED
 
 import time
 

--- a/python/sbp/client/examples/simple.py
+++ b/python/sbp/client/examples/simple.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""
+the :mod:`sbp.client.examples.simple` module contains a basic example of
+reading SBP messages from a serial port, decoding BASELINE_NED messages and
+printing them out.
+"""
+
+from ..drivers.pyserial_driver import PySerialDriver
+from ..handler                 import Handler
+from ...navigation             import SBP_MSG_BASELINE_NED, MsgBaselineNED
+
+import time
+
+def baseline_callback(msg):
+  # This function is called every time we receive a BASELINE_NED message
+
+  # First decode the SBP message in "msg" into a python object, the sbp library
+  # has functions that do this for all the message types defined in the
+  # specification.
+  b = MsgBaselineNED(msg)
+
+  # b now contains the decoded baseline information and
+  # has fields with the same names as in the SBP docs
+
+  # Print out the N, E, D coordinates of the baseline
+  print "%.4f,%.4f,%.4f" % \
+    (b.n * 1e-3, b.e * 1e-3, b.d * 1e-3)
+
+def main():
+
+  import argparse
+  parser = argparse.ArgumentParser(description="Swift Navigation SBP Example.")
+  parser.add_argument("-p", "--port",
+                      default=['/dev/ttyUSB0'], nargs=1,
+                      help="specify the serial port to use.")
+  args = parser.parse_args()
+
+  # Open a connection to Piksi using the default baud rate (1Mbaud)
+  with PySerialDriver(args.port[0], 1000000) as driver:
+    # Create a handler to connect our Piksi driver to our callbacks
+    with Handler(driver.read, driver.write, verbose=True) as handler:
+      # Add a callback for BASELINE_NED messages
+      handler.add_callback(baseline_callback, msg_type=SBP_MSG_BASELINE_NED)
+      handler.start()
+
+      # Sleep until the user presses Ctrl-C
+      try:
+        while True:
+          time.sleep(0.1)
+      except KeyboardInterrupt:
+        pass
+
+if __name__ == "__main__":
+  main()
+

--- a/python/sbp/client/examples/simple.py
+++ b/python/sbp/client/examples/simple.py
@@ -45,7 +45,7 @@ def main():
   args = parser.parse_args()
 
   # Open a connection to Piksi using the default baud rate (1Mbaud)
-  with PySerialDriver(args.port[0], 1000000) as driver:
+  with PySerialDriver(args.port[0], baud=1000000) as driver:
     # Create a handler to connect our Piksi driver to our callbacks
     with Handler(driver.read, driver.write, verbose=True) as handler:
       # Add a callback for BASELINE_NED messages

--- a/python/sbp/client/examples/udp.py
+++ b/python/sbp/client/examples/udp.py
@@ -13,8 +13,8 @@ the :mod:`sbp.client.examples.udp` module contains an example of reading SBP
 messages from a serial port and sending them to a UDP socket.
 """
 
-from ..drivers.pyserial_driver import PySerialDriver
-from ..handler                 import Handler
+from sbp.client.drivers.pyserial_driver import PySerialDriver
+from sbp.client.handler import Handler
 
 import socket
 import struct

--- a/python/sbp/client/examples/udp.py
+++ b/python/sbp/client/examples/udp.py
@@ -16,6 +16,7 @@ messages from a serial port and sending them to a UDP socket.
 from sbp.client.drivers.pyserial_driver import PySerialDriver
 from sbp.client.handler import Handler
 
+from contextlib import closing
 import socket
 import struct
 import time
@@ -63,15 +64,15 @@ def main():
 
   with PySerialDriver(args.serial_port[0], args.baud[0]) as driver:
     with Handler(driver.read, driver.write) as handler:
-      udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-      handler.add_callback(send_udp_callback_generator(udp, args))
-      handler.start()
+      with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as udp:
+        handler.add_callback(send_udp_callback_generator(udp, args))
+        handler.start()
 
-      try:
-        while True:
-          time.sleep(0.1)
-      except KeyboardInterrupt:
-        pass
+        try:
+          while True:
+            time.sleep(0.1)
+        except KeyboardInterrupt:
+          pass
 
 if __name__ == "__main__":
   main()

--- a/python/sbp/client/examples/udp.py
+++ b/python/sbp/client/examples/udp.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""
+the :mod:`sbp.client.examples.udp` module contains an example of reading SBP
+messages from a serial port and sending them to a UDP socket.
+"""
+
+from ..drivers.pyserial_driver import PySerialDriver
+from ..handler                 import Handler
+
+import socket
+import struct
+import time
+
+DEFAULT_SERIAL_PORT = "/dev/ttyUSB0"
+DEFAULT_SERIAL_BAUD = 1000000
+
+DEFAULT_UDP_ADDRESS = "127.0.0.1"
+DEFAULT_UDP_PORT    = 13320
+
+DEFAULT_LOG_FILENAME = time.strftime("sbp-%Y%m%d-%H%M%S.log")
+
+def get_args():
+  """
+  Get and parse arguments.
+  """
+  import argparse
+  parser = argparse.ArgumentParser(description="Swift Navigation SBP Example.")
+  parser.add_argument("-s", "--serial-port",
+                      default=[DEFAULT_SERIAL_PORT], nargs=1,
+                      help="specify the serial port to use.")
+  parser.add_argument("-b", "--baud",
+                      default=[DEFAULT_SERIAL_BAUD], nargs=1,
+                      help="specify the baud rate to use.")
+  parser.add_argument("-a", "--address",
+                      default=[DEFAULT_UDP_ADDRESS], nargs=1,
+                      help="specify the serial port to use.")
+  parser.add_argument("-p", "--udp-port",
+                      default=[DEFAULT_UDP_PORT], nargs=1,
+                      help="specify the baud rate to use.")
+  return parser.parse_args()
+
+def send_udp_callback_generator(udp, args):
+  def send_udp_callback(msg):
+    s = ""
+    s += struct.pack("<BHHB", 0x55, msg.msg_type, msg.sender, msg.length)
+    s += msg.payload
+    s += struct.pack("<H", msg.crc)
+    udp.sendto(s, (args.address[0], args.udp_port[0]))
+
+  return send_udp_callback
+
+def main():
+  args = get_args()
+
+  with PySerialDriver(args.serial_port[0], args.baud[0]) as driver:
+    with Handler(driver.read, driver.write) as handler:
+      udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      handler.add_callback(send_udp_callback_generator(udp, args))
+      handler.start()
+
+      try:
+        while True:
+          time.sleep(0.1)
+      except KeyboardInterrupt:
+        pass
+
+if __name__ == "__main__":
+  main()
+


### PR DESCRIPTION
An example of how we may want to incorporate examples using the python client library.

Adds two examples:

 - Simple example of reading and printing BASELINE_NED messages
 - Sending SBP over UDP

In this case I needed something to send SBP over UDB so it can be fed into MAVProxy and eventually make its way into the telemetry stream up to a ArduPilot quadcopter (so we can use just one pair of radios for corrections and telemetry).