### PR TITLE
Make the handler test more robust

### DIFF
--- a/python/tests/sbp/client/test_handler.py
+++ b/python/tests/sbp/client/test_handler.py
@@ -65,22 +65,21 @@ def test_framer_ok():
   assert msg.length == 13
   assert msg.crc == 0x4feb
 
+def until(p, limit=1000):
+  for i in itertools.count():
+    if p():
+      break
+    assert i < limit
+
 def test_listener_thread_ok():
   sema = TestCallbackSemaphore()
   listener_thread = ReceiveThread(lambda: SBP(True, None, None, None, None), sema)
   listener_thread.start()
   assert listener_thread.is_alive()
-  for i in itertools.count():
-    if sema.sema.acquire(False):
-      break
-    assert i < 1000
+  until(lambda: sema.sema.acquire(False))
   listener_thread.stop()
-  while listener_thread.is_alive():
-    pass
-  for i in itertools.count():
-    if not sema.sema.acquire(False):
-      break
-    assert i < 1000
+  until(lambda: listener_thread.is_alive())
+  until(lambda: sema.sema.acquire(False))
 
 def test_handler_callbacks():
   handler = Handler(None, None)

--- a/python/tests/sbp/client/test_logger.py
+++ b/python/tests/sbp/client/test_logger.py
@@ -46,7 +46,6 @@ def test_log():
         pass
   assert exc_info.value.message == "next() not implemented!"
 
-@pytest.mark.skipif(True, reason="missing terminator.")
 def test_pickle_log():
   """
   pickle log iterator sanity tests.
@@ -67,7 +66,6 @@ def test_pickle_log():
       assert "SBP payload deserialization error! 0x18" in w[0].message
     assert count == 1111
 
-@pytest.mark.skipif(True, reason="missing terminator.")
 def test_basic_pickle_log():
   """
   pickle log iterator sanity tests with a normal handle.
@@ -100,7 +98,6 @@ def test_json_log():
       assert len(w) == 0
   assert count == 2650
 
-@pytest.mark.skipif(True, reason="missing terminator.")
 def test_pickle_log_missing():
   """
   Remove a key from the dispatch and make sure that the iterator


### PR DESCRIPTION
Use semaphores to track progress and avoid race conditions:

1. start the thread, which constantly calls release
2. spin until we can acquire the lock (ensure thread is active)
3. stop the thread
4. spin until we can't acquire the lock (ensure thread is dead)

/cc @fnoble @mookerji 

