### PR TITLE
Add locks to the contexts around resources. Also flushes.

### DIFF
--- a/python/sbp/client/drivers/file_driver.py
+++ b/python/sbp/client/drivers/file_driver.py
@@ -42,17 +42,19 @@ class FileDriver(BaseDriver):
       current position and 2 means seek relative to the file's end
 
     """
-    self.handle.seek(pos, whence)
+    with self.lock:
+      self.handle.seek(pos, whence)
 
   def next(self):
     """
     Call handle's iterator.
 
     """
-    line = self.handle.readline()
-    if not line:
-      raise StopIteration
-    return line
+    with self.lock:
+      line = self.handle.readline()
+      if not line:
+        raise StopIteration
+      return line
 
   def readline(self):
     """
@@ -60,4 +62,5 @@ class FileDriver(BaseDriver):
     (EOL) character ('\n' by default), or until timeout.
 
     """
-    return self.handle.readline()
+    with self.lock:
+      return self.handle.readline()

--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -54,11 +54,12 @@ class PySerialDriver(BaseDriver):
     size : int
       Number of bytes to read.
     """
-    import serial
-    try:
-      return self.handle.read(size)
-    except (OSError, serial.SerialException):
-      print
-      print "Piksi disconnected"
-      print
-      raise SystemExit
+    with self.lock:
+      import serial
+      try:
+        return self.handle.read(size)
+      except (OSError, serial.SerialException):
+        print
+        print "Piksi disconnected"
+        print
+        raise SystemExit

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -166,7 +166,7 @@ class Handler(object):
   def add_callback(self, callback, msg_type=None):
     """
     Add per message type or global callback.
-    
+
     Parameters
     ----------
     callback : fn

--- a/python/sbp/client/loggers/byte_logger.py
+++ b/python/sbp/client/loggers/byte_logger.py
@@ -29,4 +29,5 @@ class ByteLogger(BaseLogger):
     return s
 
   def call(self, msg):
-    self.handle.write(self.fmt_msg(msg))
+    with self.lock:
+      self.handle.write(self.fmt_msg(msg))

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -27,7 +27,8 @@ class JSONLogger(BaseLogger):
             "data": msg.to_json_dict()}
 
   def call(self, msg):
-    self.handle.write(json.dumps(self.fmt_msg(msg)) + "\n")
+    with self.lock:
+      self.handle.write(json.dumps(self.fmt_msg(msg)) + "\n")
 
 
 class JSONLogIterator(LogIterator):
@@ -57,14 +58,15 @@ class JSONLogIterator(LogIterator):
       (elapsed msec since beginning of log, UTC timestamp, msg)
 
     """
-    for line in self.handle:
-      data = json.loads(line)
-      delta = data['delta']
-      timestamp = data['timestamp']
-      item = SBP.from_json_dict(data['data'])
-      try:
-        yield (delta, timestamp, self.dispatcher(item))
-      except KeyError:
-        yield (delta, timestamp, item)
-    self.handle.seek(0, 0)
-    raise StopIteration
+    with self.lock:
+      for line in self.handle:
+        data = json.loads(line)
+        delta = data['delta']
+        timestamp = data['timestamp']
+        item = SBP.from_json_dict(data['data'])
+        try:
+          yield (delta, timestamp, self.dispatcher(item))
+        except KeyError:
+          yield (delta, timestamp, item)
+      self.handle.seek(0, 0)
+      raise StopIteration

--- a/python/sbp/client/loggers/pickle_logger.py
+++ b/python/sbp/client/loggers/pickle_logger.py
@@ -55,14 +55,15 @@ class PickleLogIterator(LogIterator):
       (elapsed msec since beginning of log, UTC timestamp, msg)
 
     """
-    with self.lock:
-      try:
-        while True:
+    try:
+      while True:
+        with self.lock:
           delta, timestamp, item = pickle.load(self.handle)
-          try:
-            yield (delta, timestamp, self.dispatcher(item))
-          except KeyError:
-            yield (delta, timestamp, item)
-      except EOFError:
+        try:
+          yield (delta, timestamp, self.dispatcher(item))
+        except KeyError:
+          yield (delta, timestamp, item)
+    except EOFError:
+      with self.lock:
         self.handle.seek(0, 0)
-        raise StopIteration
+      raise StopIteration


### PR DESCRIPTION
Not sure what this is going to buy us - how do threads escape another thread's context? Flushes are good addition here, plus the flushing on `__enter__` for drivers. Is there a better pattern to accomplish this? Should we be using `acquire`/`release` instead of `__enter__`/`__exit__`? Really want to enter a lock's context management inside these contexts, but don't know how to do that.

/cc @mookerji 
