### PR TITLE
Python client updates: materialization and tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAKEFLAGS += SWIFTNAV_ROOT=$(SWIFTNAV_ROOT)
 SBP_SPEC_DIR := $(SWIFTNAV_ROOT)/spec/yaml/swiftnav/sbp/
 SBP_GEN_BIN := python sbpg/generator.py
 
-.PHONY: help all c python docs pdf html
+.PHONY: help all c python docs pdf html test
 
 help:
 	@echo
@@ -16,13 +16,14 @@ help:
 	@echo "  help      to display this help message"
 	@echo "  all       to make SBP clients across all languages"
 	@echo "  c         to make C headers"
-	@echo "  python    to make Python bindings"
+	@echo "  docs      to make HTML and pdf documentation"
 	@echo "  html      to make all HTML language docs"
 	@echo "  pdf       to make SBP LaTeX datasheet"
-	@echo "  docs      to make HTML and pdf documentation"
+	@echo "  python    to make Python bindings"
+	@echo "  test      to run all tests"
 	@echo
 
-all: c python docs
+all: c python test docs
 
 c:
 	@echo "Generating C headers..."
@@ -74,6 +75,24 @@ html:
 	@echo "Generating Python documentation..."
 	@echo
 	cd $(SWIFTNAV_ROOT)/python/docs/ && make html
+	cd $(SWIFTNAV_ROOT);
+	@echo
+	@echo "Finished!"
+
+test:
+	@echo
+	@echo "Run tests..."
+	@echo
+	@echo "Running C tests..."
+	@echo
+	cd $(SWIFTNAV_ROOT)/c; \
+	mkdir -p build/ && cd build/; \
+	cmake ../; \
+	make test;
+	@echo
+	@echo "Running Python tests..."
+	@echo
+	cd $(SWIFTNAV_ROOT)/python/ && tox
 	cd $(SWIFTNAV_ROOT);
 	@echo
 	@echo "Finished!"

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -16,7 +16,7 @@
 
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 ((*- for i in include *))
@@ -80,6 +80,11 @@ class ((( m.identifier )))(object):
 SBP_(((m.identifier))) = ((('0x%04X'|format(m.sbp_id))))
 class ((( m.identifier | classnameify )))(SBP):
   """SBP class for message (((m.identifier))) ((('(0x%04X)'|format(m.sbp_id)))).
+
+  You can have (((m.identifier))) inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   ((* if m.desc *))
   (((m.desc)))
   ((*- endif *))
@@ -88,6 +93,8 @@ class ((( m.identifier | classnameify )))(SBP):
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   ((*- for f in m.fields *))
   (((f.identifier))) : (((f.type_id|pydoc)))
   ((*- if f.desc *))
@@ -104,23 +111,39 @@ class ((( m.identifier | classnameify )))(SBP):
                    ((*- endfor *)))
   ((*- endif *))
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
       ((*- if m.fields *))
-    self.from_binary(sbp.payload)
+      self.from_binary(sbp.payload)
       ((*- else *))
-    self.payload = sbp.payload
+      self.payload = sbp.payload
       ((*- endif *))
+    ((*- if m.fields*))
+    else:
+      ((*- for f in m.fields *))
+      self.(((f.identifier))) = kwargs.pop('(((f.identifier)))')
+      ((*- endfor *))
+    ((*- endif *))
 
   def __repr__(self):
     return fmt_repr(self)
  ((* if m.fields *))
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = ((( m.identifier | classnameify )))._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return ((( m.identifier | classnameify ))).build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = ((( m.identifier | classnameify )))._parser.build(c)
+    return self.pack()
     ((*- endif *))
     ((* endif *))
   ((*- else *))

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -9,18 +9,28 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Satellite acquisition messages from the Piksi.
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/acquisition.yaml
-# with generate.py at 2015-04-06 23:40:11.138411. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.838143. Please do not hand edit!
 
 
 SBP_MSG_ACQ_RESULT = 0x0015
 class MsgAcqResult(SBP):
   """SBP class for message MSG_ACQ_RESULT (0x0015).
+
+  You can have MSG_ACQ_RESULT inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message describes the results from an attempted GPS signal
 acquisition search for a satellite PRN over a code phase/carrier
@@ -31,15 +41,17 @@ ratio.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   snr : float
-    SNR of best point.
+    SNR of best point
   cp : float
-    Code phase of best point.
+    Code phase of best point
   cf : float
-    Carrier frequency of best point.
+    Carrier frequency of best point
   prn : int
     PRN identifier of the satellite signal for which
-acquisition was attempted.
+acquisition was attempted
 
 
   """
@@ -49,19 +61,34 @@ acquisition was attempted.
                    LFloat32('cf'),
                    ULInt8('prn'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.snr = kwargs.pop('snr')
+      self.cp = kwargs.pop('cp')
+      self.cf = kwargs.pop('cf')
+      self.prn = kwargs.pop('prn')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgAcqResult._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgAcqResult.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgAcqResult._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -9,32 +9,49 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Messages for the bootloading configuration on the Piksi. These are
+in the implementation-defined range (0x0000-0x00FF), and intended
+for internal-use only. Note that some of these messages taking a
+request from a host and a response from the Piksi share the same
+message type ID.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/bootload.yaml
-# with generate.py at 2015-04-06 23:40:11.121602. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.809448. Please do not hand edit!
 
 
 SBP_MSG_BOOTLOADER_HANDSHAKE = 0x00B0
 class MsgBootloaderHandshake(SBP):
   """SBP class for message MSG_BOOTLOADER_HANDSHAKE (0x00B0).
+
+  You can have MSG_BOOTLOADER_HANDSHAKE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The bootloader continually sends a handshake message to the host
 for a short period of time, and then jumps to the firmware if it
 doesn't receive a handshake from the host. If the host replies
 with a handshake the bootloader doesn't jump to the firmware and
-nwaits for flash programming messages, and the host has to send a
-MSG_BOOTLOADER_JUMP_TO_APP when it's done programming. On old
-versions of the bootloader (<=v0.1), hardcoded u8=0. On new
-versions, return the git describe string for the bootloader
+nwaits for flash programming messages, and the host has to send
+a MSG_BOOTLOADER_JUMP_TO_APP when it's done programming. On old
+versions of the bootloader (less than v0.1), hardcoded to 0. On
+new versions, return the git describe string for the bootloader
 build.
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   handshake : int
     Handshake value
 
@@ -42,53 +59,89 @@ build.
   _parser = Struct("MsgBootloaderHandshake",
                    ULInt8('handshake'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.handshake = kwargs.pop('handshake')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgBootloaderHandshake._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgBootloaderHandshake.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgBootloaderHandshake._parser.build(c)
+    return self.pack()
     
 SBP_MSG_BOOTLOADER_JUMP_TO_APP = 0x00B1
 class MsgBootloaderJumpToApp(SBP):
   """SBP class for message MSG_BOOTLOADER_JUMP_TO_APP (0x00B1).
+
+  You can have MSG_BOOTLOADER_JUMP_TO_APP inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The host initiates the bootloader to jump to the application.
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   jump : int
-    Ignored by the Piksi.
+    Ignored by the Piksi
 
   """
   _parser = Struct("MsgBootloaderJumpToApp",
                    ULInt8('jump'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.jump = kwargs.pop('jump')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgBootloaderJumpToApp._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgBootloaderJumpToApp.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgBootloaderJumpToApp._parser.build(c)
+    return self.pack()
     
 SBP_MSG_NAP_DEVICE_DNA = 0x00DD
 class MsgNapDeviceDna(SBP):
   """SBP class for message MSG_NAP_DEVICE_DNA (0x00DD).
+
+  You can have MSG_NAP_DEVICE_DNA inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The device DNA message from the host reads the unique device
 DNA from the Swift Navigation Acceleration Peripheral
@@ -99,6 +152,8 @@ MSG_NAP_DEVICE_DNA message.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   dna : array
     57-bit SwiftNAP FPGA Device DNA
 
@@ -106,19 +161,31 @@ MSG_NAP_DEVICE_DNA message.
   _parser = Struct("MsgNapDeviceDna",
                    Struct('dna', Array(8, ULInt8('dna'))),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.dna = kwargs.pop('dna')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgNapDeviceDna._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgNapDeviceDna.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgNapDeviceDna._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -9,35 +9,56 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Messges for using Piksi's onboard flash filesystem functionality
+from the Contiki project. This allows data to be stored persistently
+in the microcontroller's program flash with wear-levelling using a
+simple filesystem interface. The Contiki file system interface (CFS)
+defines an abstract API for reading directories and for reading and
+writing files. These are in the implementation-defined range
+(0x0000-0x00FF), and intended for internal-use only. Note that some
+of these messages taking a request from a host and a response from
+the Piksi share the same message type ID.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/file_io.yaml
-# with generate.py at 2015-04-06 23:40:11.122858. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.812817. Please do not hand edit!
 
 
 SBP_MSG_FILEIO_READ = 0x00A8
 class MsgFileioRead(SBP):
   """SBP class for message MSG_FILEIO_READ (0x00A8).
+
+  You can have MSG_FILEIO_READ inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The file read message reads a certain length (up to 255 bytes)
 from a given offset into a file, and returns the data in a
 MSG_FILEIO_READ message where the message length field indicates
 how many bytes were succesfully read. If the message is invalid,
-a followup MsgPrint message will print "Invalid fileio read
+a followup MSG_PRINT message will print "Invalid fileio read
 message".
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   offset : int
-    File offset.
+    File offset
   chunk_size : int
-    Chunk size to read.
+    Chunk size to read
   filename : string
-    Name of the file to read from (NULL terminated).
+    Name of the file to read from (NULL terminated)
 
   """
   _parser = Struct("MsgFileioRead",
@@ -45,23 +66,42 @@ message".
                    ULInt8('chunk_size'),
                    String('filename', 20),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.offset = kwargs.pop('offset')
+      self.chunk_size = kwargs.pop('chunk_size')
+      self.filename = kwargs.pop('filename')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFileioRead._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFileioRead.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFileioRead._parser.build(c)
+    return self.pack()
     
 SBP_MSG_FILEIO_READ_DIR = 0x00A9
 class MsgFileioReadDir(SBP):
   """SBP class for message MSG_FILEIO_READ_DIR (0x00A9).
+
+  You can have MSG_FILEIO_READ_DIR inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The read directory message lists the files in a directory on the
 Piksi's onboard flash file system.  The offset parameter can be
@@ -70,48 +110,70 @@ MSG_FILEIO_READ_DIR message containing the directory listings as
 a NULL delimited list. The listing is chunked over multiple SBP
 packets and the end of the list is identified by an entry
 containing just the character 0xFF. If message is invalid, a
-followup MsgPrint message will print "Invalid fileio read
+followup MSG_PRINT message will print "Invalid fileio read
 message".
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   offset : int
-    The offset to skip the first n elements of the file list.
+    The offset to skip the first n elements of the file list
 
   dirname : string
-    Name of the directory to list.
+    Name of the directory to list
 
   """
   _parser = Struct("MsgFileioReadDir",
                    ULInt32('offset'),
                    String('dirname', 20),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.offset = kwargs.pop('offset')
+      self.dirname = kwargs.pop('dirname')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFileioReadDir._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFileioReadDir.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFileioReadDir._parser.build(c)
+    return self.pack()
     
 SBP_MSG_FILEIO_REMOVE = 0x00AC
 class MsgFileioRemove(SBP):
   """SBP class for message MSG_FILEIO_REMOVE (0x00AC).
+
+  You can have MSG_FILEIO_REMOVE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The file remove message deletes a file from the file system. If
-message is invalid, a followup MsgPrint message will print
+message is invalid, a followup MSG_PRINT message will print
 "Invalid fileio remove message".
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   filename : string
     Name of the file to delete (NULL terminated)
 
@@ -119,33 +181,52 @@ message is invalid, a followup MsgPrint message will print
   _parser = Struct("MsgFileioRemove",
                    String('filename', 20),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.filename = kwargs.pop('filename')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFileioRemove._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFileioRemove.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFileioRemove._parser.build(c)
+    return self.pack()
     
 SBP_MSG_FILEIO_WRITE = 0x00AD
 class MsgFileioWrite(SBP):
   """SBP class for message MSG_FILEIO_WRITE (0x00AD).
+
+  You can have MSG_FILEIO_WRITE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The file write message writes a certain length (up to 255 bytes)
 of data to a file at a given offset. Returns a copy of the
 original MSG_FILEIO_WRITE message to check integrity of the
-write. If message is invalid, a followup MsgPrint message will
+write. If message is invalid, a followup MSG_PRINT message will
 print "Invalid fileio write message".
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   filename : string
     Name of the file to write to (NULL terminated)
   offset : int
@@ -159,19 +240,33 @@ print "Invalid fileio write message".
                    ULInt32('offset'),
                    OptionalGreedyRange(Struct('data', ULInt8('data'))),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.filename = kwargs.pop('filename')
+      self.offset = kwargs.pop('offset')
+      self.data = kwargs.pop('data')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFileioWrite._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFileioWrite.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFileioWrite._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -9,18 +9,31 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Messages for reading/writing the Piksi's onboard flash memory. These
+are in the implementation-defined range (0x0000-0x00FF), and largely
+intended for internal-use only.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/flash.yaml
-# with generate.py at 2015-04-06 23:40:11.126002. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.817277. Please do not hand edit!
 
 
 SBP_MSG_FLASH_PROGRAM = 0x00E0
 class MsgFlashProgram(SBP):
   """SBP class for message MSG_FLASH_PROGRAM (0x00E0).
+
+  You can have MSG_FLASH_PROGRAM inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The flash program message programs a set of addresses of either
 the STM or M25 flash. The Piksi replies with either a
@@ -32,16 +45,18 @@ erased before addresses can be programmed.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   target : int
     Target flags
   addr_start : array
     Starting address offset to program
   addr_len : int
     Length of set of addresses to program, counting up from
-starting address.
+starting address
 
   data : array
-    Data to program addresses with, sized by addr_len.
+    Data to program addresses with, sized by addr_len
 
   """
   _parser = Struct("MsgFlashProgram",
@@ -50,23 +65,43 @@ starting address.
                    ULInt8('addr_len'),
                    OptionalGreedyRange(Struct('data', ULInt8('data'))),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.target = kwargs.pop('target')
+      self.addr_start = kwargs.pop('addr_start')
+      self.addr_len = kwargs.pop('addr_len')
+      self.data = kwargs.pop('data')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFlashProgram._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFlashProgram.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFlashProgram._parser.build(c)
+    return self.pack()
     
 SBP_MSG_FLASH_DONE = 0x00E0
 class MsgFlashDone(SBP):
   """SBP class for message MSG_FLASH_DONE (0x00E0).
+
+  You can have MSG_FLASH_DONE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message defines success or failure codes for a variety of
 flash memory requests from the host to the Piksi. Flash read and
@@ -76,6 +111,8 @@ return this message on failure.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   response : int
     Response flags
 
@@ -83,23 +120,40 @@ return this message on failure.
   _parser = Struct("MsgFlashDone",
                    ULInt8('response'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.response = kwargs.pop('response')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFlashDone._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFlashDone.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFlashDone._parser.build(c)
+    return self.pack()
     
 SBP_MSG_FLASH_READ = 0x00E1
 class MsgFlashRead(SBP):
   """SBP class for message MSG_FLASH_READ (0x00E1).
+
+  You can have MSG_FLASH_READ inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The flash read message reads a set of addresses of either the
 STM or M25 onboard flash. The Piksi replies with a
@@ -112,13 +166,15 @@ range.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   target : int
     Target flags
   addr_start : array
     Starting address offset to read from
   addr_len : int
     Length of set of addresses to read, counting up from
-starting address.
+starting address
 
 
   """
@@ -127,23 +183,42 @@ starting address.
                    Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.target = kwargs.pop('target')
+      self.addr_start = kwargs.pop('addr_start')
+      self.addr_len = kwargs.pop('addr_len')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFlashRead._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFlashRead.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFlashRead._parser.build(c)
+    return self.pack()
     
 SBP_MSG_FLASH_ERASE = 0x00E2
 class MsgFlashErase(SBP):
   """SBP class for message MSG_FLASH_ERASE (0x00E2).
+
+  You can have MSG_FLASH_ERASE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The flash erase message from the host erases a sector of either
 the STM or M25 onboard flash memory. The Piksi will reply with a
@@ -154,11 +229,13 @@ invalid.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   target : int
     Target flags
   sector_num : int
     Flash sector number to erase (0-11 for the STM, 0-15 for
-the M25).
+the M25)
 
 
   """
@@ -166,23 +243,41 @@ the M25).
                    ULInt8('target'),
                    ULInt8('sector_num'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.target = kwargs.pop('target')
+      self.sector_num = kwargs.pop('sector_num')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgFlashErase._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgFlashErase.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgFlashErase._parser.build(c)
+    return self.pack()
     
 SBP_MSG_STM_FLASH_LOCK_SECTOR = 0x00E3
 class MsgStmFlashLockSector(SBP):
   """SBP class for message MSG_STM_FLASH_LOCK_SECTOR (0x00E3).
+
+  You can have MSG_STM_FLASH_LOCK_SECTOR inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The flash lock message locks a sector of the STM flash
 memory. The Piksi replies with a MSG_FLASH_DONE message.
@@ -190,30 +285,49 @@ memory. The Piksi replies with a MSG_FLASH_DONE message.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   sector : array
-    Flash sector number to lock.
+    Flash sector number to lock
 
   """
   _parser = Struct("MsgStmFlashLockSector",
                    Struct('sector', Array(1, ULInt8('sector'))),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.sector = kwargs.pop('sector')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgStmFlashLockSector._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgStmFlashLockSector.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgStmFlashLockSector._parser.build(c)
+    return self.pack()
     
 SBP_MSG_STM_FLASH_UNLOCK_SECTOR = 0x00E4
 class MsgStmFlashUnlockSector(SBP):
   """SBP class for message MSG_STM_FLASH_UNLOCK_SECTOR (0x00E4).
+
+  You can have MSG_STM_FLASH_UNLOCK_SECTOR inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The flash unlock message unlocks a sector of the STM flash
 memory. The Piksi replies with a MSG_FLASH_DONE message.
@@ -221,30 +335,49 @@ memory. The Piksi replies with a MSG_FLASH_DONE message.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   sector : array
-    Flash sector number to unlock.
+    Flash sector number to unlock
 
   """
   _parser = Struct("MsgStmFlashUnlockSector",
                    Struct('sector', Array(1, ULInt8('sector'))),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.sector = kwargs.pop('sector')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgStmFlashUnlockSector._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgStmFlashUnlockSector.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgStmFlashUnlockSector._parser.build(c)
+    return self.pack()
     
 SBP_MSG_STM_UNIQUE_ID = 0x00E5
 class MsgStmUniqueId(SBP):
   """SBP class for message MSG_STM_UNIQUE_ID (0x00E5).
+
+  You can have MSG_STM_UNIQUE_ID inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reads the STM32F4's hardcoded unique ID. The Piksi
 returns STM32F4 unique ID (12 bytes) back to host.
@@ -252,30 +385,49 @@ returns STM32F4 unique ID (12 bytes) back to host.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   stm_id : string
-    STM32F4 unique ID.
+    STM32F4 unique ID
 
   """
   _parser = Struct("MsgStmUniqueId",
                    String('stm_id', 12),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.stm_id = kwargs.pop('stm_id')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgStmUniqueId._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgStmUniqueId.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgStmUniqueId._parser.build(c)
+    return self.pack()
     
 SBP_MSG_M25_FLASH_WRITE_STATUS = 0x00F3
 class MsgM25FlashWriteStatus(SBP):
   """SBP class for message MSG_M25_FLASH_WRITE_STATUS (0x00F3).
+
+  You can have MSG_M25_FLASH_WRITE_STATUS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The flash status message writes to the 8-bit M25 flash status
 register. The Piksi replies with a MSG_FLASH_DONE message.
@@ -283,26 +435,40 @@ register. The Piksi replies with a MSG_FLASH_DONE message.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   status : array
-    Byte to write to the M25 flash status register.
+    Byte to write to the M25 flash status register
 
   """
   _parser = Struct("MsgM25FlashWriteStatus",
                    Struct('status', Array(1, ULInt8('status'))),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.status = kwargs.pop('status')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgM25FlashWriteStatus._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgM25FlashWriteStatus.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgM25FlashWriteStatus._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -9,18 +9,30 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Logging and debugging messages from the Piksi. These are in the
+implementation-defined range (0x0000-0x00FF).
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/logging.yaml
-# with generate.py at 2015-04-06 23:40:11.124135. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.815735. Please do not hand edit!
 
 
 SBP_MSG_PRINT = 0x0010
 class MsgPrint(SBP):
   """SBP class for message MSG_PRINT (0x0010).
+
+  You can have MSG_PRINT inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message contains a human-reabable payload string from the
 Piksi containing errors, warnings and informational messages at
@@ -31,30 +43,49 @@ info on function entry/exit when enabled within the firmware.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   text : string
-    Informative, human-readable string.
+    Informative, human-readable string
 
   """
   _parser = Struct("MsgPrint",
                    CString('text', six.b('\n')),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.text = kwargs.pop('text')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgPrint._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgPrint.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgPrint._parser.build(c)
+    return self.pack()
     
 SBP_MSG_DEBUG_VAR = 0x0011
 class MsgDebugVar(SBP):
   """SBP class for message MSG_DEBUG_VAR (0x0011).
+
+  You can have MSG_DEBUG_VAR inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This is an unused legacy message for tracing variable values
 within the Piksi firmware and streaming those back to the host.
@@ -62,9 +93,10 @@ within the Piksi firmware and streaming those back to the host.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -9,18 +9,30 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Geodetic navigation messages reporting GPS time, single-point
+position, and RTK baseline position solutions.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/navigation.yaml
-# with generate.py at 2015-04-06 23:40:11.131635. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.828885. Please do not hand edit!
 
 
 SBP_MSG_GPS_TIME = 0x0100
 class MsgGPSTime(SBP):
   """SBP class for message MSG_GPS_TIME (0x0100).
+
+  You can have MSG_GPS_TIME inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reports the GPS time, an integer time scale
 beginning at January 6, 1980 midnight. GPS time counts the weeks
@@ -32,6 +44,8 @@ between between 0 and 604800 seconds (=60*60*24*7).
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   wn : int
     GPS week number
   tow : int
@@ -48,23 +62,43 @@ between between 0 and 604800 seconds (=60*60*24*7).
                    SLInt32('ns'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.wn = kwargs.pop('wn')
+      self.tow = kwargs.pop('tow')
+      self.ns = kwargs.pop('ns')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgGPSTime._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgGPSTime.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgGPSTime._parser.build(c)
+    return self.pack()
     
 SBP_MSG_DOPS = 0x0206
 class MsgDops(SBP):
   """SBP class for message MSG_DOPS (0x0206).
+
+  You can have MSG_DOPS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This dilution of precision (DOP) message describes the effect of
 navigation satellite geometry on positional measurement
@@ -73,6 +107,8 @@ precision.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   gdop : int
@@ -95,23 +131,45 @@ precision.
                    ULInt16('hdop'),
                    ULInt16('vdop'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.gdop = kwargs.pop('gdop')
+      self.pdop = kwargs.pop('pdop')
+      self.tdop = kwargs.pop('tdop')
+      self.hdop = kwargs.pop('hdop')
+      self.vdop = kwargs.pop('vdop')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgDops._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgDops.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgDops._parser.build(c)
+    return self.pack()
     
 SBP_MSG_POS_ECEF = 0x0200
 class MsgPosECEF(SBP):
   """SBP class for message MSG_POS_ECEF (0x0200).
+
+  You can have MSG_POS_ECEF inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The single-point position solution message reports absolute
 Earth Centered Earth Fixed (ECEF) coordinates and the status
@@ -124,6 +182,8 @@ baseline vector.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   x : double
@@ -149,23 +209,46 @@ baseline vector.
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.x = kwargs.pop('x')
+      self.y = kwargs.pop('y')
+      self.z = kwargs.pop('z')
+      self.accuracy = kwargs.pop('accuracy')
+      self.n_sats = kwargs.pop('n_sats')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgPosECEF._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgPosECEF.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgPosECEF._parser.build(c)
+    return self.pack()
     
 SBP_MSG_POS_LLH = 0x0201
 class MsgPosLLH(SBP):
   """SBP class for message MSG_POS_LLH (0x0201).
+
+  You can have MSG_POS_LLH inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This single-point position solution message reports the absolute
 geodetic coordinates and the status (single point absolute vs
@@ -177,6 +260,8 @@ station position and the rover's RTK baseline vector.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   lat : double
@@ -205,23 +290,47 @@ station position and the rover's RTK baseline vector.
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.lat = kwargs.pop('lat')
+      self.lon = kwargs.pop('lon')
+      self.height = kwargs.pop('height')
+      self.h_accuracy = kwargs.pop('h_accuracy')
+      self.v_accuracy = kwargs.pop('v_accuracy')
+      self.n_sats = kwargs.pop('n_sats')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgPosLLH._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgPosLLH.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgPosLLH._parser.build(c)
+    return self.pack()
     
 SBP_MSG_BASELINE_ECEF = 0x0202
 class MsgBaselineECEF(SBP):
   """SBP class for message MSG_BASELINE_ECEF (0x0202).
+
+  You can have MSG_BASELINE_ECEF inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reports the baseline position solution in Earth
 Centered Earth Fixed (ECEF) coordinates.
@@ -229,6 +338,8 @@ Centered Earth Fixed (ECEF) coordinates.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   x : int
@@ -254,23 +365,46 @@ Centered Earth Fixed (ECEF) coordinates.
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.x = kwargs.pop('x')
+      self.y = kwargs.pop('y')
+      self.z = kwargs.pop('z')
+      self.accuracy = kwargs.pop('accuracy')
+      self.n_sats = kwargs.pop('n_sats')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgBaselineECEF._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgBaselineECEF.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgBaselineECEF._parser.build(c)
+    return self.pack()
     
 SBP_MSG_BASELINE_NED = 0x0203
 class MsgBaselineNED(SBP):
   """SBP class for message MSG_BASELINE_NED (0x0203).
+
+  You can have MSG_BASELINE_NED inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reports the baseline position solution in North
 East Down (NED) coordinates.
@@ -278,6 +412,8 @@ East Down (NED) coordinates.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   n : int
@@ -306,23 +442,47 @@ East Down (NED) coordinates.
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.n = kwargs.pop('n')
+      self.e = kwargs.pop('e')
+      self.d = kwargs.pop('d')
+      self.h_accuracy = kwargs.pop('h_accuracy')
+      self.v_accuracy = kwargs.pop('v_accuracy')
+      self.n_sats = kwargs.pop('n_sats')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgBaselineNED._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgBaselineNED.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgBaselineNED._parser.build(c)
+    return self.pack()
     
 SBP_MSG_VEL_ECEF = 0x0204
 class MsgVelECEF(SBP):
   """SBP class for message MSG_VEL_ECEF (0x0204).
+
+  You can have MSG_VEL_ECEF inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reports the velocity in Earth Centered Earth Fixed
 (ECEF) coordinates.
@@ -330,6 +490,8 @@ class MsgVelECEF(SBP):
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   x : int
@@ -355,23 +517,46 @@ class MsgVelECEF(SBP):
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.x = kwargs.pop('x')
+      self.y = kwargs.pop('y')
+      self.z = kwargs.pop('z')
+      self.accuracy = kwargs.pop('accuracy')
+      self.n_sats = kwargs.pop('n_sats')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgVelECEF._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgVelECEF.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgVelECEF._parser.build(c)
+    return self.pack()
     
 SBP_MSG_VEL_NED = 0x0205
 class MsgVelNED(SBP):
   """SBP class for message MSG_VEL_NED (0x0205).
+
+  You can have MSG_VEL_NED inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reports the velocity in local North East Down (NED)
 coordinates.
@@ -379,6 +564,8 @@ coordinates.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tow : int
     GPS Time of Week
   n : int
@@ -407,19 +594,38 @@ coordinates.
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.n = kwargs.pop('n')
+      self.e = kwargs.pop('e')
+      self.d = kwargs.pop('d')
+      self.h_accuracy = kwargs.pop('h_accuracy')
+      self.v_accuracy = kwargs.pop('v_accuracy')
+      self.n_sats = kwargs.pop('n_sats')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgVelNED._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgVelNED.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgVelNED._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -9,13 +9,18 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Satellite observation messages from the Piksi.
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/observation.yaml
-# with generate.py at 2015-04-06 23:40:11.079832. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.763906. Please do not hand edit!
 
 
 class ObsGPSTime(object):
@@ -62,9 +67,9 @@ cycles and 8-bits of fractional cycles.
   Parameters
   ----------
   i : int
-    Carrier phase whole cycles.
+    Carrier phase whole cycles
   f : int
-    Carrier phase fractional part.
+    Carrier phase fractional part
 
   """
   _parser = Embedded(Struct("CarrierPhase",
@@ -92,7 +97,7 @@ class ObservationHeader(object):
   Parameters
   ----------
   t : ObsGPSTime
-    GPS time of this observation.
+    GPS time of this observation
   n_obs : int
     Total number of observations. First nibble is the size
 of the sequence (n), second nibble is the zero-indexed
@@ -127,16 +132,16 @@ tracked.
   Parameters
   ----------
   P : int
-    Pseudorange observation.
+    Pseudorange observation
   L : CarrierPhase
-    Carrier phase observation.
+    Carrier phase observation
   cn0 : int
     Carrier-to-Noise density
   lock : int
     Lock indicator. This value changes whenever a satellite
 signal has lost and regained lock, indicating that the
 carrier phase ambiguity may have changed. There is no
-significance to the value of the lock indicator.
+significance to the value of the lock indicator
 
   prn : int
     PRN identifier of the satellite signal
@@ -165,6 +170,11 @@ significance to the value of the lock indicator.
 SBP_MSG_OBS = 0x0045
 class MsgObs(SBP):
   """SBP class for message MSG_OBS (0x0045).
+
+  You can have MSG_OBS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The GPS observations message reports all the pseudo range and
 carrier phase observations for the satellites being tracked by
@@ -173,11 +183,13 @@ the Piksi.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   header : ObservationHeader
     Header of a GPS observation message
   obs : array
     Pseudorange and carrier phase observation for a
-satellite being tracked.
+satellite being tracked
 
 
   """
@@ -185,23 +197,41 @@ satellite being tracked.
                    Struct('header', ObservationHeader._parser),
                    OptionalGreedyRange(Struct('obs', PackedObsContent._parser)),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.header = kwargs.pop('header')
+      self.obs = kwargs.pop('obs')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgObs._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgObs.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgObs._parser.build(c)
+    return self.pack()
     
 SBP_MSG_BASE_POS = 0x0044
 class MsgBasePos(SBP):
   """SBP class for message MSG_BASE_POS (0x0044).
+
+  You can have MSG_BASE_POS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This may be the position as reported by the base station itself or the
 position obtained from doing a single point solution using the base
@@ -210,6 +240,8 @@ station observations.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   lat : double
     Latitude
   lon : double
@@ -223,19 +255,33 @@ station observations.
                    LFloat64('lon'),
                    LFloat64('height'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.lat = kwargs.pop('lat')
+      self.lon = kwargs.pop('lon')
+      self.height = kwargs.pop('height')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgBasePos._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgBasePos.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgBasePos._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -9,39 +9,49 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+System health, configuration, and diagnostic messages specific to
+the Piksi L1 receiver, including a variety of legacy messages that
+may no longer be used. These messages are in the
+implementation-defined range (0x0000-0x00FF), and largely intended
+for internal-use only.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/piksi.yaml
-# with generate.py at 2015-04-06 23:40:11.127759. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.821815. Please do not hand edit!
 
 
 class UARTChannel(object):
   """UARTChannel.
   
   Throughput, utilization, and error counts on the RX/TX buffers
-of this UART channel. Values require renormalization.
+of this UART channel. Values require renormalization
 
   
   Parameters
   ----------
   tx_throughput : float
-    UART transmit throughput.
+    UART transmit throughput
   rx_throughput : float
-    UART receive throughput.
+    UART receive throughput
   crc_error_count : int
-    UART CRC error count.
+    UART CRC error count
   io_error_count : int
-    UART IO error count.
+    UART IO error count
   tx_buffer_level : int
     UART transmit buffer percentage utilization. Ranges from
-0 - 255 and needs to be renormalized to 100.
+0 - 255 and needs to be renormalized to 100
 
   rx_buffer_level : int
     UART receive buffer percentage utilization. Ranges from
-0 - 255 and needs to be renormalized to 100.
+0 - 255 and needs to be renormalized to 100
 
 
   """
@@ -79,13 +89,13 @@ communication latency in the system.
   Parameters
   ----------
   avg : int
-    Average latency.
+    Average latency
   lmin : int
-    Minimum latency.
+    Minimum latency
   lmax : int
-    Maximum latency.
+    Maximum latency
   current : int
-    Smoothed estimate of the current latency.
+    Smoothed estimate of the current latency
 
   """
   _parser = Embedded(Struct("Latency",
@@ -110,6 +120,11 @@ communication latency in the system.
 SBP_MSG_ALMANAC = 0x0069
 class MsgAlmanac(SBP):
   """SBP class for message MSG_ALMANAC (0x0069).
+
+  You can have MSG_ALMANAC inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This is a legacy message for sending and loading a satellite
 alamanac onto the Piksi's flash memory from the host.
@@ -117,9 +132,10 @@ alamanac onto the Piksi's flash memory from the host.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -128,6 +144,11 @@ alamanac onto the Piksi's flash memory from the host.
 SBP_MSG_SET_TIME = 0x0068
 class MsgSetTime(SBP):
   """SBP class for message MSG_SET_TIME (0x0068).
+
+  You can have MSG_SET_TIME inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message sets up timing functionality using a coarse GPS
 time estimate sent by the host.
@@ -135,9 +156,10 @@ time estimate sent by the host.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -146,6 +168,11 @@ time estimate sent by the host.
 SBP_MSG_RESET = 0x00B2
 class MsgReset(SBP):
   """SBP class for message MSG_RESET (0x00B2).
+
+  You can have MSG_RESET inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message from the host resets the Piksi back into the
 bootloader. It ensures that all outstanding memory accesses
@@ -154,9 +181,10 @@ including buffered writes are completed before reset begins.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -165,6 +193,11 @@ including buffered writes are completed before reset begins.
 SBP_MSG_CW_RESULTS = 0x00C0
 class MsgCwResults(SBP):
   """SBP class for message MSG_CW_RESULTS (0x00C0).
+
+  You can have MSG_CW_RESULTS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This is an unused legacy message for result reporting from the
 CW interference channel on the SwiftNAP. This message will be
@@ -173,9 +206,10 @@ removed in a future release.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -184,6 +218,11 @@ removed in a future release.
 SBP_MSG_CW_START = 0x00C1
 class MsgCwStart(SBP):
   """SBP class for message MSG_CW_START (0x00C1).
+
+  You can have MSG_CW_START inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This is an unused legacy message from those host for starting
 the CW interference channel on the SwiftNAP. This message will
@@ -192,9 +231,10 @@ be removed in a future release.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -203,6 +243,11 @@ be removed in a future release.
 SBP_MSG_RESET_FILTERS = 0x0022
 class MsgResetFilters(SBP):
   """SBP class for message MSG_RESET_FILTERS (0x0022).
+
+  You can have MSG_RESET_FILTERS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message resets either the DGNSS Kalman filters or Integer
 Ambiguity Resolution (IAR) process.
@@ -210,6 +255,8 @@ Ambiguity Resolution (IAR) process.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   filter : int
     Filter flags
 
@@ -217,23 +264,40 @@ Ambiguity Resolution (IAR) process.
   _parser = Struct("MsgResetFilters",
                    ULInt8('filter'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.filter = kwargs.pop('filter')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgResetFilters._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgResetFilters.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgResetFilters._parser.build(c)
+    return self.pack()
     
 SBP_MSG_INIT_BASE = 0x0023
 class MsgInitBase(SBP):
   """SBP class for message MSG_INIT_BASE (0x0023).
+
+  You can have MSG_INIT_BASE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message initializes the Integer Ambiguity Resolution (IAR)
 process on the Piksi to use an assumed baseline position between
@@ -244,9 +308,10 @@ observations between the two.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -255,6 +320,11 @@ observations between the two.
 SBP_MSG_THREAD_STATE = 0x0017
 class MsgThreadState(SBP):
   """SBP class for message MSG_THREAD_STATE (0x0017).
+
+  You can have MSG_THREAD_STATE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The thread usage message from the Piksi reports RTOS thread
 usage statistics for the named thread. The reported values
@@ -263,14 +333,16 @@ require renormalization.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   name : string
     Thread name (NULL terminated)
   cpu : int
     Percentage cpu use for this thread. Ranges from 0 - 1000
-and needs to be renormalized to 100.
+and needs to be renormalized to 100
 
   stack_free : int
-    Free stack space for this thread.
+    Free stack space for this thread
 
   """
   _parser = Struct("MsgThreadState",
@@ -278,23 +350,42 @@ and needs to be renormalized to 100.
                    ULInt16('cpu'),
                    ULInt32('stack_free'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.name = kwargs.pop('name')
+      self.cpu = kwargs.pop('cpu')
+      self.stack_free = kwargs.pop('stack_free')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgThreadState._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgThreadState.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgThreadState._parser.build(c)
+    return self.pack()
     
 SBP_MSG_UART_STATE = 0x0018
 class MsgUartState(SBP):
   """SBP class for message MSG_UART_STATE (0x0018).
+
+  You can have MSG_UART_STATE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The UART message reports data latency and throughput of the UART
 channels providing SBP I/O. On the default Piksi configuration,
@@ -305,6 +396,8 @@ future.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   uart_a : UARTChannel
     State of UART A
   uart_b : UARTChannel
@@ -321,23 +414,43 @@ future.
                    Struct('uart_ftdi', UARTChannel._parser),
                    Struct('latency', Latency._parser),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.uart_a = kwargs.pop('uart_a')
+      self.uart_b = kwargs.pop('uart_b')
+      self.uart_ftdi = kwargs.pop('uart_ftdi')
+      self.latency = kwargs.pop('latency')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgUartState._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgUartState.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgUartState._parser.build(c)
+    return self.pack()
     
 SBP_MSG_IAR_STATE = 0x0019
 class MsgIarState(SBP):
   """SBP class for message MSG_IAR_STATE (0x0019).
+
+  You can have MSG_IAR_STATE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   This message reports the state of the Integer Ambiguity
 Resolution (IAR) process, which resolves unknown integer
@@ -347,26 +460,40 @@ from satellite observations.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   num_hyps : int
-    Number of integer ambiguity hypotheses remaining.
+    Number of integer ambiguity hypotheses remaining
 
   """
   _parser = Struct("MsgIarState",
                    ULInt32('num_hyps'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.num_hyps = kwargs.pop('num_hyps')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgIarState._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgIarState.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgIarState._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -9,52 +9,87 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Messages for reading and writing the Piksi's device settings. These
+are in the implementation-defined range (0x0000-0x00FF), and
+intended for internal-use only. Please see the accompanying
+description of settings configurations for more details. Note that
+some of these messages taking a request from a host and a response
+from the Piksi share the same message type ID.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/settings.yaml
-# with generate.py at 2015-04-06 23:40:11.129530. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.824989. Please do not hand edit!
 
 
 SBP_MSG_SETTINGS = 0x00A0
 class MsgSettings(SBP):
   """SBP class for message MSG_SETTINGS (0x00A0).
+
+  You can have MSG_SETTINGS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The setting message reads and writes the Piksi's configuration.
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   setting : string
-    A NULL delimited (and terminated) string, with a single
-"<setting section>\0<setting>\0<value>\0" on writes or a
-series of "<setting section>\0<setting>\0<value>\0" on
-reads.
+    A NULL delimited (and terminated) string, with the A
+NULL-terminated and delimited string with contents
+[SECTION_SETTING, SETTING, VALUE] on writes or a series of
+such strings on reads.
 
 
   """
   _parser = Struct("MsgSettings",
                    CString('setting', six.b('\n')),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.setting = kwargs.pop('setting')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgSettings._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgSettings.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgSettings._parser.build(c)
+    return self.pack()
     
 SBP_MSG_SETTINGS_SAVE = 0x00A1
 class MsgSettingsSave(SBP):
   """SBP class for message MSG_SETTINGS_SAVE (0x00A1).
+
+  You can have MSG_SETTINGS_SAVE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The save settings message persists the Piksi's current settings
 configuration to its onboard flash memory file system.
@@ -62,9 +97,10 @@ configuration to its onboard flash memory file system.
 
   """
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.payload = sbp.payload
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.payload = sbp.payload
 
   def __repr__(self):
     return fmt_repr(self)
@@ -73,36 +109,56 @@ configuration to its onboard flash memory file system.
 SBP_MSG_SETTINGS_READ_BY_INDEX = 0x00A2
 class MsgSettingsReadByIndex(SBP):
   """SBP class for message MSG_SETTINGS_READ_BY_INDEX (0x00A2).
+
+  You can have MSG_SETTINGS_READ_BY_INDEX inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The settings message for iterating through the settings
-values. It will read the setting at an index, returning
-"<setting section>\0<setting>\0<value>\0" from the Piksi.
+values. It will read the setting at an index, returning a
+NULL-terminated and delimited string with contents
+[SECTION_SETTING, SETTING, VALUE].
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   index : int
     An index into the Piksi settings, with values ranging from
-0 to length(settings).
+0 to length(settings)
 
 
   """
   _parser = Struct("MsgSettingsReadByIndex",
                    ULInt16('index'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.index = kwargs.pop('index')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgSettingsReadByIndex._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgSettingsReadByIndex.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgSettingsReadByIndex._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -9,18 +9,28 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Standardized system messages from Swift Navigation devices.
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/system.yaml
-# with generate.py at 2015-04-06 23:40:11.134335. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.832345. Please do not hand edit!
 
 
 SBP_MSG_STARTUP = 0xFF00
 class MsgStartup(SBP):
   """SBP class for message MSG_STARTUP (0xFF00).
+
+  You can have MSG_STARTUP inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The system start-up message is sent once on system
 start-up. It is intended to be used to notify the host or
@@ -30,6 +40,8 @@ ready to respond to commands or configuration requests.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   reserved : int
     Reserved
 
@@ -37,23 +49,40 @@ ready to respond to commands or configuration requests.
   _parser = Struct("MsgStartup",
                    ULInt32('reserved'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.reserved = kwargs.pop('reserved')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgStartup._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgStartup.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgStartup._parser.build(c)
+    return self.pack()
     
 SBP_MSG_HEARTBEAT = 0xFFFF
 class MsgHeartbeat(SBP):
   """SBP class for message MSG_HEARTBEAT (0xFFFF).
+
+  You can have MSG_HEARTBEAT inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The heartbeat message is sent periodically to inform the host
 or other attached devices that the system is running. It is
@@ -68,6 +97,8 @@ the remaining error flags should be inspected.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   flags : int
     Status flags
 
@@ -75,19 +106,31 @@ the remaining error flags should be inspected.
   _parser = Struct("MsgHeartbeat",
                    ULInt32('flags'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgHeartbeat._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgHeartbeat.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgHeartbeat._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -9,13 +9,19 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+
+"""
+Satellite code and carrier-phase tracking messages from the Piksi.
+
+"""
+
 from construct import *
 from sbp import SBP
-from sbp.utils import fmt_repr
+from sbp.utils import fmt_repr, exclude_fields
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/tracking.yaml
-# with generate.py at 2015-04-06 23:40:11.135754. Please do not hand edit!
+# with generate.py at 2015-04-12 20:54:10.835086. Please do not hand edit!
 
 
 class TrackingChannelState(object):
@@ -28,9 +34,9 @@ signal power.
   Parameters
   ----------
   state : int
-    Status of tracking channel.
+    Status of tracking channel
   prn : int
-    PRN being tracked.
+    PRN being tracked
   cn0 : float
     Carrier-to-noise density
 
@@ -56,6 +62,11 @@ signal power.
 SBP_MSG_TRACKING_STATE = 0x0016
 class MsgTrackingState(SBP):
   """SBP class for message MSG_TRACKING_STATE (0x0016).
+
+  You can have MSG_TRACKING_STATE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The tracking message returns a variable-length array of tracking
 channel states. It reports status and code/carrier phase signal
@@ -64,41 +75,61 @@ power measurements for all tracked satellites.
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   states : array
-    Satellite tracking channel state.
+    Satellite tracking channel state
 
   """
   _parser = Struct("MsgTrackingState",
                    OptionalGreedyRange(Struct('states', TrackingChannelState._parser)),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.states = kwargs.pop('states')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgTrackingState._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgTrackingState.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgTrackingState._parser.build(c)
+    return self.pack()
     
 SBP_MSG_EPHEMERIS = 0x001A
 class MsgEphemeris(SBP):
   """SBP class for message MSG_EPHEMERIS (0x001A).
+
+  You can have MSG_EPHEMERIS inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
   
   The ephemeris message returns a set of satellite orbit
 parameters that is used to calculate GPS satellite position,
 velocity, and clock offset (WGS84). Please see the Navstar GPS
 Space Segment/Navigation user interfaces (ICD-GPS-200, Table
-20-III) for more details
-(http://www.navcen.uscg.gov/pubs/gps/icd200/icd200cw1234.pdf).
+20-III) for more details.
 
 
   Parameters
   ----------
+  sbp : SBP
+    SBP parent object to inherit from.
   tgd : double
     Group delay differential between L1 and L2 (?)
   crs : double
@@ -181,19 +212,56 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                    ULInt8('healthy'),
                    ULInt8('prn'),)
 
-  def __init__(self, sbp):
-    self.__dict__.update(sbp.__dict__)
-    self.from_binary(sbp.payload)
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      self.tgd = kwargs.pop('tgd')
+      self.crs = kwargs.pop('crs')
+      self.crc = kwargs.pop('crc')
+      self.cuc = kwargs.pop('cuc')
+      self.cus = kwargs.pop('cus')
+      self.cic = kwargs.pop('cic')
+      self.cis = kwargs.pop('cis')
+      self.dn = kwargs.pop('dn')
+      self.m0 = kwargs.pop('m0')
+      self.ecc = kwargs.pop('ecc')
+      self.sqrta = kwargs.pop('sqrta')
+      self.omega0 = kwargs.pop('omega0')
+      self.omegadot = kwargs.pop('omegadot')
+      self.w = kwargs.pop('w')
+      self.inc = kwargs.pop('inc')
+      self.inc_dot = kwargs.pop('inc_dot')
+      self.af0 = kwargs.pop('af0')
+      self.af1 = kwargs.pop('af1')
+      self.af2 = kwargs.pop('af2')
+      self.toe_tow = kwargs.pop('toe_tow')
+      self.toe_wn = kwargs.pop('toe_wn')
+      self.toc_tow = kwargs.pop('toc_tow')
+      self.toc_wn = kwargs.pop('toc_wn')
+      self.valid = kwargs.pop('valid')
+      self.healthy = kwargs.pop('healthy')
+      self.prn = kwargs.pop('prn')
 
   def __repr__(self):
     return fmt_repr(self)
  
   def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
     p = MsgEphemeris._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
-    return MsgEphemeris.build(self.__dict__)
+    """Produce a framed/packed SBP message.
+
+    """
+    c = Container(**exclude_fields(self))
+    self.payload = MsgEphemeris._parser.build(c)
+    return self.pack()
     
 
 msg_classes = {

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -13,15 +13,20 @@
 
 """
 
-import pprint
+EXCLUDE = ['sender', 'msg_type', 'crc', 'length', 'preamble', 'payload']
 
-TO_REMOVE = ['sender','msg_type','crc','length', 'preamble']
+
+def exclude_fields(obj, exclude=EXCLUDE):
+  """
+  Return dict of object without parent attrs.
+  """
+  return {k: v for k, v in obj.__dict__.items() if k not in exclude}
+
 
 def fmt_repr(obj):
   """Print a orphaned string representation of an object without the
   clutter of its parent object.
 
   """
-  items = {k: v for k, v in obj.__dict__.items() if k not in TO_REMOVE}
-  items = ["%s = %r" % (k, v) for k, v in items.items()]
+  items = ["%s = %r" % (k, v) for k, v in exclude_fields(obj).items()]
   return "<%s: {%s}>" % (obj.__class__.__name__, ', '.join(items))

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 import os
 
-VERSION = "0.29"
+VERSION = "0.30"
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',

--- a/python/tests/sbp/build_test_data.py
+++ b/python/tests/sbp/build_test_data.py
@@ -96,7 +96,7 @@ def walk_json_dict(coll):
   else:
     return coll
 
-def dump_modules_to_yaml(test_map):
+def dump_modules_to_yaml(test_map, version):
   """
   Take unit test data data from test, format as YAML, and write to
   local files.
@@ -110,10 +110,9 @@ def dump_modules_to_yaml(test_map):
   """
   for k, v in test_map.iteritems():
     item = {'package': k,
-            'description': "Unit tests for swiftnav.%s v%s." \
-              % (k, sbp.__version__),
+            'description': "Unit tests for swiftnav.%s v%s." % (k, version),
             'generated_on': datetime.datetime.now(),
-            'version': sbp.__version__,
+            'version': version,
             'tests': v}
     d = yaml.dump(item, explicit_start=True,
                   default_flow_style=False,
@@ -193,6 +192,9 @@ def get_args():
   parser.add_argument("-j", "--json",
                       action="store_true",
                       help="JSON serialize SBP messages.")
+  parser.add_argument("-s", "--version",
+                      default=[None], nargs=1,
+                      help="SBP version number (e.g. 0.29).")
   parser.add_argument("-v", "--verbose",
                       action="store_true",
                       help="print extra debugging information.")
@@ -206,6 +208,7 @@ def main():
   """
   args = get_args()
   log_datafile = args.log_file[0]
+  version = args.version[0]
   json = args.json
   verbose = args.verbose
   if json:
@@ -224,7 +227,8 @@ def main():
         except TypeError as ex_info:
           # Note data errors as they come up, but don't crash the test
           # generation.
-          out = "Warning! %s for message 0x00%x." % (ex_info.message, msg.msg_type)
+          out = "Warning! %s for message 0x00%x." \
+                % (ex_info.message, msg.msg_type)
           warnings.warn(out, RuntimeWarning)
           continue
         # For a given SBP message type, sample only num_test_cases
@@ -236,7 +240,7 @@ def main():
             test_table[msg.msg_type].append(i)
           elif test_table[msg.msg_type][-1] != i:
             test_table[msg.msg_type].append(i)
-  dump_modules_to_yaml(gather_by_module(test_table))
+  dump_modules_to_yaml(gather_by_module(test_table), version)
 
 if __name__ == "__main__":
   main()

--- a/python/tests/sbp/test_acquisition.py
+++ b/python/tests/sbp/test_acquisition.py
@@ -12,6 +12,6 @@
 from utils import assert_package
 
 def test_package():
-  FILEPATH = "../spec/tests/yaml/swiftnav/sbp/test_standard.yaml"
-  MODULE_NAME = "sbp.standard"
+  FILEPATH = "../spec/tests/yaml/swiftnav/sbp/test_acquisition.yaml"
+  MODULE_NAME = "sbp.acquisition"
   assert_package(FILEPATH, MODULE_NAME)

--- a/python/tests/sbp/test_bootload.py
+++ b/python/tests/sbp/test_bootload.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from utils import assert_package
+import pytest
+
+@pytest.mark.skipif(True, reason="Unused serialization throwing error.")
+def test_package():
+  FILEPATH = "../spec/tests/yaml/swiftnav/sbp/test_bootload.yaml"
+  MODULE_NAME = "sbp.bootload"
+  assert_package(FILEPATH, MODULE_NAME)

--- a/python/tests/sbp/test_logging.py
+++ b/python/tests/sbp/test_logging.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from utils import assert_package
+
+def test_package():
+  FILEPATH = "../spec/tests/yaml/swiftnav/sbp/test_logging.yaml"
+  MODULE_NAME = "sbp.logging"
+  assert_package(FILEPATH, MODULE_NAME)

--- a/python/tests/sbp/test_system.py
+++ b/python/tests/sbp/test_system.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from utils import assert_package
+
+def test_package():
+  FILEPATH = "../spec/tests/yaml/swiftnav/sbp/test_system.yaml"
+  MODULE_NAME = "sbp.system"
+  assert_package(FILEPATH, MODULE_NAME)

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -55,13 +55,9 @@ def field_eq(p, e):
 
   """
   if isinstance(e, dict):
-    k = e.keys()[0]
-    if isinstance(e[k], list):
-      return k == p.keys()[0] and all(field_eq(i, j) for (i, j) in zip(p[k], e[k]))
-    elif isinstance(e[k], dict):
-      return k == p.keys()[0] and all(field_eq(p[k][i], j) for (i, j) in e[k].iteritems())
-    else:
-      return k == p.keys()[0] and all(field_eq(p[i], j) for (i, j) in e.iteritems())
+    return all(field_eq(p[i], j) for (i, j) in e.iteritems())
+  elif isinstance(e, list):
+    return all(field_eq(p[i], j) for (i, j) in enumerate(e))
   else:
     return p == e
 
@@ -84,6 +80,21 @@ def _assert_msg(msg, test_case):
       assert field_eq(msg.__dict__[field_name], field_value), \
         "Unequal field values: got %s, but expected %s!" \
         % (msg.__dict__[field_name], field_value)
+
+def _assert_msg_roundtrip(msg, raw_packet):
+  """
+  Asserts that a msg gets serialized back into binary with the
+  expected value.
+
+  Parameters
+  ----------
+  msg : Parsed SBP message.
+    Parsed SBP message.
+  raw_packet : dict
+    Unit test case for this message.
+
+  """
+  assert base64.standard_b64encode(msg.to_binary()) == raw_packet
 
 def _assert_sane_package(pkg_name, pkg):
   """
@@ -124,3 +135,4 @@ def assert_package(test_filename, pkg_name):
       sbp = SBP.unpack(base64.standard_b64decode(test_case['raw_packet']))
       _assert_sbp(sbp, test_case['sbp'])
       _assert_msg(dispatch(sbp), test_case['msg'])
+      _assert_msg_roundtrip(dispatch(sbp), test_case['raw_packet'])

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -2,10 +2,8 @@
 envlist = py27
 
 [testenv]
-deps =
-    pytest
-    -rrequirements.txt
-commands = py.test -v --cov sbp tests/
+deps = -rrequirements.txt
+commands = py.test -v tests/
 sitepackages = False
 usedevelop = True
 

--- a/spec/tests/yaml/swiftnav/sbp/test_acquisition.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_acquisition.yaml
@@ -1,115 +1,115 @@
 ---
-description: Unit tests for swiftnav.sbp.acquisition v0.23.
-generated_on: 2015-03-24 11:31:59.657065
+description: Unit tests for swiftnav.sbp.acquisition v0.29.
+generated_on: 2015-04-12 20:15:47.194575
 package: sbp.acquisition
 tests:
 
 - msg:
     fields:
-      cf: -7742.43212890625
-      cp: 272.0
-      prn: 24
-      snr: 18.77777862548828
+      cf: 8241.943359375
+      cp: 727.0
+      prn: 8
+      snr: 14.5
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQN5DiWQQAAiEN18/HFGLWs
+  raw_packet: VRUAwwQNAABoQQDANUTGxwBGCAJE
   sbp:
-    crc: '0xacb5'
+    crc: '0x4402'
     length: 13
     msg_type: '0x15'
-    payload: 5DiWQQAAiEN18/HFGA==
+    payload: AABoQQDANUTGxwBGCA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cf: -1998.0469970703125
-      cp: 493.0
-      prn: 25
-      snr: 14.44444465637207
+      cf: 749.2676391601562
+      cp: 359.5
+      prn: 9
+      snr: 15.300000190734863
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQNchxnQQCA9kOBwfnEGce/
+  raw_packet: VRUAwwQNzcx0QQDAs0MhUTtECdsb
   sbp:
-    crc: '0xbfc7'
+    crc: '0x1bdb'
     length: 13
     msg_type: '0x15'
-    payload: chxnQQCA9kOBwfnEGQ==
+    payload: zcx0QQDAs0MhUTtECQ==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cf: 4245.849609375
-      cp: 759.5
-      prn: 26
-      snr: 15.11111068725586
+      cf: -6493.65283203125
+      cp: 40.5
+      prn: 11
+      snr: 18.100000381469727
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQNHMdxQQDgPUTMroRFGn/x
+  raw_packet: VRUAwwQNzcyQQQAAIkI57crFC5Yj
   sbp:
-    crc: '0xf17f'
+    crc: '0x2396'
     length: 13
     msg_type: '0x15'
-    payload: HMdxQQDgPUTMroRFGg==
+    payload: zcyQQQAAIkI57crFCw==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cf: -749.2676391601562
-      cp: 209.0
-      prn: 28
-      snr: 17.44444465637207
+      cf: -999.0234985351562
+      cp: 548.5
+      prn: 12
+      snr: 15.300000190734863
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQNOY6LQQAAUUMhUTvEHDz7
+  raw_packet: VRUAwwQNzcx0QQAgCUSBwXnEDJJ2
   sbp:
-    crc: '0xfb3c'
+    crc: '0x7692'
     length: 13
     msg_type: '0x15'
-    payload: OY6LQQAAUUMhUTvEHA==
+    payload: zcx0QQAgCUSBwXnEDA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cf: 249.75587463378906
-      cp: 928.5
-      prn: 29
-      snr: 16.55555534362793
+      cf: 4745.361328125
+      cp: 780.5
+      prn: 14
+      snr: 15.300000190734863
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQNx3GEQQAgaESBwXlDHRDR
+  raw_packet: VRUAwwQNzcx0QQAgQ0TkSpRFDhdL
   sbp:
-    crc: '0xd110'
+    crc: '0x4b17'
     length: 13
     msg_type: '0x15'
-    payload: x3GEQQAgaESBwXlDHQ==
+    payload: zcx0QQAgQ0TkSpRFDg==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cf: -2997.070556640625
-      cp: 188.0
+      cf: -499.5117492675781
+      cp: 584.5
       prn: 0
-      snr: 53.125
+      snr: 163.22222900390625
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQNAIBUQgAAPEMhUTvFAG2F
+  raw_packet: VRUAwwQN5DgjQwAgEkSBwfnDAMzP
   sbp:
-    crc: '0x856d'
+    crc: '0xcfcc'
     length: 13
     msg_type: '0x15'
-    payload: AIBUQgAAPEMhUTvFAA==
+    payload: 5DgjQwAgEkSBwfnDAA==
     preamble: '0x55'
-    sender: '0x4cc'
-version: '0.23'
+    sender: '0x4c3'
+version: '0.29'
 ...

--- a/spec/tests/yaml/swiftnav/sbp/test_bootload.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_bootload.yaml
@@ -1,0 +1,22 @@
+---
+description: Unit tests for swiftnav.sbp.bootload v0.29.
+generated_on: 2015-04-12 20:15:47.084788
+package: sbp.bootload
+tests:
+
+- msg:
+    fields:
+      handshake: 118
+    module: sbp.bootload
+    name: MsgBootloaderHandshake
+  msg_type: '0xb0'
+  raw_packet: VbAAwwQEdjEuMgHO
+  sbp:
+    crc: '0xce01'
+    length: 4
+    msg_type: '0xb0'
+    payload: djEuMg==
+    preamble: '0x55'
+    sender: '0x4c3'
+version: '0.29'
+...

--- a/spec/tests/yaml/swiftnav/sbp/test_logging.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_logging.yaml
@@ -1,0 +1,97 @@
+---
+description: Unit tests for swiftnav.sbp.logging v0.29.
+generated_on: 2015-04-12 20:15:47.212229
+package: sbp.logging
+tests:
+
+- msg:
+    fields:
+      text: 'INFO: Piksi Starting...'
+    module: sbp.logging
+    name: MsgPrint
+  msg_type: '0x10'
+  raw_packet: VRAAwwQYSU5GTzogUGlrc2kgU3RhcnRpbmcuLi4KvoQ=
+  sbp:
+    crc: '0x84be'
+    length: 24
+    msg_type: '0x10'
+    payload: SU5GTzogUGlrc2kgU3RhcnRpbmcuLi4K
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      text: 'INFO: Firmware Version: v0.15-rc1'
+    module: sbp.logging
+    name: MsgPrint
+  msg_type: '0x10'
+  raw_packet: VRAAwwQiSU5GTzogRmlybXdhcmUgVmVyc2lvbjogdjAuMTUtcmMxCklr
+  sbp:
+    crc: '0x6b49'
+    length: 34
+    msg_type: '0x10'
+    payload: SU5GTzogRmlybXdhcmUgVmVyc2lvbjogdjAuMTUtcmMxCg==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      text: 'INFO: Built: Apr  2 2015 00:31:34'
+    module: sbp.logging
+    name: MsgPrint
+  msg_type: '0x10'
+  raw_packet: VRAAwwQiSU5GTzogQnVpbHQ6IEFwciAgMiAyMDE1IDAwOjMxOjM0CgQI
+  sbp:
+    crc: '0x804'
+    length: 34
+    msg_type: '0x10'
+    payload: SU5GTzogQnVpbHQ6IEFwciAgMiAyMDE1IDAwOjMxOjM0Cg==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      text: 'INFO: No telemetry radio found on UARTA, skipping configuration.'
+    module: sbp.logging
+    name: MsgPrint
+  msg_type: '0x10'
+  raw_packet: VRAAwwRBSU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRBLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgoOMw==
+  sbp:
+    crc: '0x330e'
+    length: 65
+    msg_type: '0x10'
+    payload: SU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRBLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgo=
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      text: 'INFO: No telemetry radio found on UARTB, skipping configuration.'
+    module: sbp.logging
+    name: MsgPrint
+  msg_type: '0x10'
+  raw_packet: VRAAwwRBSU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRCLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgqkDA==
+  sbp:
+    crc: '0xca4'
+    length: 65
+    msg_type: '0x10'
+    payload: SU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRCLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgo=
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      text: 'INFO: NAP firmware version: v0.11'
+    module: sbp.logging
+    name: MsgPrint
+  msg_type: '0x10'
+  raw_packet: VRAAwwQiSU5GTzogTkFQIGZpcm13YXJlIHZlcnNpb246IHYwLjExCvN1
+  sbp:
+    crc: '0x75f3'
+    length: 34
+    msg_type: '0x10'
+    payload: SU5GTzogTkFQIGZpcm13YXJlIHZlcnNpb246IHYwLjExCg==
+    preamble: '0x55'
+    sender: '0x4c3'
+version: '0.29'
+...

--- a/spec/tests/yaml/swiftnav/sbp/test_navigation.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_navigation.yaml
@@ -1,1009 +1,1009 @@
 ---
-description: Unit tests for swiftnav.sbp.navigation v0.23.
-generated_on: 2015-03-24 11:31:59.478763
+description: Unit tests for swiftnav.sbp.navigation v0.29.
+generated_on: 2015-04-12 20:15:47.325309
 package: sbp.navigation
 tests:
 
 - msg:
     fields:
       flags: 0
-      ns: 130676
-      tow: 416205300
-      wn: 1836
+      ns: -224401
+      tow: 407084500
+      wn: 1838
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
-  raw_packet: VQABzAQLLAf0yc4YdP4BAAACjQ==
+  raw_packet: VQABwwQLLgfUnUMYb5P8/wDXvg==
   sbp:
-    crc: '0x8d02'
+    crc: '0xbed7'
     length: 11
     msg_type: '0x100'
-    payload: LAf0yc4YdP4BAAA=
+    payload: LgfUnUMYb5P8/wA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
-      ns: -130616
-      tow: 416205400
-      wn: 1836
+      ns: 223085
+      tow: 407084600
+      wn: 1838
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
-  raw_packet: VQABzAQLLAdYys4YyAH+/wADyg==
+  raw_packet: VQABwwQLLgc4nkMYbWcDAACGWQ==
   sbp:
-    crc: '0xca03'
+    crc: '0x5986'
     length: 11
     msg_type: '0x100'
-    payload: LAdYys4YyAH+/wA=
+    payload: Lgc4nkMYbWcDAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
-      ns: 107849
-      tow: 416205500
-      wn: 1836
+      ns: -222999
+      tow: 407084700
+      wn: 1838
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
-  raw_packet: VQABzAQLLAe8ys4YSaUBAADhdQ==
+  raw_packet: VQABwwQLLgecnkMY6Zj8/wDO8Q==
   sbp:
-    crc: '0x75e1'
+    crc: '0xf1ce'
     length: 11
     msg_type: '0x100'
-    payload: LAe8ys4YSaUBAAA=
+    payload: LgecnkMY6Zj8/wA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
-      ns: -107738
-      tow: 416205600
-      wn: 1836
+      ns: 236272
+      tow: 407084800
+      wn: 1838
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
-  raw_packet: VQABzAQLLAcgy84YJlv+/wDA5g==
+  raw_packet: VQABwwQLLgcAn0MY8JoDAACTYg==
   sbp:
-    crc: '0xe6c0'
+    crc: '0x6293'
     length: 11
     msg_type: '0x100'
-    payload: LAcgy84YJlv+/wA=
+    payload: LgcAn0MY8JoDAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
-      ns: 107941
-      tow: 416205700
-      wn: 1836
+      ns: -236144
+      tow: 407084900
+      wn: 1838
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
-  raw_packet: VQABzAQLLAeEy84YpaUBAADoXw==
+  raw_packet: VQABwwQLLgdkn0MYkGX8/wC6mA==
   sbp:
-    crc: '0x5fe8'
+    crc: '0x98ba'
     length: 11
     msg_type: '0x100'
-    payload: LAeEy84YpaUBAAA=
+    payload: Lgdkn0MYkGX8/wA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
-      ns: -376443
-      tow: 416271985
-      wn: 1836
+      ns: -334131
+      tow: 407151150
+      wn: 1838
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
-  raw_packet: VQABzAQLLAdxzs8YhUH6/wBhmg==
+  raw_packet: VQABwwQLLgcuokQYzeb6/wAL4Q==
   sbp:
-    crc: '0x9a61'
+    crc: '0xe10b'
     length: 11
     msg_type: '0x100'
-    payload: LAdxzs8YhUH6/wA=
+    payload: LgcuokQYzeb6/wA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205300
-      x: -2704370.23071671
-      y: -4263209.768852571
-      z: 3884632.160476233
+      tow: 407084500
+      x: -2704376.0110433814
+      y: -4263209.753232954
+      z: 3884633.142084079
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
-  raw_packet: VQACzAQg9MnOGAogiB35oUTBauE0cUpDUME2fIoULKNNQQAACACt5Q==
+  raw_packet: VQACwwQg1J1DGJneaQH8oUTB/vc0cEpDUMGkzy+SLKNNQQAACACRBA==
   sbp:
-    crc: '0xe5ad'
+    crc: '0x491'
     length: 32
     msg_type: '0x200'
-    payload: 9MnOGAogiB35oUTBauE0cUpDUME2fIoULKNNQQAACAA=
+    payload: 1J1DGJneaQH8oUTB/vc0cEpDUMGkzy+SLKNNQQAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205400
-      x: -2704370.231990972
-      y: -4263209.238942821
-      z: 3884632.515552627
+      tow: 407084600
+      x: -2704375.9287024545
+      y: -4263208.610442672
+      z: 3884632.627157578
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
-  raw_packet: VQACzAQgWMrOGFPhsR35oUTB1NZKT0pDUMHkoP1BLKNNQQAACAAiMA==
+  raw_packet: VQACwwQgOJ5DGNe43/b7oUTBJH4RJ0pDUMETs0ZQLKNNQQAACAD1Qg==
   sbp:
-    crc: '0x3022'
+    crc: '0x42f5'
     length: 32
     msg_type: '0x200'
-    payload: WMrOGFPhsR35oUTB1NZKT0pDUMHkoP1BLKNNQQAACAA=
+    payload: OJ5DGNe43/b7oUTBJH4RJ0pDUMETs0ZQLKNNQQAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205500
-      x: -2704370.798992603
-      y: -4263208.685579704
-      z: 3884631.6499627293
+      tow: 407084700
+      x: -2704375.162789617
+      y: -4263207.370641668
+      z: 3884631.282421521
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
-  raw_packet: VQACzAQgvMrOGL5jRWb5oUTBsongK0pDUMGN+jHTK6NNQQAACACEnw==
+  raw_packet: VQACwwQgnJ5DGElK1pT7oUTB1Ze410lDUMFuYyakK6NNQQAACAAF3w==
   sbp:
-    crc: '0x9f84'
+    crc: '0xdf05'
     length: 32
     msg_type: '0x200'
-    payload: vMrOGL5jRWb5oUTBsongK0pDUMGN+jHTK6NNQQAACAA=
+    payload: nJ5DGElK1pT7oUTB1Ze410lDUMFuYyakK6NNQQAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205600
-      x: -2704368.695420795
-      y: -4263206.244835725
-      z: 3884630.888898498
+      tow: 407084800
+      x: -2704376.3549937834
+      y: -4263207.965250214
+      z: 3884632.1007095524
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
-  raw_packet: VQACzAQgIMvOGHKMA1n4oUTBdmOrj0lDUMENbcdxK6NNQQAACADcEA==
+  raw_packet: VQACwwQgAJ9DGLFvcC38oUTB1ajG/UlDUMH1DOQMLKNNQQAACACP1A==
   sbp:
-    crc: '0x10dc'
+    crc: '0xd48f'
     length: 32
     msg_type: '0x200'
-    payload: IMvOGHKMA1n4oUTBdmOrj0lDUMENbcdxK6NNQQAACAA=
+    payload: AJ9DGLFvcC38oUTB1ajG/UlDUMH1DOQMLKNNQQAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205700
-      x: -2704368.2897845428
-      y: -4263205.365082516
-      z: 3884630.2962536444
+      tow: 407084900
+      x: -2704375.291287334
+      y: -4263207.314747473
+      z: 3884631.4773294823
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
-  raw_packet: VQACzAQghMvOGO+oFyX4oUTBD4NdV0lDUMGxo+slK6NNQQAACAACyg==
+  raw_packet: VQACwwQgZJ9DGEPnSKX7oUTBltIk1ElDUMHqIRm9K6NNQQAACABG3Q==
   sbp:
-    crc: '0xca02'
+    crc: '0xdd46'
     length: 32
     msg_type: '0x200'
-    payload: hMvOGO+oFyX4oUTBD4NdV0lDUMGxo+slK6NNQQAACAA=
+    payload: ZJ9DGEPnSKX7oUTBltIk1ElDUMHqIRm9K6NNQQAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 5
+      tow: 407151150
+      x: -2704375.68369399
+      y: -4263209.482329298
+      z: 3884635.5118107493
+    module: sbp.navigation
+    name: MsgPosECEF
+  msg_type: '0x200'
+  raw_packet: VQACwwQgLqJEGOBIg9f7oUTBtHveXkpDUMG/A4PBLaNNQQAABQAR3Q==
+  sbp:
+    crc: '0xdd11'
+    length: 32
+    msg_type: '0x200'
+    payload: LqJEGOBIg9f7oUTBtHveXkpDUMG/A4PBLaNNQQAABQA=
+    preamble: '0x55'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 6
-      tow: 416271985
-      x: -2704373.5406212616
-      y: -4263208.295121756
-      z: 3884631.5700485427
+      tow: 407180700
+      x: -6231
+      y: -12186
+      z: 7419
     module: sbp.navigation
-    name: MsgPosECEF
-  msg_type: '0x200'
-  raw_packet: VQACzAQgcc7PGNcTM8X6oUTBXUbjEkpDUMHEWffIK6NNQQAABgAnbA==
+    name: MsgBaselineECEF
+  msg_type: '0x202'
+  raw_packet: VQICwwQUnBVFGKnn//9m0P//+xwAAAAABgCSqA==
   sbp:
-    crc: '0x6c27'
-    length: 32
-    msg_type: '0x200'
-    payload: cc7PGNcTM8X6oUTBXUbjEkpDUMHEWffIK6NNQQAABgA=
+    crc: '0xa892'
+    length: 20
+    msg_type: '0x202'
+    payload: nBVFGKnn//9m0P//+xwAAAAABgA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
-      n_sats: 5
-      tow: 416300100
-      x: -3180
-      y: -5284
-      z: 5345
+      n_sats: 6
+      tow: 407180800
+      x: -6231
+      y: -12185
+      z: 7420
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
-  raw_packet: VQICzAQURDzQGJTz//9c6///4RQAAAAABQDKIw==
+  raw_packet: VQICwwQUABZFGKnn//9n0P///BwAAAAABgAidA==
   sbp:
-    crc: '0x23ca'
+    crc: '0x7422'
     length: 20
     msg_type: '0x202'
-    payload: RDzQGJTz//9c6///4RQAAAAABQA=
+    payload: ABZFGKnn//9n0P///BwAAAAABgA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
-      n_sats: 5
-      tow: 416300200
-      x: -3182
-      y: -5286
-      z: 5355
+      n_sats: 6
+      tow: 407180900
+      x: -8162
+      y: -18496
+      z: 13807
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
-  raw_packet: VQICzAQUqDzQGJLz//9a6///6xQAAAAABQB2Ew==
+  raw_packet: VQICwwQUZBZFGB7g///At///7zUAAAAABgDhDw==
   sbp:
-    crc: '0x1376'
+    crc: '0xfe1'
     length: 20
     msg_type: '0x202'
-    payload: qDzQGJLz//9a6///6xQAAAAABQA=
+    payload: ZBZFGB7g///At///7zUAAAAABgA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
-      n_sats: 5
-      tow: 416300300
-      x: -4147
-      y: -5905
-      z: 6375
+      n_sats: 6
+      tow: 407181000
+      x: -8164
+      y: -18497
+      z: 13810
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
-  raw_packet: VQICzAQUDD3QGM3v///v6P//5xgAAAAABQBrRQ==
+  raw_packet: VQICwwQUyBZFGBzg//+/t///8jUAAAAABgAjZA==
   sbp:
-    crc: '0x456b'
+    crc: '0x6423'
     length: 20
     msg_type: '0x202'
-    payload: DD3QGM3v///v6P//5xgAAAAABQA=
+    payload: yBZFGBzg//+/t///8jUAAAAABgA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
-      n_sats: 5
-      tow: 416300400
-      x: -4145
-      y: -5905
-      z: 6384
+      n_sats: 6
+      tow: 407181100
+      x: -7400
+      y: -15591
+      z: 15257
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
-  raw_packet: VQICzAQUcD3QGM/v///v6P//8BgAAAAABQBDlA==
+  raw_packet: VQICwwQULBdFGBjj//8Zw///mTsAAAAABgBCQg==
   sbp:
-    crc: '0x9443'
+    crc: '0x4242'
     length: 20
     msg_type: '0x202'
-    payload: cD3QGM/v///v6P//8BgAAAAABQA=
+    payload: LBdFGBjj//8Zw///mTsAAAAABgA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
-      n_sats: 5
-      tow: 416300500
-      x: 2500
-      y: -6211
-      z: 9117
+      n_sats: 6
+      tow: 407181200
+      x: -7401
+      y: -15591
+      z: 15257
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
-  raw_packet: VQICzAQU1D3QGMQJAAC95///nSMAAAAABQCjNQ==
+  raw_packet: VQICwwQUkBdFGBfj//8Zw///mTsAAAAABgAjhw==
   sbp:
-    crc: '0x35a3'
+    crc: '0x8723'
     length: 20
     msg_type: '0x202'
-    payload: 1D3QGMQJAAC95///nSMAAAAABQA=
+    payload: kBdFGBfj//8Zw///mTsAAAAABgA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      accuracy: 0
-      flags: 0
-      n_sats: 5
-      tow: 416300600
-      x: 2498
-      y: -6215
-      z: 9130
-    module: sbp.navigation
-    name: MsgBaselineECEF
-  msg_type: '0x202'
-  raw_packet: VQICzAQUOD7QGMIJAAC55///qiMAAAAABQBNYQ==
-  sbp:
-    crc: '0x614d'
-    length: 20
-    msg_type: '0x202'
-    payload: OD7QGMIJAAC55///qiMAAAAABQA=
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      d: -8146
-      e: 145
+      d: -15325
+      e: 1265
       flags: 0
       h_accuracy: 0
-      n: 477
-      n_sats: 5
-      tow: 416300100
+      n: -2430
+      n_sats: 6
+      tow: 407180700
       v_accuracy: 0
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
-  raw_packet: VQMCzAQWRDzQGN0BAACRAAAALuD//wAAAAAFACRG
+  raw_packet: VQMCwwQWnBVFGIL2///xBAAAI8T//wAAAAAGAPoV
   sbp:
-    crc: '0x4624'
+    crc: '0x15fa'
     length: 22
     msg_type: '0x203'
-    payload: RDzQGN0BAACRAAAALuD//wAAAAAFAA==
+    payload: nBVFGIL2///xBAAAI8T//wAAAAAGAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      d: -8154
-      e: 145
+      d: -15325
+      e: 1265
       flags: 0
       h_accuracy: 0
-      n: 482
-      n_sats: 5
-      tow: 416300200
+      n: -2430
+      n_sats: 6
+      tow: 407180800
       v_accuracy: 0
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
-  raw_packet: VQMCzAQWqDzQGOIBAACRAAAAJuD//wAAAAAFAHX2
+  raw_packet: VQMCwwQWABZFGIL2///xBAAAI8T//wAAAAAGAPCF
   sbp:
-    crc: '0xf675'
+    crc: '0x85f0'
     length: 22
     msg_type: '0x203'
-    payload: qDzQGOIBAACRAAAAJuD//wAAAAAFAA==
+    payload: ABZFGIL2///xBAAAI8T//wAAAAAGAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      d: -9600
-      e: -338
+      d: -24263
+      e: 3015
       flags: 0
       h_accuracy: 0
-      n: 657
-      n_sats: 5
-      tow: 416300300
+      n: -1248
+      n_sats: 6
+      tow: 407180900
       v_accuracy: 0
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
-  raw_packet: VQMCzAQWDD3QGJECAACu/v//gNr//wAAAAAFADw4
+  raw_packet: VQMCwwQWZBZFGCD7///HCwAAOaH//wAAAAAGAAy1
   sbp:
-    crc: '0x383c'
+    crc: '0xb50c'
     length: 22
     msg_type: '0x203'
-    payload: DD3QGJECAACu/v//gNr//wAAAAAFAA==
+    payload: ZBZFGCD7///HCwAAOaH//wAAAAAGAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      d: -9604
-      e: -337
+      d: -24266
+      e: 3015
       flags: 0
       h_accuracy: 0
-      n: 665
-      n_sats: 5
-      tow: 416300400
+      n: -1247
+      n_sats: 6
+      tow: 407181000
       v_accuracy: 0
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
-  raw_packet: VQMCzAQWcD3QGJkCAACv/v//fNr//wAAAAAFAKqV
+  raw_packet: VQMCwwQWyBZFGCH7///HCwAANqH//wAAAAAGAFY6
   sbp:
-    crc: '0x95aa'
+    crc: '0x3a56'
     length: 22
     msg_type: '0x203'
-    payload: cD3QGJkCAACv/v//fNr//wAAAAAFAA==
+    payload: yBZFGCH7///HCwAANqH//wAAAAAGAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      d: -8655
-      e: 5438
+      d: -22880
+      e: 2103
       flags: 0
       h_accuracy: 0
-      n: 4844
-      n_sats: 5
-      tow: 416300500
+      n: 1646
+      n_sats: 6
+      tow: 407181100
       v_accuracy: 0
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
-  raw_packet: VQMCzAQW1D3QGOwSAAA+FQAAMd7//wAAAAAFAMMO
+  raw_packet: VQMCwwQWLBdFGG4GAAA3CAAAoKb//wAAAAAGADP5
   sbp:
-    crc: '0xec3'
+    crc: '0xf933'
     length: 22
     msg_type: '0x203'
-    payload: 1D3QGOwSAAA+FQAAMd7//wAAAAAFAA==
+    payload: LBdFGG4GAAA3CAAAoKb//wAAAAAGAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      d: -8667
-      e: 5438
+      d: -22880
+      e: 2102
       flags: 0
       h_accuracy: 0
-      n: 4852
-      n_sats: 5
-      tow: 416300600
+      n: 1646
+      n_sats: 6
+      tow: 407181200
       v_accuracy: 0
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
-  raw_packet: VQMCzAQWOD7QGPQSAAA+FQAAJd7//wAAAAAFAEum
+  raw_packet: VQMCwwQWkBdFGG4GAAA2CAAAoKb//wAAAAAGAM4W
   sbp:
-    crc: '0xa64b'
+    crc: '0x16ce'
     length: 22
     msg_type: '0x203'
-    payload: OD7QGPQSAAA+FQAAJd7//wAAAAAFAA==
+    payload: kBdFGG4GAAA2CAAAoKb//wAAAAAGAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205300
+      tow: 407084500
+      x: 24
+      y: -11
+      z: -37
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_packet: VQQCwwQU1J1DGBgAAAD1////2////wAACABE/w==
+  sbp:
+    crc: '0xff44'
+    length: 20
+    msg_type: '0x204'
+    payload: 1J1DGBgAAAD1////2////wAACAA=
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 8
+      tow: 407084600
       x: 4
-      y: -43
-      z: 12
+      y: -22
+      z: 18
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
-  raw_packet: VQQCzAQU9MnOGAQAAADV////DAAAAAAACAB4Mw==
+  raw_packet: VQQCwwQUOJ5DGAQAAADq////EgAAAAAACADWiA==
   sbp:
-    crc: '0x3378'
+    crc: '0x88d6'
     length: 20
     msg_type: '0x204'
-    payload: 9MnOGAQAAADV////DAAAAAAACAA=
+    payload: OJ5DGAQAAADq////EgAAAAAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205400
-      x: 20
-      y: 37
-      z: 12
-    module: sbp.navigation
-    name: MsgVelECEF
-  msg_type: '0x204'
-  raw_packet: VQQCzAQUWMrOGBQAAAAlAAAADAAAAAAACAB5ww==
-  sbp:
-    crc: '0xc379'
-    length: 20
-    msg_type: '0x204'
-    payload: WMrOGBQAAAAlAAAADAAAAAAACAA=
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      accuracy: 0
-      flags: 0
-      n_sats: 8
-      tow: 416205500
-      x: -21
-      y: -6
-      z: -50
-    module: sbp.navigation
-    name: MsgVelECEF
-  msg_type: '0x204'
-  raw_packet: VQQCzAQUvMrOGOv////6////zv///wAACAAT8w==
-  sbp:
-    crc: '0xf313'
-    length: 20
-    msg_type: '0x204'
-    payload: vMrOGOv////6////zv///wAACAA=
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      accuracy: 0
-      flags: 0
-      n_sats: 8
-      tow: 416205600
-      x: 2
+      tow: 407084700
+      x: -26
       y: 4
-      z: 19
+      z: 1
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
-  raw_packet: VQQCzAQUIMvOGAIAAAAEAAAAEwAAAAAACABVyg==
+  raw_packet: VQQCwwQUnJ5DGOb///8EAAAAAQAAAAAACAB6nw==
   sbp:
-    crc: '0xca55'
+    crc: '0x9f7a'
     length: 20
     msg_type: '0x204'
-    payload: IMvOGAIAAAAEAAAAEwAAAAAACAA=
+    payload: nJ5DGOb///8EAAAAAQAAAAAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
       n_sats: 8
-      tow: 416205700
-      x: -16
-      y: -61
-      z: 30
+      tow: 407084800
+      x: -9
+      y: -19
+      z: 28
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
-  raw_packet: VQQCzAQUhMvOGPD////D////HgAAAAAACAArKw==
+  raw_packet: VQQCwwQUAJ9DGPf////t////HAAAAAAACADokg==
   sbp:
-    crc: '0x2b2b'
+    crc: '0x92e8'
     length: 20
     msg_type: '0x204'
-    payload: hMvOGPD////D////HgAAAAAACAA=
+    payload: AJ9DGPf////t////HAAAAAAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       accuracy: 0
       flags: 0
-      n_sats: 6
-      tow: 416271985
-      x: 16
-      y: 19
-      z: -21
+      n_sats: 8
+      tow: 407084900
+      x: -1
+      y: 2
+      z: -11
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
-  raw_packet: VQQCzAQUcc7PGBAAAAATAAAA6////wAABgCoyA==
+  raw_packet: VQQCwwQUZJ9DGP////8CAAAA9f///wAACACr7g==
   sbp:
-    crc: '0xc8a8'
+    crc: '0xeeab'
     length: 20
     msg_type: '0x204'
-    payload: cc7PGBAAAAATAAAA6////wAABgA=
+    payload: ZJ9DGP////8CAAAA9f///wAACAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 5
+      tow: 407151150
+      x: -49
+      y: -71
+      z: 65
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_packet: VQQCwwQULqJEGM////+5////QQAAAAAABQBSmg==
+  sbp:
+    crc: '0x9a52'
+    length: 20
+    msg_type: '0x204'
+    payload: LqJEGM////+5////QQAAAAAABQA=
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      d: 25
+      e: 26
+      flags: 0
+      h_accuracy: 0
+      n: -27
+      n_sats: 8
+      tow: 407084500
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_packet: VQUCwwQW1J1DGOX///8aAAAAGQAAAAAAAAAIAIQZ
+  sbp:
+    crc: '0x1984'
+    length: 22
+    msg_type: '0x205'
+    payload: 1J1DGOX///8aAAAAGQAAAAAAAAAIAA==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      d: -24
+      e: 15
+      flags: 0
+      h_accuracy: 0
+      n: 4
+      n_sats: 8
+      tow: 407084600
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_packet: VQUCwwQWOJ5DGAQAAAAPAAAA6P///wAAAAAIACoO
+  sbp:
+    crc: '0xe2a'
+    length: 22
+    msg_type: '0x205'
+    payload: OJ5DGAQAAAAPAAAA6P///wAAAAAIAA==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      d: -9
+      e: -24
+      flags: 0
+      h_accuracy: 0
+      n: -5
+      n_sats: 8
+      tow: 407084700
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_packet: VQUCwwQWnJ5DGPv////o////9////wAAAAAIANqU
+  sbp:
+    crc: '0x94da'
+    length: 22
+    msg_type: '0x205'
+    payload: nJ5DGPv////o////9////wAAAAAIAA==
+    preamble: '0x55'
+    sender: '0x4c3'
 
 - msg:
     fields:
       d: -34
-      e: 26
+      e: 2
       flags: 0
       h_accuracy: 0
-      n: -11
+      n: 10
       n_sats: 8
-      tow: 416205300
+      tow: 407084800
       v_accuracy: 0
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
-  raw_packet: VQUCzAQW9MnOGPX///8aAAAA3v///wAAAAAIAPO1
+  raw_packet: VQUCwwQWAJ9DGAoAAAACAAAA3v///wAAAAAIAJQQ
   sbp:
-    crc: '0xb5f3'
+    crc: '0x1094'
     length: 22
     msg_type: '0x205'
-    payload: 9MnOGPX///8aAAAA3v///wAAAAAIAA==
+    payload: AJ9DGAoAAAACAAAA3v///wAAAAAIAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      d: 26
+      d: 7
+      e: -2
+      flags: 0
+      h_accuracy: 0
+      n: -8
+      n_sats: 8
+      tow: 407084900
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_packet: VQUCwwQWZJ9DGPj////+////BwAAAAAAAAAIAP/s
+  sbp:
+    crc: '0xecff'
+    length: 22
+    msg_type: '0x205'
+    payload: ZJ9DGPj////+////BwAAAAAAAAAIAA==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      d: -108
       e: -3
       flags: 0
       h_accuracy: 0
-      n: 34
-      n_sats: 8
-      tow: 416205400
-      v_accuracy: 0
-    module: sbp.navigation
-    name: MsgVelNED
-  msg_type: '0x205'
-  raw_packet: VQUCzAQWWMrOGCIAAAD9////GgAAAAAAAAAIABRf
-  sbp:
-    crc: '0x5f14'
-    length: 22
-    msg_type: '0x205'
-    payload: WMrOGCIAAAD9////GgAAAAAAAAAIAA==
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      d: 18
-      e: -15
-      flags: 0
-      h_accuracy: 0
-      n: -49
-      n_sats: 8
-      tow: 416205500
-      v_accuracy: 0
-    module: sbp.navigation
-    name: MsgVelNED
-  msg_type: '0x205'
-  raw_packet: VQUCzAQWvMrOGM/////x////EgAAAAAAAAAIAK+M
-  sbp:
-    crc: '0x8caf'
-    length: 22
-    msg_type: '0x205'
-    payload: vMrOGM/////x////EgAAAAAAAAAIAA==
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      d: -8
-      e: -1
-      flags: 0
-      h_accuracy: 0
-      n: 18
-      n_sats: 8
-      tow: 416205600
-      v_accuracy: 0
-    module: sbp.navigation
-    name: MsgVelNED
-  msg_type: '0x205'
-  raw_packet: VQUCzAQWIMvOGBIAAAD/////+P///wAAAAAIALjr
-  sbp:
-    crc: '0xebb8'
-    length: 22
-    msg_type: '0x205'
-    payload: IMvOGBIAAAD/////+P///wAAAAAIAA==
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      d: -66
-      e: 19
-      flags: 0
-      h_accuracy: 0
-      n: -13
-      n_sats: 8
-      tow: 416205700
-      v_accuracy: 0
-    module: sbp.navigation
-    name: MsgVelNED
-  msg_type: '0x205'
-  raw_packet: VQUCzAQWhMvOGPP///8TAAAAvv///wAAAAAIAHbX
-  sbp:
-    crc: '0xd776'
-    length: 22
-    msg_type: '0x205'
-    payload: hMvOGPP///8TAAAAvv///wAAAAAIAA==
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      d: 32
-      e: 3
-      flags: 0
-      h_accuracy: 0
       n: -1
-      n_sats: 6
-      tow: 416271985
+      n_sats: 5
+      tow: 407151150
       v_accuracy: 0
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
-  raw_packet: VQUCzAQWcc7PGP////8DAAAAIAAAAAAAAAAGAFAy
+  raw_packet: VQUCwwQWLqJEGP/////9////lP///wAAAAAFAKa9
   sbp:
-    crc: '0x3250'
+    crc: '0xbda6'
     length: 22
     msg_type: '0x205'
-    payload: cc7PGP////8DAAAAIAAAAAAAAAAGAA==
+    payload: LqJEGP/////9////lP///wAAAAAFAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      gdop: 247
+      hdop: 273
+      pdop: 215
+      tdop: 123
+      tow: 407084500
+      vdop: 44
+    module: sbp.navigation
+    name: MsgDops
+  msg_type: '0x206'
+  raw_packet: VQYCwwQO1J1DGPcA1wB7ABEBLADOFQ==
+  sbp:
+    crc: '0x15ce'
+    length: 14
+    msg_type: '0x206'
+    payload: 1J1DGPcA1wB7ABEBLAA=
+    preamble: '0x55'
+    sender: '0x4c3'
 
 - msg:
     fields:
       gdop: 65535
       hdop: 0
       pdop: 65535
-      tdop: 64519
-      tow: 4294967292
+      tdop: 0
+      tow: 0
       vdop: 0
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
-  raw_packet: VQYCzAQO/P////////8H/AAAAAAgJQ==
+  raw_packet: VQYCwwQOAAAAAP////8AAAAAAACSDA==
   sbp:
-    crc: '0x2520'
+    crc: '0xc92'
     length: 14
     msg_type: '0x206'
-    payload: /P////////8H/AAAAAA=
+    payload: AAAAAP////8AAAAAAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      gdop: 269
-      hdop: 340
-      pdop: 243
-      tdop: 114
-      tow: 416272900
-      vdop: 73
+      gdop: 348
+      hdop: 637
+      pdop: 312
+      tdop: 155
+      tow: 407152000
+      vdop: 113
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
-  raw_packet: VQYCzAQOBNLPGA0B8wByAFQBSQCvIw==
+  raw_packet: VQYCwwQOgKVEGFwBOAGbAH0CcQCBXQ==
   sbp:
-    crc: '0x23af'
+    crc: '0x5d81'
     length: 14
     msg_type: '0x206'
-    payload: BNLPGA0B8wByAFQBSQA=
+    payload: gKVEGFwBOAGbAH0CcQA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      gdop: 269
-      hdop: 340
-      pdop: 243
-      tdop: 114
-      tow: 416273900
-      vdop: 73
+      gdop: 348
+      hdop: 637
+      pdop: 311
+      tdop: 155
+      tow: 407153000
+      vdop: 113
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
-  raw_packet: VQYCzAQO7NXPGA0B8wByAFQBSQDC4w==
+  raw_packet: VQYCwwQOaKlEGFwBNwGbAH0CcQDRgA==
   sbp:
-    crc: '0xe3c2'
+    crc: '0x80d1'
     length: 14
     msg_type: '0x206'
-    payload: 7NXPGA0B8wByAFQBSQA=
+    payload: aKlEGFwBNwGbAH0CcQA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      gdop: 269
-      hdop: 340
-      pdop: 243
-      tdop: 114
-      tow: 416274900
-      vdop: 73
+      gdop: 348
+      hdop: 637
+      pdop: 311
+      tdop: 155
+      tow: 407154000
+      vdop: 112
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
-  raw_packet: VQYCzAQO1NnPGA0B8wByAFQBSQBmXQ==
+  raw_packet: VQYCwwQOUK1EGFwBNwGbAH0CcAAeBg==
   sbp:
-    crc: '0x5d66'
+    crc: '0x61e'
     length: 14
     msg_type: '0x206'
-    payload: 1NnPGA0B8wByAFQBSQA=
+    payload: UK1EGFwBNwGbAH0CcAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      gdop: 269
-      hdop: 339
-      pdop: 243
-      tdop: 114
-      tow: 416275900
-      vdop: 73
+      gdop: 348
+      hdop: 637
+      pdop: 311
+      tdop: 155
+      tow: 407155000
+      vdop: 112
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
-  raw_packet: VQYCzAQOvN3PGA0B8wByAFMBSQD9VA==
+  raw_packet: VQYCwwQOOLFEGFwBNwGbAH0CcABGQw==
   sbp:
-    crc: '0x54fd'
+    crc: '0x4346'
     length: 14
     msg_type: '0x206'
-    payload: vN3PGA0B8wByAFMBSQA=
+    payload: OLFEGFwBNwGbAH0CcAA=
     preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields:
-      gdop: 269
-      hdop: 339
-      pdop: 243
-      tdop: 114
-      tow: 416276900
-      vdop: 73
-    module: sbp.navigation
-    name: MsgDops
-  msg_type: '0x206'
-  raw_packet: VQYCzAQOpOHPGA0B8wByAFMBSQBKTA==
-  sbp:
-    crc: '0x4c4a'
-    length: 14
-    msg_type: '0x206'
-    payload: pOHPGA0B8wByAFMBSQA=
-    preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
       h_accuracy: 0
-      height: 1.0012943775156375
-      lat: 37.76243173344967
-      lon: -122.38902888953618
+      height: 4.039810885214956
+      lat: 37.76242171418386
+      lon: -122.38908437889262
       n_sats: 8
-      tow: 416205300
+      tow: 407084500
       v_accuracy: 0
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
-  raw_packet: VQECzAQi9MnOGKlM8FyX4UJAdHBt2eWYXsDOktFATQXwPwAAAAAIAFSJ
+  raw_packet: VQECwwQi1J1DGAgX5AiX4UJAnK4qwuaYXsCZF0gvxCgQQAAAAAAIAO2p
   sbp:
-    crc: '0x8954'
+    crc: '0xa9ed'
     length: 34
     msg_type: '0x201'
-    payload: 9MnOGKlM8FyX4UJAdHBt2eWYXsDOktFATQXwPwAAAAAIAA==
+    payload: 1J1DGAgX5AiX4UJAnK4qwuaYXsCZF0gvxCgQQAAAAAAIAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
       h_accuracy: 0
-      height: 0.8655268744638001
-      lat: 37.76243672765506
-      lon: -122.3890321231515
+      height: 2.926714087009657
+      lat: 37.76242361423985
+      lon: -122.38909053700489
       n_sats: 8
-      tow: 416205400
+      tow: 407084600
       v_accuracy: 0
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
-  raw_packet: VQECzAQiWMrOGBxG1YaX4UJA3YH95uWYXsAgMnRqZbLrPwAAAAAIADHn
+  raw_packet: VQECwwQiOJ5DGNxt1BiX4UJAn+f+2+aYXsCAl0MT6WkHQAAAAAAIAJgL
   sbp:
-    crc: '0xe731'
+    crc: '0xb98'
     length: 34
     msg_type: '0x201'
-    payload: WMrOGBxG1YaX4UJA3YH95uWYXsAgMnRqZbLrPwAAAAAIAA==
+    payload: OJ5DGNxt1BiX4UJAn+f+2+aYXsCAl0MT6WkHQAAAAAAIAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
       h_accuracy: 0
-      height: 0.20615086902140606
-      lat: 37.76243146475766
-      lon: -122.38904092086298
+      height: 0.9512146647395566
+      lat: 37.762422076126406
+      lon: -122.3890907340148
       n_sats: 8
-      tow: 416205500
+      tow: 407084700
       v_accuracy: 0
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
-  raw_packet: VQECzAQivMrOGKtJr1qX4UJAYvrjC+aYXsDilD7UJmPKPwAAAAAIAErr
+  raw_packet: VQECwwQinJ5DGA1b7QuX4UJAS3HS3OaYXsAlBpG8WXDuPwAAAAAIAN2b
   sbp:
-    crc: '0xeb4a'
+    crc: '0x9bdd'
     length: 34
     msg_type: '0x201'
-    payload: vMrOGKtJr1qX4UJAYvrjC+aYXsDilD7UJmPKPwAAAAAIAA==
+    payload: nJ5DGA1b7QuX4UJAS3HS3OaYXsAlBpG8WXDuPwAAAAAIAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
       h_accuracy: 0
-      height: -2.7800915061277087
-      lat: 37.762443632655156
-      lon: -122.38903559942881
+      height: 2.354135752047538
+      lat: 37.762421610632735
+      lon: -122.38909854449612
       n_sats: 8
-      tow: 416205600
+      tow: 407084800
       v_accuracy: 0
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
-  raw_packet: VQECzAQiIMvOGA+mwcCX4UJAsiGS9eWYXsCrpZWdoD0GwAAAAAAIAJG3
+  raw_packet: VQECwwQiAJ9DGDO3BQiX4UJADeKU/eaYXsC7GwsgRdUCQAAAAAAIAFJe
   sbp:
-    crc: '0xb791'
+    crc: '0x5e52'
     length: 34
     msg_type: '0x201'
-    payload: IMvOGA+mwcCX4UJAsiGS9eWYXsCrpZWdoD0GwAAAAAAIAA==
+    payload: AJ9DGDO3BQiX4UJADeKU/eaYXsC7GwsgRdUCQAAAAAAIAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
       h_accuracy: 0
-      height: -3.9020938562345213
-      lat: 37.76244470914511
-      lon: -122.38903706026538
+      height: 1.0876763181642641
+      lat: 37.76242334502801
+      lon: -122.38909230523223
       n_sats: 8
-      tow: 416205700
+      tow: 407084900
       v_accuracy: 0
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
-  raw_packet: VQECzAQihMvOGKtkycmX4UJAZbGy++WYXsAumdP7fDcPwAAAAAAIAIa8
+  raw_packet: VQECwwQiZJ9DGBZNkhaX4UJAQIZp4+aYXsAlY3JIH2fxPwAAAAAIAEY8
   sbp:
-    crc: '0xbc86'
+    crc: '0x3c46'
     length: 34
     msg_type: '0x201'
-    payload: hMvOGKtkycmX4UJAZbGy++WYXsAumdP7fDcPwAAAAAAIAA==
+    payload: ZJ9DGBZNkhaX4UJAQIZp4+aYXsAlY3JIH2fxPwAAAAAIAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
       h_accuracy: 0
-      height: 1.057562688832796
-      lat: 37.76242461187733
-      lon: -122.3890695682817
-      n_sats: 6
-      tow: 416271985
+      height: 5.171533844654222
+      lat: 37.76244082253376
+      lon: -122.38908288868525
+      n_sats: 5
+      tow: 407151150
       v_accuracy: 0
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
-  raw_packet: VQECzAQicc7PGN3WMiGX4UJA4egLhOaYXsBgG6DaxuvwPwAAAAAGAK4U
+  raw_packet: VQECwwQiLqJEGHz1LqmX4UJAh5Xqu+aYXsDCyXORpq8UQAAAAAAFANR5
   sbp:
-    crc: '0x14ae'
+    crc: '0x79d4'
     length: 34
     msg_type: '0x201'
-    payload: cc7PGN3WMiGX4UJA4egLhOaYXsBgG6DaxuvwPwAAAAAGAA==
+    payload: LqJEGHz1LqmX4UJAh5Xqu+aYXsDCyXORpq8UQAAAAAAFAA==
     preamble: '0x55'
-    sender: '0x4cc'
-version: '0.23'
+    sender: '0x4c3'
+version: '0.29'
 ...

--- a/spec/tests/yaml/swiftnav/sbp/test_observation.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_observation.yaml
@@ -1,369 +1,309 @@
 ---
-description: Unit tests for swiftnav.sbp.observation v0.23.
-generated_on: 2015-03-24 11:31:59.766910
+description: Unit tests for swiftnav.sbp.observation v0.29.
+generated_on: 2015-04-12 20:15:47.093026
 package: sbp.observation
 tests:
 
 - msg:
     fields:
       header:
-        ObservationHeader:
-          n_obs: 32
-          t:
-            ObsGPSTime:
-              tow: 416205400
-              wn: 1836
+        n_obs: 32
+        t:
+          tow: 407084600
+          wn: 1838
       obs:
-        PackedObsContent:
-        - L:
-            CarrierPhase:
-              f: 174
-              i: -235696
-          P: 2231495077
-          cn0: 21
-          lock: 38768
-          prn: 0
-        - L:
-            CarrierPhase:
-              f: 19
-              i: 13563
-          P: 1869850003
-          cn0: 25
-          lock: 21056
-          prn: 2
-        - L:
-            CarrierPhase:
-              f: 103
-              i: 106804
-          P: 2298000000
-          cn0: 17
-          lock: 54429
-          prn: 5
-        - L:
-            CarrierPhase:
-              f: 117
-              i: 129163
-          P: 2179721960
-          cn0: 26
-          lock: 37300
-          prn: 8
-        - L:
-            CarrierPhase:
-              f: 121
-              i: 224769
-          P: 2082264686
-          cn0: 26
-          lock: 7258
-          prn: 15
-        - L:
-            CarrierPhase:
-              f: 26
-              i: 131900
-          P: 1993973655
-          cn0: 46
-          lock: 54534
-          prn: 22
-        - L:
-            CarrierPhase:
-              f: 219
-              i: -235729
-          P: 2194259129
-          cn0: 27
-          lock: 64155
-          prn: 30
+      - L:
+          f: 33
+          i: -36108
+        P: 2046421816
+        cn0: 46
+        lock: 55875
+        prn: 0
+      - L:
+          f: 98
+          i: 203030
+        P: 2085014510
+        cn0: 43
+        lock: 40376
+        prn: 2
+      - L:
+          f: 185
+          i: -178306
+        P: 2110096816
+        cn0: 39
+        lock: 14148
+        prn: 3
+      - L:
+          f: 139
+          i: -137374
+        P: 2208476476
+        cn0: 30
+        lock: 4129
+        prn: 10
+      - L:
+          f: 40
+          i: -167638
+        P: 2298000000
+        cn0: 20
+        lock: 18218
+        prn: 13
+      - L:
+          f: 64
+          i: 209919
+        P: 2266101494
+        cn0: 27
+        lock: 63852
+        prn: 22
+      - L:
+          f: 31
+          i: -53117
+        P: 1987193298
+        cn0: 52
+        lock: 15074
+        prn: 30
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
-  raw_packet: VUUAzARiWMrOGCwHIKXpAYVQZ/z/rhVwlwCTpXNv+zQAABMZQFICgLL4iDShAQBnEZ3UBejq64GL+AEAdRq0kQhu1hx8AW4DAHkaWhwPl5/ZdjwDAgAaLgbVFrm8yYIvZ/z/2xub+h4ucA==
+  raw_packet: VUUAwwRiOJ5DGC4HIDjr+Xn0cv//IS5D2gDuy0Z8FhkDAGIruJ0CsIXFfX5H/f+5J0Q3AzytooNi5/3/ix4hEAqAsviIKnH9/ygUKkcN9vYRh/8zAwBAG2z5FtIpcnaDMP//HzTiOh4X2Q==
   sbp:
-    crc: '0x702e'
+    crc: '0xd917'
     length: 98
     msg_type: '0x45'
-    payload: WMrOGCwHIKXpAYVQZ/z/rhVwlwCTpXNv+zQAABMZQFICgLL4iDShAQBnEZ3UBejq64GL+AEAdRq0kQhu1hx8AW4DAHkaWhwPl5/ZdjwDAgAaLgbVFrm8yYIvZ/z/2xub+h4=
+    payload: OJ5DGC4HIDjr+Xn0cv//IS5D2gDuy0Z8FhkDAGIruJ0CsIXFfX5H/f+5J0Q3AzytooNi5/3/ix4hEAqAsviIKnH9/ygUKkcN9vYRh/8zAwBAG2z5FtIpcnaDMP//HzTiOh4=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       header:
-        ObservationHeader:
-          n_obs: 33
-          t:
-            ObsGPSTime:
-              tow: 416205400
-              wn: 1836
+        n_obs: 33
+        t:
+          tow: 407084600
+          wn: 1838
       obs:
-        PackedObsContent:
-        - L:
-            CarrierPhase:
-              f: 156
-              i: -183560
-          P: 2074245293
-          cn0: 29
-          lock: 53285
-          prn: 31
+      - L:
+          f: 147
+          i: 8294
+        P: 1973695572
+        cn0: 62
+        lock: 64062
+        prn: 31
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
-  raw_packet: VUUAzAQUWMrOGCwHIa14onv4Mv3/nB0l0B/KDw==
+  raw_packet: VUUAwwQUOJ5DGC4HIVQ0pHVmIAAAkz4++h/qDg==
   sbp:
-    crc: '0xfca'
+    crc: '0xeea'
     length: 20
     msg_type: '0x45'
-    payload: WMrOGCwHIa14onv4Mv3/nB0l0B8=
+    payload: OJ5DGC4HIVQ0pHVmIAAAkz4++h8=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       header:
-        ObservationHeader:
-          n_obs: 32
-          t:
-            ObsGPSTime:
-              tow: 416205600
-              wn: 1836
+        n_obs: 32
+        t:
+          tow: 407084800
+          wn: 1838
       obs:
-        PackedObsContent:
-        - L:
-            CarrierPhase:
-              f: 242
-              i: -236295
-          P: 2231513016
-          cn0: 20
-          lock: 38768
-          prn: 0
-        - L:
-            CarrierPhase:
-              f: 210
-              i: 13594
-          P: 1869856131
-          cn0: 26
-          lock: 21056
-          prn: 2
-        - L:
-            CarrierPhase:
-              f: 183
-              i: 107132
-          P: 2298000000
-          cn0: 19
-          lock: 54429
-          prn: 5
-        - L:
-            CarrierPhase:
-              f: 215
-              i: 129687
-          P: 2179718442
-          cn0: 26
-          lock: 37300
-          prn: 8
-        - L:
-            CarrierPhase:
-              f: 132
-              i: 225342
-          P: 2082260424
-          cn0: 27
-          lock: 7258
-          prn: 15
-        - L:
-            CarrierPhase:
-              f: 3
-              i: 132239
-          P: 1993973752
-          cn0: 49
-          lock: 54534
-          prn: 22
-        - L:
-            CarrierPhase:
-              f: 225
-              i: -236348
-          P: 2194277408
-          cn0: 26
-          lock: 64155
-          prn: 30
+      - L:
+          f: 141
+          i: -36207
+        P: 2046415136
+        cn0: 45
+        lock: 55875
+        prn: 0
+      - L:
+          f: 159
+          i: 203599
+        P: 2084995249
+        cn0: 44
+        lock: 40376
+        prn: 2
+      - L:
+          f: 77
+          i: -178769
+        P: 2110097211
+        cn0: 40
+        lock: 14148
+        prn: 3
+      - L:
+          f: 20
+          i: -137807
+        P: 2208476371
+        cn0: 31
+        lock: 4129
+        prn: 10
+      - L:
+          f: 94
+          i: -168076
+        P: 2298000000
+        cn0: 21
+        lock: 18218
+        prn: 13
+      - L:
+          f: 214
+          i: 210469
+        P: 2266082742
+        cn0: 27
+        lock: 63852
+        prn: 22
+      - L:
+          f: 129
+          i: -53264
+        P: 1987187803
+        cn0: 52
+        lock: 15074
+        prn: 30
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
-  raw_packet: VUUAzARiIMvOGCwHILgvAoX5ZPz/8hRwlwCDvXNvGjUAANIaQFICgLL4iHyiAQC3E53UBSrd64GX+gEA1xq0kQjIxRx8PnADAIQbWhwP+J/Zdo8EAgADMQbVFiAEyoLEZPz/4Rqb+h6sFg==
+  raw_packet: VUUAwwRiAJ9DGC4HICDR+XmRcv//jS1D2gCxgEZ8TxsDAJ8suJ0CO4fFfa9F/f9NKEQ3A9OsooOx5f3/FB8hEAqAsviIdG/9/14VKkcNtq0RhyU2AwDWG2z5FlsUcnbwL///gTTiOh7Idw==
   sbp:
-    crc: '0x16ac'
+    crc: '0x77c8'
     length: 98
     msg_type: '0x45'
-    payload: IMvOGCwHILgvAoX5ZPz/8hRwlwCDvXNvGjUAANIaQFICgLL4iHyiAQC3E53UBSrd64GX+gEA1xq0kQjIxRx8PnADAIQbWhwP+J/Zdo8EAgADMQbVFiAEyoLEZPz/4Rqb+h4=
+    payload: AJ9DGC4HICDR+XmRcv//jS1D2gCxgEZ8TxsDAJ8suJ0CO4fFfa9F/f9NKEQ3A9OsooOx5f3/FB8hEAqAsviIdG/9/14VKkcNtq0RhyU2AwDWG2z5FlsUcnbwL///gTTiOh4=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       header:
-        ObservationHeader:
-          n_obs: 33
-          t:
-            ObsGPSTime:
-              tow: 416205600
-              wn: 1836
+        n_obs: 33
+        t:
+          tow: 407084800
+          wn: 1838
       obs:
-        PackedObsContent:
-        - L:
-            CarrierPhase:
-              f: 211
-              i: -184045
-          P: 2074260983
-          cn0: 28
-          lock: 53285
-          prn: 31
+      - L:
+          f: 222
+          i: 8312
+        P: 1973687089
+        cn0: 63
+        lock: 64062
+        prn: 31
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
-  raw_packet: VUUAzAQUIMvOGCwHIfe1onsTMf3/0xwl0B+YSg==
+  raw_packet: VUUAwwQUAJ9DGC4HITETpHV4IAAA3j8++h8L5w==
   sbp:
-    crc: '0x4a98'
+    crc: '0xe70b'
     length: 20
     msg_type: '0x45'
-    payload: IMvOGCwHIfe1onsTMf3/0xwl0B8=
+    payload: AJ9DGC4HITETpHV4IAAA3j8++h8=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       header:
-        ObservationHeader:
-          n_obs: 16
-          t:
-            ObsGPSTime:
-              tow: 416271000
-              wn: 1836
+        n_obs: 16
+        t:
+          tow: 407151200
+          wn: 1838
       obs:
-        PackedObsContent:
-        - L:
-            CarrierPhase:
-              f: 92
-              i: 8209
-          P: 1871702242
-          cn0: 45
-          lock: 20410
-          prn: 2
-        - L:
-            CarrierPhase:
-              f: 171
-              i: 49927
-          P: 2298000000
-          cn0: 12
-          lock: 63838
-          prn: 5
-        - L:
-            CarrierPhase:
-              f: 126
-              i: 134157
-          P: 2178477396
-          cn0: 19
-          lock: 44760
-          prn: 8
-        - L:
-            CarrierPhase:
-              f: 7
-              i: 143721
-          P: 2080732352
-          cn0: 27
-          lock: 5189
-          prn: 15
-        - L:
-            CarrierPhase:
-              f: 70
-              i: -142917
-          P: 2200152385
-          cn0: 19
-          lock: 16647
-          prn: 30
-        - L:
-            CarrierPhase:
-              f: 109
-              i: -111250
-          P: 2079310706
-          cn0: 43
-          lock: 51160
-          prn: 31
+      - L:
+          f: 189
+          i: -27527
+        P: 2044298327
+        cn0: 43
+        lock: 37807
+        prn: 0
+      - L:
+          f: 1
+          i: -123030
+        P: 2110275716
+        cn0: 41
+        lock: 45326
+        prn: 3
+      - L:
+          f: 166
+          i: -113594
+        P: 2298000000
+        cn0: 18
+        lock: 34232
+        prn: 13
+      - L:
+          f: 249
+          i: 137478
+        P: 2259844888
+        cn0: 28
+        lock: 24609
+        prn: 22
+      - L:
+          f: 203
+          i: -36797
+        P: 1985374378
+        cn0: 56
+        lock: 22736
+        prn: 30
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
-  raw_packet: VUUAAABVmMrPGCwHEOLoj28RIAAAXC26TwKAsviIB8MAAKsMXvkFVO3YgQ0MAgB+E9iuCMB0BXxpMQIABxtFFA9BqSODu9H9/0YTB0EecsPve25N/v9tK9jHH4zE
+  raw_packet: VUUAwwRIYKJEGC4HEFeE2Xl5lP//vSuvkwCEQMh9ah/+/wEpDrEDgLL4iEZE/v+mEriFDRh/soYGGQIA+RwhYBaqaFZ2Q3D//8s40FgeK2s=
   sbp:
-    crc: '0xc48c'
-    length: 85
+    crc: '0x6b2b'
+    length: 72
     msg_type: '0x45'
-    payload: mMrPGCwHEOLoj28RIAAAXC26TwKAsviIB8MAAKsMXvkFVO3YgQ0MAgB+E9iuCMB0BXxpMQIABxtFFA9BqSODu9H9/0YTB0EecsPve25N/v9tK9jHHw==
+    payload: YKJEGC4HEFeE2Xl5lP//vSuvkwCEQMh9ah/+/wEpDrEDgLL4iEZE/v+mEriFDRh/soYGGQIA+RwhYBaqaFZ2Q3D//8s40Fge
     preamble: '0x55'
-    sender: '0x0'
+    sender: '0x4c3'
 
 - msg:
     fields:
       header:
-        ObservationHeader:
-          n_obs: 16
-          t:
-            ObsGPSTime:
-              tow: 416271200
-              wn: 1836
+        n_obs: 16
+        t:
+          tow: 407151400
+          wn: 1838
       obs:
-        PackedObsContent:
-        - L:
-            CarrierPhase:
-              f: 154
-              i: 8251
-          P: 1871707673
-          cn0: 45
-          lock: 20410
-          prn: 2
-        - L:
-            CarrierPhase:
-              f: 243
-              i: 50266
-          P: 2298000000
-          cn0: 14
-          lock: 63838
-          prn: 5
-        - L:
-            CarrierPhase:
-              f: 32
-              i: 134699
-          P: 2178473393
-          cn0: 21
-          lock: 44760
-          prn: 8
-        - L:
-            CarrierPhase:
-              f: 174
-              i: 144306
-          P: 2080727580
-          cn0: 28
-          lock: 5189
-          prn: 15
-        - L:
-            CarrierPhase:
-              f: 72
-              i: -143519
-          P: 2200170036
-          cn0: 19
-          lock: 16647
-          prn: 30
-        - L:
-            CarrierPhase:
-              f: 144
-              i: -111721
-          P: 2079326011
-          cn0: 43
-          lock: 51160
-          prn: 31
+      - L:
+          f: 1
+          i: -27634
+        P: 2044291972
+        cn0: 44
+        lock: 37807
+        prn: 0
+      - L:
+          f: 153
+          i: -123500
+        P: 2110276225
+        cn0: 41
+        lock: 45326
+        prn: 3
+      - L:
+          f: 222
+          i: -114033
+        P: 2298000000
+        cn0: 18
+        lock: 34232
+        prn: 13
+      - L:
+          f: 237
+          i: 138026
+        P: 2259826078
+        cn0: 30
+        lock: 24609
+        prn: 22
+      - L:
+          f: 45
+          i: -36952
+        P: 1985368870
+        cn0: 56
+        lock: 22736
+        prn: 30
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
-  raw_packet: VUUAAABVYMvPGCwHEBn+j287IAAAmi26TwKAsviIWsQAAPMOXvkFsd3YgSsOAgAgFdiuCBxiBXyyMwIArhxFFA807iODYc/9/0gTB0EeO//ve5dL/v+QK9jHH/cy
+  raw_packet: VUUAwwRIKKNEGC4HEIRr2XkOlP//ASyvkwCBQsh9lB3+/5kpDrEDgLL4iI9C/v/eEriFDZ41soYqGwIA7R4hYBYmU1Z2qG///y040FgeAa8=
   sbp:
-    crc: '0x32f7'
-    length: 85
+    crc: '0xaf01'
+    length: 72
     msg_type: '0x45'
-    payload: YMvPGCwHEBn+j287IAAAmi26TwKAsviIWsQAAPMOXvkFsd3YgSsOAgAgFdiuCBxiBXyyMwIArhxFFA807iODYc/9/0gTB0EeO//ve5dL/v+QK9jHHw==
+    payload: KKNEGC4HEIRr2XkOlP//ASyvkwCBQsh9lB3+/5kpDrEDgLL4iI9C/v/eEriFDZ41soYqGwIA7R4hYBYmU1Z2qG///y040Fge
     preamble: '0x55'
-    sender: '0x0'
-version: '0.23'
+    sender: '0x4c3'
+version: '0.29'
 ...

--- a/spec/tests/yaml/swiftnav/sbp/test_piksi.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_piksi.yaml
@@ -1,92 +1,8 @@
 ---
-description: Unit tests for swiftnav.sbp.piksi v0.23.
-generated_on: 2015-03-24 11:31:59.676598
+description: Unit tests for swiftnav.sbp.piksi v0.29.
+generated_on: 2015-04-12 20:15:47.241265
 package: sbp.piksi
 tests:
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgPrint
-  msg_type: '0x10'
-  raw_packet: VRAAzAQhSU5GTzogYWNxOiByZXN0YXJ0aW5nIFBSTiBzZWFyY2gKJEs=
-  sbp:
-    crc: '0x4b24'
-    length: 33
-    msg_type: '0x10'
-    payload: SU5GTzogYWNxOiByZXN0YXJ0aW5nIFBSTiBzZWFyY2gK
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgPrint
-  msg_type: '0x10'
-  raw_packet: VRAAzAQYSU5GTzogUGlrc2kgU3RhcnRpbmcuLi4KvEU=
-  sbp:
-    crc: '0x45bc'
-    length: 24
-    msg_type: '0x10'
-    payload: SU5GTzogUGlrc2kgU3RhcnRpbmcuLi4K
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgPrint
-  msg_type: '0x10'
-  raw_packet: VRAAzAQqSU5GTzogRmlybXdhcmUgVmVyc2lvbjogdjAuMTQtMzktZzViZjNmZWEK0R0=
-  sbp:
-    crc: '0x1dd1'
-    length: 42
-    msg_type: '0x10'
-    payload: SU5GTzogRmlybXdhcmUgVmVyc2lvbjogdjAuMTQtMzktZzViZjNmZWEK
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgPrint
-  msg_type: '0x10'
-  raw_packet: VRAAzAQiSU5GTzogQnVpbHQ6IE1hciAxOSAyMDE1IDE5OjA3OjAxCuQh
-  sbp:
-    crc: '0x21e4'
-    length: 34
-    msg_type: '0x10'
-    payload: SU5GTzogQnVpbHQ6IE1hciAxOSAyMDE1IDE5OjA3OjAxCg==
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgPrint
-  msg_type: '0x10'
-  raw_packet: VRAAzARBSU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRBLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgpSUA==
-  sbp:
-    crc: '0x5052'
-    length: 65
-    msg_type: '0x10'
-    payload: SU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRBLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgo=
-    preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgPrint
-  msg_type: '0x10'
-  raw_packet: VRAAzARBSU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRCLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgr4bw==
-  sbp:
-    crc: '0x6ff8'
-    length: 65
-    msg_type: '0x10'
-    payload: SU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRCLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgo=
-    preamble: '0x55'
-    sender: '0x4cc'
 
 - msg:
     fields:
@@ -96,65 +12,65 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
-  raw_packet: VRcAzAQabWFpbgAAAAAAAAAAAAAAAAAAAAAAAJQJAADk0Q==
+  raw_packet: VRcAwwQabWFpbgAAAAAAAAAAAAAAAAAAAAAAAJQJAADD1A==
   sbp:
-    crc: '0xd1e4'
+    crc: '0xd4c3'
     length: 26
     msg_type: '0x17'
     payload: bWFpbgAAAAAAAAAAAAAAAAAAAAAAAJQJAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cpu: 512
+      cpu: 484
       name: "idle\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
       stack_free: 36
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
-  raw_packet: VRcAzAQaaWRsZQAAAAAAAAAAAAAAAAAAAAAAAiQAAACNdA==
+  raw_packet: VRcAwwQaaWRsZQAAAAAAAAAAAAAAAAAAAADkASQAAADhEg==
   sbp:
-    crc: '0x748d'
+    crc: '0x12e1'
     length: 26
     msg_type: '0x17'
-    payload: aWRsZQAAAAAAAAAAAAAAAAAAAAAAAiQAAAA=
+    payload: aWRsZQAAAAAAAAAAAAAAAAAAAADkASQAAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      cpu: 371
+      cpu: 394
       name: "NAP ISR\0\0\0\0\0\0\0\0\0\0\0\0\0"
       stack_free: 1884
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
-  raw_packet: VRcAzAQaTkFQIElTUgAAAAAAAAAAAAAAAABzAVwHAADfqA==
+  raw_packet: VRcAwwQaTkFQIElTUgAAAAAAAAAAAAAAAACKAVwHAACmdA==
   sbp:
-    crc: '0xa8df'
+    crc: '0x74a6'
     length: 26
     msg_type: '0x17'
-    payload: TkFQIElTUgAAAAAAAAAAAAAAAABzAVwHAAA=
+    payload: TkFQIElTUgAAAAAAAAAAAAAAAACKAVwHAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       cpu: 1
       name: "SBP\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-      stack_free: 3052
+      stack_free: 3076
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
-  raw_packet: VRcAzAQaU0JQAAAAAAAAAAAAAAAAAAAAAAABAOwLAAB7Lw==
+  raw_packet: VRcAwwQaU0JQAAAAAAAAAAAAAAAAAAAAAAABAAQMAADlrg==
   sbp:
-    crc: '0x2f7b'
+    crc: '0xaee5'
     length: 26
     msg_type: '0x17'
-    payload: U0JQAAAAAAAAAAAAAAAAAAAAAAABAOwLAAA=
+    payload: U0JQAAAAAAAAAAAAAAAAAAAAAAABAAQMAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
@@ -164,14 +80,14 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
-  raw_packet: VRcAzAQabWFuYWdlIGFjcQAAAAAAAAAAAAAKAHwJAAATBw==
+  raw_packet: VRcAwwQabWFuYWdlIGFjcQAAAAAAAAAAAAAKAHwJAAA0Ag==
   sbp:
-    crc: '0x713'
+    crc: '0x234'
     length: 26
     msg_type: '0x17'
     payload: bWFuYWdlIGFjcQAAAAAAAAAAAAAKAHwJAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
@@ -181,278 +97,254 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
-  raw_packet: VRcAzAQabWFuYWdlIHRyYWNrAAAAAAAAAAAAABwJAABdMw==
+  raw_packet: VRcAwwQabWFuYWdlIHRyYWNrAAAAAAAAAAAAABwJAAB6Ng==
   sbp:
-    crc: '0x335d'
+    crc: '0x367a'
     length: 26
     msg_type: '0x17'
     payload: bWFuYWdlIHRyYWNrAAAAAAAAAAAAABwJAAA=
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       latency:
-        Latency:
-          avg: -1
-          current: -1
-          lmax: 0
-          lmin: 0
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
       uart_a:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_b:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_ftdi:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 16
-          tx_throughput: 12.40000057220459
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 15
+        tx_throughput: 11.600000381469727
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
-  raw_packet: VRgAzAQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGdmRkEAAAAAAAAAABAA/////wAAAAAAAAAA/////3h7
+  raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJqZOUEAAAAAAAAAAA8A/////wAAAAAAAAAA//////cF
   sbp:
-    crc: '0x7b78'
+    crc: '0x5f7'
     length: 58
     msg_type: '0x18'
-    payload: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGdmRkEAAAAAAAAAABAA/////wAAAAAAAAAA/////w==
+    payload: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJqZOUEAAAAAAAAAAA8A/////wAAAAAAAAAA/////w==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       latency:
-        Latency:
-          avg: -1
-          current: -1
-          lmax: 0
-          lmin: 0
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
       uart_a:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_b:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_ftdi:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.06599999964237213
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.06599999964237213
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
-  raw_packet: VRgAzAQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////7If
+  raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////0Fu
   sbp:
-    crc: '0x1fb2'
+    crc: '0x6e41'
     length: 58
     msg_type: '0x18'
     payload: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////w==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       latency:
-        Latency:
-          avg: -1
-          current: -1
-          lmax: 0
-          lmin: 0
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
       uart_a:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_b:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_ftdi:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 10
-          tx_throughput: 0.13899999856948853
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 10
+        tx_throughput: 0.13899999856948853
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
-  raw_packet: VRgAzAQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARWDj4AAAAAAAAAAAoA/////wAAAAAAAAAA/////zVV
+  raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARWDj4AAAAAAAAAAAoA/////wAAAAAAAAAA/////8Yk
   sbp:
-    crc: '0x5535'
+    crc: '0x24c6'
     length: 58
     msg_type: '0x18'
     payload: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARWDj4AAAAAAAAAAAoA/////wAAAAAAAAAA/////w==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       latency:
-        Latency:
-          avg: -1
-          current: -1
-          lmax: 0
-          lmin: 0
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
       uart_a:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_b:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_ftdi:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 0
-          tx_throughput: 0.06599999964237213
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 0
+        tx_throughput: 0.06599999964237213
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
-  raw_packet: VRgAzAQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////7If
+  raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////0Fu
   sbp:
-    crc: '0x1fb2'
+    crc: '0x6e41'
     length: 58
     msg_type: '0x18'
     payload: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////w==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       latency:
-        Latency:
-          avg: -1
-          current: -1
-          lmax: 0
-          lmin: 0
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
       uart_a:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0051282052882015705
-          tx_buffer_level: 0
-          tx_throughput: 0.0
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.008196720853447914
+        tx_buffer_level: 0
+        tx_throughput: 0.0
       uart_b:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 2
-          tx_throughput: 0.061538465321063995
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 2
+        tx_throughput: 0.09836065769195557
       uart_ftdi:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 38
-          tx_throughput: 0.5139999985694885
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 38
+        tx_throughput: 0.49399998784065247
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
-  raw_packet: VRgAzAQ6AAAAAIEKqDsAAAAAAADCD3w9AAAAAAAAAAACAIGVAz8AAAAAAAAAACYA/////wAAAAAAAAAA/////+Gy
+  raw_packet: VRgAwwQ6AAAAAIpLBjwAAAAAAABQcck9AAAAAAAAAAACAJHt/D4AAAAAAAAAACYA/////wAAAAAAAAAA/////3Bv
   sbp:
-    crc: '0xb2e1'
+    crc: '0x6f70'
     length: 58
     msg_type: '0x18'
-    payload: AAAAAIEKqDsAAAAAAADCD3w9AAAAAAAAAAACAIGVAz8AAAAAAAAAACYA/////wAAAAAAAAAA/////w==
+    payload: AAAAAIpLBjwAAAAAAABQcck9AAAAAAAAAAACAJHt/D4AAAAAAAAAACYA/////wAAAAAAAAAA/////w==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       latency:
-        Latency:
-          avg: -1
-          current: -1
-          lmax: 0
-          lmin: 0
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
       uart_a:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 2
-          tx_throughput: 0.012000000104308128
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 2
+        tx_throughput: 0.012000000104308128
       uart_b:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 2
-          tx_throughput: 0.012000000104308128
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 2
+        tx_throughput: 0.012000000104308128
       uart_ftdi:
-        UARTChannel:
-          crc_error_count: 0
-          io_error_count: 0
-          rx_buffer_level: 0
-          rx_throughput: 0.0
-          tx_buffer_level: 50
-          tx_throughput: 1.2130000591278076
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 50
+        tx_throughput: 1.315000057220459
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
-  raw_packet: VRgAzAQ6pptEPAAAAAAAAAAAAgCmm0Q8AAAAAAAAAAACAJZDmz8AAAAAAAAAADIA/////wAAAAAAAAAA/////0h+
+  raw_packet: VRgAwwQ6pptEPAAAAAAAAAAAAgCmm0Q8AAAAAAAAAAACAOxRqD8AAAAAAAAAADIA/////wAAAAAAAAAA/////xZI
   sbp:
-    crc: '0x7e48'
+    crc: '0x4816'
     length: 58
     msg_type: '0x18'
-    payload: pptEPAAAAAAAAAAAAgCmm0Q8AAAAAAAAAAACAJZDmz8AAAAAAAAAADIA/////wAAAAAAAAAA/////w==
+    payload: pptEPAAAAAAAAAAAAgCmm0Q8AAAAAAAAAAACAOxRqD8AAAAAAAAAADIA/////wAAAAAAAAAA/////w==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
@@ -460,14 +352,14 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
-  raw_packet: VRkAzAQEAAAAAPs6
+  raw_packet: VRkAwwQEAAAAABKw
   sbp:
-    crc: '0x3afb'
+    crc: '0xb012'
     length: 4
     msg_type: '0x19'
     payload: AAAAAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
@@ -475,87 +367,73 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
-  raw_packet: VRkAzAQEAQAAAE9M
+  raw_packet: VRkAwwQEAQAAAKbG
   sbp:
-    crc: '0x4c4f'
+    crc: '0xc6a6'
     length: 4
     msg_type: '0x19'
     payload: AQAAAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      num_hyps: 972
+      num_hyps: 729
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
-  raw_packet: VRkAzAQEzAMAAD2f
+  raw_packet: VRkAwwQE2QIAAAaF
   sbp:
-    crc: '0x9f3d'
+    crc: '0x8506'
     length: 4
     msg_type: '0x19'
-    payload: zAMAAA==
+    payload: 2QIAAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      num_hyps: 971
+      num_hyps: 728
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
-  raw_packet: VRkAzAQEywMAABDO
+  raw_packet: VRkAwwQE2AIAALLz
   sbp:
-    crc: '0xce10'
+    crc: '0xf3b2'
     length: 4
     msg_type: '0x19'
-    payload: ywMAAA==
+    payload: 2AIAAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      num_hyps: 967
+      num_hyps: 727
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
-  raw_packet: VRkAzAQExwMAACKB
+  raw_packet: VRkAwwQE1wIAAFwn
   sbp:
-    crc: '0x8122'
+    crc: '0x275c'
     length: 4
     msg_type: '0x19'
-    payload: xwMAAA==
+    payload: 1wIAAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
-      num_hyps: 957
+      num_hyps: 723
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
-  raw_packet: VRkAzAQEvQMAAPyr
+  raw_packet: VRkAwwQE0wIAAK3t
   sbp:
-    crc: '0xabfc'
+    crc: '0xedad'
     length: 4
     msg_type: '0x19'
-    payload: vQMAAA==
+    payload: 0wIAAA==
     preamble: '0x55'
-    sender: '0x4cc'
-
-- msg:
-    fields: null
-    module: sbp.piksi
-    name: MsgBootloaderHandshake
-  msg_type: '0xb0'
-  raw_packet: VbAAzAQEdjEuMuhE
-  sbp:
-    crc: '0x44e8'
-    length: 4
-    msg_type: '0xb0'
-    payload: djEuMg==
-    preamble: '0x55'
-    sender: '0x4cc'
-version: '0.23'
+    sender: '0x4c3'
+version: '0.29'
 ...

--- a/spec/tests/yaml/swiftnav/sbp/test_system.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_system.yaml
@@ -1,37 +1,37 @@
 ---
-description: Unit tests for swiftnav.sbp.standard v0.23.
-generated_on: 2015-03-24 11:31:59.831529
-package: sbp.standard
+description: Unit tests for swiftnav.sbp.system v0.29.
+generated_on: 2015-04-12 20:15:47.087953
+package: sbp.system
 tests:
 
 - msg:
     fields:
       reserved: 0
-    module: sbp.standard
+    module: sbp.system
     name: MsgStartup
   msg_type: '0xff00'
-  raw_packet: VQD/zAQEAAAAAJY/
+  raw_packet: VQD/wwQEAAAAAH+1
   sbp:
-    crc: '0x3f96'
+    crc: '0xb57f'
     length: 4
     msg_type: '0xff00'
     payload: AAAAAA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       flags: 0
-    module: sbp.standard
+    module: sbp.system
     name: MsgHeartbeat
   msg_type: '0xffff'
-  raw_packet: Vf//zAQEAAAAAKuz
+  raw_packet: Vf//wwQEAAAAAEI5
   sbp:
-    crc: '0xb3ab'
+    crc: '0x3942'
     length: 4
     msg_type: '0xffff'
     payload: AAAAAA==
     preamble: '0x55'
-    sender: '0x4cc'
-version: '0.23'
+    sender: '0x4c3'
+version: '0.29'
 ...

--- a/spec/tests/yaml/swiftnav/sbp/test_tracking.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_tracking.yaml
@@ -1,301 +1,295 @@
 ---
-description: Unit tests for swiftnav.sbp.tracking v0.23.
-generated_on: 2015-03-24 11:31:59.432050
+description: Unit tests for swiftnav.sbp.tracking v0.29.
+generated_on: 2015-04-12 20:15:47.019143
 package: sbp.tracking
 tests:
 
 - msg:
     fields:
       states:
-        TrackingChannelState:
-        - cn0: 5.2681565284729
-          prn: 0
-          state: 1
-        - cn0: 1.2068965435028076
-          prn: 27
-          state: 1
-        - cn0: 6.305882453918457
-          prn: 2
-          state: 1
-        - cn0: 11.842391014099121
-          prn: 7
-          state: 1
-        - cn0: 6.406779766082764
-          prn: 8
-          state: 1
-        - cn0: 7.05142879486084
-          prn: 15
-          state: 1
-        - cn0: 11.536842346191406
-          prn: 22
-          state: 1
-        - cn0: 6.736263751983643
-          prn: 30
-          state: 1
-        - cn0: 7.245614051818848
-          prn: 31
-          state: 1
-        - cn0: 4.375722408294678
-          prn: 5
-          state: 1
-        - cn0: -1.0
-          prn: 14
-          state: 0
+      - cn0: 11.230907440185547
+        prn: 0
+        state: 1
+      - cn0: 10.438665390014648
+        prn: 2
+        state: 1
+      - cn0: 9.732142448425293
+        prn: 3
+        state: 1
+      - cn0: 14.341922760009766
+        prn: 7
+        state: 1
+      - cn0: 7.8549017906188965
+        prn: 10
+        state: 1
+      - cn0: 5.0982866287231445
+        prn: 13
+        state: 1
+      - cn0: 6.741272926330566
+        prn: 22
+        state: 1
+      - cn0: 12.700549125671387
+        prn: 30
+        state: 1
+      - cn0: 15.893081665039062
+        prn: 31
+        state: 1
+      - cn0: 4.242738723754883
+        prn: 25
+        state: 1
+      - cn0: 6.97599983215332
+        prn: 6
+        state: 1
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
-  raw_packet: VRYAzARCAQC9lKhAARuWe5o/AQLKyclAAQdvej1BAQhXBM1AAQ9OpeFAARboljhBAR55j9dAAR8S3OdAAQXrBYxAAA4AAIC/Oek=
+  raw_packet: VRYAwwRCAQDMsTNBAQLGBCdBAQPbthtBAQeEeGVBAQpbW/tAAQ0qJaNAARaCuNdAAR5zNUtBAR8QSn5BARmExIdAAQZkO99AEeE=
   sbp:
-    crc: '0xe939'
+    crc: '0xe111'
     length: 66
     msg_type: '0x16'
-    payload: AQC9lKhAARuWe5o/AQLKyclAAQdvej1BAQhXBM1AAQ9OpeFAARboljhBAR55j9dAAR8S3OdAAQXrBYxAAA4AAIC/
+    payload: AQDMsTNBAQLGBCdBAQPbthtBAQeEeGVBAQpbW/tAAQ0qJaNAARaCuNdAAR5zNUtBAR8QSn5BARmExIdAAQZkO99A
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       states:
-        TrackingChannelState:
-        - cn0: 5.247252941131592
-          prn: 0
-          state: 1
-        - cn0: 0.9884393215179443
-          prn: 27
-          state: 1
-        - cn0: 6.298121929168701
-          prn: 2
-          state: 1
-        - cn0: 12.005524635314941
-          prn: 7
-          state: 1
-        - cn0: 6.464088439941406
-          prn: 8
-          state: 1
-        - cn0: 6.468208312988281
-          prn: 15
-          state: 1
-        - cn0: 11.792552947998047
-          prn: 22
-          state: 1
-        - cn0: 6.596590995788574
-          prn: 30
-          state: 1
-        - cn0: 7.169590473175049
-          prn: 31
-          state: 1
-        - cn0: 5.035502910614014
-          prn: 5
-          state: 1
-        - cn0: -1.0
-          prn: 14
-          state: 0
+      - cn0: 11.014122009277344
+        prn: 0
+        state: 1
+      - cn0: 10.885148048400879
+        prn: 2
+        state: 1
+      - cn0: 10.131351470947266
+        prn: 3
+        state: 1
+      - cn0: 14.829026222229004
+        prn: 7
+        state: 1
+      - cn0: 7.79104471206665
+        prn: 10
+        state: 1
+      - cn0: 4.868161201477051
+        prn: 13
+        state: 1
+      - cn0: 6.721095561981201
+        prn: 22
+        state: 1
+      - cn0: 12.971323013305664
+        prn: 30
+        state: 1
+      - cn0: 15.481405258178711
+        prn: 31
+        state: 1
+      - cn0: 3.8834354877471924
+        prn: 25
+        state: 1
+      - cn0: 4.061488628387451
+        prn: 6
+        state: 1
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
-  raw_packet: VRYAzARCAQB/6adAARtcCn0/AQI3islAAQehFkBBAQjQ2c5AAQ+Q+85AARZMrjxBAR5GF9NAAR9JbeVAAQXXIqFAAA4AAIC/tIc=
+  raw_packet: VRYAwwRCAQDYOTBBAQKRKS5BAQMEGiJBAQexQ21BAQo9UPlAAQ36x5tAARY3E9dAAR6Kik9BAR/Ws3dBARk1inhAAQa394FAqK0=
   sbp:
-    crc: '0x87b4'
+    crc: '0xada8'
     length: 66
     msg_type: '0x16'
-    payload: AQB/6adAARtcCn0/AQI3islAAQehFkBBAQjQ2c5AAQ+Q+85AARZMrjxBAR5GF9NAAR9JbeVAAQXXIqFAAA4AAIC/
+    payload: AQDYOTBBAQKRKS5BAQMEGiJBAQexQ21BAQo9UPlAAQ36x5tAARY3E9dAAR6Kik9BAR/Ws3dBARk1inhAAQa394FA
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       states:
-        TrackingChannelState:
-        - cn0: 4.796703338623047
-          prn: 0
-          state: 1
-        - cn0: 0.9127907156944275
-          prn: 27
-          state: 1
-        - cn0: 6.24178409576416
-          prn: 2
-          state: 1
-        - cn0: 12.573033332824707
-          prn: 7
-          state: 1
-        - cn0: 6.131868362426758
-          prn: 8
-          state: 1
-        - cn0: 6.693181991577148
-          prn: 15
-          state: 1
-        - cn0: 11.875675201416016
-          prn: 22
-          state: 1
-        - cn0: 6.856321811676025
-          prn: 30
-          state: 1
-        - cn0: 7.206896781921387
-          prn: 31
-          state: 1
-        - cn0: 4.526627063751221
-          prn: 5
-          state: 1
-        - cn0: -1.0
-          prn: 14
-          state: 0
+      - cn0: 11.768689155578613
+        prn: 0
+        state: 1
+      - cn0: 10.909001350402832
+        prn: 2
+        state: 1
+      - cn0: 9.881731033325195
+        prn: 3
+        state: 1
+      - cn0: 14.076395988464355
+        prn: 7
+        state: 1
+      - cn0: 7.619818210601807
+        prn: 10
+        state: 1
+      - cn0: 5.208371162414551
+        prn: 13
+        state: 1
+      - cn0: 6.2935872077941895
+        prn: 22
+        state: 1
+      - cn0: 13.232341766357422
+        prn: 30
+        state: 1
+      - cn0: 15.547346115112305
+        prn: 31
+        state: 1
+      - cn0: 4.130964279174805
+        prn: 25
+        state: 1
+      - cn0: 2.856823205947876
+        prn: 6
+        state: 1
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
-  raw_packet: VRYAzARCAQCYfplAARunrGk/AQKyvMdAAQclK0lBAQhEOMRAAQ+MLtZAARbEAj5BAR79ZttAAR/mnuZAAQUh2pBAAA4AAIC/5Rg=
+  raw_packet: VRYAwwRCAQCNTDxBAQJFiy5BAQOSGx5BAQfrOGFBAQqN1fNAAQ36qqZAARYRZclAAR6st1NBAR/uwXhBARncMIRAAQYx1jZAbrM=
   sbp:
-    crc: '0x18e5'
+    crc: '0xb36e'
     length: 66
     msg_type: '0x16'
-    payload: AQCYfplAARunrGk/AQKyvMdAAQclK0lBAQhEOMRAAQ+MLtZAARbEAj5BAR79ZttAAR/mnuZAAQUh2pBAAA4AAIC/
+    payload: AQCNTDxBAQJFiy5BAQOSGx5BAQfrOGFBAQqN1fNAAQ36qqZAARYRZclAAR6st1NBAR/uwXhBARncMIRAAQYx1jZA
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       states:
-        TrackingChannelState:
-        - cn0: 11.941176414489746
-          prn: 0
-          state: 1
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
+      - cn0: 62.13985824584961
+        prn: 0
+        state: 1
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
-  raw_packet: VRYAzARCAQAPDz9BAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/z2Q=
+  raw_packet: VRYAwwRCAQA3j3hCAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/+Fk=
   sbp:
-    crc: '0x64cf'
+    crc: '0x59f8'
     length: 66
     msg_type: '0x16'
-    payload: AQAPDz9BAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
+    payload: AQA3j3hCAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       states:
-        TrackingChannelState:
-        - cn0: 4.888888835906982
-          prn: 0
-          state: 1
-        - cn0: 7.107142925262451
-          prn: 2
-          state: 1
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
+      - cn0: 36.764503479003906
+        prn: 0
+        state: 1
+      - cn0: 9.313432693481445
+        prn: 2
+        state: 1
+      - cn0: 16.854938507080078
+        prn: 3
+        state: 1
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
-  raw_packet: VRYAzARCAQDHcZxAAQK3beNAAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC//pI=
+  raw_packet: VRYAwwRCAQDaDhNCAQLSAxVBAQPq1oZBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/VGU=
   sbp:
-    crc: '0x92fe'
+    crc: '0x6554'
     length: 66
     msg_type: '0x16'
-    payload: AQDHcZxAAQK3beNAAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
+    payload: AQDaDhNCAQLSAxVBAQPq1oZBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 - msg:
     fields:
       states:
-        TrackingChannelState:
-        - cn0: 2.6417911052703857
-          prn: 0
-          state: 1
-        - cn0: 3.7407407760620117
-          prn: 2
-          state: 1
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
-        - cn0: -1.0
-          prn: 0
-          state: 0
+      - cn0: 27.394229888916016
+        prn: 0
+        state: 1
+      - cn0: 2.875
+        prn: 2
+        state: 1
+      - cn0: 8.467644691467285
+        prn: 3
+        state: 1
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
+      - cn0: -1.0
+        prn: 0
+        state: 0
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
-  raw_packet: VRYAzARCAQAbEylAAQJMaG9AAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/nbQ=
+  raw_packet: VRYAwwRCAQBiJ9tBAQIAADhAAQN5ewdBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/JXs=
   sbp:
-    crc: '0xb49d'
+    crc: '0x7b25'
     length: 66
     msg_type: '0x16'
-    payload: AQAbEylAAQJMaG9AAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
+    payload: AQBiJ9tBAQIAADhAAQN5ewdBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
     preamble: '0x55'
-    sender: '0x4cc'
-version: '0.23'
+    sender: '0x4c3'
+version: '0.29'
 ...


### PR DESCRIPTION
0. Updates serializations tests, which got dropped with the last
message migration.
1. Optionally, materialize SBP objects from fields. Previously an SBP
object was required, since we were only ever deserializing.
2. Docstring clarifications.

/cc @mfine