### PR TITLE
New message MSG_EXT_EVENT for reporting timestamped external pin transitions

### DIFF
--- a/c/include/libsbp/ext_events.h
+++ b/c/include/libsbp/ext_events.h
@@ -12,7 +12,7 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/ext_events.yaml
- * with generate.py at 2015-04-10 18:08:47.554362. Please do not hand edit!
+ * with generate.py at 2015-04-14 13:57:47.376336. Please do not hand edit!
  *****************************************************************************/
 
 /** \defgroup ext_events Ext_events
@@ -32,7 +32,7 @@
  * Reports detection of an external event, the GPS time it occurred,
  * which pin it was and whether it was rising or falling.
  */
-#define SBP_MSG_EXT_EVENT 0x0300
+#define SBP_MSG_EXT_EVENT 0x0101
 typedef struct __attribute__((packed)) {
   u16 wn;       /**< GPS week number [weeks] */
   u32 tow;      /**< GPS Time of Week rounded to the nearest ms [ms] */

--- a/c/include/libsbp/ext_events.h
+++ b/c/include/libsbp/ext_events.h
@@ -12,7 +12,7 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/ext_events.yaml
- * with generate.py at 2015-04-10 11:45:32.694320. Please do not hand edit!
+ * with generate.py at 2015-04-10 18:08:47.554362. Please do not hand edit!
  *****************************************************************************/
 
 /** \defgroup ext_events Ext_events
@@ -41,5 +41,7 @@ typedef struct __attribute__((packed)) {
   u8 pin;      /**< Pin number.  0..9 = DEBUG0..9. */
 } msg_ext_event_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_EXT_EVENTS_MESSAGES_H */

--- a/c/include/libsbp/ext_events.h
+++ b/c/include/libsbp/ext_events.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Fergus Noble <fergus@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ext_events.yaml
+ * with generate.py at 2015-04-10 11:45:32.694320. Please do not hand edit!
+ *****************************************************************************/
+
+/** \defgroup ext_events Ext_events
+ *
+ *  * Messages reporting accurately-timestamped external events,
+ * e.g. camera shutter time
+ * \{ */
+
+#ifndef LIBSBP_EXT_EVENTS_MESSAGES_H
+#define LIBSBP_EXT_EVENTS_MESSAGES_H
+
+#include "common.h"
+
+
+/** Reports timestamped external pin event
+ *
+ * Reports detection of an external event, the GPS time it occurred,
+ * which pin it was and whether it was rising or falling.
+ */
+#define SBP_MSG_EXT_EVENT 0x0300
+typedef struct __attribute__((packed)) {
+  u16 wn;       /**< GPS week number [weeks] */
+  u32 tow;      /**< GPS Time of Week rounded to the nearest ms [ms] */
+  s32 ns;       /**< Nanosecond remainder of rounded tow [ns] */
+  u8 flags;    /**< Flags */
+  u8 pin;      /**< Pin number.  0..9 = DEBUG0..9. */
+} msg_ext_event_t;
+
+
+#endif /* LIBSBP_EXT_EVENTS_MESSAGES_H */

--- a/generator/README.md
+++ b/generator/README.md
@@ -27,17 +27,24 @@ For example,
 
 ```shell
 # Output C bindings:
-python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../c/ --c
+python sbpg/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../c/ --c
 
 # Output Python bindings:
-python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../python/ --c
-python sbp/generator.py -i ../spec/yaml/swiftnav/sbp/navigation.yaml -o ../python/ --c
+python sbpg/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../python/ --python
+python sbpg/generator.py -i ../spec/yaml/swiftnav/sbp/navigation.yaml -o ../python/ --python
+
+# Output LaTeX documentation
+python sbpg/generator.py -i ../spec/yaml/swiftnav/sbp/ -o ../latex/ --latex
 
 ```
 
 ## Testing and Deployment
 
 ```shell
+# (Optional) Install LaTeX dependencies - ~2 GB!
+sudo apt-get install texlive-extra texlive-fonts-extra
+sudo pip install sphinx
+
 # Install dependencies
 pip install -r requirements.txt
 

--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -55,6 +55,7 @@ API Reference
    sbp.client
    sbp.acquisition
    sbp.bootload
+   sbp.ext_events
    sbp.file_io
    sbp.flash
    sbp.logging

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -18,16 +18,21 @@ e.g. camera shutter time
 
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml
-# with generate.py at 2015-04-10 18:08:47.870113. Please do not hand edit!
+# with generate.py at 2015-04-14 13:57:47.706966. Please do not hand edit!
 
 
-SBP_MSG_EXT_EVENT = 0x0300
+SBP_MSG_EXT_EVENT = 0x0101
 class MsgExtEvent(SBP):
-  """SBP class for message MSG_EXT_EVENT (0x0300).
+  """SBP class for message MSG_EXT_EVENT (0x0101).
+
+  You can have MSG_EXT_EVENT inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   Reports detection of an external event, the GPS time it occurred,
 which pin it was and whether it was rising or falling.
@@ -35,6 +40,8 @@ which pin it was and whether it was rising or falling.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   wn : int
     GPS week number
   tow : int
@@ -54,21 +61,37 @@ which pin it was and whether it was rising or falling.
                    ULInt8('flags'),
                    ULInt8('pin'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.wn = kwargs.pop('wn')
+      self.tow = kwargs.pop('tow')
+      self.ns = kwargs.pop('ns')
+      self.flags = kwargs.pop('flags')
+      self.pin = kwargs.pop('pin')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgExtEvent._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgExtEvent.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgExtEvent._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {
-  0x0300: MsgExtEvent,
+  0x0101: MsgExtEvent,
 }

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -22,7 +22,7 @@ from sbp.utils import fmt_repr
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml
-# with generate.py at 2015-04-10 11:45:33.011582. Please do not hand edit!
+# with generate.py at 2015-04-10 18:08:47.870113. Please do not hand edit!
 
 
 SBP_MSG_EXT_EVENT = 0x0300

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -17,12 +17,13 @@ e.g. camera shutter time
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml
-# with generate.py at 2015-04-14 13:57:47.706966. Please do not hand edit!
+# with generate.py at 2015-04-14 16:07:48.890750. Please do not hand edit!
 
 
 SBP_MSG_EXT_EVENT = 0x0101
@@ -90,6 +91,24 @@ which pin it was and whether it was rising or falling.
     c = Container(**exclude_fields(self))
     self.payload = MsgExtEvent._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgExtEvent, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgExtEvent(sbp)
     
 
 msg_classes = {

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+"""
+Messages reporting accurately-timestamped external events,
+e.g. camera shutter time
+
+"""
+
+from construct import *
+from sbp import SBP
+from sbp.utils import fmt_repr
+import six
+
+# Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml
+# with generate.py at 2015-04-10 11:45:33.011582. Please do not hand edit!
+
+
+SBP_MSG_EXT_EVENT = 0x0300
+class MsgExtEvent(SBP):
+  """SBP class for message MSG_EXT_EVENT (0x0300).
+  
+  Reports detection of an external event, the GPS time it occurred,
+which pin it was and whether it was rising or falling.
+
+
+  Parameters
+  ----------
+  wn : int
+    GPS week number
+  tow : int
+    GPS Time of Week rounded to the nearest ms
+  ns : int
+    Nanosecond remainder of rounded tow
+  flags : int
+    Flags
+  pin : int
+    Pin number.  0..9 = DEBUG0..9.
+
+  """
+  _parser = Struct("MsgExtEvent",
+                   ULInt16('wn'),
+                   ULInt32('tow'),
+                   SLInt32('ns'),
+                   ULInt8('flags'),
+                   ULInt8('pin'),)
+
+  def __init__(self, sbp):
+    self.__dict__.update(sbp.__dict__)
+    self.from_binary(sbp.payload)
+
+  def __repr__(self):
+    return fmt_repr(self)
+ 
+  def from_binary(self, d):
+    p = MsgExtEvent._parser.parse(d)
+    self.__dict__.update(dict(p.viewitems()))
+
+  def to_binary(self):
+    return MsgExtEvent.build(self.__dict__)
+    
+
+msg_classes = {
+  0x0300: MsgExtEvent,
+}

--- a/python/sbp/table.py
+++ b/python/sbp/table.py
@@ -26,6 +26,7 @@ from . import piksi as piksi
 from . import settings as settings
 from . import system as sys
 from . import tracking as trac
+from . import ext_events as ext_events
 import warnings
 
 _SBP_TABLE = dict(acq.msg_classes.items()
@@ -38,7 +39,8 @@ _SBP_TABLE = dict(acq.msg_classes.items()
                   + piksi.msg_classes.items()
                   + settings.msg_classes.items()
                   + sys.msg_classes.items()
-                  + trac.msg_classes.items())
+                  + trac.msg_classes.items()
+                  + ext_events.msg_classes.items())
 
 class InvalidSBPMessageType(NotImplementedError):
   """

--- a/python/tests/sbp/test_ext_events.py
+++ b/python/tests/sbp/test_ext_events.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Henry Hallam <henry@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from utils import assert_package
+
+def test_package():
+  FILEPATH = "../spec/tests/yaml/swiftnav/sbp/test_ext_events.yaml"
+  MODULE_NAME = "sbp.ext_events"
+  assert_package(FILEPATH, MODULE_NAME)

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -20,7 +20,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 44
+  number_of_messages = 45
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_available_messages():

--- a/spec/tests/yaml/swiftnav/sbp/test_ext_events.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_ext_events.yaml
@@ -1,25 +1,28 @@
 ---
 description: Unit tests for swiftnav.sbp.ext_events vNone.
-generated_on: 2015-04-14 14:21:56.952802
+generated_on: 2015-04-14 16:07:52.589360
 package: sbp.ext_events
 tests:
 
 - msg:
     fields:
-      flags: 1
-      ns: 218617
+      flags: 3
+      ns: 999882
       pin: 0
-      tow: 229108605
+      tow: 254924999
       wn: 1840
     module: sbp.ext_events
     name: MsgExtEvent
   msg_type: '0x101'
-  raw_packet: VQEB9QYMMAd966cN+VUDAAEAa60=
+  raw_json: '{"sender": 1781, "msg_type": 257, "wn": 1840, "tow": 254924999, "crc":
+    52286, "length": 12, "flags": 3, "pin": 0, "ns": 999882, "preamble": 85, "payload":
+    "MAfH2DEPykEPAAMA"}'
+  raw_packet: VQEB9QYMMAfH2DEPykEPAAMAPsw=
   sbp:
-    crc: '0xad6b'
+    crc: '0xcc3e'
     length: 12
     msg_type: '0x101'
-    payload: MAd966cN+VUDAAEA
+    payload: MAfH2DEPykEPAAMA
     preamble: '0x55'
     sender: '0x6f5'
 version: null

--- a/spec/tests/yaml/swiftnav/sbp/test_ext_events.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_ext_events.yaml
@@ -1,0 +1,26 @@
+---
+description: Unit tests for swiftnav.sbp.ext_events vNone.
+generated_on: 2015-04-14 14:21:56.952802
+package: sbp.ext_events
+tests:
+
+- msg:
+    fields:
+      flags: 1
+      ns: 218617
+      pin: 0
+      tow: 229108605
+      wn: 1840
+    module: sbp.ext_events
+    name: MsgExtEvent
+  msg_type: '0x101'
+  raw_packet: VQEB9QYMMAd966cN+VUDAAEAa60=
+  sbp:
+    crc: '0xad6b'
+    length: 12
+    msg_type: '0x101'
+    payload: MAd966cN+VUDAAEA
+    preamble: '0x55'
+    sender: '0x6f5'
+version: null
+...

--- a/spec/yaml/swiftnav/sbp/ext_events.yaml
+++ b/spec/yaml/swiftnav/sbp/ext_events.yaml
@@ -43,8 +43,13 @@ definitions:
             type: u8
             desc: Flags
             fields:
-              - 1-7:
+              - 2-7:
                   desc: Reserved
+              - 1:
+                  desc: Time quality
+                  values:
+                      - 0: Unknown - don't have nav solution
+                      - 1: Good (< 1 microsecond)
               - 0:
                   desc: New level of pin
                   values:

--- a/spec/yaml/swiftnav/sbp/ext_events.yaml
+++ b/spec/yaml/swiftnav/sbp/ext_events.yaml
@@ -1,0 +1,48 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.ext_events
+description: |
+  Messages reporting accurately-timestamped external events,
+  e.g. camera shutter time
+
+stable: False
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_EXT_EVENT:
+    id: 0x0300
+    public: True
+    short_desc: External event
+    desc: |
+        Reports detection of an external event, the GPS time it occurred,
+        which pin it was and whether it was rising or falling.
+    fields:
+        - wn:
+            type: u16
+            units: weeks
+            desc: GPS week number
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week rounded to the nearest ms
+        - ns:
+            type: s32
+            units: ns
+            desc: Nanosecond remainder of rounded tow
+        - pin_edge:
+            type: u8
+            desc: |
+                Bit 7 (MSB) denotes the new level of the pin, i.e. 1 for
+                rising edge, 0 for falling edge.
+                Bits 6:4 reserved.
+                Bits 3:0 denote pin number, i.e. 0x0 for DEBUG0.

--- a/spec/yaml/swiftnav/sbp/ext_events.yaml
+++ b/spec/yaml/swiftnav/sbp/ext_events.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Swift Navigation Inc.
-# Contact: Fergus Noble <fergus@swiftnav.com>
+# Contact: Henry Hallam <henry@swiftnav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
@@ -22,7 +22,7 @@ definitions:
  - MSG_EXT_EVENT:
     id: 0x0300
     public: True
-    short_desc: External event
+    short_desc: Reports timestamped external pin event
     desc: |
         Reports detection of an external event, the GPS time it occurred,
         which pin it was and whether it was rising or falling.
@@ -39,10 +39,18 @@ definitions:
             type: s32
             units: ns
             desc: Nanosecond remainder of rounded tow
-        - pin_edge:
+        - flags:
             type: u8
-            desc: |
-                Bit 7 (MSB) denotes the new level of the pin, i.e. 1 for
-                rising edge, 0 for falling edge.
-                Bits 6:4 reserved.
-                Bits 3:0 denote pin number, i.e. 0x0 for DEBUG0.
+            desc: Flags
+            fields:
+              - 1-7:
+                  desc: Reserved
+              - 0:
+                  desc: New level of pin
+                  values:
+                      - 0: Low (falling edge)
+                      - 1: High (rising edge)
+        - pin:
+            type: u8
+            desc: Pin number.  0..9 = DEBUG0..9.
+

--- a/spec/yaml/swiftnav/sbp/ext_events.yaml
+++ b/spec/yaml/swiftnav/sbp/ext_events.yaml
@@ -20,7 +20,7 @@ include:
 definitions:
 
  - MSG_EXT_EVENT:
-    id: 0x0300
+    id: 0x0101
     public: True
     short_desc: Reports timestamped external pin event
     desc: |
@@ -58,4 +58,3 @@ definitions:
         - pin:
             type: u8
             desc: Pin number.  0..9 = DEBUG0..9.
-


### PR DESCRIPTION
Untested at the moment, since I can't get the generator to work.
@denniszollo @fnoble thoughts on the message structure appreciated.  Also, the message ID - does it make sense to make this independently maskable, or should it just be in the same bunch as e.g. the navigation messages?

What should the behavior be if we detect an event but don't yet have a navigation solution and hence can't convert to GPS time?  Perhaps output the time as all zeros, and/or use a flag bit?  Alternately, just don't output messages in that situation.

We should potentially also add an option to generate and output an interpolated RTK position, but I think that would be a separate message.

<!---
@huboard:{"order":92.0,"milestone_order":80,"custom_state":""}
-->
