### PR TITLE
Object-based JSON serialization

### DIFF
--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -15,8 +15,9 @@
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 ((*- for i in include *))
@@ -144,6 +145,24 @@ class ((( m.identifier | classnameify )))(SBP):
     c = Container(**exclude_fields(self))
     self.payload = ((( m.identifier | classnameify )))._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( ((( m.identifier | classnameify ))), self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return ((( m.identifier | classnameify )))(sbp)
     ((*- endif *))
     ((* endif *))
   ((*- else *))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,5 +10,6 @@ pylibftdi==0.14.2
 pyserial==2.7
 pytest==2.6.4
 pytest-cov==1.8.1
+pyyaml==3.11
 tox==1.8.1
 virtualenv==1.11.6

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -15,12 +15,13 @@ Satellite acquisition messages from the Piksi.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/acquisition.yaml
-# with generate.py at 2015-04-12 20:54:10.838143. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.025823. Please do not hand edit!
 
 
 SBP_MSG_ACQ_RESULT = 0x0015
@@ -89,6 +90,24 @@ acquisition was attempted
     c = Container(**exclude_fields(self))
     self.payload = MsgAcqResult._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgAcqResult, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgAcqResult(sbp)
     
 
 msg_classes = {

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -20,12 +20,13 @@ message type ID.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/bootload.yaml
-# with generate.py at 2015-04-12 20:54:10.809448. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.029893. Please do not hand edit!
 
 
 SBP_MSG_BOOTLOADER_HANDSHAKE = 0x00B0
@@ -84,6 +85,24 @@ build.
     c = Container(**exclude_fields(self))
     self.payload = MsgBootloaderHandshake._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgBootloaderHandshake, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgBootloaderHandshake(sbp)
     
 SBP_MSG_BOOTLOADER_JUMP_TO_APP = 0x00B1
 class MsgBootloaderJumpToApp(SBP):
@@ -133,6 +152,24 @@ class MsgBootloaderJumpToApp(SBP):
     c = Container(**exclude_fields(self))
     self.payload = MsgBootloaderJumpToApp._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgBootloaderJumpToApp, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgBootloaderJumpToApp(sbp)
     
 SBP_MSG_NAP_DEVICE_DNA = 0x00DD
 class MsgNapDeviceDna(SBP):
@@ -186,6 +223,24 @@ MSG_NAP_DEVICE_DNA message.
     c = Container(**exclude_fields(self))
     self.payload = MsgNapDeviceDna._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgNapDeviceDna, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgNapDeviceDna(sbp)
     
 
 msg_classes = {

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -24,12 +24,13 @@ the Piksi share the same message type ID.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/file_io.yaml
-# with generate.py at 2015-04-12 20:54:10.812817. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.031777. Please do not hand edit!
 
 
 SBP_MSG_FILEIO_READ = 0x00A8
@@ -93,6 +94,24 @@ message".
     c = Container(**exclude_fields(self))
     self.payload = MsgFileioRead._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFileioRead, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioRead(sbp)
     
 SBP_MSG_FILEIO_READ_DIR = 0x00A9
 class MsgFileioReadDir(SBP):
@@ -155,6 +174,24 @@ message".
     c = Container(**exclude_fields(self))
     self.payload = MsgFileioReadDir._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFileioReadDir, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioReadDir(sbp)
     
 SBP_MSG_FILEIO_REMOVE = 0x00AC
 class MsgFileioRemove(SBP):
@@ -206,6 +243,24 @@ message is invalid, a followup MSG_PRINT message will print
     c = Container(**exclude_fields(self))
     self.payload = MsgFileioRemove._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFileioRemove, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioRemove(sbp)
     
 SBP_MSG_FILEIO_WRITE = 0x00AD
 class MsgFileioWrite(SBP):
@@ -267,6 +322,24 @@ print "Invalid fileio write message".
     c = Container(**exclude_fields(self))
     self.payload = MsgFileioWrite._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFileioWrite, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioWrite(sbp)
     
 
 msg_classes = {

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -18,12 +18,13 @@ intended for internal-use only.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/flash.yaml
-# with generate.py at 2015-04-12 20:54:10.817277. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.030879. Please do not hand edit!
 
 
 SBP_MSG_FLASH_PROGRAM = 0x00E0
@@ -93,6 +94,24 @@ starting address
     c = Container(**exclude_fields(self))
     self.payload = MsgFlashProgram._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFlashProgram, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFlashProgram(sbp)
     
 SBP_MSG_FLASH_DONE = 0x00E0
 class MsgFlashDone(SBP):
@@ -145,6 +164,24 @@ return this message on failure.
     c = Container(**exclude_fields(self))
     self.payload = MsgFlashDone._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFlashDone, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFlashDone(sbp)
     
 SBP_MSG_FLASH_READ = 0x00E1
 class MsgFlashRead(SBP):
@@ -210,6 +247,24 @@ starting address
     c = Container(**exclude_fields(self))
     self.payload = MsgFlashRead._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFlashRead, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFlashRead(sbp)
     
 SBP_MSG_FLASH_ERASE = 0x00E2
 class MsgFlashErase(SBP):
@@ -269,6 +324,24 @@ the M25)
     c = Container(**exclude_fields(self))
     self.payload = MsgFlashErase._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgFlashErase, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgFlashErase(sbp)
     
 SBP_MSG_STM_FLASH_LOCK_SECTOR = 0x00E3
 class MsgStmFlashLockSector(SBP):
@@ -319,6 +392,24 @@ memory. The Piksi replies with a MSG_FLASH_DONE message.
     c = Container(**exclude_fields(self))
     self.payload = MsgStmFlashLockSector._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgStmFlashLockSector, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgStmFlashLockSector(sbp)
     
 SBP_MSG_STM_FLASH_UNLOCK_SECTOR = 0x00E4
 class MsgStmFlashUnlockSector(SBP):
@@ -369,6 +460,24 @@ memory. The Piksi replies with a MSG_FLASH_DONE message.
     c = Container(**exclude_fields(self))
     self.payload = MsgStmFlashUnlockSector._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgStmFlashUnlockSector, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgStmFlashUnlockSector(sbp)
     
 SBP_MSG_STM_UNIQUE_ID = 0x00E5
 class MsgStmUniqueId(SBP):
@@ -419,6 +528,24 @@ returns STM32F4 unique ID (12 bytes) back to host.
     c = Container(**exclude_fields(self))
     self.payload = MsgStmUniqueId._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgStmUniqueId, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgStmUniqueId(sbp)
     
 SBP_MSG_M25_FLASH_WRITE_STATUS = 0x00F3
 class MsgM25FlashWriteStatus(SBP):
@@ -469,6 +596,24 @@ register. The Piksi replies with a MSG_FLASH_DONE message.
     c = Container(**exclude_fields(self))
     self.payload = MsgM25FlashWriteStatus._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgM25FlashWriteStatus, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgM25FlashWriteStatus(sbp)
     
 
 msg_classes = {

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -17,12 +17,13 @@ implementation-defined range (0x0000-0x00FF).
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/logging.yaml
-# with generate.py at 2015-04-12 20:54:10.815735. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.025289. Please do not hand edit!
 
 
 SBP_MSG_PRINT = 0x0010
@@ -77,6 +78,24 @@ info on function entry/exit when enabled within the firmware.
     c = Container(**exclude_fields(self))
     self.payload = MsgPrint._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgPrint, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgPrint(sbp)
     
 SBP_MSG_DEBUG_VAR = 0x0011
 class MsgDebugVar(SBP):

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -17,12 +17,13 @@ position, and RTK baseline position solutions.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/navigation.yaml
-# with generate.py at 2015-04-12 20:54:10.828885. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:06.978883. Please do not hand edit!
 
 
 SBP_MSG_GPS_TIME = 0x0100
@@ -90,6 +91,24 @@ between between 0 and 604800 seconds (=60*60*24*7).
     c = Container(**exclude_fields(self))
     self.payload = MsgGPSTime._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgGPSTime, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgGPSTime(sbp)
     
 SBP_MSG_DOPS = 0x0206
 class MsgDops(SBP):
@@ -161,6 +180,24 @@ precision.
     c = Container(**exclude_fields(self))
     self.payload = MsgDops._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgDops, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgDops(sbp)
     
 SBP_MSG_POS_ECEF = 0x0200
 class MsgPosECEF(SBP):
@@ -240,6 +277,24 @@ baseline vector.
     c = Container(**exclude_fields(self))
     self.payload = MsgPosECEF._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgPosECEF, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgPosECEF(sbp)
     
 SBP_MSG_POS_LLH = 0x0201
 class MsgPosLLH(SBP):
@@ -322,6 +377,24 @@ station position and the rover's RTK baseline vector.
     c = Container(**exclude_fields(self))
     self.payload = MsgPosLLH._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgPosLLH, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgPosLLH(sbp)
     
 SBP_MSG_BASELINE_ECEF = 0x0202
 class MsgBaselineECEF(SBP):
@@ -396,6 +469,24 @@ Centered Earth Fixed (ECEF) coordinates.
     c = Container(**exclude_fields(self))
     self.payload = MsgBaselineECEF._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgBaselineECEF, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgBaselineECEF(sbp)
     
 SBP_MSG_BASELINE_NED = 0x0203
 class MsgBaselineNED(SBP):
@@ -474,6 +565,24 @@ East Down (NED) coordinates.
     c = Container(**exclude_fields(self))
     self.payload = MsgBaselineNED._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgBaselineNED, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgBaselineNED(sbp)
     
 SBP_MSG_VEL_ECEF = 0x0204
 class MsgVelECEF(SBP):
@@ -548,6 +657,24 @@ class MsgVelECEF(SBP):
     c = Container(**exclude_fields(self))
     self.payload = MsgVelECEF._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgVelECEF, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgVelECEF(sbp)
     
 SBP_MSG_VEL_NED = 0x0205
 class MsgVelNED(SBP):
@@ -626,6 +753,24 @@ coordinates.
     c = Container(**exclude_fields(self))
     self.payload = MsgVelNED._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgVelNED, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgVelNED(sbp)
     
 
 msg_classes = {

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -15,12 +15,13 @@ Satellite observation messages from the Piksi.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/observation.yaml
-# with generate.py at 2015-04-12 20:54:10.763906. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.029389. Please do not hand edit!
 
 
 class ObsGPSTime(object):
@@ -223,6 +224,24 @@ satellite being tracked
     c = Container(**exclude_fields(self))
     self.payload = MsgObs._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgObs, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgObs(sbp)
     
 SBP_MSG_BASE_POS = 0x0044
 class MsgBasePos(SBP):
@@ -282,6 +301,24 @@ station observations.
     c = Container(**exclude_fields(self))
     self.payload = MsgBasePos._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgBasePos, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgBasePos(sbp)
     
 
 msg_classes = {

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -20,12 +20,13 @@ for internal-use only.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/piksi.yaml
-# with generate.py at 2015-04-12 20:54:10.821815. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.026493. Please do not hand edit!
 
 
 class UARTChannel(object):
@@ -289,6 +290,24 @@ Ambiguity Resolution (IAR) process.
     c = Container(**exclude_fields(self))
     self.payload = MsgResetFilters._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgResetFilters, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgResetFilters(sbp)
     
 SBP_MSG_INIT_BASE = 0x0023
 class MsgInitBase(SBP):
@@ -377,6 +396,24 @@ and needs to be renormalized to 100
     c = Container(**exclude_fields(self))
     self.payload = MsgThreadState._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgThreadState, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgThreadState(sbp)
     
 SBP_MSG_UART_STATE = 0x0018
 class MsgUartState(SBP):
@@ -442,6 +479,24 @@ future.
     c = Container(**exclude_fields(self))
     self.payload = MsgUartState._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgUartState, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgUartState(sbp)
     
 SBP_MSG_IAR_STATE = 0x0019
 class MsgIarState(SBP):
@@ -494,6 +549,24 @@ from satellite observations.
     c = Container(**exclude_fields(self))
     self.payload = MsgIarState._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgIarState, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgIarState(sbp)
     
 
 msg_classes = {

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -21,12 +21,13 @@ from the Piksi share the same message type ID.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/settings.yaml
-# with generate.py at 2015-04-12 20:54:10.824989. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.027259. Please do not hand edit!
 
 
 SBP_MSG_SETTINGS = 0x00A0
@@ -81,6 +82,24 @@ such strings on reads.
     c = Container(**exclude_fields(self))
     self.payload = MsgSettings._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgSettings, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgSettings(sbp)
     
 SBP_MSG_SETTINGS_SAVE = 0x00A1
 class MsgSettingsSave(SBP):
@@ -159,6 +178,24 @@ NULL-terminated and delimited string with contents
     c = Container(**exclude_fields(self))
     self.payload = MsgSettingsReadByIndex._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgSettingsReadByIndex, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgSettingsReadByIndex(sbp)
     
 
 msg_classes = {

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -15,12 +15,13 @@ Standardized system messages from Swift Navigation devices.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/system.yaml
-# with generate.py at 2015-04-12 20:54:10.832345. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.028810. Please do not hand edit!
 
 
 SBP_MSG_STARTUP = 0xFF00
@@ -74,6 +75,24 @@ ready to respond to commands or configuration requests.
     c = Container(**exclude_fields(self))
     self.payload = MsgStartup._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgStartup, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgStartup(sbp)
     
 SBP_MSG_HEARTBEAT = 0xFFFF
 class MsgHeartbeat(SBP):
@@ -131,6 +150,24 @@ the remaining error flags should be inspected.
     c = Container(**exclude_fields(self))
     self.payload = MsgHeartbeat._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgHeartbeat, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgHeartbeat(sbp)
     
 
 msg_classes = {

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -16,12 +16,13 @@ Satellite code and carrier-phase tracking messages from the Piksi.
 """
 
 from construct import *
+import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/tracking.yaml
-# with generate.py at 2015-04-12 20:54:10.835086. Please do not hand edit!
+# with generate.py at 2015-04-14 12:12:07.028186. Please do not hand edit!
 
 
 class TrackingChannelState(object):
@@ -109,6 +110,24 @@ power measurements for all tracked satellites.
     c = Container(**exclude_fields(self))
     self.payload = MsgTrackingState._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgTrackingState, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgTrackingState(sbp)
     
 SBP_MSG_EPHEMERIS = 0x001A
 class MsgEphemeris(SBP):
@@ -262,6 +281,24 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     c = Container(**exclude_fields(self))
     self.payload = MsgEphemeris._parser.build(c)
     return self.pack()
+
+  def to_json(self):
+    """Produce a JSON-encoded SBP message.
+
+    """
+    d = super( MsgEphemeris, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return json.dumps(d)
+
+  @staticmethod
+  def from_json(data):
+    """Given a JSON-encoded message, build an object.
+
+    """
+    d = json.loads(data)
+    sbp = SBP.from_json_dict(d)
+    return MsgEphemeris(sbp)
     
 
 msg_classes = {

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -15,13 +15,28 @@
 
 EXCLUDE = ['sender', 'msg_type', 'crc', 'length', 'preamble', 'payload']
 
-
 def exclude_fields(obj, exclude=EXCLUDE):
   """
   Return dict of object without parent attrs.
   """
   return {k: v for k, v in obj.__dict__.items() if k not in exclude}
 
+def walk_json_dict(coll):
+  """
+  Flatten a parsed SBP object into a dicts and lists, which are
+  compatible for JSON output.
+
+  Parameters
+  ----------
+  coll : dict
+
+  """
+  if isinstance(coll, dict):
+    return dict((k, walk_json_dict(v)) for (k, v) in coll.iteritems())
+  elif hasattr(coll, '__iter__'):
+    return [walk_json_dict(dict(seq.items())) for seq in coll]
+  else:
+    return coll
 
 def fmt_repr(obj):
   """Print a orphaned string representation of an object without the

--- a/python/tests/sbp/build_test_data.py
+++ b/python/tests/sbp/build_test_data.py
@@ -28,21 +28,23 @@ package: sbp.acquisition
 tests:
 - msg:
     fields:
-      cf: -7742.43212890625
-      cp: 272.0
-      prn: 24
-      snr: 18.77777862548828
+      cf: 8241.943359375
+      cp: 727.0
+      prn: 8
+      snr: 14.5
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
-  raw_packet: VRUAzAQN5DiWQQAAiEN18/HFGLWs
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 8, "cf": 8241.943359375, "crc":
+    17410, "length": 13, "snr": 14.5, "cp": 727.0, "preamble": 85, "payload": "AABoQQDANUTGxwBGCA=="}'
+  raw_packet: VRUAwwQNAABoQQDANUTGxwBGCAJE
   sbp:
-    crc: '0xacb5'
+    crc: '0x4402'
     length: 13
     msg_type: '0x15'
-    payload: 5DiWQQAAiEN18/HFGA==
+    payload: AABoQQDANUTGxwBGCA==
     preamble: '0x55'
-    sender: '0x4cc'
+    sender: '0x4c3'
 
 For the sake of readability, some of the fields that are typically
 displayed as hex, such as SBP message type, crc, and preamble are cast
@@ -173,6 +175,7 @@ def mk_readable_msg(msg, keys=_TO_REMOVE):
   for k in keys:
     del f[k]
   i = {'raw_packet' : base64.standard_b64encode(msg.pack()),
+       'raw_json'   : msg.to_json(),
        'msg_type'   : hex(msg.msg_type),
        'sbp'        : _to_readable_dict(msg),
        'msg'        : { 'module' : msg.__class__.__module__,

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -96,6 +96,15 @@ def _assert_msg_roundtrip(msg, raw_packet):
   """
   assert base64.standard_b64encode(msg.to_binary()) == raw_packet
 
+def _assert_msg_roundtrip_json(msg, raw_json):
+  """
+  Asserts that a msg gets serialized back into JSON with the
+  expected value, as well as gets serialized from JSON into
+  an expected object.
+  """
+  assert msg.to_json() == raw_json
+  assert msg == msg.from_json(raw_json)
+
 def _assert_sane_package(pkg_name, pkg):
   """
   Sanity check the package collection of tests before actually
@@ -136,3 +145,4 @@ def assert_package(test_filename, pkg_name):
       _assert_sbp(sbp, test_case['sbp'])
       _assert_msg(dispatch(sbp), test_case['msg'])
       _assert_msg_roundtrip(dispatch(sbp), test_case['raw_packet'])
+      _assert_msg_roundtrip_json(dispatch(sbp), test_case['raw_json'])

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27
 
 [testenv]
-deps = -rrequirements.txt
+deps = -r{toxinidir}/requirements.txt
 commands = py.test -v tests/
 sitepackages = False
 usedevelop = True

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -3,7 +3,6 @@ envlist = py27
 
 [testenv]
 deps = -rrequirements.txt
-       pyyaml
 commands = py.test -v tests/
 sitepackages = False
 usedevelop = True

--- a/spec/tests/yaml/swiftnav/sbp/test_acquisition.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_acquisition.yaml
@@ -13,6 +13,8 @@ tests:
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 8, "cf": 8241.943359375, "crc":
+    17410, "length": 13, "snr": 14.5, "cp": 727.0, "preamble": 85, "payload": "AABoQQDANUTGxwBGCA=="}'
   raw_packet: VRUAwwQNAABoQQDANUTGxwBGCAJE
   sbp:
     crc: '0x4402'
@@ -31,6 +33,9 @@ tests:
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 9, "cf": 749.2676391601562, "crc":
+    7131, "length": 13, "snr": 15.300000190734863, "cp": 359.5, "preamble": 85, "payload":
+    "zcx0QQDAs0MhUTtECQ=="}'
   raw_packet: VRUAwwQNzcx0QQDAs0MhUTtECdsb
   sbp:
     crc: '0x1bdb'
@@ -49,6 +54,9 @@ tests:
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 11, "cf": -6493.65283203125,
+    "crc": 9110, "length": 13, "snr": 18.100000381469727, "cp": 40.5, "preamble":
+    85, "payload": "zcyQQQAAIkI57crFCw=="}'
   raw_packet: VRUAwwQNzcyQQQAAIkI57crFC5Yj
   sbp:
     crc: '0x2396'
@@ -67,6 +75,9 @@ tests:
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 12, "cf": -999.0234985351562,
+    "crc": 30354, "length": 13, "snr": 15.300000190734863, "cp": 548.5, "preamble":
+    85, "payload": "zcx0QQAgCUSBwXnEDA=="}'
   raw_packet: VRUAwwQNzcx0QQAgCUSBwXnEDJJ2
   sbp:
     crc: '0x7692'
@@ -85,6 +96,9 @@ tests:
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 14, "cf": 4745.361328125, "crc":
+    19223, "length": 13, "snr": 15.300000190734863, "cp": 780.5, "preamble": 85, "payload":
+    "zcx0QQAgQ0TkSpRFDg=="}'
   raw_packet: VRUAwwQNzcx0QQAgQ0TkSpRFDhdL
   sbp:
     crc: '0x4b17'
@@ -103,6 +117,9 @@ tests:
     module: sbp.acquisition
     name: MsgAcqResult
   msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 0, "cf": -499.5117492675781,
+    "crc": 53196, "length": 13, "snr": 163.22222900390625, "cp": 584.5, "preamble":
+    85, "payload": "5DgjQwAgEkSBwfnDAA=="}'
   raw_packet: VRUAwwQN5DgjQwAgEkSBwfnDAMzP
   sbp:
     crc: '0xcfcc'

--- a/spec/tests/yaml/swiftnav/sbp/test_logging.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_logging.yaml
@@ -10,6 +10,8 @@ tests:
     module: sbp.logging
     name: MsgPrint
   msg_type: '0x10'
+  raw_json: '{"sender": 1219, "msg_type": 16, "text": "INFO: Piksi Starting...", "crc":
+    33982, "length": 24, "preamble": 85, "payload": "SU5GTzogUGlrc2kgU3RhcnRpbmcuLi4K"}'
   raw_packet: VRAAwwQYSU5GTzogUGlrc2kgU3RhcnRpbmcuLi4KvoQ=
   sbp:
     crc: '0x84be'
@@ -25,6 +27,8 @@ tests:
     module: sbp.logging
     name: MsgPrint
   msg_type: '0x10'
+  raw_json: '{"sender": 1219, "msg_type": 16, "text": "INFO: Firmware Version: v0.15-rc1",
+    "crc": 27465, "length": 34, "preamble": 85, "payload": "SU5GTzogRmlybXdhcmUgVmVyc2lvbjogdjAuMTUtcmMxCg=="}'
   raw_packet: VRAAwwQiSU5GTzogRmlybXdhcmUgVmVyc2lvbjogdjAuMTUtcmMxCklr
   sbp:
     crc: '0x6b49'
@@ -40,6 +44,8 @@ tests:
     module: sbp.logging
     name: MsgPrint
   msg_type: '0x10'
+  raw_json: '{"sender": 1219, "msg_type": 16, "text": "INFO: Built: Apr  2 2015 00:31:34",
+    "crc": 2052, "length": 34, "preamble": 85, "payload": "SU5GTzogQnVpbHQ6IEFwciAgMiAyMDE1IDAwOjMxOjM0Cg=="}'
   raw_packet: VRAAwwQiSU5GTzogQnVpbHQ6IEFwciAgMiAyMDE1IDAwOjMxOjM0CgQI
   sbp:
     crc: '0x804'
@@ -55,6 +61,9 @@ tests:
     module: sbp.logging
     name: MsgPrint
   msg_type: '0x10'
+  raw_json: '{"sender": 1219, "msg_type": 16, "text": "INFO: No telemetry radio found
+    on UARTA, skipping configuration.", "crc": 13070, "length": 65, "preamble": 85,
+    "payload": "SU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRBLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgo="}'
   raw_packet: VRAAwwRBSU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRBLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgoOMw==
   sbp:
     crc: '0x330e'
@@ -70,6 +79,9 @@ tests:
     module: sbp.logging
     name: MsgPrint
   msg_type: '0x10'
+  raw_json: '{"sender": 1219, "msg_type": 16, "text": "INFO: No telemetry radio found
+    on UARTB, skipping configuration.", "crc": 3236, "length": 65, "preamble": 85,
+    "payload": "SU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRCLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgo="}'
   raw_packet: VRAAwwRBSU5GTzogTm8gdGVsZW1ldHJ5IHJhZGlvIGZvdW5kIG9uIFVBUlRCLCBza2lwcGluZyBjb25maWd1cmF0aW9uLgqkDA==
   sbp:
     crc: '0xca4'
@@ -85,6 +97,8 @@ tests:
     module: sbp.logging
     name: MsgPrint
   msg_type: '0x10'
+  raw_json: '{"sender": 1219, "msg_type": 16, "text": "INFO: NAP firmware version:
+    v0.11", "crc": 30195, "length": 34, "preamble": 85, "payload": "SU5GTzogTkFQIGZpcm13YXJlIHZlcnNpb246IHYwLjExCg=="}'
   raw_packet: VRAAwwQiSU5GTzogTkFQIGZpcm13YXJlIHZlcnNpb246IHYwLjExCvN1
   sbp:
     crc: '0x75f3'

--- a/spec/tests/yaml/swiftnav/sbp/test_navigation.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_navigation.yaml
@@ -13,6 +13,8 @@ tests:
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
+  raw_json: '{"sender": 1219, "msg_type": 256, "wn": 1838, "tow": 407084500, "crc":
+    48855, "length": 11, "flags": 0, "ns": -224401, "preamble": 85, "payload": "LgfUnUMYb5P8/wA="}'
   raw_packet: VQABwwQLLgfUnUMYb5P8/wDXvg==
   sbp:
     crc: '0xbed7'
@@ -31,6 +33,8 @@ tests:
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
+  raw_json: '{"sender": 1219, "msg_type": 256, "wn": 1838, "tow": 407084600, "crc":
+    22918, "length": 11, "flags": 0, "ns": 223085, "preamble": 85, "payload": "Lgc4nkMYbWcDAAA="}'
   raw_packet: VQABwwQLLgc4nkMYbWcDAACGWQ==
   sbp:
     crc: '0x5986'
@@ -49,6 +53,8 @@ tests:
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
+  raw_json: '{"sender": 1219, "msg_type": 256, "wn": 1838, "tow": 407084700, "crc":
+    61902, "length": 11, "flags": 0, "ns": -222999, "preamble": 85, "payload": "LgecnkMY6Zj8/wA="}'
   raw_packet: VQABwwQLLgecnkMY6Zj8/wDO8Q==
   sbp:
     crc: '0xf1ce'
@@ -67,6 +73,8 @@ tests:
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
+  raw_json: '{"sender": 1219, "msg_type": 256, "wn": 1838, "tow": 407084800, "crc":
+    25235, "length": 11, "flags": 0, "ns": 236272, "preamble": 85, "payload": "LgcAn0MY8JoDAAA="}'
   raw_packet: VQABwwQLLgcAn0MY8JoDAACTYg==
   sbp:
     crc: '0x6293'
@@ -85,6 +93,8 @@ tests:
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
+  raw_json: '{"sender": 1219, "msg_type": 256, "wn": 1838, "tow": 407084900, "crc":
+    39098, "length": 11, "flags": 0, "ns": -236144, "preamble": 85, "payload": "Lgdkn0MYkGX8/wA="}'
   raw_packet: VQABwwQLLgdkn0MYkGX8/wC6mA==
   sbp:
     crc: '0x98ba'
@@ -103,6 +113,8 @@ tests:
     module: sbp.navigation
     name: MsgGPSTime
   msg_type: '0x100'
+  raw_json: '{"sender": 1219, "msg_type": 256, "wn": 1838, "tow": 407151150, "crc":
+    57611, "length": 11, "flags": 0, "ns": -334131, "preamble": 85, "payload": "LgcuokQYzeb6/wA="}'
   raw_packet: VQABwwQLLgcuokQYzeb6/wAL4Q==
   sbp:
     crc: '0xe10b'
@@ -124,6 +136,10 @@ tests:
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 512, "tow": 407084500, "crc":
+    1169, "length": 32, "flags": 0, "y": -4263209.753232954, "x": -2704376.0110433814,
+    "z": 3884633.142084079, "preamble": 85, "payload": "1J1DGJneaQH8oUTB/vc0cEpDUMGkzy+SLKNNQQAACAA=",
+    "accuracy": 0}'
   raw_packet: VQACwwQg1J1DGJneaQH8oUTB/vc0cEpDUMGkzy+SLKNNQQAACACRBA==
   sbp:
     crc: '0x491'
@@ -145,6 +161,10 @@ tests:
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 512, "tow": 407084600, "crc":
+    17141, "length": 32, "flags": 0, "y": -4263208.610442672, "x": -2704375.9287024545,
+    "z": 3884632.627157578, "preamble": 85, "payload": "OJ5DGNe43/b7oUTBJH4RJ0pDUMETs0ZQLKNNQQAACAA=",
+    "accuracy": 0}'
   raw_packet: VQACwwQgOJ5DGNe43/b7oUTBJH4RJ0pDUMETs0ZQLKNNQQAACAD1Qg==
   sbp:
     crc: '0x42f5'
@@ -166,6 +186,10 @@ tests:
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 512, "tow": 407084700, "crc":
+    57093, "length": 32, "flags": 0, "y": -4263207.370641668, "x": -2704375.162789617,
+    "z": 3884631.282421521, "preamble": 85, "payload": "nJ5DGElK1pT7oUTB1Ze410lDUMFuYyakK6NNQQAACAA=",
+    "accuracy": 0}'
   raw_packet: VQACwwQgnJ5DGElK1pT7oUTB1Ze410lDUMFuYyakK6NNQQAACAAF3w==
   sbp:
     crc: '0xdf05'
@@ -187,6 +211,10 @@ tests:
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 512, "tow": 407084800, "crc":
+    54415, "length": 32, "flags": 0, "y": -4263207.965250214, "x": -2704376.3549937834,
+    "z": 3884632.1007095524, "preamble": 85, "payload": "AJ9DGLFvcC38oUTB1ajG/UlDUMH1DOQMLKNNQQAACAA=",
+    "accuracy": 0}'
   raw_packet: VQACwwQgAJ9DGLFvcC38oUTB1ajG/UlDUMH1DOQMLKNNQQAACACP1A==
   sbp:
     crc: '0xd48f'
@@ -208,6 +236,10 @@ tests:
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 512, "tow": 407084900, "crc":
+    56646, "length": 32, "flags": 0, "y": -4263207.314747473, "x": -2704375.291287334,
+    "z": 3884631.4773294823, "preamble": 85, "payload": "ZJ9DGEPnSKX7oUTBltIk1ElDUMHqIRm9K6NNQQAACAA=",
+    "accuracy": 0}'
   raw_packet: VQACwwQgZJ9DGEPnSKX7oUTBltIk1ElDUMHqIRm9K6NNQQAACABG3Q==
   sbp:
     crc: '0xdd46'
@@ -229,6 +261,10 @@ tests:
     module: sbp.navigation
     name: MsgPosECEF
   msg_type: '0x200'
+  raw_json: '{"n_sats": 5, "sender": 1219, "msg_type": 512, "tow": 407151150, "crc":
+    56593, "length": 32, "flags": 0, "y": -4263209.482329298, "x": -2704375.68369399,
+    "z": 3884635.5118107493, "preamble": 85, "payload": "LqJEGOBIg9f7oUTBtHveXkpDUMG/A4PBLaNNQQAABQA=",
+    "accuracy": 0}'
   raw_packet: VQACwwQgLqJEGOBIg9f7oUTBtHveXkpDUMG/A4PBLaNNQQAABQAR3Q==
   sbp:
     crc: '0xdd11'
@@ -250,6 +286,9 @@ tests:
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
+  raw_json: '{"n_sats": 6, "sender": 1219, "msg_type": 514, "tow": 407180700, "crc":
+    43154, "length": 20, "flags": 0, "y": -12186, "x": -6231, "z": 7419, "preamble":
+    85, "payload": "nBVFGKnn//9m0P//+xwAAAAABgA=", "accuracy": 0}'
   raw_packet: VQICwwQUnBVFGKnn//9m0P//+xwAAAAABgCSqA==
   sbp:
     crc: '0xa892'
@@ -271,6 +310,9 @@ tests:
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
+  raw_json: '{"n_sats": 6, "sender": 1219, "msg_type": 514, "tow": 407180800, "crc":
+    29730, "length": 20, "flags": 0, "y": -12185, "x": -6231, "z": 7420, "preamble":
+    85, "payload": "ABZFGKnn//9n0P///BwAAAAABgA=", "accuracy": 0}'
   raw_packet: VQICwwQUABZFGKnn//9n0P///BwAAAAABgAidA==
   sbp:
     crc: '0x7422'
@@ -292,6 +334,9 @@ tests:
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
+  raw_json: '{"n_sats": 6, "sender": 1219, "msg_type": 514, "tow": 407180900, "crc":
+    4065, "length": 20, "flags": 0, "y": -18496, "x": -8162, "z": 13807, "preamble":
+    85, "payload": "ZBZFGB7g///At///7zUAAAAABgA=", "accuracy": 0}'
   raw_packet: VQICwwQUZBZFGB7g///At///7zUAAAAABgDhDw==
   sbp:
     crc: '0xfe1'
@@ -313,6 +358,9 @@ tests:
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
+  raw_json: '{"n_sats": 6, "sender": 1219, "msg_type": 514, "tow": 407181000, "crc":
+    25635, "length": 20, "flags": 0, "y": -18497, "x": -8164, "z": 13810, "preamble":
+    85, "payload": "yBZFGBzg//+/t///8jUAAAAABgA=", "accuracy": 0}'
   raw_packet: VQICwwQUyBZFGBzg//+/t///8jUAAAAABgAjZA==
   sbp:
     crc: '0x6423'
@@ -334,6 +382,9 @@ tests:
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
+  raw_json: '{"n_sats": 6, "sender": 1219, "msg_type": 514, "tow": 407181100, "crc":
+    16962, "length": 20, "flags": 0, "y": -15591, "x": -7400, "z": 15257, "preamble":
+    85, "payload": "LBdFGBjj//8Zw///mTsAAAAABgA=", "accuracy": 0}'
   raw_packet: VQICwwQULBdFGBjj//8Zw///mTsAAAAABgBCQg==
   sbp:
     crc: '0x4242'
@@ -355,6 +406,9 @@ tests:
     module: sbp.navigation
     name: MsgBaselineECEF
   msg_type: '0x202'
+  raw_json: '{"n_sats": 6, "sender": 1219, "msg_type": 514, "tow": 407181200, "crc":
+    34595, "length": 20, "flags": 0, "y": -15591, "x": -7401, "z": 15257, "preamble":
+    85, "payload": "kBdFGBfj//8Zw///mTsAAAAABgA=", "accuracy": 0}'
   raw_packet: VQICwwQUkBdFGBfj//8Zw///mTsAAAAABgAjhw==
   sbp:
     crc: '0x8723'
@@ -377,6 +431,10 @@ tests:
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": 1265, "sender": 1219, "msg_type": 515, "tow":
+    407180700, "n": -2430, "crc": 5626, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 6, "preamble": 85, "payload": "nBVFGIL2///xBAAAI8T//wAAAAAGAA==", "d":
+    -15325}'
   raw_packet: VQMCwwQWnBVFGIL2///xBAAAI8T//wAAAAAGAPoV
   sbp:
     crc: '0x15fa'
@@ -399,6 +457,10 @@ tests:
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": 1265, "sender": 1219, "msg_type": 515, "tow":
+    407180800, "n": -2430, "crc": 34288, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 6, "preamble": 85, "payload": "ABZFGIL2///xBAAAI8T//wAAAAAGAA==", "d":
+    -15325}'
   raw_packet: VQMCwwQWABZFGIL2///xBAAAI8T//wAAAAAGAPCF
   sbp:
     crc: '0x85f0'
@@ -421,6 +483,10 @@ tests:
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": 3015, "sender": 1219, "msg_type": 515, "tow":
+    407180900, "n": -1248, "crc": 46348, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 6, "preamble": 85, "payload": "ZBZFGCD7///HCwAAOaH//wAAAAAGAA==", "d":
+    -24263}'
   raw_packet: VQMCwwQWZBZFGCD7///HCwAAOaH//wAAAAAGAAy1
   sbp:
     crc: '0xb50c'
@@ -443,6 +509,10 @@ tests:
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": 3015, "sender": 1219, "msg_type": 515, "tow":
+    407181000, "n": -1247, "crc": 14934, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 6, "preamble": 85, "payload": "yBZFGCH7///HCwAANqH//wAAAAAGAA==", "d":
+    -24266}'
   raw_packet: VQMCwwQWyBZFGCH7///HCwAANqH//wAAAAAGAFY6
   sbp:
     crc: '0x3a56'
@@ -465,6 +535,10 @@ tests:
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": 2103, "sender": 1219, "msg_type": 515, "tow":
+    407181100, "n": 1646, "crc": 63795, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 6, "preamble": 85, "payload": "LBdFGG4GAAA3CAAAoKb//wAAAAAGAA==", "d":
+    -22880}'
   raw_packet: VQMCwwQWLBdFGG4GAAA3CAAAoKb//wAAAAAGADP5
   sbp:
     crc: '0xf933'
@@ -487,6 +561,10 @@ tests:
     module: sbp.navigation
     name: MsgBaselineNED
   msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": 2102, "sender": 1219, "msg_type": 515, "tow":
+    407181200, "n": 1646, "crc": 5838, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 6, "preamble": 85, "payload": "kBdFGG4GAAA2CAAAoKb//wAAAAAGAA==", "d":
+    -22880}'
   raw_packet: VQMCwwQWkBdFGG4GAAA2CAAAoKb//wAAAAAGAM4W
   sbp:
     crc: '0x16ce'
@@ -508,6 +586,9 @@ tests:
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 516, "tow": 407084500, "crc":
+    65348, "length": 20, "flags": 0, "y": -11, "x": 24, "z": -37, "preamble": 85,
+    "payload": "1J1DGBgAAAD1////2////wAACAA=", "accuracy": 0}'
   raw_packet: VQQCwwQU1J1DGBgAAAD1////2////wAACABE/w==
   sbp:
     crc: '0xff44'
@@ -529,6 +610,9 @@ tests:
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 516, "tow": 407084600, "crc":
+    35030, "length": 20, "flags": 0, "y": -22, "x": 4, "z": 18, "preamble": 85, "payload":
+    "OJ5DGAQAAADq////EgAAAAAACAA=", "accuracy": 0}'
   raw_packet: VQQCwwQUOJ5DGAQAAADq////EgAAAAAACADWiA==
   sbp:
     crc: '0x88d6'
@@ -550,6 +634,9 @@ tests:
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 516, "tow": 407084700, "crc":
+    40826, "length": 20, "flags": 0, "y": 4, "x": -26, "z": 1, "preamble": 85, "payload":
+    "nJ5DGOb///8EAAAAAQAAAAAACAA=", "accuracy": 0}'
   raw_packet: VQQCwwQUnJ5DGOb///8EAAAAAQAAAAAACAB6nw==
   sbp:
     crc: '0x9f7a'
@@ -571,6 +658,9 @@ tests:
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 516, "tow": 407084800, "crc":
+    37608, "length": 20, "flags": 0, "y": -19, "x": -9, "z": 28, "preamble": 85, "payload":
+    "AJ9DGPf////t////HAAAAAAACAA=", "accuracy": 0}'
   raw_packet: VQQCwwQUAJ9DGPf////t////HAAAAAAACADokg==
   sbp:
     crc: '0x92e8'
@@ -592,6 +682,9 @@ tests:
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
+  raw_json: '{"n_sats": 8, "sender": 1219, "msg_type": 516, "tow": 407084900, "crc":
+    61099, "length": 20, "flags": 0, "y": 2, "x": -1, "z": -11, "preamble": 85, "payload":
+    "ZJ9DGP////8CAAAA9f///wAACAA=", "accuracy": 0}'
   raw_packet: VQQCwwQUZJ9DGP////8CAAAA9f///wAACACr7g==
   sbp:
     crc: '0xeeab'
@@ -613,6 +706,9 @@ tests:
     module: sbp.navigation
     name: MsgVelECEF
   msg_type: '0x204'
+  raw_json: '{"n_sats": 5, "sender": 1219, "msg_type": 516, "tow": 407151150, "crc":
+    39506, "length": 20, "flags": 0, "y": -71, "x": -49, "z": 65, "preamble": 85,
+    "payload": "LqJEGM////+5////QQAAAAAABQA=", "accuracy": 0}'
   raw_packet: VQQCwwQULqJEGM////+5////QQAAAAAABQBSmg==
   sbp:
     crc: '0x9a52'
@@ -635,6 +731,9 @@ tests:
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 26, "sender": 1219, "msg_type": 517, "tow": 407084500,
+    "n": -27, "crc": 6532, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats": 8,
+    "preamble": 85, "payload": "1J1DGOX///8aAAAAGQAAAAAAAAAIAA==", "d": 25}'
   raw_packet: VQUCwwQW1J1DGOX///8aAAAAGQAAAAAAAAAIAIQZ
   sbp:
     crc: '0x1984'
@@ -657,6 +756,9 @@ tests:
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 15, "sender": 1219, "msg_type": 517, "tow": 407084600,
+    "n": 4, "crc": 3626, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats": 8, "preamble":
+    85, "payload": "OJ5DGAQAAAAPAAAA6P///wAAAAAIAA==", "d": -24}'
   raw_packet: VQUCwwQWOJ5DGAQAAAAPAAAA6P///wAAAAAIACoO
   sbp:
     crc: '0xe2a'
@@ -679,6 +781,9 @@ tests:
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": -24, "sender": 1219, "msg_type": 517, "tow": 407084700,
+    "n": -5, "crc": 38106, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats": 8,
+    "preamble": 85, "payload": "nJ5DGPv////o////9////wAAAAAIAA==", "d": -9}'
   raw_packet: VQUCwwQWnJ5DGPv////o////9////wAAAAAIANqU
   sbp:
     crc: '0x94da'
@@ -701,6 +806,9 @@ tests:
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 2, "sender": 1219, "msg_type": 517, "tow": 407084800,
+    "n": 10, "crc": 4244, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats": 8,
+    "preamble": 85, "payload": "AJ9DGAoAAAACAAAA3v///wAAAAAIAA==", "d": -34}'
   raw_packet: VQUCwwQWAJ9DGAoAAAACAAAA3v///wAAAAAIAJQQ
   sbp:
     crc: '0x1094'
@@ -723,6 +831,9 @@ tests:
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": -2, "sender": 1219, "msg_type": 517, "tow": 407084900,
+    "n": -8, "crc": 60671, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats": 8,
+    "preamble": 85, "payload": "ZJ9DGPj////+////BwAAAAAAAAAIAA==", "d": 7}'
   raw_packet: VQUCwwQWZJ9DGPj////+////BwAAAAAAAAAIAP/s
   sbp:
     crc: '0xecff'
@@ -745,6 +856,9 @@ tests:
     module: sbp.navigation
     name: MsgVelNED
   msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": -3, "sender": 1219, "msg_type": 517, "tow": 407151150,
+    "n": -1, "crc": 48550, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats": 5,
+    "preamble": 85, "payload": "LqJEGP/////9////lP///wAAAAAFAA==", "d": -108}'
   raw_packet: VQUCwwQWLqJEGP/////9////lP///wAAAAAFAKa9
   sbp:
     crc: '0xbda6'
@@ -765,6 +879,9 @@ tests:
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
+  raw_json: '{"gdop": 247, "tdop": 123, "vdop": 44, "sender": 1219, "msg_type": 518,
+    "tow": 407084500, "pdop": 215, "crc": 5582, "length": 14, "preamble": 85, "payload":
+    "1J1DGPcA1wB7ABEBLAA=", "hdop": 273}'
   raw_packet: VQYCwwQO1J1DGPcA1wB7ABEBLADOFQ==
   sbp:
     crc: '0x15ce'
@@ -785,6 +902,9 @@ tests:
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
+  raw_json: '{"gdop": 65535, "tdop": 0, "vdop": 0, "sender": 1219, "msg_type": 518,
+    "tow": 0, "pdop": 65535, "crc": 3218, "length": 14, "preamble": 85, "payload":
+    "AAAAAP////8AAAAAAAA=", "hdop": 0}'
   raw_packet: VQYCwwQOAAAAAP////8AAAAAAACSDA==
   sbp:
     crc: '0xc92'
@@ -805,6 +925,9 @@ tests:
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
+  raw_json: '{"gdop": 348, "tdop": 155, "vdop": 113, "sender": 1219, "msg_type": 518,
+    "tow": 407152000, "pdop": 312, "crc": 23937, "length": 14, "preamble": 85, "payload":
+    "gKVEGFwBOAGbAH0CcQA=", "hdop": 637}'
   raw_packet: VQYCwwQOgKVEGFwBOAGbAH0CcQCBXQ==
   sbp:
     crc: '0x5d81'
@@ -825,6 +948,9 @@ tests:
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
+  raw_json: '{"gdop": 348, "tdop": 155, "vdop": 113, "sender": 1219, "msg_type": 518,
+    "tow": 407153000, "pdop": 311, "crc": 32977, "length": 14, "preamble": 85, "payload":
+    "aKlEGFwBNwGbAH0CcQA=", "hdop": 637}'
   raw_packet: VQYCwwQOaKlEGFwBNwGbAH0CcQDRgA==
   sbp:
     crc: '0x80d1'
@@ -845,6 +971,9 @@ tests:
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
+  raw_json: '{"gdop": 348, "tdop": 155, "vdop": 112, "sender": 1219, "msg_type": 518,
+    "tow": 407154000, "pdop": 311, "crc": 1566, "length": 14, "preamble": 85, "payload":
+    "UK1EGFwBNwGbAH0CcAA=", "hdop": 637}'
   raw_packet: VQYCwwQOUK1EGFwBNwGbAH0CcAAeBg==
   sbp:
     crc: '0x61e'
@@ -865,6 +994,9 @@ tests:
     module: sbp.navigation
     name: MsgDops
   msg_type: '0x206'
+  raw_json: '{"gdop": 348, "tdop": 155, "vdop": 112, "sender": 1219, "msg_type": 518,
+    "tow": 407155000, "pdop": 311, "crc": 17222, "length": 14, "preamble": 85, "payload":
+    "OLFEGFwBNwGbAH0CcAA=", "hdop": 637}'
   raw_packet: VQYCwwQOOLFEGFwBNwGbAH0CcABGQw==
   sbp:
     crc: '0x4346'
@@ -887,6 +1019,10 @@ tests:
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 8, "sender": 1219, "msg_type": 513, "lon":
+    -122.38908437889262, "tow": 407084500, "height": 4.039810885214956, "crc": 43501,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.76242171418386, "preamble":
+    85, "payload": "1J1DGAgX5AiX4UJAnK4qwuaYXsCZF0gvxCgQQAAAAAAIAA=="}'
   raw_packet: VQECwwQi1J1DGAgX5AiX4UJAnK4qwuaYXsCZF0gvxCgQQAAAAAAIAO2p
   sbp:
     crc: '0xa9ed'
@@ -909,6 +1045,10 @@ tests:
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 8, "sender": 1219, "msg_type": 513, "lon":
+    -122.38909053700489, "tow": 407084600, "height": 2.926714087009657, "crc": 2968,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.76242361423985, "preamble":
+    85, "payload": "OJ5DGNxt1BiX4UJAn+f+2+aYXsCAl0MT6WkHQAAAAAAIAA=="}'
   raw_packet: VQECwwQiOJ5DGNxt1BiX4UJAn+f+2+aYXsCAl0MT6WkHQAAAAAAIAJgL
   sbp:
     crc: '0xb98'
@@ -931,6 +1071,10 @@ tests:
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 8, "sender": 1219, "msg_type": 513, "lon":
+    -122.3890907340148, "tow": 407084700, "height": 0.9512146647395566, "crc": 39901,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.762422076126406, "preamble":
+    85, "payload": "nJ5DGA1b7QuX4UJAS3HS3OaYXsAlBpG8WXDuPwAAAAAIAA=="}'
   raw_packet: VQECwwQinJ5DGA1b7QuX4UJAS3HS3OaYXsAlBpG8WXDuPwAAAAAIAN2b
   sbp:
     crc: '0x9bdd'
@@ -953,6 +1097,10 @@ tests:
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 8, "sender": 1219, "msg_type": 513, "lon":
+    -122.38909854449612, "tow": 407084800, "height": 2.354135752047538, "crc": 24146,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.762421610632735, "preamble":
+    85, "payload": "AJ9DGDO3BQiX4UJADeKU/eaYXsC7GwsgRdUCQAAAAAAIAA=="}'
   raw_packet: VQECwwQiAJ9DGDO3BQiX4UJADeKU/eaYXsC7GwsgRdUCQAAAAAAIAFJe
   sbp:
     crc: '0x5e52'
@@ -975,6 +1123,10 @@ tests:
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 8, "sender": 1219, "msg_type": 513, "lon":
+    -122.38909230523223, "tow": 407084900, "height": 1.0876763181642641, "crc": 15430,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.76242334502801, "preamble":
+    85, "payload": "ZJ9DGBZNkhaX4UJAQIZp4+aYXsAlY3JIH2fxPwAAAAAIAA=="}'
   raw_packet: VQECwwQiZJ9DGBZNkhaX4UJAQIZp4+aYXsAlY3JIH2fxPwAAAAAIAEY8
   sbp:
     crc: '0x3c46'
@@ -997,6 +1149,10 @@ tests:
     module: sbp.navigation
     name: MsgPosLLH
   msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 5, "sender": 1219, "msg_type": 513, "lon":
+    -122.38908288868525, "tow": 407151150, "height": 5.171533844654222, "crc": 31188,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.76244082253376, "preamble":
+    85, "payload": "LqJEGHz1LqmX4UJAh5Xqu+aYXsDCyXORpq8UQAAAAAAFAA=="}'
   raw_packet: VQECwwQiLqJEGHz1LqmX4UJAh5Xqu+aYXsDCyXORpq8UQAAAAAAFANR5
   sbp:
     crc: '0x79d4'

--- a/spec/tests/yaml/swiftnav/sbp/test_observation.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_observation.yaml
@@ -64,6 +64,16 @@ tests:
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
+  raw_json: '{"sender": 1219, "msg_type": 69, "header": {"n_obs": 32, "t": {"wn":
+    1838, "tow": 407084600}}, "obs": [{"P": 2046421816, "prn": 0, "L": {"i": -36108,
+    "f": 33}, "cn0": 46, "lock": 55875}, {"P": 2085014510, "prn": 2, "L": {"i": 203030,
+    "f": 98}, "cn0": 43, "lock": 40376}, {"P": 2110096816, "prn": 3, "L": {"i": -178306,
+    "f": 185}, "cn0": 39, "lock": 14148}, {"P": 2208476476, "prn": 10, "L": {"i":
+    -137374, "f": 139}, "cn0": 30, "lock": 4129}, {"P": 2298000000, "prn": 13, "L":
+    {"i": -167638, "f": 40}, "cn0": 20, "lock": 18218}, {"P": 2266101494, "prn": 22,
+    "L": {"i": 209919, "f": 64}, "cn0": 27, "lock": 63852}, {"P": 1987193298, "prn":
+    30, "L": {"i": -53117, "f": 31}, "cn0": 52, "lock": 15074}], "crc": 55575, "length":
+    98, "preamble": 85, "payload": "OJ5DGC4HIDjr+Xn0cv//IS5D2gDuy0Z8FhkDAGIruJ0CsIXFfX5H/f+5J0Q3AzytooNi5/3/ix4hEAqAsviIKnH9/ygUKkcN9vYRh/8zAwBAG2z5FtIpcnaDMP//HzTiOh4="}'
   raw_packet: VUUAwwRiOJ5DGC4HIDjr+Xn0cv//IS5D2gDuy0Z8FhkDAGIruJ0CsIXFfX5H/f+5J0Q3AzytooNi5/3/ix4hEAqAsviIKnH9/ygUKkcN9vYRh/8zAwBAG2z5FtIpcnaDMP//HzTiOh4X2Q==
   sbp:
     crc: '0xd917'
@@ -91,6 +101,10 @@ tests:
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
+  raw_json: '{"sender": 1219, "msg_type": 69, "header": {"n_obs": 33, "t": {"wn":
+    1838, "tow": 407084600}}, "obs": [{"P": 1973695572, "prn": 31, "L": {"i": 8294,
+    "f": 147}, "cn0": 62, "lock": 64062}], "crc": 3818, "length": 20, "preamble":
+    85, "payload": "OJ5DGC4HIVQ0pHVmIAAAkz4++h8="}'
   raw_packet: VUUAwwQUOJ5DGC4HIVQ0pHVmIAAAkz4++h/qDg==
   sbp:
     crc: '0xeea'
@@ -160,6 +174,16 @@ tests:
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
+  raw_json: '{"sender": 1219, "msg_type": 69, "header": {"n_obs": 32, "t": {"wn":
+    1838, "tow": 407084800}}, "obs": [{"P": 2046415136, "prn": 0, "L": {"i": -36207,
+    "f": 141}, "cn0": 45, "lock": 55875}, {"P": 2084995249, "prn": 2, "L": {"i": 203599,
+    "f": 159}, "cn0": 44, "lock": 40376}, {"P": 2110097211, "prn": 3, "L": {"i": -178769,
+    "f": 77}, "cn0": 40, "lock": 14148}, {"P": 2208476371, "prn": 10, "L": {"i": -137807,
+    "f": 20}, "cn0": 31, "lock": 4129}, {"P": 2298000000, "prn": 13, "L": {"i": -168076,
+    "f": 94}, "cn0": 21, "lock": 18218}, {"P": 2266082742, "prn": 22, "L": {"i": 210469,
+    "f": 214}, "cn0": 27, "lock": 63852}, {"P": 1987187803, "prn": 30, "L": {"i":
+    -53264, "f": 129}, "cn0": 52, "lock": 15074}], "crc": 30664, "length": 98, "preamble":
+    85, "payload": "AJ9DGC4HICDR+XmRcv//jS1D2gCxgEZ8TxsDAJ8suJ0CO4fFfa9F/f9NKEQ3A9OsooOx5f3/FB8hEAqAsviIdG/9/14VKkcNtq0RhyU2AwDWG2z5FlsUcnbwL///gTTiOh4="}'
   raw_packet: VUUAwwRiAJ9DGC4HICDR+XmRcv//jS1D2gCxgEZ8TxsDAJ8suJ0CO4fFfa9F/f9NKEQ3A9OsooOx5f3/FB8hEAqAsviIdG/9/14VKkcNtq0RhyU2AwDWG2z5FlsUcnbwL///gTTiOh7Idw==
   sbp:
     crc: '0x77c8'
@@ -187,6 +211,10 @@ tests:
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
+  raw_json: '{"sender": 1219, "msg_type": 69, "header": {"n_obs": 33, "t": {"wn":
+    1838, "tow": 407084800}}, "obs": [{"P": 1973687089, "prn": 31, "L": {"i": 8312,
+    "f": 222}, "cn0": 63, "lock": 64062}], "crc": 59147, "length": 20, "preamble":
+    85, "payload": "AJ9DGC4HITETpHV4IAAA3j8++h8="}'
   raw_packet: VUUAwwQUAJ9DGC4HITETpHV4IAAA3j8++h8L5w==
   sbp:
     crc: '0xe70b'
@@ -242,6 +270,14 @@ tests:
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
+  raw_json: '{"sender": 1219, "msg_type": 69, "header": {"n_obs": 16, "t": {"wn":
+    1838, "tow": 407151200}}, "obs": [{"P": 2044298327, "prn": 0, "L": {"i": -27527,
+    "f": 189}, "cn0": 43, "lock": 37807}, {"P": 2110275716, "prn": 3, "L": {"i": -123030,
+    "f": 1}, "cn0": 41, "lock": 45326}, {"P": 2298000000, "prn": 13, "L": {"i": -113594,
+    "f": 166}, "cn0": 18, "lock": 34232}, {"P": 2259844888, "prn": 22, "L": {"i":
+    137478, "f": 249}, "cn0": 28, "lock": 24609}, {"P": 1985374378, "prn": 30, "L":
+    {"i": -36797, "f": 203}, "cn0": 56, "lock": 22736}], "crc": 27435, "length": 72,
+    "preamble": 85, "payload": "YKJEGC4HEFeE2Xl5lP//vSuvkwCEQMh9ah/+/wEpDrEDgLL4iEZE/v+mEriFDRh/soYGGQIA+RwhYBaqaFZ2Q3D//8s40Fge"}'
   raw_packet: VUUAwwRIYKJEGC4HEFeE2Xl5lP//vSuvkwCEQMh9ah/+/wEpDrEDgLL4iEZE/v+mEriFDRh/soYGGQIA+RwhYBaqaFZ2Q3D//8s40FgeK2s=
   sbp:
     crc: '0x6b2b'
@@ -297,6 +333,14 @@ tests:
     module: sbp.observation
     name: MsgObs
   msg_type: '0x45'
+  raw_json: '{"sender": 1219, "msg_type": 69, "header": {"n_obs": 16, "t": {"wn":
+    1838, "tow": 407151400}}, "obs": [{"P": 2044291972, "prn": 0, "L": {"i": -27634,
+    "f": 1}, "cn0": 44, "lock": 37807}, {"P": 2110276225, "prn": 3, "L": {"i": -123500,
+    "f": 153}, "cn0": 41, "lock": 45326}, {"P": 2298000000, "prn": 13, "L": {"i":
+    -114033, "f": 222}, "cn0": 18, "lock": 34232}, {"P": 2259826078, "prn": 22, "L":
+    {"i": 138026, "f": 237}, "cn0": 30, "lock": 24609}, {"P": 1985368870, "prn": 30,
+    "L": {"i": -36952, "f": 45}, "cn0": 56, "lock": 22736}], "crc": 44801, "length":
+    72, "preamble": 85, "payload": "KKNEGC4HEIRr2XkOlP//ASyvkwCBQsh9lB3+/5kpDrEDgLL4iI9C/v/eEriFDZ41soYqGwIA7R4hYBYmU1Z2qG///y040Fge"}'
   raw_packet: VUUAwwRIKKNEGC4HEIRr2XkOlP//ASyvkwCBQsh9lB3+/5kpDrEDgLL4iI9C/v/eEriFDZ41soYqGwIA7R4hYBYmU1Z2qG///y040FgeAa8=
   sbp:
     crc: '0xaf01'

--- a/spec/tests/yaml/swiftnav/sbp/test_piksi.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_piksi.yaml
@@ -12,6 +12,9 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
+  raw_json: '{"sender": 1219, "msg_type": 23, "cpu": 0, "crc": 54467, "length": 26,
+    "stack_free": 2452, "preamble": 85, "payload": "bWFpbgAAAAAAAAAAAAAAAAAAAAAAAJQJAAA=",
+    "name": "main\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
   raw_packet: VRcAwwQabWFpbgAAAAAAAAAAAAAAAAAAAAAAAJQJAADD1A==
   sbp:
     crc: '0xd4c3'
@@ -29,6 +32,9 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
+  raw_json: '{"sender": 1219, "msg_type": 23, "cpu": 484, "crc": 4833, "length": 26,
+    "stack_free": 36, "preamble": 85, "payload": "aWRsZQAAAAAAAAAAAAAAAAAAAADkASQAAAA=",
+    "name": "idle\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
   raw_packet: VRcAwwQaaWRsZQAAAAAAAAAAAAAAAAAAAADkASQAAADhEg==
   sbp:
     crc: '0x12e1'
@@ -46,6 +52,9 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
+  raw_json: '{"sender": 1219, "msg_type": 23, "cpu": 394, "crc": 29862, "length":
+    26, "stack_free": 1884, "preamble": 85, "payload": "TkFQIElTUgAAAAAAAAAAAAAAAACKAVwHAAA=",
+    "name": "NAP ISR\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
   raw_packet: VRcAwwQaTkFQIElTUgAAAAAAAAAAAAAAAACKAVwHAACmdA==
   sbp:
     crc: '0x74a6'
@@ -63,6 +72,9 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
+  raw_json: '{"sender": 1219, "msg_type": 23, "cpu": 1, "crc": 44773, "length": 26,
+    "stack_free": 3076, "preamble": 85, "payload": "U0JQAAAAAAAAAAAAAAAAAAAAAAABAAQMAAA=",
+    "name": "SBP\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
   raw_packet: VRcAwwQaU0JQAAAAAAAAAAAAAAAAAAAAAAABAAQMAADlrg==
   sbp:
     crc: '0xaee5'
@@ -80,6 +92,9 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
+  raw_json: '{"sender": 1219, "msg_type": 23, "cpu": 10, "crc": 564, "length": 26,
+    "stack_free": 2428, "preamble": 85, "payload": "bWFuYWdlIGFjcQAAAAAAAAAAAAAKAHwJAAA=",
+    "name": "manage acq\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
   raw_packet: VRcAwwQabWFuYWdlIGFjcQAAAAAAAAAAAAAKAHwJAAA0Ag==
   sbp:
     crc: '0x234'
@@ -97,6 +112,9 @@ tests:
     module: sbp.piksi
     name: MsgThreadState
   msg_type: '0x17'
+  raw_json: '{"sender": 1219, "msg_type": 23, "cpu": 0, "crc": 13946, "length": 26,
+    "stack_free": 2332, "preamble": 85, "payload": "bWFuYWdlIHRyYWNrAAAAAAAAAAAAABwJAAA=",
+    "name": "manage track\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
   raw_packet: VRcAwwQabWFuYWdlIHRyYWNrAAAAAAAAAAAAABwJAAB6Ng==
   sbp:
     crc: '0x367a'
@@ -137,6 +155,14 @@ tests:
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    1219, "msg_type": 24, "crc": 1527, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.0}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.0}, "preamble": 85, "payload": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJqZOUEAAAAAAAAAAA8A/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 0, "tx_buffer_level": 15, "rx_throughput": 0.0,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 11.600000381469727}}'
   raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJqZOUEAAAAAAAAAAA8A/////wAAAAAAAAAA//////cF
   sbp:
     crc: '0x5f7'
@@ -177,6 +203,14 @@ tests:
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    1219, "msg_type": 24, "crc": 28225, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.0}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.0}, "preamble": 85, "payload": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 0, "tx_buffer_level": 0, "rx_throughput": 0.0,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 0.06599999964237213}}'
   raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////0Fu
   sbp:
     crc: '0x6e41'
@@ -217,6 +251,14 @@ tests:
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    1219, "msg_type": 24, "crc": 9414, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.0}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.0}, "preamble": 85, "payload": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARWDj4AAAAAAAAAAAoA/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 0, "tx_buffer_level": 10, "rx_throughput": 0.0,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 0.13899999856948853}}'
   raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARWDj4AAAAAAAAAAAoA/////wAAAAAAAAAA/////8Yk
   sbp:
     crc: '0x24c6'
@@ -257,6 +299,14 @@ tests:
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    1219, "msg_type": 24, "crc": 28225, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.0}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    0, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.0}, "preamble": 85, "payload": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 0, "tx_buffer_level": 0, "rx_throughput": 0.0,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 0.06599999964237213}}'
   raw_packet: VRgAwwQ6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIrhz0AAAAAAAAAAAAA/////wAAAAAAAAAA/////0Fu
   sbp:
     crc: '0x6e41'
@@ -297,6 +347,14 @@ tests:
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    1219, "msg_type": 24, "crc": 28528, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 2, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.09836065769195557}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    0, "rx_throughput": 0.008196720853447914, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.0}, "preamble": 85, "payload": "AAAAAIpLBjwAAAAAAABQcck9AAAAAAAAAAACAJHt/D4AAAAAAAAAACYA/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 0, "tx_buffer_level": 38, "rx_throughput": 0.0,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 0.49399998784065247}}'
   raw_packet: VRgAwwQ6AAAAAIpLBjwAAAAAAABQcck9AAAAAAAAAAACAJHt/D4AAAAAAAAAACYA/////wAAAAAAAAAA/////3Bv
   sbp:
     crc: '0x6f70'
@@ -337,6 +395,14 @@ tests:
     module: sbp.piksi
     name: MsgUartState
   msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    1219, "msg_type": 24, "crc": 18454, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 2, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 0.012000000104308128}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    2, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.012000000104308128}, "preamble": 85, "payload": "pptEPAAAAAAAAAAAAgCmm0Q8AAAAAAAAAAACAOxRqD8AAAAAAAAAADIA/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 0, "tx_buffer_level": 50, "rx_throughput": 0.0,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 1.315000057220459}}'
   raw_packet: VRgAwwQ6pptEPAAAAAAAAAAAAgCmm0Q8AAAAAAAAAAACAOxRqD8AAAAAAAAAADIA/////wAAAAAAAAAA/////xZI
   sbp:
     crc: '0x4816'
@@ -352,6 +418,8 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
+  raw_json: '{"sender": 1219, "msg_type": 25, "num_hyps": 0, "crc": 45074, "length":
+    4, "preamble": 85, "payload": "AAAAAA=="}'
   raw_packet: VRkAwwQEAAAAABKw
   sbp:
     crc: '0xb012'
@@ -367,6 +435,8 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
+  raw_json: '{"sender": 1219, "msg_type": 25, "num_hyps": 1, "crc": 50854, "length":
+    4, "preamble": 85, "payload": "AQAAAA=="}'
   raw_packet: VRkAwwQEAQAAAKbG
   sbp:
     crc: '0xc6a6'
@@ -382,6 +452,8 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
+  raw_json: '{"sender": 1219, "msg_type": 25, "num_hyps": 729, "crc": 34054, "length":
+    4, "preamble": 85, "payload": "2QIAAA=="}'
   raw_packet: VRkAwwQE2QIAAAaF
   sbp:
     crc: '0x8506'
@@ -397,6 +469,8 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
+  raw_json: '{"sender": 1219, "msg_type": 25, "num_hyps": 728, "crc": 62386, "length":
+    4, "preamble": 85, "payload": "2AIAAA=="}'
   raw_packet: VRkAwwQE2AIAALLz
   sbp:
     crc: '0xf3b2'
@@ -412,6 +486,8 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
+  raw_json: '{"sender": 1219, "msg_type": 25, "num_hyps": 727, "crc": 10076, "length":
+    4, "preamble": 85, "payload": "1wIAAA=="}'
   raw_packet: VRkAwwQE1wIAAFwn
   sbp:
     crc: '0x275c'
@@ -427,6 +503,8 @@ tests:
     module: sbp.piksi
     name: MsgIarState
   msg_type: '0x19'
+  raw_json: '{"sender": 1219, "msg_type": 25, "num_hyps": 723, "crc": 60845, "length":
+    4, "preamble": 85, "payload": "0wIAAA=="}'
   raw_packet: VRkAwwQE0wIAAK3t
   sbp:
     crc: '0xedad'

--- a/spec/tests/yaml/swiftnav/sbp/test_system.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_system.yaml
@@ -10,6 +10,8 @@ tests:
     module: sbp.system
     name: MsgStartup
   msg_type: '0xff00'
+  raw_json: '{"reserved": 0, "sender": 1219, "msg_type": 65280, "crc": 46463, "length":
+    4, "preamble": 85, "payload": "AAAAAA=="}'
   raw_packet: VQD/wwQEAAAAAH+1
   sbp:
     crc: '0xb57f'
@@ -25,6 +27,8 @@ tests:
     module: sbp.system
     name: MsgHeartbeat
   msg_type: '0xffff'
+  raw_json: '{"sender": 1219, "msg_type": 65535, "crc": 14658, "length": 4, "flags":
+    0, "preamble": 85, "payload": "AAAAAA=="}'
   raw_packet: Vf//wwQEAAAAAEI5
   sbp:
     crc: '0x3942'

--- a/spec/tests/yaml/swiftnav/sbp/test_tracking.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_tracking.yaml
@@ -43,6 +43,14 @@ tests:
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
+  raw_json: '{"sender": 1219, "msg_type": 22, "states": [{"state": 1, "prn": 0, "cn0":
+    11.230907440185547}, {"state": 1, "prn": 2, "cn0": 10.438665390014648}, {"state":
+    1, "prn": 3, "cn0": 9.732142448425293}, {"state": 1, "prn": 7, "cn0": 14.341922760009766},
+    {"state": 1, "prn": 10, "cn0": 7.8549017906188965}, {"state": 1, "prn": 13, "cn0":
+    5.0982866287231445}, {"state": 1, "prn": 22, "cn0": 6.741272926330566}, {"state":
+    1, "prn": 30, "cn0": 12.700549125671387}, {"state": 1, "prn": 31, "cn0": 15.893081665039062},
+    {"state": 1, "prn": 25, "cn0": 4.242738723754883}, {"state": 1, "prn": 6, "cn0":
+    6.97599983215332}], "crc": 57617, "length": 66, "preamble": 85, "payload": "AQDMsTNBAQLGBCdBAQPbthtBAQeEeGVBAQpbW/tAAQ0qJaNAARaCuNdAAR5zNUtBAR8QSn5BARmExIdAAQZkO99A"}'
   raw_packet: VRYAwwRCAQDMsTNBAQLGBCdBAQPbthtBAQeEeGVBAQpbW/tAAQ0qJaNAARaCuNdAAR5zNUtBAR8QSn5BARmExIdAAQZkO99AEeE=
   sbp:
     crc: '0xe111'
@@ -91,6 +99,14 @@ tests:
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
+  raw_json: '{"sender": 1219, "msg_type": 22, "states": [{"state": 1, "prn": 0, "cn0":
+    11.014122009277344}, {"state": 1, "prn": 2, "cn0": 10.885148048400879}, {"state":
+    1, "prn": 3, "cn0": 10.131351470947266}, {"state": 1, "prn": 7, "cn0": 14.829026222229004},
+    {"state": 1, "prn": 10, "cn0": 7.79104471206665}, {"state": 1, "prn": 13, "cn0":
+    4.868161201477051}, {"state": 1, "prn": 22, "cn0": 6.721095561981201}, {"state":
+    1, "prn": 30, "cn0": 12.971323013305664}, {"state": 1, "prn": 31, "cn0": 15.481405258178711},
+    {"state": 1, "prn": 25, "cn0": 3.8834354877471924}, {"state": 1, "prn": 6, "cn0":
+    4.061488628387451}], "crc": 44456, "length": 66, "preamble": 85, "payload": "AQDYOTBBAQKRKS5BAQMEGiJBAQexQ21BAQo9UPlAAQ36x5tAARY3E9dAAR6Kik9BAR/Ws3dBARk1inhAAQa394FA"}'
   raw_packet: VRYAwwRCAQDYOTBBAQKRKS5BAQMEGiJBAQexQ21BAQo9UPlAAQ36x5tAARY3E9dAAR6Kik9BAR/Ws3dBARk1inhAAQa394FAqK0=
   sbp:
     crc: '0xada8'
@@ -139,6 +155,14 @@ tests:
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
+  raw_json: '{"sender": 1219, "msg_type": 22, "states": [{"state": 1, "prn": 0, "cn0":
+    11.768689155578613}, {"state": 1, "prn": 2, "cn0": 10.909001350402832}, {"state":
+    1, "prn": 3, "cn0": 9.881731033325195}, {"state": 1, "prn": 7, "cn0": 14.076395988464355},
+    {"state": 1, "prn": 10, "cn0": 7.619818210601807}, {"state": 1, "prn": 13, "cn0":
+    5.208371162414551}, {"state": 1, "prn": 22, "cn0": 6.2935872077941895}, {"state":
+    1, "prn": 30, "cn0": 13.232341766357422}, {"state": 1, "prn": 31, "cn0": 15.547346115112305},
+    {"state": 1, "prn": 25, "cn0": 4.130964279174805}, {"state": 1, "prn": 6, "cn0":
+    2.856823205947876}], "crc": 45934, "length": 66, "preamble": 85, "payload": "AQCNTDxBAQJFiy5BAQOSGx5BAQfrOGFBAQqN1fNAAQ36qqZAARYRZclAAR6st1NBAR/uwXhBARncMIRAAQYx1jZA"}'
   raw_packet: VRYAwwRCAQCNTDxBAQJFiy5BAQOSGx5BAQfrOGFBAQqN1fNAAQ36qqZAARYRZclAAR6st1NBAR/uwXhBARncMIRAAQYx1jZAbrM=
   sbp:
     crc: '0xb36e'
@@ -187,6 +211,13 @@ tests:
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
+  raw_json: '{"sender": 1219, "msg_type": 22, "states": [{"state": 1, "prn": 0, "cn0":
+    62.13985824584961}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0,
+    "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0":
+    -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0},
+    {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state":
+    0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}], "crc": 23032,
+    "length": 66, "preamble": 85, "payload": "AQA3j3hCAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/"}'
   raw_packet: VRYAwwRCAQA3j3hCAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/+Fk=
   sbp:
     crc: '0x59f8'
@@ -235,6 +266,13 @@ tests:
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
+  raw_json: '{"sender": 1219, "msg_type": 22, "states": [{"state": 1, "prn": 0, "cn0":
+    36.764503479003906}, {"state": 1, "prn": 2, "cn0": 9.313432693481445}, {"state":
+    1, "prn": 3, "cn0": 16.854938507080078}, {"state": 0, "prn": 0, "cn0": -1.0},
+    {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state":
+    0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn":
+    0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0":
+    -1.0}], "crc": 25940, "length": 66, "preamble": 85, "payload": "AQDaDhNCAQLSAxVBAQPq1oZBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/"}'
   raw_packet: VRYAwwRCAQDaDhNCAQLSAxVBAQPq1oZBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/VGU=
   sbp:
     crc: '0x6554'
@@ -283,6 +321,13 @@ tests:
     module: sbp.tracking
     name: MsgTrackingState
   msg_type: '0x16'
+  raw_json: '{"sender": 1219, "msg_type": 22, "states": [{"state": 1, "prn": 0, "cn0":
+    27.394229888916016}, {"state": 1, "prn": 2, "cn0": 2.875}, {"state": 1, "prn":
+    3, "cn0": 8.467644691467285}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0,
+    "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn":
+    0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0":
+    -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}, {"state": 0, "prn": 0, "cn0": -1.0}],
+    "crc": 31525, "length": 66, "preamble": 85, "payload": "AQBiJ9tBAQIAADhAAQN5ewdBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/"}'
   raw_packet: VRYAwwRCAQBiJ9tBAQIAADhAAQN5ewdBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/JXs=
   sbp:
     crc: '0x7b25'


### PR DESCRIPTION
Provide full serialization of JSON objects. This change introduces a static `from_json` method for each message class, and a `to_json` method for each message class. This enables serializing and deserializing full objects to and from JSON. It's not super optimal on deserialization in that it parses out the JSON and then parses it again through construct, but that can be fixed up later (it wasn't trivial to reconstitute the construct containering). Tests were added around the JSON serialization and deserialization via raw_json outputs in the test YAML. Sub-objects do not have JSON serdes methods.

/cc @mookerji 