### PR TITLE
Catch message dispatch KeyErrors and make them warnings.

### DIFF
--- a/python/sbp/table.py
+++ b/python/sbp/table.py
@@ -68,9 +68,10 @@ def dispatch(msg, table=_SBP_TABLE):
   try:
     return table[msg.msg_type](msg)
   except KeyError:
-    error_msg = "No message found for msg_type id %d for msg %s." \
-                % (msg.msg_type, msg)
-    raise InvalidSBPMessageType(error_msg)
+    warn = "No message found for msg_type id %d for msg %s." \
+           % (msg.msg_type, msg)
+    warnings.warn(warn, RuntimeWarning)
+    return msg
   except FieldError:
     warnings.warn("SBP payload deserialization error! 0x%x" % msg.msg_type,
                   RuntimeWarning)

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -14,6 +14,7 @@ from sbp.table import InvalidSBPMessageType
 import pytest
 import sbp.acquisition as acq
 import sbp.logging as log
+import warnings
 
 def test_table_count():
   """
@@ -37,6 +38,9 @@ def test_available_messages():
   # object.
   assert dispatch(msg, table) == acq.MsgAcqResult(msg)
   msg = SBP(msg_type=0xB0, sender=1219, length=4, payload='v1.2', crc=0xCE01)
-  with pytest.raises(InvalidSBPMessageType) as exc_info:
+  with warnings.catch_warnings(record=True) as w:
     dispatch(msg, table)
-  assert str(exc_info.value).find("No message found for msg_type id 176*")
+    warnings.simplefilter("always")
+    assert len(w) == 1
+    assert issubclass(w[0].category, RuntimeWarning)
+    assert str(w[0].message).find("No message found for msg_type id 176 for msg*")


### PR DESCRIPTION
In the event that we're missing a message in the dispatch table, raise
a warning instead of throwing an exception.

/cc @fnoble @mfine