### PR TITLE
WIP JSON serialization

### DIFF
--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -15,8 +15,9 @@
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 ((*- for i in include *))
@@ -144,6 +145,19 @@ class ((( m.identifier | classnameify )))(SBP):
     c = Container(**exclude_fields(self))
     self.payload = ((( m.identifier | classnameify )))._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    return json.dumps(walk_json_dict(self.__dict__))
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    return ((( m.identifier | classnameify )))(**json.loads(data))
     ((*- endif *))
     ((* endif *))
   ((*- else *))

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -15,13 +15,28 @@
 
 EXCLUDE = ['sender', 'msg_type', 'crc', 'length', 'preamble', 'payload']
 
-
 def exclude_fields(obj, exclude=EXCLUDE):
   """
   Return dict of object without parent attrs.
   """
   return {k: v for k, v in obj.__dict__.items() if k not in exclude}
 
+def walk_json_dict(coll):
+  """
+  Flatten a parsed SBP object into a dicts and lists, which are
+  compatible for JSON output.
+
+  Parameters
+  ----------
+  coll : dict
+
+  """
+  if isinstance(coll, dict):
+    return dict((k, walk_json_dict(v)) for (k, v) in coll.iteritems())
+  elif hasattr(coll, '__iter__'):
+    return [walk_json_dict(dict(seq.items())) for seq in coll]
+  else:
+    return coll
 
 def fmt_repr(obj):
   """Print a orphaned string representation of an object without the

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -96,6 +96,9 @@ def _assert_msg_roundtrip(msg, raw_packet):
   """
   assert base64.standard_b64encode(msg.to_binary()) == raw_packet
 
+def _assert_json(msg):
+  assert msg.from_json(msg.to_json()) == msg
+
 def _assert_sane_package(pkg_name, pkg):
   """
   Sanity check the package collection of tests before actually
@@ -136,3 +139,4 @@ def assert_package(test_filename, pkg_name):
       _assert_sbp(sbp, test_case['sbp'])
       _assert_msg(dispatch(sbp), test_case['msg'])
       _assert_msg_roundtrip(dispatch(sbp), test_case['raw_packet'])
+      _assert_json(dispatch(sbp))


### PR DESCRIPTION
Playing around with JSON serialization. This is pretty broken and not working:

+ the parent objects are getting lost or not able to be serialized (e.g., `payload`); what really needs to happen is that the json dict from the parent needs to be merged in with the child's json dict. Or some such.
+ the `from_json` approach here is no bueno with nested structures - `json.loads` returns dicts and lists, while the existing objects are built up from construct into containers. Need some kind of json-to-construct mapping function.

Thoughts and ideas on how to do a better job here very welcome!

DO NOT MERGE

/cc @mookerji 