### PR TITLE
Added new shell script and line to swiftnav.sty to do a git describe

### DIFF
--- a/docs/swift_git_tag.sh
+++ b/docs/swift_git_tag.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+tag=`git describe --dirty`
+if [ -z "$tag" ]
+then
+  tag=`git log --pretty=format:'%h' -n 1`
+fi
+echo '\gdef\gitdescribe{'$tag'}' > gitdescribe.tex

--- a/docs/swiftnav.sty
+++ b/docs/swiftnav.sty
@@ -33,6 +33,12 @@
 % Define our alternate color
 \definecolor{alt}{RGB}{140,0,0}
 
+\makeatletter
+% Version control macros
+\immediate\write18{sh swift_git_tag.sh}
+\input{gitdescribe}
+\immediate\write18{rm gitdescribe.tex}
+
 % Colored section headings
 \titleformat*{\section}{\color{alt}\normalfont\huge\bfseries}
 \titleformat*{\subsection}{\color{alt}\normalfont\Large\bfseries}
@@ -45,9 +51,9 @@
 \setlength\multicolsep{20pt}
 
 % Define command to set a document version.
-\newcommand{\theversion}{\VCRevisionMod}
+\newcommand{\theversion}{\gitdescribe}
 \newcommand{\version}[1]{
-  \renewcommand{\theversion}{#1}
+ \renewcommand{\theversion}{#1}
 }
 
 \newcommand{\thesubtitle}{}


### PR DESCRIPTION
This allows git describe or a git log to go into a latex doc.  Requres command line option --shell-escape to pdflatex, which is a bit unsecure


<!---
@huboard:{"order":2.5,"milestone_order":56,"custom_state":""}
-->
