### PR TITLE
Move the version into setup.py for now

### DIFF
--- a/python/sbp/__init__.py
+++ b/python/sbp/__init__.py
@@ -13,8 +13,6 @@ from construct import *
 import base64
 import struct
 
-__version__ = "0.28"
-
 SBP_PREAMBLE = 0x55
 
 crc16_tab = [0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from sbp import __version__
 from setuptools import setup
 import os
+
+VERSION = "0.29"
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',
@@ -39,7 +40,7 @@ with open(cwd + '/requirements.txt') as f:
 setup(name='sbp',
       description='Python bindings for Swift Binary Protocol',
       long_description=readme,
-      version=__version__,
+      version=VERSION,
       author='Swift Navigation',
       author_email='dev@swiftnav.com',
       url='https://github.com/swift-nav/libsbp',


### PR DESCRIPTION
There's a dependency issue with `construct` in `sbp/__init__.py`. For now, move the version into `setup.py`.

/cc @mookerji 