### PR TITLE
Correct some errors in README examples

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -27,11 +27,11 @@ For example,
 
 ```shell
 # Output C bindings:
-python sbp/generator.py -i ../spec/yaml/swift/sbp/ -o ../c/ --c
+python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../c/ --c
 
 # Output Python bindings:
-python sbp/generator.py -i ../spec/yaml/swift/sbp/ -o ../python/ --c
-python sbp/generator.py -i ../spec/yaml/swift/sbp/navigation.yaml -o ../python/ --c
+python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../python/ --c
+python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/navigation.yaml -o ../python/ --c
 
 ```
 
@@ -42,7 +42,7 @@ python sbp/generator.py -i ../spec/yaml/swift/sbp/navigation.yaml -o ../python/ 
 pip install -r requirements.txt
 
 # Running tests
-py.test -q -vv test/
+py.test -q -vv tests/
 
 # Deploying to pypi
 

--- a/python/README.rst
+++ b/python/README.rst
@@ -12,7 +12,7 @@ Install dependencies only::
 
 Install from repo::
 
-  $ sudo pip setup.py install
+  $ sudo python setup.py install
 
 Install package from pypi::
 


### PR DESCRIPTION
However, it's still not quite right, because I get the following error when trying to run the generator:
```
henry@hank:~/swift/libsbp/generator$ python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../c/ --c
Traceback (most recent call last):
  File "sbp/generator.py", line 20, in <module>
    import sbp.specs.yaml2 as yaml
ImportError: No module named specs.yaml2
```
This is after setuptools-installing the latest libsbp and generator packages.  It's some path bullshit.  I can make it work by copying libsbp/generator/sbp/generator.py into libsbp/generator/, but then I encounter a different error:
```
henry@hank:~/swift/libsbp/generator$ ./generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../c/ --c
Invalid SBP YAML specification: /home/henry/swift/libsbp/spec/yaml/swiftnav/sbp/bootload.yaml.
Traceback (most recent call last):
  File "./generator.py", line 94, in <module>
    main()
  File "./generator.py", line 71, in main
    file_index = yaml.resolve_deps(*yaml.get_files(input_file))
  File "/home/henry/swift/libsbp/generator/sbp/specs/yaml2.py", line 102, in resolve_deps
    file_index[fname] = read_spec(fname)
  File "/home/henry/swift/libsbp/generator/sbp/specs/yaml2.py", line 63, in read_spec
    raise e
voluptuous.MultipleInvalid: expected a list for dictionary value @ data['definitions'][2]['MSG_NAP_DEVICE_DNA']['fields']
```
