### PR TITLE
Doxygen groups for C headers.

### DIFF
--- a/c/docs/Doxyfile.in
+++ b/c/docs/Doxyfile.in
@@ -1526,20 +1526,14 @@ PERLMOD_MAKEVAR_PREFIX =
 # evaluate all C-preprocessor directives found in the sources and include
 # files.
 
-ENABLE_PREPROCESSING   = YES
-
 # If the MACRO_EXPANSION tag is set to YES Doxygen will expand all macro
 # names in the source code. If set to NO (the default) only conditional
 # compilation will be performed. Macro expansion can be done in a controlled
 # way by setting EXPAND_ONLY_PREDEF to YES.
 
-MACRO_EXPANSION        = NO
-
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES
 # then the macro expansion is limited to the macros specified with the
 # PREDEFINED and EXPAND_AS_DEFINED tags.
-
-EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES (the default) the includes files
 # pointed to by INCLUDE_PATH will be searched when a #include is found.
@@ -1848,3 +1842,9 @@ GENERATE_LEGEND        = YES
 # the various graphs.
 
 DOT_CLEANUP            = YES
+
+# See: http://doxygen.10944.n7.nabble.com/struct-attribute-packed-not-working-td2666.html
+ENABLE_PREPROCESSING   = YES 
+MACRO_EXPANSION        = YES 
+EXPAND_ONLY_PREDEF     = YES 
+PREDEFINED             = __attribute__(x)= 

--- a/c/include/libsbp/acquisition.h
+++ b/c/include/libsbp/acquisition.h
@@ -12,8 +12,13 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/acquisition.yaml
- * with generate.py at 2015-04-02 12:08:48.650967. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.265810. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup acquisition Acquisition
+ *
+ * * Satellite acquisition messages from the Piksi.
+ * \{ */
 
 #ifndef LIBSBP_ACQUISITION_MESSAGES_H
 #define LIBSBP_ACQUISITION_MESSAGES_H
@@ -21,7 +26,7 @@
 #include "common.h"
 
 
-/** Satellite acquisition result.
+/** Satellite acquisition result
  *
  * This message describes the results from an attempted GPS signal
  * acquisition search for a satellite PRN over a code phase/carrier
@@ -31,13 +36,15 @@
  */
 #define SBP_MSG_ACQ_RESULT 0x0015
 typedef struct __attribute__((packed)) {
-  float snr;    /**< SNR of best point. */
-  float cp;     /**< Code phase of best point. [chips] */
-  float cf;     /**< Carrier frequency of best point. [hz] */
+  float snr;    /**< SNR of best point */
+  float cp;     /**< Code phase of best point [chips] */
+  float cf;     /**< Carrier frequency of best point [hz] */
   u8 prn;    /**< PRN identifier of the satellite signal for which
-acquisition was attempted.
+acquisition was attempted
  */
 } msg_acq_result_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_ACQUISITION_MESSAGES_H */

--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -12,8 +12,17 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/bootload.yaml
- * with generate.py at 2015-04-02 12:08:48.470750. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.130849. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup bootload Bootload
+ *
+ *  * Messages for the bootloading configuration on the Piksi. These are
+ * in the implementation-defined range (0x0000-0x00FF), and intended
+ * for internal-use only. Note that some of these messages taking a
+ * request from a host and a response from the Piksi share the same
+ * message type ID.
+ * \{ */
 
 #ifndef LIBSBP_BOOTLOAD_MESSAGES_H
 #define LIBSBP_BOOTLOAD_MESSAGES_H
@@ -27,10 +36,10 @@
  * for a short period of time, and then jumps to the firmware if it
  * doesn't receive a handshake from the host. If the host replies
  * with a handshake the bootloader doesn't jump to the firmware and
- * nwaits for flash programming messages, and the host has to send a
- * MSG_BOOTLOADER_JUMP_TO_APP when it's done programming. On old
- * versions of the bootloader (<=v0.1), hardcoded u8=0. On new
- * versions, return the git describe string for the bootloader
+ * nwaits for flash programming messages, and the host has to send
+ * a MSG_BOOTLOADER_JUMP_TO_APP when it's done programming. On old
+ * versions of the bootloader (less than v0.1), hardcoded to 0. On
+ * new versions, return the git describe string for the bootloader
  * build.
  */
 #define SBP_MSG_BOOTLOADER_HANDSHAKE   0x00B0
@@ -45,7 +54,7 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_BOOTLOADER_JUMP_TO_APP 0x00B1
 typedef struct __attribute__((packed)) {
-  u8 jump;    /**< Ignored by the Piksi. */
+  u8 jump;    /**< Ignored by the Piksi */
 } msg_bootloader_jump_to_app_t;
 
 
@@ -62,5 +71,7 @@ typedef struct __attribute__((packed)) {
   u8 dna[8]; /**< 57-bit SwiftNAP FPGA Device DNA */
 } msg_nap_device_dna_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_BOOTLOAD_MESSAGES_H */

--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -12,8 +12,21 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/file_io.yaml
- * with generate.py at 2015-04-02 12:08:48.473141. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.147495. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup file_io File_io
+ *
+ *  * Messges for using Piksi's onboard flash filesystem functionality
+ * from the Contiki project. This allows data to be stored persistently
+ * in the microcontroller's program flash with wear-levelling using a
+ * simple filesystem interface. The Contiki file system interface (CFS)
+ * defines an abstract API for reading directories and for reading and
+ * writing files. These are in the implementation-defined range
+ * (0x0000-0x00FF), and intended for internal-use only. Note that some
+ * of these messages taking a request from a host and a response from
+ * the Piksi share the same message type ID.
+ * \{ */
 
 #ifndef LIBSBP_FILE_IO_MESSAGES_H
 #define LIBSBP_FILE_IO_MESSAGES_H
@@ -27,14 +40,14 @@
  * from a given offset into a file, and returns the data in a
  * MSG_FILEIO_READ message where the message length field indicates
  * how many bytes were succesfully read. If the message is invalid,
- * a followup MsgPrint message will print "Invalid fileio read
+ * a followup MSG_PRINT message will print "Invalid fileio read
  * message".
  */
 #define SBP_MSG_FILEIO_READ     0x00A8
 typedef struct __attribute__((packed)) {
-  u32 offset;        /**< File offset. [bytes] */
-  u8 chunk_size;    /**< Chunk size to read. [bytes] */
-  char filename[20];  /**< Name of the file to read from (NULL terminated). */
+  u32 offset;        /**< File offset [bytes] */
+  u8 chunk_size;    /**< Chunk size to read [bytes] */
+  char filename[20];  /**< Name of the file to read from (NULL terminated) */
 } msg_fileio_read_t;
 
 
@@ -47,21 +60,21 @@ typedef struct __attribute__((packed)) {
  * a NULL delimited list. The listing is chunked over multiple SBP
  * packets and the end of the list is identified by an entry
  * containing just the character 0xFF. If message is invalid, a
- * followup MsgPrint message will print "Invalid fileio read
+ * followup MSG_PRINT message will print "Invalid fileio read
  * message".
  */
 #define SBP_MSG_FILEIO_READ_DIR 0x00A9
 typedef struct __attribute__((packed)) {
-  u32 offset;     /**< The offset to skip the first n elements of the file list.
+  u32 offset;     /**< The offset to skip the first n elements of the file list
  */
-  char dirname[20]; /**< Name of the directory to list. */
+  char dirname[20]; /**< Name of the directory to list */
 } msg_fileio_read_dir_t;
 
 
 /** Delete a file from the file system (Host => Piksi).
  *
  * The file remove message deletes a file from the file system. If
- * message is invalid, a followup MsgPrint message will print
+ * message is invalid, a followup MSG_PRINT message will print
  * "Invalid fileio remove message".
  */
 #define SBP_MSG_FILEIO_REMOVE   0x00AC
@@ -75,7 +88,7 @@ typedef struct __attribute__((packed)) {
  * The file write message writes a certain length (up to 255 bytes)
  * of data to a file at a given offset. Returns a copy of the
  * original MSG_FILEIO_WRITE message to check integrity of the
- * write. If message is invalid, a followup MsgPrint message will
+ * write. If message is invalid, a followup MSG_PRINT message will
  * print "Invalid fileio write message".
  */
 #define SBP_MSG_FILEIO_WRITE    0x00AD
@@ -85,5 +98,7 @@ typedef struct __attribute__((packed)) {
   u8 data[0];     /**< Data to write */
 } msg_fileio_write_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_FILE_IO_MESSAGES_H */

--- a/c/include/libsbp/flash.h
+++ b/c/include/libsbp/flash.h
@@ -12,8 +12,15 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/flash.yaml
- * with generate.py at 2015-04-02 12:08:48.484565. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.174906. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup flash Flash
+ *
+ *  * Messages for reading/writing the Piksi's onboard flash memory. These
+ * are in the implementation-defined range (0x0000-0x00FF), and largely
+ * intended for internal-use only.
+ * \{ */
 
 #ifndef LIBSBP_FLASH_MESSAGES_H
 #define LIBSBP_FLASH_MESSAGES_H
@@ -35,13 +42,13 @@ typedef struct __attribute__((packed)) {
   u8 target;        /**< Target flags */
   u8 addr_start[3]; /**< Starting address offset to program [bytes] */
   u8 addr_len;      /**< Length of set of addresses to program, counting up from
-starting address.
+starting address
  [bytes] */
-  u8 data[0];       /**< Data to program addresses with, sized by addr_len. */
+  u8 data[0];       /**< Data to program addresses with, sized by addr_len */
 } msg_flash_program_t;
 
 
-/** Flash response message (Piksi => Host).
+/** Flash response message (Host <= Piksi).
  *
  * This message defines success or failure codes for a variety of
  * flash memory requests from the host to the Piksi. Flash read and
@@ -69,7 +76,7 @@ typedef struct __attribute__((packed)) {
   u8 target;        /**< Target flags */
   u8 addr_start[3]; /**< Starting address offset to read from [bytes] */
   u8 addr_len;      /**< Length of set of addresses to read, counting up from
-starting address.
+starting address
  [bytes] */
 } msg_flash_read_t;
 
@@ -86,7 +93,7 @@ starting address.
 typedef struct __attribute__((packed)) {
   u8 target;        /**< Target flags */
   u8 sector_num;    /**< Flash sector number to erase (0-11 for the STM, 0-15 for
-the M25).
+the M25)
  */
 } msg_flash_erase_t;
 
@@ -98,7 +105,7 @@ the M25).
  */
 #define SBP_MSG_STM_FLASH_LOCK_SECTOR   0x00E3
 typedef struct __attribute__((packed)) {
-  u8 sector[1]; /**< Flash sector number to lock. */
+  u8 sector[1]; /**< Flash sector number to lock */
 } msg_stm_flash_lock_sector_t;
 
 
@@ -109,7 +116,7 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_STM_FLASH_UNLOCK_SECTOR 0x00E4
 typedef struct __attribute__((packed)) {
-  u8 sector[1]; /**< Flash sector number to unlock. */
+  u8 sector[1]; /**< Flash sector number to unlock */
 } msg_stm_flash_unlock_sector_t;
 
 
@@ -121,7 +128,7 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_STM_UNIQUE_ID           0x00E5
 typedef struct __attribute__((packed)) {
-  char stm_id[12]; /**< STM32F4 unique ID. */
+  char stm_id[12]; /**< STM32F4 unique ID */
 } msg_stm_unique_id_t;
 
 
@@ -132,8 +139,10 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_M25_FLASH_WRITE_STATUS  0x00F3
 typedef struct __attribute__((packed)) {
-  u8 status[1]; /**< Byte to write to the M25 flash status register. */
+  u8 status[1]; /**< Byte to write to the M25 flash status register */
 } msg_m25_flash_write_status_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_FLASH_MESSAGES_H */

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -12,8 +12,14 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/logging.yaml
- * with generate.py at 2015-04-02 12:08:48.482015. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.163088. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup logging Logging
+ *
+ *  * Logging and debugging messages from the Piksi. These are in the
+ * implementation-defined range (0x0000-0x00FF).
+ * \{ */
 
 #ifndef LIBSBP_LOGGING_MESSAGES_H
 #define LIBSBP_LOGGING_MESSAGES_H
@@ -21,7 +27,7 @@
 #include "common.h"
 
 
-/** Plaintext logging messages (Piksi => Host).
+/** Plaintext logging messages
  *
  * This message contains a human-reabable payload string from the
  * Piksi containing errors, warnings and informational messages at
@@ -31,16 +37,18 @@
  */
 #define SBP_MSG_PRINT     0x0010
 typedef struct __attribute__((packed)) {
-  char* text;    /**< Informative, human-readable string. */
+  char* text;    /**< Informative, human-readable string */
 } msg_print_t;
 
 
-/** Legacy message for tracing variable values (Piksi => Host).
+/** Legacy message for tracing variable values
  *
  * This is an unused legacy message for tracing variable values
  * within the Piksi firmware and streaming those back to the host.
  */
 #define SBP_MSG_DEBUG_VAR 0x0011
 
+
+/** \} */
 
 #endif /* LIBSBP_LOGGING_MESSAGES_H */

--- a/c/include/libsbp/navigation.h
+++ b/c/include/libsbp/navigation.h
@@ -12,8 +12,14 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/navigation.yaml
- * with generate.py at 2015-04-02 12:08:48.537325. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.223624. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup navigation Navigation
+ *
+ *  * Geodetic navigation messages reporting GPS time, single-point
+ * position, and RTK baseline position solutions.
+ * \{ */
 
 #ifndef LIBSBP_NAVIGATION_MESSAGES_H
 #define LIBSBP_NAVIGATION_MESSAGES_H
@@ -23,12 +29,17 @@
 
 /** GPS Time
  *
- * This message reports the GPS Time.
+ * This message reports the GPS time, an integer time scale
+ * beginning at January 6, 1980 midnight. GPS time counts the weeks
+ * and seconds of the week. The weeks begin at the Saturday/Sunday
+ * transition. GPS week 0 began at the beginning of the GPS time
+ * scale. Within each week number, the GPS time of the week is
+ * between between 0 and 604800 seconds (=60*60*24*7).
  */
 #define SBP_MSG_GPS_TIME      0x0100
 typedef struct __attribute__((packed)) {
   u16 wn;       /**< GPS week number [weeks] */
-  u32 tow;      /**< GPS Time of Week rounded to the nearest ms [ms] */
+  u32 tow;      /**< GPS time of week rounded to the nearest ms [ms] */
   s32 ns;       /**< Nanosecond remainder of rounded tow [ns] */
   u8 flags;    /**< Status flags (reserved) */
 } msg_gps_time_t;
@@ -164,5 +175,7 @@ typedef struct __attribute__((packed)) {
   u8 flags;         /**< Status flags (reserved) */
 } msg_vel_ned_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_NAVIGATION_MESSAGES_H */

--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -12,8 +12,13 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/observation.yaml
- * with generate.py at 2015-04-02 12:08:48.412942. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.087199. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup observation Observation
+ *
+ * * Satellite observation messages from the Piksi.
+ * \{ */
 
 #ifndef LIBSBP_OBSERVATION_MESSAGES_H
 #define LIBSBP_OBSERVATION_MESSAGES_H
@@ -21,7 +26,7 @@
 #include "common.h"
 
 
-/** Millisecond-accurate GPS time.
+/** Millisecond-accurate GPS time
  *
  * A wire-appropriate GPS time, defined as the number of
  * milliseconds since beginning of the week on the Saturday/Sunday
@@ -40,17 +45,17 @@ typedef struct __attribute__((packed)) {
  * cycles and 8-bits of fractional cycles.
  */
 typedef struct __attribute__((packed)) {
-  s32 i;    /**< Carrier phase whole cycles. [cycles] */
-  u8 f;    /**< Carrier phase fractional part. [cycles / 255] */
+  s32 i;    /**< Carrier phase whole cycles [cycles] */
+  u8 f;    /**< Carrier phase fractional part [cycles / 255] */
 } carrier_phase_t;
 
 
 /** Header for observation message.
  *
-
+* Header of a GPS observation message.
  */
 typedef struct __attribute__((packed)) {
-  obs_gps_time_t t;        /**< GPS time of this observation. */
+  obs_gps_time_t t;        /**< GPS time of this observation */
   u8 n_obs;    /**< Total number of observations. First nibble is the size
 of the sequence (n), second nibble is the zero-indexed
 counter (ith packet of n)
@@ -64,19 +69,19 @@ counter (ith packet of n)
  * tracked.
  */
 typedef struct __attribute__((packed)) {
-  u32 P;       /**< Pseudorange observation. [cm] */
-  carrier_phase_t L;       /**< Carrier phase observation. */
+  u32 P;       /**< Pseudorange observation [cm] */
+  carrier_phase_t L;       /**< Carrier phase observation */
   u8 cn0;     /**< Carrier-to-Noise density [dB Hz] */
   u16 lock;    /**< Lock indicator. This value changes whenever a satellite
 signal has lost and regained lock, indicating that the
 carrier phase ambiguity may have changed. There is no
-significance to the value of the lock indicator.
+significance to the value of the lock indicator
  */
   u8 prn;     /**< PRN identifier of the satellite signal */
 } packed_obs_content_t;
 
 
-/** GPS satellite observations.
+/** GPS satellite observations
  *
  * The GPS observations message reports all the pseudo range and
  * carrier phase observations for the satellites being tracked by
@@ -86,12 +91,12 @@ significance to the value of the lock indicator.
 typedef struct __attribute__((packed)) {
   observation_header_t header;    /**< Header of a GPS observation message */
   packed_obs_content_t obs[0];    /**< Pseudorange and carrier phase observation for a
-satellite being tracked.
+satellite being tracked
  */
 } msg_obs_t;
 
 
-/** Base station position.
+/** Base station position
  *
  * This may be the position as reported by the base station itself or the
  * position obtained from doing a single point solution using the base
@@ -104,5 +109,7 @@ typedef struct __attribute__((packed)) {
   double height;    /**< Height [m] */
 } msg_base_pos_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_OBSERVATION_MESSAGES_H */

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -12,8 +12,17 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/piksi.yaml
- * with generate.py at 2015-04-02 12:08:48.499356. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.183540. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup piksi Piksi
+ *
+ *  * System health, configuration, and diagnostic messages specific to
+ * the Piksi L1 receiver, including a variety of legacy messages that
+ * may no longer be used. These messages are in the
+ * implementation-defined range (0x0000-0x00FF), and largely intended
+ * for internal-use only.
+ * \{ */
 
 #ifndef LIBSBP_PIKSI_MESSAGES_H
 #define LIBSBP_PIKSI_MESSAGES_H
@@ -21,7 +30,7 @@
 #include "common.h"
 
 
-/** Legacy message to load satellite almanac (Host => Piksi).
+/** Legacy message to load satellite almanac (Host => Piksi)
  *
  * This is a legacy message for sending and loading a satellite
  * alamanac onto the Piksi's flash memory from the host.
@@ -29,7 +38,7 @@
 #define SBP_MSG_ALMANAC       0x0069
 
 
-/** Send GPS time from host (Host => Piksi).
+/** Send GPS time from host (Host => Piksi)
  *
  * This message sets up timing functionality using a coarse GPS
  * time estimate sent by the host.
@@ -37,7 +46,7 @@
 #define SBP_MSG_SET_TIME      0x0068
 
 
-/** Reset the device (Host => Piksi).
+/** Reset the device (Host => Piksi)
  *
  * This message from the host resets the Piksi back into the
  * bootloader. It ensures that all outstanding memory accesses
@@ -46,7 +55,7 @@
 #define SBP_MSG_RESET         0x00B2
 
 
-/** Legacy message for CW interference channel (Piksi => Host).
+/** Legacy message for CW interference channel (Piksi => Host)
  *
  * This is an unused legacy message for result reporting from the
  * CW interference channel on the SwiftNAP. This message will be
@@ -55,7 +64,7 @@
 #define SBP_MSG_CW_RESULTS    0x00C0
 
 
-/** Legacy message for CW interference channel (Host => Piksi).
+/** Legacy message for CW interference channel (Host => Piksi)
  *
  * This is an unused legacy message from those host for starting
  * the CW interference channel on the SwiftNAP. This message will
@@ -75,7 +84,7 @@ typedef struct __attribute__((packed)) {
 } msg_reset_filters_t;
 
 
-/** Initialize IAR from known baseline (Host => Piksi).
+/** Initialize IAR from known baseline (Host => Piksi)
  *
  * This message initializes the Integer Ambiguity Resolution (IAR)
  * process on the Piksi to use an assumed baseline position between
@@ -86,7 +95,7 @@ typedef struct __attribute__((packed)) {
 #define SBP_MSG_INIT_BASE     0x0023
 
 
-/** State of a CPU/RTOS thread.
+/** State of a CPU/RTOS thread
  *
  * The thread usage message from the Piksi reports RTOS thread
  * usage statistics for the named thread. The reported values
@@ -96,32 +105,32 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
   char name[20];      /**< Thread name (NULL terminated) */
   u16 cpu;           /**< Percentage cpu use for this thread. Ranges from 0 - 1000
-and needs to be renormalized to 100.
- [Utilization percentage /1000.] */
-  u32 stack_free;    /**< Free stack space for this thread. [kB] */
+and needs to be renormalized to 100
+ [Utilization percentage /1000] */
+  u32 stack_free;    /**< Free stack space for this thread [kB] */
 } msg_thread_state_t;
 
 
-/** State of the UART channel.
+/** State of the UART channel
  *
  * Throughput, utilization, and error counts on the RX/TX buffers
- * of this UART channel. Values require renormalization.
+ * of this UART channel. Values require renormalization
  */
 typedef struct __attribute__((packed)) {
-  float tx_throughput;      /**< UART transmit throughput. [kB/s] */
-  float rx_throughput;      /**< UART receive throughput. [kB/s] */
-  u16 crc_error_count;    /**< UART CRC error count. */
-  u16 io_error_count;     /**< UART IO error count. */
+  float tx_throughput;      /**< UART transmit throughput [kB/s] */
+  float rx_throughput;      /**< UART receive throughput [kB/s] */
+  u16 crc_error_count;    /**< UART CRC error count */
+  u16 io_error_count;     /**< UART IO error count */
   u8 tx_buffer_level;    /**< UART transmit buffer percentage utilization. Ranges from
-0 - 255 and needs to be renormalized to 100.
+0 - 255 and needs to be renormalized to 100
  [Utilization /255] */
   u8 rx_buffer_level;    /**< UART receive buffer percentage utilization. Ranges from
-0 - 255 and needs to be renormalized to 100.
+0 - 255 and needs to be renormalized to 100
  [Utilization /255] */
 } uart_channel_t;
 
 
-/** Receiver-to-base station latency.
+/** Receiver-to-base station latency
  *
  * Statistics on the latency of observations received from the base
  * station. As observation packets are received their GPS time is
@@ -130,14 +139,14 @@ typedef struct __attribute__((packed)) {
  * communication latency in the system.
  */
 typedef struct __attribute__((packed)) {
-  s32 avg;        /**< Average latency. [ms] */
-  s32 lmin;       /**< Minimum latency. [ms] */
-  s32 lmax;       /**< Maximum latency. [ms] */
-  s32 current;    /**< Smoothed estimate of the current latency. [ms] */
+  s32 avg;        /**< Average latency [ms] */
+  s32 lmin;       /**< Minimum latency [ms] */
+  s32 lmax;       /**< Maximum latency [ms] */
+  s32 current;    /**< Smoothed estimate of the current latency [ms] */
 } latency_t;
 
 
-/** State of the UART channels.
+/** State of the UART channels
  *
  * The UART message reports data latency and throughput of the UART
  * channels providing SBP I/O. On the default Piksi configuration,
@@ -154,7 +163,7 @@ typedef struct __attribute__((packed)) {
 } msg_uart_state_t;
 
 
-/** State of the Integer Ambiguity Resolution (IAR) process.
+/** State of the Integer Ambiguity Resolution (IAR) process
  *
  * This message reports the state of the Integer Ambiguity
  * Resolution (IAR) process, which resolves unknown integer
@@ -163,8 +172,10 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_IAR_STATE     0x0019
 typedef struct __attribute__((packed)) {
-  u32 num_hyps;    /**< Number of integer ambiguity hypotheses remaining. */
+  u32 num_hyps;    /**< Number of integer ambiguity hypotheses remaining */
 } msg_iar_state_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_PIKSI_MESSAGES_H */

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -12,8 +12,18 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/settings.yaml
- * with generate.py at 2015-04-02 12:08:48.533952. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.198589. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup settings Settings
+ *
+ *  * Messages for reading and writing the Piksi's device settings. These
+ * are in the implementation-defined range (0x0000-0x00FF), and
+ * intended for internal-use only. Please see the accompanying
+ * description of settings configurations for more details. Note that
+ * some of these messages taking a request from a host and a response
+ * from the Piksi share the same message type ID.
+ * \{ */
 
 #ifndef LIBSBP_SETTINGS_MESSAGES_H
 #define LIBSBP_SETTINGS_MESSAGES_H
@@ -27,10 +37,10 @@
  */
 #define SBP_MSG_SETTINGS               0x00A0
 typedef struct __attribute__((packed)) {
-  char* setting;    /**< A NULL delimited (and terminated) string, with a single
-"<setting section>\0<setting>\0<value>\0" on writes or a
-series of "<setting section>\0<setting>\0<value>\0" on
-reads.
+  char* setting;    /**< A NULL delimited (and terminated) string, with the A
+NULL-terminated and delimited string with contents
+[SECTION_SETTING, SETTING, VALUE] on writes or a series of
+such strings on reads.
  */
 } msg_settings_t;
 
@@ -46,15 +56,18 @@ reads.
 /** Read setting by direct index (Host <=> Piksi)
  *
  * The settings message for iterating through the settings
- * values. It will read the setting at an index, returning
- * "<setting section>\0<setting>\0<value>\0" from the Piksi.
+ * values. It will read the setting at an index, returning a
+ * NULL-terminated and delimited string with contents
+ * [SECTION_SETTING, SETTING, VALUE].
  */
 #define SBP_MSG_SETTINGS_READ_BY_INDEX 0x00A2
 typedef struct __attribute__((packed)) {
   u16 index;    /**< An index into the Piksi settings, with values ranging from
-0 to length(settings).
+0 to length(settings)
  */
 } msg_settings_read_by_index_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_SETTINGS_MESSAGES_H */

--- a/c/include/libsbp/system.h
+++ b/c/include/libsbp/system.h
@@ -12,8 +12,13 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/system.yaml
- * with generate.py at 2015-04-02 12:08:48.603510. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.229383. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup system System
+ *
+ * * Standardized system messages from Swift Navigation devices.
+ * \{ */
 
 #ifndef LIBSBP_SYSTEM_MESSAGES_H
 #define LIBSBP_SYSTEM_MESSAGES_H
@@ -51,5 +56,7 @@ typedef struct __attribute__((packed)) {
   u32 flags;    /**< Status flags */
 } msg_heartbeat_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_SYSTEM_MESSAGES_H */

--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -12,8 +12,13 @@
 
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/tracking.yaml
- * with generate.py at 2015-04-02 12:08:48.606597. Please do not hand edit!
+ * with generate.py at 2015-04-10 12:07:06.236392. Please do not hand edit!
  *****************************************************************************/
+
+/** \defgroup tracking Tracking
+ *
+ *  * Satellite code and carrier-phase tracking messages from the Piksi.
+ * \{ */
 
 #ifndef LIBSBP_TRACKING_MESSAGES_H
 #define LIBSBP_TRACKING_MESSAGES_H
@@ -21,19 +26,19 @@
 #include "common.h"
 
 
-/** Satellite tracking channel state.
+/** Satellite tracking channel state
  *
  * Tracking channel state for a specific satellite PRN and measured
  * signal power.
  */
 typedef struct __attribute__((packed)) {
-  u8 state;    /**< Status of tracking channel. */
-  u8 prn;      /**< PRN being tracked. */
+  u8 state;    /**< Status of tracking channel */
+  u8 prn;      /**< PRN being tracked */
   float cn0;      /**< Carrier-to-noise density [dB Hz] */
 } tracking_channel_state_t;
 
 
-/** Satellite tracking channel states.
+/** Satellite tracking channel states
  *
  * The tracking message returns a variable-length array of tracking
  * channel states. It reports status and code/carrier phase signal
@@ -41,7 +46,7 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_TRACKING_STATE 0x0016
 typedef struct __attribute__((packed)) {
-  tracking_channel_state_t states[0]; /**< Satellite tracking channel state. */
+  tracking_channel_state_t states[0]; /**< Satellite tracking channel state */
 } msg_tracking_state_t;
 
 
@@ -51,8 +56,7 @@ typedef struct __attribute__((packed)) {
  * parameters that is used to calculate GPS satellite position,
  * velocity, and clock offset (WGS84). Please see the Navstar GPS
  * Space Segment/Navigation user interfaces (ICD-GPS-200, Table
- * 20-III) for more details
- * (http://www.navcen.uscg.gov/pubs/gps/icd200/icd200cw1234.pdf).
+ * 20-III) for more details.
  */
 #define SBP_MSG_EPHEMERIS      0x001A
 typedef struct __attribute__((packed)) {
@@ -84,5 +88,7 @@ typedef struct __attribute__((packed)) {
   u8 prn;         /**< PRN being tracked */
 } msg_ephemeris_t;
 
+
+/** \} */
 
 #endif /* LIBSBP_TRACKING_MESSAGES_H */

--- a/generator/sbpg/targets/resources/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/sbp_messages_template.h
@@ -51,4 +51,6 @@ typedef struct __attribute__((packed)) {
 ((*- endif *))
 
 ((* endfor *))
+/** \} */
+
 #endif /* LIBSBP_(((pkg_name|upper)))_MESSAGES_H */


### PR DESCRIPTION
Adds groups, packaging information, and correct struct handling for
the Doxygen-generated C documentation.

Closes #89.

/cc @henryhallam