### PR TITLE
Updated YAML descriptions.

### DIFF
--- a/spec/yaml/swiftnav/sbp/acquisition.yaml
+++ b/spec/yaml/swiftnav/sbp/acquisition.yaml
@@ -19,10 +19,13 @@ definitions:
  - MSG_ACQ_RESULT:
     id: 0x0015
     public: True
+    short_desc: Satellite acquisition result.
     desc: |
-      Results of an attempted GPS signal acquisition. Contains the
-      parameters of the point in the acquisition search space with the
-      best signal-to-noise ratio.
+      This message describes the results from an attempted GPS signal
+      acquisition search for a satellite PRN over a code phase/carrier
+      frequency range. It contains the parameters of the point in the
+      acquisition search space with the best signal-to-noise (SNR)
+      ratio.
     fields:
         - snr:
             type: float
@@ -30,11 +33,11 @@ definitions:
         - cp:
             type: float
             units: chips
-            desc: Code phase.
+            desc: Code phase of best point.
         - cf:
             type: float
             units: hz
-            desc: Carrier frequency.
+            desc: Carrier frequency of best point.
         - prn:
             type: u8
             desc: |

--- a/spec/yaml/swiftnav/sbp/base.yaml
+++ b/spec/yaml/swiftnav/sbp/base.yaml
@@ -17,16 +17,21 @@ include:
 definitions:
 
  - SBP:
+    desc: Packet structure for Swift Navigation Binary Protocol (SBP).
     desc: |
-      Defines full packet structure for Swift Navigation Binary Protocol
-      (SBP).
+      Definition of the over-the-wire message framing format and packet
+      structure for Swift Navigation Binary Protocol (SBP), a minimal
+      binary protocol for communicating with Swift devices. It is used
+      to transmit solutions, observations, status and debugging
+      messages, as well as receive messages from the host operating
+      system.
     fields:
         - preamble:
             type: u8
             desc: Denotes the start of frame transmission. For v1.0, always 0x55.
         - msg_type:
             type: u16
-            desc: Identifies the payload contents
+            desc: Uniquely identifies the type of the payload contents
         - sender:
             type: u16
             desc: |
@@ -35,7 +40,8 @@ definitions:
               number.
         - length:
             type: u8
-            desc: Length in bytes of the Payload field.
+            units: bytes
+            desc: Byte-length of the payload field.
         - payload:
             type: bytes
             size_fn: length

--- a/spec/yaml/swiftnav/sbp/bootload.yaml
+++ b/spec/yaml/swiftnav/sbp/bootload.yaml
@@ -1,0 +1,69 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.bootload
+description: |
+  Messages for the bootloading configuration on the Piksi. These are
+  in the implementation-defined range (0x0000-0x00FF), and intended
+  for internal-use only. Note that some of these messages taking a
+  request from a host and a response from the Piksi share the same
+  message type ID.
+stable: False
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_BOOTLOADER_HANDSHAKE:
+    id: 0x00B0
+    public: True
+    short_desc: Bootloading handshake (Host <=> Piksi).
+    desc: |
+      The bootloader continually sends a handshake message to the host
+      for a short period of time, and then jumps to the firmware if it
+      doesn't receive a handshake from the host. If the host replies
+      with a handshake the bootloader doesn't jump to the firmware and
+      waits for flash programming messages, and the host has to send a
+      MSG_BOOTLOADER_JUMP_TO_APP when it's done programming. On old
+      versions of the bootloader (<=v0.1), hardcoded u8=0. On new
+      versions, return the git describe string for the bootloader
+      build.
+    fields:
+      - handshake:
+          type: u8
+          desc: Handshake value
+
+ - MSG_BOOTLOADER_JUMP_TO_APP:
+    id: 0x00B1
+    public: True
+    short_desc: Bootloader jump to application (Host => Piksi)
+    desc: |
+      The host initiates the bootloader to jump to the application.
+    fields:
+      - jump:
+          type: u8
+          desc: Ignored by the Piksi.
+
+ - MSG_NAP_DEVICE_DNA:
+    id: 0x00DD
+    public: True
+    short_desc: Send FPGA device DNA over UART (Host <=> Piksi).
+    desc: |
+      The device DNA message from the host reads the unique device
+      DNA from the Swift Navigation Acceleration Peripheral
+      (SwiftNAP), a Spartan 6 FPGA. By convention, the host message
+      buffer is empty; the Piksi returns the device DNA in a
+      MSG_NAP_DEVICE_DNA message.
+    fields:
+      dna:
+        type: array
+        fill: u8
+        size: 8
+        desc: 57-bit SwiftNAP FPGA Device DNA

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -1,0 +1,108 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.file_io
+description: |
+  Messges for using Piksi's onboard flash filesystem functionality
+  from the Contiki project. This allows data to be stored persistently
+  in the microcontroller's program flash with wear-levelling using a
+  simple filesystem interface. The Contiki file system interface (CFS)
+  defines an abstract API for reading directories and for reading and
+  writing files. These are in the implementation-defined range
+  (0x0000-0x00FF), and intended for internal-use only. Note that some
+  of these messages taking a request from a host and a response from
+  the Piksi share the same message type ID.
+stable: False
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_FILEIO_READ:
+    id: 0x00A8
+    public: True
+    short_desc: Read file from the file system (Host <=> Piksi).
+    desc: |
+      The file read message reads a certain length (up to 255 bytes)
+      from a given offset into a file, and returns the data in a
+      MSG_FILEIO_READ message where the message length field indicates
+      how many bytes were succesfully read. If the message is invalid,
+      a followup MsgPrint message will print "Invalid fileio read
+      message".
+    fields:
+      - offset:
+          type: u32
+          units: bytes
+          desc: File offset.
+      - chunk_size:
+          type: u8
+          units: bytes
+          desc: Chunk size to read.
+      - filename:
+          type: string
+          desc: Name of the file to read from (NULL terminated).
+
+ - MSG_FILEIO_READ_DIR:
+    id: 0x00A9
+    public: True
+    short_desc: List files in a directory (Host <=> Piksi).
+    desc: |
+      The read directory message lists the files in a directory on the
+      Piksi's onboard flash file system.  The offset parameter can be
+      used to skip the first n elements of the file list. Returns a
+      MSG_FILEIO_READ_DIR message containing the directory listings as
+      a NULL delimited list. The listing is chunked over multiple SBP
+      packets and the end of the list is identified by an entry
+      containing just the character 0xFF. If message is invalid, a
+      followup MsgPrint message will print "Invalid fileio read
+      message".
+    fields:
+      - offset:
+          type: u32
+          desc: |
+            The offset to skip the first n elements of the file list.
+      - dirname:
+          type: string
+          desc: Name of the directory to list.
+
+ - MSG_FILEIO_REMOVE:
+    id: 0x00AC
+    public: True
+    short_desc: Delete a file from the file system (Host => Piksi).
+    desc: |
+      The file remove message deletes a file from the file system. If
+      message is invalid, a followup MsgPrint message will print
+      "Invalid fileio remove message".
+    fields:
+      - filename:
+          type: string
+          desc: Name of the file to delete (NULL terminated)
+
+ - MSG_FILEIO_WRITE:
+    id: 0x00AD
+    public: True
+    short_desc: Write to file (Host <=> Piksi)
+    desc: |
+      The file write message writes a certain length (up to 255 bytes)
+      of data to a file at a given offset. Returns a copy of the
+      original MSG_FILEIO_WRITE message to check integrity of the
+      write. If message is invalid, a followup MsgPrint message will
+      print "Invalid fileio write message".
+    fields:
+      - filename:
+          type: string
+          desc: Name of the file to write to (NULL terminated)
+      - offset:
+          type: u32
+          units: bytes
+          desc: Offset into the file at which to start writing in bytes
+      - data:
+          type: bytes
+          desc: Data to write

--- a/spec/yaml/swiftnav/sbp/flash.yaml
+++ b/spec/yaml/swiftnav/sbp/flash.yaml
@@ -1,0 +1,208 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.flash
+description: |
+  Messages for reading/writing the Piksi's onboard flash memory. These
+  are in the implementation-defined range (0x0000-0x00FF), and largely
+  intended for internal-use only.
+stable: False
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_FLASH_PROGRAM:
+    id: 0x00E0
+    public: True
+    short_desc: Program addresses of the STM or M25 flash (Host => Piksi).
+    desc: |
+      The flash program message programs a set of addresses of either
+      the STM or M25 flash. The Piksi replies with either a
+      MSG_FLASH_DONE message containing the return code FLASH_OK (0)
+      on success, or FLASH_INVALID_LEN (2) if the maximum write size
+      is exceeded. Note that the sector-containing addresses must be
+      erased before addresses can be programmed.
+    fields:
+      - target:
+          type: u8
+          desc: Target flags
+          fields:
+            - 1-8:
+                desc: Reserved
+            - 0:
+                desc: Flash target to read.
+                values:
+                  - 0: FLASH_STM
+                  - 1: FLASH_M25
+      - addr_start:
+          type: array
+          fill: u8
+          size: 3
+          units: bytes
+          desc: Starting address offset to program
+      - addr_len:
+          type: u8
+          units: bytes
+          desc: |
+            Length of set of addresses to program, counting up from
+            starting address.
+      - data:
+          type: array
+          fill: u8
+          size_fn: addr_len
+          desc: Data to program addresses with, sized by addr_len.
+
+ - MSG_FLASH_DONE:
+    id: 0x00E0
+    public: True
+    short_desc: Flash response message (Piksi => Host).
+    desc: |
+      This message defines success or failure codes for a variety of
+      flash memory requests from the host to the Piksi. Flash read and
+      write messages, such as MSG_FLASH_READ or MSG_FLASH_WRITE, may
+      return this message on failure.
+    fields:
+      - response:
+          type: u8
+          desc: Response flags
+          fields:
+            - 3-7:
+                desc: Reserved
+            - 0-2:
+                desc: Response code
+                values:
+                  - 0: FLASH_OK
+                  - 1: FLASH_INVALID_FLASH
+                  - 2: FLASH_INVALID_LEN
+                  - 3: FLASH_INVALID_ADDR
+                  - 4: FLASH_INVALID_RANGE
+                  - 5: FLASH_INVALID_SECTOR
+
+ - MSG_FLASH_READ:
+    id: 0x00E1
+    public: True
+    short_desc: Read STM or M25 flash address (Host <=> Piksi).
+    desc: |
+      The flash read message reads a set of addresses of either the
+      STM or M25 onboard flash. The Piksi replies with a
+      MSG_FLASH_READ message containing either the read data on
+      success or a MSG_FLASH_DONE message containing the return code
+      FLASH_INVALID_LEN (2) if the maximum read size is exceeded or
+      FLASH_INVALID_ADDR (3) if the address is outside of the allowed
+      range.
+    fields:
+      - target:
+          type: u8
+          desc: Target flags
+          fields:
+            - 1-8:
+                desc: Reserved
+            - 0:
+                desc: Flash target to read.
+                values:
+                  - 0: FLASH_STM
+                  - 1: FLASH_M25
+      - addr_start:
+          type: array
+          fill: u8
+          size: 3
+          units: bytes
+          desc: Starting address offset to read from
+      - addr_len:
+          type: u8
+          units: bytes
+          desc: |
+            Length of set of addresses to read, counting up from
+            starting address.
+
+ - MSG_FLASH_ERASE:
+    id: 0x00E2
+    public: True
+    short_desc: Erase sector of Piksi flash memory (Host => Piksi).
+    desc: |
+      The flash erase message from the host erases a sector of either
+      the STM or M25 onboard flash memory. The Piksi will reply with a
+      MSG_FLASH_DONE message containing the return code - FLASH_OK (0)
+      on success or FLASH_INVALID_FLASH (1) if the flash specified is
+      invalid.
+    fields:
+      - target:
+          type: u8
+          desc: Target flags
+          fields:
+            - 1-8:
+                desc: Reserved
+            - 0:
+                desc: Flash target to read
+                values:
+                  - 0: FLASH_STM
+                  - 1: FLASH_M25
+      - sector_num:
+          type: u8
+          desc: |
+            Flash sector number to erase (0-11 for the STM, 0-15 for
+            the M25).
+
+ - MSG_STM_FLASH_LOCK_SECTOR:
+    id: 0x00E3
+    public: True
+    short_desc: Lock sector of STM flash memory (Host => Piksi).
+    desc: |
+      The flash lock message locks a sector of the STM flash
+      memory. The Piksi replies with a MSG_FLASH_DONE message.
+    fields:
+      - sector:
+          type: array
+          size: 1
+          fill: u8
+          desc: Flash sector number to lock.
+
+ - MSG_STM_FLASH_UNLOCK_SECTOR:
+    id: 0x00E4
+    public: True
+    short_desc: Unlock sector of STM flash memory (Host => Piksi)
+    desc: |
+      The flash unlock message unlocks a sector of the STM flash
+      memory. The Piksi replies with a MSG_FLASH_DONE message.
+    fields:
+      - sector:
+          type: array
+          fill: u8
+          size: 1
+          desc: Flash sector number to unlock.
+
+ - MSG_STM_UNIQUE_ID:
+    id: 0x00E5
+    public: True
+    short_desc: |
+      Read STM32F4's hardcoded unique ID (Host <=> Piksi).
+    desc: |
+      This message reads the STM32F4's hardcoded unique ID. The Piksi
+      returns STM32F4 unique ID (12 bytes) back to host.
+    fields:
+      - stm_id:
+          type: string
+          size: 12
+          desc: STM32F4 unique ID.
+
+ - MSG_M25_FLASH_WRITE_STATUS:
+    id: 0x00F3
+    public: True
+    short_desc: Write M25 flash status register (Host => Piksi).
+    desc: |
+      The flash status message writes to the 8-bit M25 flash status
+      register. The Piksi replies with a MSG_FLASH_DONE message.
+    fields:
+      - status:
+          type: array
+          size: 1
+          fill: u8
+          desc: Byte to write to the M25 flash status register.

--- a/spec/yaml/swiftnav/sbp/logging.yaml
+++ b/spec/yaml/swiftnav/sbp/logging.yaml
@@ -1,0 +1,41 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.logging
+description: |
+  Logging and debugging messages from the Piksi. These are in the
+  implementation-defined range (0x0000-0x00FF).
+stable: False
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_PRINT:
+    id: 0x0010
+    public: True
+    short_desc: Plaintext logging messages (Piksi => Host).
+    desc: |
+      This message contains a human-reabable payload string from the
+      Piksi containing errors, warnings and informational messages at
+      ERROR, WARNING, DEBUG, INFO logging levels. These message may
+      also contain information tagged by filename, as well as debug
+      info on function entry/exit when enabled within the firmware.
+    fields:
+      - text:
+          type: string
+          desc: Informative, human-readable string.
+
+ - MSG_DEBUG_VAR:
+    id: 0x0011
+    short_desc: Legacy message for tracing variable values (Piksi => Host).
+    desc: |
+      This is an unused legacy message for tracing variable values
+      within the Piksi firmware and streaming those back to the host.

--- a/spec/yaml/swiftnav/sbp/navigation.yaml
+++ b/spec/yaml/swiftnav/sbp/navigation.yaml
@@ -9,17 +9,21 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 package: swiftnav.sbp.navigation
-description: Geodetic navigation messages from the Piksi.
+description: |
+  Geodetic navigation messages reporting GPS time, single-point
+  position, and RTK baseline position solutions.
 stable: True
+public: True
 include:
   - types.yaml
 definitions:
 
  - MSG_GPS_TIME:
     id: 0x0100
+    public: True
     short_desc: GPS Time
     desc: |
-        GPS Time.
+        This message reports the GPS Time.
     fields:
         - wn:
             type: u16
@@ -39,9 +43,12 @@ definitions:
 
  - MSG_DOPS:
     id: 0x0206
+    public: True
     short_desc: Dilution of Precision
     desc: |
-      Dilution of Precision.
+      This dilution of precision (DOP) message describes the effect of
+      navigation satellite geometry on positional measurement
+      precision.
     fields:
         - tow:
             type: u32
@@ -71,10 +78,16 @@ definitions:
 
  - MSG_POS_ECEF:
     id: 0x0200
-    short_desc: Position in ECEF
+    public: True
+    short_desc: Single-point position in ECEF
     desc: |
-      Position solution in absolute Earth Centered Earth Fixed (ECEF)
-      coordinates.
+      The single-point position solution message reports absolute
+      Earth Centered Earth Fixed (ECEF) coordinates and the status
+      (single point absolute vs RTK) of the position solution. If the
+      rover receiver knows the single-point point position of the base
+      station and has an RTK solution, this reports a pseudo-absolute
+      position solution using the base station single-point position
+      solution and the rover's RTK baseline vector.
     fields:
         - tow:
             type: u32
@@ -114,9 +127,16 @@ definitions:
 
  - MSG_POS_LLH:
     id: 0x0201
+    public: True
     short_desc: Geodetic Position
     desc: |
-        Geodetic position solution.
+      This single-point position solution message reports the absolute
+      geodetic coordinates and the status (single point absolute vs
+      RTK) of the position solution. If the rover receiver knows
+      single-point point position of the base station and has an RTK
+      solution, this reports a pseudo-absolute position solution using
+      the base station single-point position solution and the rover's
+      RTK baseline vector.
     fields:
         - tow:
             type: u32
@@ -165,9 +185,11 @@ definitions:
 
  - MSG_BASELINE_ECEF:
     id: 0x0202
-    short_desc: Baseline in ECEF
+    public: True
+    short_desc: Baseline Position in ECEF
     desc: |
-        Baseline in Earth Centered Earth Fixed (ECEF) coordinates.
+      This message reports the baseline position solution in Earth
+      Centered Earth Fixed (ECEF) coordinates.
     fields:
           - tow:
               type: u32
@@ -206,9 +228,11 @@ definitions:
 
  - MSG_BASELINE_NED:
     id: 0x0203
+    public: True
     short_desc: Baseline in NED
     desc: |
-        Baseline in local North East Down (NED) coordinates.
+      This message reports the baseline position solution in North
+      East Down (NED) coordinates.
     fields:
           - tow:
               type: u32
@@ -251,9 +275,11 @@ definitions:
 
  - MSG_VEL_ECEF:
     id: 0x0204
+    public: True
     short_desc: Velocity in ECEF
     desc: |
-        Velocity in Earth Centered Earth Fixed (ECEF) coordinates.
+      This message reports the velocity in Earth Centered Earth Fixed
+      (ECEF) coordinates.
     fields:
           - tow:
               type: u32
@@ -284,9 +310,11 @@ definitions:
 
  - MSG_VEL_NED:
     id: 0x0205
+    public: True
     short_desc: Velocity in NED
     desc: |
-        Velocity in local North East Down (NED) coordinates.
+      This message reports the velocity in local North East Down (NED)
+      coordinates.
     fields:
           - tow:
               type: u32

--- a/spec/yaml/swiftnav/sbp/observation.yaml
+++ b/spec/yaml/swiftnav/sbp/observation.yaml
@@ -9,7 +9,7 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 package: swiftnav.sbp.observation
-description: Observation messages from the Piksi.
+description: Satellite observation messages from the Piksi.
 stable: False
 public: True
 include:
@@ -18,6 +18,7 @@ definitions:
 
  - ObsGPSTime:
     public: True
+    short_desc: Millisecond-accurate GPS time.
     desc: |
       A wire-appropriate GPS time, defined as the number of
       milliseconds since beginning of the week on the Saturday/Sunday
@@ -34,6 +35,7 @@ definitions:
 
  - CarrierPhase:
     public: True
+    short_desc: GPS carrier phase measurement.
     desc: |
       Carrier phase measurement in cycles represented as a 40-bit
       fixed point number with Q32.8 layout, i.e. 32-bits of whole
@@ -50,7 +52,8 @@ definitions:
 
  - ObservationHeader:
     public: True
-    desc: Header of a GPS observation message
+    short_desc: Header for observation message.
+    desc: Header of a GPS observation message.
     fields:
         - t:
             type: ObsGPSTime
@@ -64,7 +67,10 @@ definitions:
 
  - PackedObsContent:
     public: True
-    desc: GPS observations for a particular satellite signal.
+    short_desc: GPS observations for a particular satellite signal.
+    desc: |
+      Pseudorange and carrier phase observation for a satellite being
+      tracked.
     fields:
         - P:
             type: u32
@@ -91,7 +97,11 @@ definitions:
  - MSG_OBS:
     id: 0x0045
     public: True
-    short_desc: MSG_OBS
+    short_desc: GPS satellite observations.
+    desc: |
+      The GPS observations message reports all the pseudo range and
+      carrier phase observations for the satellites being tracked by
+      the Piksi.
     fields:
         - header:
             type: ObservationHeader
@@ -100,12 +110,18 @@ definitions:
             type: array
             fill: PackedObsContent
             map_by: prn
-            desc: Observations
+            desc: |
+              Pseudorange and carrier phase observation for a
+              satellite being tracked.
 
  - MSG_BASE_POS:
     id: 0x0044
     public: True
-    short_desc: MSG_BASE_POS
+    short_desc: Base station position.
+    desc: |
+      This may be the position as reported by the base station itself or the
+      position obtained from doing a single point solution using the base
+      station observations.
     fields:
         - lat:
             type: double

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -9,133 +9,106 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 package: swiftnav.sbp.piksi
-description: System messages from the Piksi.
+description: |
+  System health, configuration, and diagnostic messages specific to
+  the Piksi L1 receiver, including a variety of legacy messages that
+  may no longer be used. These messages are in the
+  implementation-defined range (0x0000-0x00FF), and largely intended
+  for internal-use only.
 stable: False
 public: True
 include:
   - types.yaml
 definitions:
 
- - MSG_PRINT:
-    id: 0x0010
-    public: True
-    desc: Information and debugging information.
-
- - MSG_DEBUG_VAR:
-    id: 0x0011
-    desc: Legacy message for tracing variable values.
-
  - MSG_ALMANAC:
     id: 0x0069
-    desc: MSG_ALMANAC
+    short_desc: Legacy message to load satellite almanac (Host => Piksi).
+    desc: |
+      This is a legacy message for sending and loading a satellite
+      alamanac onto the Piksi's flash memory from the host.
 
  - MSG_SET_TIME:
     id: 0x0068
-    desc: MSG_SET_TIME
-
- - MSG_BOOTLOADER_HANDSHAKE:
-    id: 0x00B0
-    desc: MSG_BOOTLOADER_HANDSHAKE
-
- - MSG_BOOTLOADER_JUMP_TO_APP:
-    id: 0x00B1
-    desc: MSG_BOOTLOADER_JUMP_TO_APP
+    short_desc: Send GPS time from host (Host => Piksi).
+    desc: |
+      This message sets up timing functionality using a coarse GPS
+      time estimate sent by the host.
 
  - MSG_RESET:
     id: 0x00B2
-    desc: Reset the devices.
+    public: True
+    short_desc: Reset the device (Host => Piksi).
+    desc: |
+      This message from the host resets the Piksi back into the
+      bootloader. It ensures that all outstanding memory accesses
+      including buffered writes are completed before reset begins.
 
  - MSG_CW_RESULTS:
     id: 0x00C0
-    desc: MSG_CW_RESULTS
+    short_desc: Legacy message for CW interference channel (Piksi => Host).
+    desc: |
+      This is an unused legacy message for result reporting from the
+      CW interference channel on the SwiftNAP. This message will be
+      removed in a future release.
 
  - MSG_CW_START:
     id: 0x00C1
-    desc: MSG_CW_START
-
- - MSG_NAP_DEVICE_DNA:
-    id: 0x00DD
-    desc: MSG_NAP_DEVICE_DNA
-
- - MSG_FLASH_PROGRAM:
-    id: 0x00E0
-    desc: MSG_FLASH_PROGRAM
-
- - MSG_FLASH_DONE:
-    id: 0x00E0
-    desc: MSG_FLASH_DONE
-
- - MSG_FLASH_READ:
-    id: 0x00E1
-    desc: MSG_FLASH_READ
-
- - MSG_FLASH_ERASE:
-    id: 0x00E2
-    desc: MSG_FLASH_ERASE
-
- - MSG_STM_FLASH_LOCK_SECTOR:
-    id: 0x00E3
-    desc: MSG_STM_FLASH_LOCK_SECTOR
-
- - MSG_STM_FLASH_UNLOCK_SECTOR:
-    id: 0x00E4
-    desc: MSG_STM_FLASH_UNLOCK_SECTOR
-
- - MSG_STM_UNIQUE_ID:
-    id: 0x00E5
-    desc: MSG_STM_UNIQUE_ID
-
- - MSG_M25_FLASH_WRITE_STATUS:
-    id: 0x00F3
-    desc: MSG_M25_FLASH_WRITE_STATUS
+    short_desc: Legacy message for CW interference channel (Host => Piksi).
+    desc: |
+      This is an unused legacy message from those host for starting
+      the CW interference channel on the SwiftNAP. This message will
+      be removed in a future release.
 
  - MSG_RESET_FILTERS:
     id: 0x0022
-    desc: MSG_RESET_FILTERS
+    short_desc: Reset IAR filters (Host => Piksi)
+    desc: |
+      This message resets either the DGNSS Kalman filters or Integer
+      Ambiguity Resolution (IAR) process.
+    fields:
+      - filter:
+          type: u8
+          desc: Filter flags
+          fields:
+            - 1-8:
+                desc: Reserved
+            - 0:
+                desc: Filter or process to reset
+                values:
+                  - 0: DGNSS filter
+                  - 1: IAR process
 
  - MSG_INIT_BASE:
     id: 0x0023
-    desc: MSG_INIT_BASE
-
- - MSG_SETTINGS:
-    id: 0x00A0
-    desc: MSG_SETTINGS
-
- - MSG_SETTINGS_SAVE:
-    id: 0x00A1
-    desc: MSG_SETTINGS_SAVE
-
- - MSG_SETTINGS_READ_BY_INDEX:
-    id: 0x00A2
-    desc: MSG_SETTINGS_READ_BY_INDEX
-
- - MSG_FILEIO_READ:
-    id: 0x00A8
-    desc: MSG_FILEIO_READ
-
- - MSG_FILEIO_READ_DIR:
-    id: 0x00A9
-    desc: MSG_FILEIO_READ_DIR
-
- - MSG_FILEIO_REMOVE:
-    id: 0x00AC
-    desc: MSG_FILEIO_REMOVE
-
- - MSG_FILEIO_WRITE:
-    id: 0x00AD
-    desc: MSG_FILEIO_WRITE
+    public: True
+    short_desc: Initialize IAR from known baseline (Host => Piksi).
+    desc: |
+      This message initializes the Integer Ambiguity Resolution (IAR)
+      process on the Piksi to use an assumed baseline position between
+      the base station and rover receivers. Warns via MsgPrint if
+      there aren't a shared minimum number (4) of satellite
+      observations between the two.
 
  - MSG_THREAD_STATE:
     id: 0x0017
-    desc: State of the CPU threads.
+    public: True
+    short_desc: State of a CPU/RTOS thread.
+    desc: |
+      The thread usage message from the Piksi reports RTOS thread
+      usage statistics for the named thread. The reported values
+      require renormalization.
     fields:
         - name:
             type: string
             size: 20
-            desc: Thread name
+            desc: Thread name (NULL terminated)
         - cpu:
             type: u16
-            desc: cpu
+            units: Utilization percentage /1000.
+            desc: |
+              Percentage cpu use for this thread. Ranges from 0 - 1000
+              and needs to be renormalized to 100.
         - stack_free:
             type: u32
             units: kB
@@ -143,7 +116,10 @@ definitions:
 
  - UARTChannel:
     public: True
-    desc: State of the UART channel.
+    short_desc: State of the UART channel.
+    desc: |
+      Throughput, utilization, and error counts on the RX/TX buffers
+      of this UART channel. Values require renormalization.
     fields:
         - tx_throughput:
             type: float
@@ -161,15 +137,20 @@ definitions:
             desc: UART IO error count.
         - tx_buffer_level:
             type: u8
-            units: Utilization % /255
-            desc: UART transmit usage percentage.
+            units: Utilization /255
+            desc: |
+              UART transmit buffer percentage utilization. Ranges from
+              0 - 255 and needs to be renormalized to 100.
         - rx_buffer_level:
             type: u8
-            units: Utilization % /255
-            desc: UART receive usage percentage.
+            units: Utilization /255
+            desc: |
+              UART receive buffer percentage utilization. Ranges from
+              0 - 255 and needs to be renormalized to 100.
 
  - Latency:
     public: True
+    short_desc: Receiver-to-base station latency.
     desc: |
       Statistics on the latency of observations received from the base
       station. As observation packets are received their GPS time is
@@ -197,24 +178,35 @@ definitions:
  - MSG_UART_STATE:
     id: 0x0018
     public: True
-    desc: State of the UART channels.
+    short_desc: State of the UART channels.
+    desc: |
+      The UART message reports data latency and throughput of the UART
+      channels providing SBP I/O. On the default Piksi configuration,
+      UARTs A and B are used for telemetry radios, but can also be be
+      host access ports for embedded hosts, or other interfaces in
+      future.
     fields:
         - uart_a:
             type: UARTChannel
-            desc: State of UART A.
+            desc: State of UART A
         - uart_b:
             type: UARTChannel
-            desc: State of UART B.
+            desc: State of UART B
         - uart_ftdi:
             type: UARTChannel
-            desc: State of UART FTDI.
+            desc: State of UART FTDI (USB logger)
         - latency:
             type: Latency
-            desc: UART communication latency.
+            desc: UART communication latency
 
  - MSG_IAR_STATE:
     id: 0x0019
-    desc: State of the Integer Ambiguity Resolution (IAR) process.
+    short_desc: State of the Integer Ambiguity Resolution (IAR) process.
+    desc: |
+      This message reports the state of the Integer Ambiguity
+      Resolution (IAR) process, which resolves unknown integer
+      ambiguities from double-differenced carrier-phase measurements
+      from satellite observations.
     fields:
         - num_hyps:
             type: u32

--- a/spec/yaml/swiftnav/sbp/settings.yaml
+++ b/spec/yaml/swiftnav/sbp/settings.yaml
@@ -1,0 +1,60 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.settings
+description: |
+  Messages for reading and writing the Piksi's device settings. These
+  are in the implementation-defined range (0x0000-0x00FF), and
+  intended for internal-use only. Please see the accompanying
+  description of settings configurations for more details. Note that
+  some of these messages taking a request from a host and a response
+  from the Piksi share the same message type ID.
+stable: False
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_SETTINGS:
+    id: 0x00A0
+    public: True
+    short_desc: Read/write Piksi configuration settings (Host <=> Piksi).
+    desc: |
+      The setting message reads and writes the Piksi's configuration.
+    fields:
+      - setting:
+          type: string
+          desc: |
+            A NULL delimited (and terminated) string, with a single
+            "<setting section>\0<setting>\0<value>\0" on writes or a
+            series of "<setting section>\0<setting>\0<value>\0" on
+            reads.
+
+ - MSG_SETTINGS_SAVE:
+    id: 0x00A1
+    public: True
+    short_desc: Save settings to flash (Host => Piksi)
+    desc: |
+      The save settings message persists the Piksi's current settings
+      configuration to its onboard flash memory file system.
+
+ - MSG_SETTINGS_READ_BY_INDEX:
+    id: 0x00A2
+    short_desc: Read the (Host <=> Piksi)
+    desc: |
+      The settings message for iterating through the settings
+      values. It will read the setting at an index, returning
+      "<setting section>\0<setting>\0<value>\0" from the Piksi.
+    fields:
+      - index:
+          type: u16
+          desc: |
+            An index into the Piksi settings, with values ranging from
+            0 to length(settings).

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -8,7 +8,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-package: swiftnav.sbp.standard
+package: swiftnav.sbp.system
 description: Standardized system messages from Swift Navigation devices.
 stable: True
 public: True
@@ -21,10 +21,10 @@ definitions:
     public: True
     short_desc: System start-up message
     desc: |
-        The system start-up message is sent once on system start-up. It is
-        intended to be used to notify the host or other attached devices that
-        the system has started and is now ready to respond to commands or
-        configuration requests.
+        The system start-up message is sent once on system
+        start-up. It is intended to be used to notify the host or
+        other attached devices that the system has started and is now
+        ready to respond to commands or configuration requests.
     fields:
         - reserved:
             type: u32
@@ -35,15 +35,15 @@ definitions:
     public: True
     short_desc: System heartbeat message
     desc: |
-        The heartbeat message is sent periodically to inform the host or
-        other attached devices that the system is running. It is intended to
-        be used to monitor for system malfunctions and also contains
-        status flags that indicate to the host the status of the system and
-        if it is operating correctly.
+        The heartbeat message is sent periodically to inform the host
+        or other attached devices that the system is running. It is
+        intended to be used to monitor for system malfunctions and
+        also contains status flags that indicate to the host the
+        status of the system and if it is operating correctly.
 
-        The system error flag is used to indicate that an error has occurred in
-        the system. To determine the source of the error the remaining error
-        flags should be inspected.
+        The system error flag is used to indicate that an error has
+        occurred in the system. To determine the source of the error
+        the remaining error flags should be inspected.
     fields:
         - flags:
             type: u32

--- a/spec/yaml/swiftnav/sbp/tracking.yaml
+++ b/spec/yaml/swiftnav/sbp/tracking.yaml
@@ -9,7 +9,8 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 package: swiftnav.sbp.tracking
-description: Satellite tracking messages from the Piksi.
+description: |
+  Satellite code and carrier-phase tracking messages from the Piksi.
 stable: False
 public: True
 include:
@@ -18,7 +19,10 @@ definitions:
 
  - TrackingChannelState:
     public: True
-    desc: State of the tracking channel.
+    short_desc: Satellite tracking channel state.
+    desc: |
+      Tracking channel state for a specific satellite PRN and measured
+      signal power.
     fields:
         - state:
             type: u8
@@ -42,18 +46,28 @@ definitions:
  - MSG_TRACKING_STATE:
     id: 0x0016
     public: True
-    desc: Tracking channel states
+    short_desc: Satellite tracking channel states.
+    desc: |
+      This message returns a variable-length array of tracking channel
+      states. It reports status and code/carrier phase signal power
+      measurements for all tracked satellites.
     fields:
       - states:
           type: array
           fill: TrackingChannelState
-          desc: State of the tracking channel.
+          desc: Satellite tracking channel state.
 
  - MSG_EPHEMERIS:
     id: 0x001A
     public: True
     short_desc: WGS84 satellite orbit ephemeris parameters
-    desc: WGS84 satellite orbit ephemeris parameters
+    desc: |
+      This message returns a set of satellite orbit parameters that is
+      used to calculate GPS satellite position, velocity, and clock
+      offset (WGS84). Please see the Navstar GPS Space
+      Segment/Navigation user interfaces (ICD-GPS-200, Table 20-III)
+      for more details
+      (http://www.navcen.uscg.gov/pubs/gps/icd200/icd200cw1234.pdf).
     fields:
       - tgd:
           type: double

--- a/spec/yaml/swiftnav/sbp/types.yaml
+++ b/spec/yaml/swiftnav/sbp/types.yaml
@@ -9,8 +9,10 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 package: swiftnav.sbp.types
-description: Defines a variety of common types. Sizes are in bytes.
-render_source: False
+description: |
+  Documents a variety of common types referenced by the SBP
+  specification. Sizes are in bytes.
+render_source: false
 stable: True
 definitions:
  - s8:


### PR DESCRIPTION
0. Clarifies and adds some field and message descriptions that were previously  missing.
1. Adds short_desc messages where they were previously missing.
2. Refactors some messages in piksi.yaml into separate modules reflecting 
hierarchy in piksi_firmware.

Replaces #58 . Closes #45 .

TODO: 
- [x] Finish describing `piksi.yaml` message fields.
- [x] Copyedit.

/cc @mfine @denniszollo @cbeighley @soulcmdc 