### PR TITLE
Update SBP fields when materializing child objects.

### DIFF
--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -17,7 +17,7 @@
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 ((*- for i in include *))
@@ -102,6 +102,8 @@ class ((( m.identifier | classnameify )))(SBP):
     (((f.desc)))
   ((*- endif *))
   ((*- endfor *))
+  sender : int
+    Optional sender ID, defaults to 0
   ((*- endif *))
 
   """
@@ -120,8 +122,11 @@ class ((( m.identifier | classnameify )))(SBP):
       ((*- else *))
       self.payload = sbp.payload
       ((*- endif *))
-    ((*- if m.fields*))
     else:
+      super( ((( m.identifier | classnameify ))), self).__init__()
+      self.msg_type = SBP_(((m.identifier)))
+      self.sender = kwargs.pop('sender', 0)
+    ((*- if m.fields*))
       ((*- for f in m.fields *))
       self.(((f.identifier))) = kwargs.pop('(((f.identifier)))')
       ((*- endfor *))
@@ -142,7 +147,7 @@ class ((( m.identifier | classnameify )))(SBP):
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = ((( m.identifier | classnameify )))._parser.build(c)
     return self.pack()
 
@@ -156,6 +161,7 @@ class ((( m.identifier | classnameify )))(SBP):
     return ((( m.identifier | classnameify )))(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( ((( m.identifier | classnameify ))), self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/__init__.py
+++ b/python/sbp/__init__.py
@@ -83,19 +83,29 @@ class SBP(object):
   def __eq__(self, other):
     return self.__dict__ == other.__dict__
 
-  def pack(self):
-    """Pack to framed binary message.
+  def __update(self):
+    raise NotImplementedError("Internal update used by children.")
+
+  def _get_framed(self):
+    """Returns the framed message and updates the CRC.
 
     """
+    self.length = len(self.payload)
     framed_msg = struct.pack('<BHHB',
                              self.preamble,
                              self.msg_type,
                              self.sender,
-                             len(self.payload))
+                             self.length)
     framed_msg += self.payload
-    crc = crc16(framed_msg[1:], 0)
-    framed_msg += struct.pack('<H', crc)
+    self.crc = crc16(framed_msg[1:], 0)
+    framed_msg += struct.pack('<H', self.crc)
     return framed_msg
+
+  def pack(self):
+    """Pack to framed binary message.
+
+    """
+    return self._get_framed()
 
   @staticmethod
   def unpack(d):
@@ -145,4 +155,3 @@ class SBP(object):
             'length': self.length,
             'payload': base64.standard_b64encode(self.payload),
             'crc': self.crc}
-

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -17,7 +17,7 @@ Satellite acquisition messages from the device.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/acquisition.yaml with generate.py.
@@ -56,6 +56,8 @@ units of dB Hz in the revision of this message.
     PRN-1 identifier of the satellite signal for which
 acquisition was attempted
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgAcqResult",
@@ -69,6 +71,9 @@ acquisition was attempted
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgAcqResult, self).__init__()
+      self.msg_type = SBP_MSG_ACQ_RESULT
+      self.sender = kwargs.pop('sender', 0)
       self.snr = kwargs.pop('snr')
       self.cp = kwargs.pop('cp')
       self.cf = kwargs.pop('cf')
@@ -89,7 +94,7 @@ acquisition was attempted
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgAcqResult._parser.build(c)
     return self.pack()
 
@@ -103,6 +108,7 @@ acquisition was attempted
     return MsgAcqResult(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgAcqResult, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -23,7 +23,7 @@ device response.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/bootload.yaml with generate.py.
@@ -51,6 +51,8 @@ earlier versions.
     SBP parent object to inherit from.
   handshake : array
     Version number string (not NULL terminated)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgBootloaderHandshake",
@@ -61,6 +63,9 @@ earlier versions.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgBootloaderHandshake, self).__init__()
+      self.msg_type = SBP_MSG_BOOTLOADER_HANDSHAKE
+      self.sender = kwargs.pop('sender', 0)
       self.handshake = kwargs.pop('handshake')
 
   def __repr__(self):
@@ -78,7 +83,7 @@ earlier versions.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgBootloaderHandshake._parser.build(c)
     return self.pack()
 
@@ -92,6 +97,7 @@ earlier versions.
     return MsgBootloaderHandshake(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgBootloaderHandshake, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -115,6 +121,8 @@ class MsgBootloaderJumpToApp(SBP):
     SBP parent object to inherit from.
   jump : int
     Ignored by the device
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgBootloaderJumpToApp",
@@ -125,6 +133,9 @@ class MsgBootloaderJumpToApp(SBP):
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgBootloaderJumpToApp, self).__init__()
+      self.msg_type = SBP_MSG_BOOTLOADER_JUMP_TO_APP
+      self.sender = kwargs.pop('sender', 0)
       self.jump = kwargs.pop('jump')
 
   def __repr__(self):
@@ -142,7 +153,7 @@ class MsgBootloaderJumpToApp(SBP):
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgBootloaderJumpToApp._parser.build(c)
     return self.pack()
 
@@ -156,6 +167,7 @@ class MsgBootloaderJumpToApp(SBP):
     return MsgBootloaderJumpToApp(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgBootloaderJumpToApp, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -186,6 +198,8 @@ to the Piksi's serial number.
     57-bit SwiftNAP FPGA Device ID. Remaining bits are padded
 on the right.
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgNapDeviceDna",
@@ -196,6 +210,9 @@ on the right.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgNapDeviceDna, self).__init__()
+      self.msg_type = SBP_MSG_NAP_DEVICE_DNA
+      self.sender = kwargs.pop('sender', 0)
       self.dna = kwargs.pop('dna')
 
   def __repr__(self):
@@ -213,7 +230,7 @@ on the right.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgNapDeviceDna._parser.build(c)
     return self.pack()
 
@@ -227,6 +244,7 @@ on the right.
     return MsgNapDeviceDna(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgNapDeviceDna, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -19,7 +19,7 @@ e.g. camera shutter time.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml with generate.py.
@@ -55,6 +55,8 @@ from -500000 to 500000)
     Flags
   pin : int
     Pin number.  0..9 = DEBUG0..9.
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgExtEvent",
@@ -69,6 +71,9 @@ from -500000 to 500000)
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgExtEvent, self).__init__()
+      self.msg_type = SBP_MSG_EXT_EVENT
+      self.sender = kwargs.pop('sender', 0)
       self.wn = kwargs.pop('wn')
       self.tow = kwargs.pop('tow')
       self.ns = kwargs.pop('ns')
@@ -90,7 +95,7 @@ from -500000 to 500000)
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgExtEvent._parser.build(c)
     return self.pack()
 
@@ -104,6 +109,7 @@ from -500000 to 500000)
     return MsgExtEvent(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgExtEvent, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -27,7 +27,7 @@ device response.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/file_io.yaml with generate.py.
@@ -61,6 +61,8 @@ message".
     Chunk size to read
   filename : string
     Name of the file to read from (NULL padded)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFileioRead",
@@ -73,6 +75,9 @@ message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFileioRead, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_READ
+      self.sender = kwargs.pop('sender', 0)
       self.offset = kwargs.pop('offset')
       self.chunk_size = kwargs.pop('chunk_size')
       self.filename = kwargs.pop('filename')
@@ -92,7 +97,7 @@ message".
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFileioRead._parser.build(c)
     return self.pack()
 
@@ -106,6 +111,7 @@ message".
     return MsgFileioRead(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFileioRead, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -140,6 +146,8 @@ message".
 
   dirname : string
     Name of the directory to list (NULL padded)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFileioReadDir",
@@ -151,6 +159,9 @@ message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFileioReadDir, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_READ_DIR
+      self.sender = kwargs.pop('sender', 0)
       self.offset = kwargs.pop('offset')
       self.dirname = kwargs.pop('dirname')
 
@@ -169,7 +180,7 @@ message".
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFileioReadDir._parser.build(c)
     return self.pack()
 
@@ -183,6 +194,7 @@ message".
     return MsgFileioReadDir(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFileioReadDir, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -208,6 +220,8 @@ message is invalid, a followup MSG_PRINT message will print
     SBP parent object to inherit from.
   filename : string
     Name of the file to delete (NULL padded)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFileioRemove",
@@ -218,6 +232,9 @@ message is invalid, a followup MSG_PRINT message will print
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFileioRemove, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_REMOVE
+      self.sender = kwargs.pop('sender', 0)
       self.filename = kwargs.pop('filename')
 
   def __repr__(self):
@@ -235,7 +252,7 @@ message is invalid, a followup MSG_PRINT message will print
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFileioRemove._parser.build(c)
     return self.pack()
 
@@ -249,6 +266,7 @@ message is invalid, a followup MSG_PRINT message will print
     return MsgFileioRemove(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFileioRemove, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -280,6 +298,8 @@ print "Invalid fileio write message".
     Offset into the file at which to start writing in bytes
   data : array
     Variable-length array of data to write
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFileioWrite",
@@ -292,6 +312,9 @@ print "Invalid fileio write message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFileioWrite, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_WRITE
+      self.sender = kwargs.pop('sender', 0)
       self.filename = kwargs.pop('filename')
       self.offset = kwargs.pop('offset')
       self.data = kwargs.pop('data')
@@ -311,7 +334,7 @@ print "Invalid fileio write message".
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFileioWrite._parser.build(c)
     return self.pack()
 
@@ -325,6 +348,7 @@ print "Invalid fileio write message".
     return MsgFileioWrite(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFileioWrite, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -24,7 +24,7 @@ are intended for internal-use only.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/flash.yaml with generate.py.
@@ -62,6 +62,8 @@ starting address
 
   data : array
     Data to program addresses with, with length N=addr_len
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFlashProgram",
@@ -75,6 +77,9 @@ starting address
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFlashProgram, self).__init__()
+      self.msg_type = SBP_MSG_FLASH_PROGRAM
+      self.sender = kwargs.pop('sender', 0)
       self.target = kwargs.pop('target')
       self.addr_start = kwargs.pop('addr_start')
       self.addr_len = kwargs.pop('addr_len')
@@ -95,7 +100,7 @@ starting address
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFlashProgram._parser.build(c)
     return self.pack()
 
@@ -109,6 +114,7 @@ starting address
     return MsgFlashProgram(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFlashProgram, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -135,6 +141,8 @@ return this message on failure.
     SBP parent object to inherit from.
   response : int
     Response flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFlashDone",
@@ -145,6 +153,9 @@ return this message on failure.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFlashDone, self).__init__()
+      self.msg_type = SBP_MSG_FLASH_DONE
+      self.sender = kwargs.pop('sender', 0)
       self.response = kwargs.pop('response')
 
   def __repr__(self):
@@ -162,7 +173,7 @@ return this message on failure.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFlashDone._parser.build(c)
     return self.pack()
 
@@ -176,6 +187,7 @@ return this message on failure.
     return MsgFlashDone(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFlashDone, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -211,6 +223,8 @@ range.
     Length of set of addresses to read, counting up from
 starting address
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFlashRead",
@@ -223,6 +237,9 @@ starting address
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFlashRead, self).__init__()
+      self.msg_type = SBP_MSG_FLASH_READ
+      self.sender = kwargs.pop('sender', 0)
       self.target = kwargs.pop('target')
       self.addr_start = kwargs.pop('addr_start')
       self.addr_len = kwargs.pop('addr_len')
@@ -242,7 +259,7 @@ starting address
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFlashRead._parser.build(c)
     return self.pack()
 
@@ -256,6 +273,7 @@ starting address
     return MsgFlashRead(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFlashRead, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -287,6 +305,8 @@ invalid.
     Flash sector number to erase (0-11 for the STM, 0-15 for
 the M25)
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFlashErase",
@@ -298,6 +318,9 @@ the M25)
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgFlashErase, self).__init__()
+      self.msg_type = SBP_MSG_FLASH_ERASE
+      self.sender = kwargs.pop('sender', 0)
       self.target = kwargs.pop('target')
       self.sector_num = kwargs.pop('sector_num')
 
@@ -316,7 +339,7 @@ the M25)
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgFlashErase._parser.build(c)
     return self.pack()
 
@@ -330,6 +353,7 @@ the M25)
     return MsgFlashErase(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgFlashErase, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -354,6 +378,8 @@ memory. The device replies with a MSG_FLASH_DONE message.
     SBP parent object to inherit from.
   sector : int
     Flash sector number to lock
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgStmFlashLockSector",
@@ -364,6 +390,9 @@ memory. The device replies with a MSG_FLASH_DONE message.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgStmFlashLockSector, self).__init__()
+      self.msg_type = SBP_MSG_STM_FLASH_LOCK_SECTOR
+      self.sender = kwargs.pop('sender', 0)
       self.sector = kwargs.pop('sector')
 
   def __repr__(self):
@@ -381,7 +410,7 @@ memory. The device replies with a MSG_FLASH_DONE message.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgStmFlashLockSector._parser.build(c)
     return self.pack()
 
@@ -395,6 +424,7 @@ memory. The device replies with a MSG_FLASH_DONE message.
     return MsgStmFlashLockSector(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgStmFlashLockSector, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -419,6 +449,8 @@ memory. The device replies with a MSG_FLASH_DONE message.
     SBP parent object to inherit from.
   sector : int
     Flash sector number to unlock
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgStmFlashUnlockSector",
@@ -429,6 +461,9 @@ memory. The device replies with a MSG_FLASH_DONE message.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgStmFlashUnlockSector, self).__init__()
+      self.msg_type = SBP_MSG_STM_FLASH_UNLOCK_SECTOR
+      self.sender = kwargs.pop('sender', 0)
       self.sector = kwargs.pop('sector')
 
   def __repr__(self):
@@ -446,7 +481,7 @@ memory. The device replies with a MSG_FLASH_DONE message.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgStmFlashUnlockSector._parser.build(c)
     return self.pack()
 
@@ -460,6 +495,7 @@ memory. The device replies with a MSG_FLASH_DONE message.
     return MsgStmFlashUnlockSector(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgStmFlashUnlockSector, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -484,6 +520,8 @@ returns 12-byte unique ID back to host.
     SBP parent object to inherit from.
   stm_id : array
     Device unique ID
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgStmUniqueId",
@@ -494,6 +532,9 @@ returns 12-byte unique ID back to host.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgStmUniqueId, self).__init__()
+      self.msg_type = SBP_MSG_STM_UNIQUE_ID
+      self.sender = kwargs.pop('sender', 0)
       self.stm_id = kwargs.pop('stm_id')
 
   def __repr__(self):
@@ -511,7 +552,7 @@ returns 12-byte unique ID back to host.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgStmUniqueId._parser.build(c)
     return self.pack()
 
@@ -525,6 +566,7 @@ returns 12-byte unique ID back to host.
     return MsgStmUniqueId(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgStmUniqueId, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -549,6 +591,8 @@ register. The device replies with a MSG_FLASH_DONE message.
     SBP parent object to inherit from.
   status : array
     Byte to write to the M25 flash status register
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgM25FlashWriteStatus",
@@ -559,6 +603,9 @@ register. The device replies with a MSG_FLASH_DONE message.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgM25FlashWriteStatus, self).__init__()
+      self.msg_type = SBP_MSG_M25_FLASH_WRITE_STATUS
+      self.sender = kwargs.pop('sender', 0)
       self.status = kwargs.pop('status')
 
   def __repr__(self):
@@ -576,7 +623,7 @@ register. The device replies with a MSG_FLASH_DONE message.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgM25FlashWriteStatus._parser.build(c)
     return self.pack()
 
@@ -590,6 +637,7 @@ register. The device replies with a MSG_FLASH_DONE message.
     return MsgM25FlashWriteStatus(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgM25FlashWriteStatus, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -19,7 +19,7 @@ implementation-defined range (0x0000-0x00FF).
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/logging.yaml with generate.py.
@@ -46,6 +46,8 @@ ERROR, WARNING, DEBUG, INFO logging levels.
     SBP parent object to inherit from.
   text : string
     Human-readable string
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgPrint",
@@ -56,6 +58,9 @@ ERROR, WARNING, DEBUG, INFO logging levels.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgPrint, self).__init__()
+      self.msg_type = SBP_MSG_PRINT
+      self.sender = kwargs.pop('sender', 0)
       self.text = kwargs.pop('text')
 
   def __repr__(self):
@@ -73,7 +78,7 @@ ERROR, WARNING, DEBUG, INFO logging levels.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgPrint._parser.build(c)
     return self.pack()
 
@@ -87,6 +92,7 @@ ERROR, WARNING, DEBUG, INFO logging levels.
     return MsgPrint(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgPrint, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -111,6 +117,10 @@ within the device firmware and streaming those back to the host.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgDebugVar, self).__init__()
+      self.msg_type = SBP_MSG_DEBUG_VAR
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -28,7 +28,7 @@ and the RTK solution in tandem.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/navigation.yaml with generate.py.
@@ -73,6 +73,8 @@ from -500000 to 500000)
 
   flags : int
     Status flags (reserved)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgGPSTime",
@@ -86,6 +88,9 @@ from -500000 to 500000)
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgGPSTime, self).__init__()
+      self.msg_type = SBP_MSG_GPS_TIME
+      self.sender = kwargs.pop('sender', 0)
       self.wn = kwargs.pop('wn')
       self.tow = kwargs.pop('tow')
       self.ns = kwargs.pop('ns')
@@ -106,7 +111,7 @@ from -500000 to 500000)
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgGPSTime._parser.build(c)
     return self.pack()
 
@@ -120,6 +125,7 @@ from -500000 to 500000)
     return MsgGPSTime(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgGPSTime, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -155,6 +161,8 @@ precision.
     Horizontal Dilution of Precision
   vdop : int
     Vertical Dilution of Precision
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgDops",
@@ -170,6 +178,9 @@ precision.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgDops, self).__init__()
+      self.msg_type = SBP_MSG_DOPS
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.gdop = kwargs.pop('gdop')
       self.pdop = kwargs.pop('pdop')
@@ -192,7 +203,7 @@ precision.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgDops._parser.build(c)
     return self.pack()
 
@@ -206,6 +217,7 @@ precision.
     return MsgDops(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgDops, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -250,6 +262,8 @@ to 0.
     Number of satellites used in solution
   flags : int
     Status flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgPosECEF",
@@ -266,6 +280,9 @@ to 0.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgPosECEF, self).__init__()
+      self.msg_type = SBP_MSG_POS_ECEF
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.x = kwargs.pop('x')
       self.y = kwargs.pop('y')
@@ -289,7 +306,7 @@ to 0.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgPosECEF._parser.build(c)
     return self.pack()
 
@@ -303,6 +320,7 @@ to 0.
     return MsgPosECEF(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgPosECEF, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -351,6 +369,8 @@ implemented). Defaults to 0.
     Number of satellites used in solution.
   flags : int
     Status flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgPosLLH",
@@ -368,6 +388,9 @@ implemented). Defaults to 0.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgPosLLH, self).__init__()
+      self.msg_type = SBP_MSG_POS_LLH
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.lat = kwargs.pop('lat')
       self.lon = kwargs.pop('lon')
@@ -392,7 +415,7 @@ implemented). Defaults to 0.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgPosLLH._parser.build(c)
     return self.pack()
 
@@ -406,6 +429,7 @@ implemented). Defaults to 0.
     return MsgPosLLH(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgPosLLH, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -447,6 +471,8 @@ to 0.
     Number of satellites used in solution
   flags : int
     Status flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgBaselineECEF",
@@ -463,6 +489,9 @@ to 0.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgBaselineECEF, self).__init__()
+      self.msg_type = SBP_MSG_BASELINE_ECEF
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.x = kwargs.pop('x')
       self.y = kwargs.pop('y')
@@ -486,7 +515,7 @@ to 0.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgBaselineECEF._parser.build(c)
     return self.pack()
 
@@ -500,6 +529,7 @@ to 0.
     return MsgBaselineECEF(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgBaselineECEF, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -546,6 +576,8 @@ implemented). Defaults to 0.
     Number of satellites used in solution
   flags : int
     Status flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgBaselineNED",
@@ -563,6 +595,9 @@ implemented). Defaults to 0.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgBaselineNED, self).__init__()
+      self.msg_type = SBP_MSG_BASELINE_NED
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.n = kwargs.pop('n')
       self.e = kwargs.pop('e')
@@ -587,7 +622,7 @@ implemented). Defaults to 0.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgBaselineNED._parser.build(c)
     return self.pack()
 
@@ -601,6 +636,7 @@ implemented). Defaults to 0.
     return MsgBaselineNED(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgBaselineNED, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -640,6 +676,8 @@ to 0.
     Number of satellites used in solution
   flags : int
     Status flags (reserved)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgVelECEF",
@@ -656,6 +694,9 @@ to 0.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgVelECEF, self).__init__()
+      self.msg_type = SBP_MSG_VEL_ECEF
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.x = kwargs.pop('x')
       self.y = kwargs.pop('y')
@@ -679,7 +720,7 @@ to 0.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgVelECEF._parser.build(c)
     return self.pack()
 
@@ -693,6 +734,7 @@ to 0.
     return MsgVelECEF(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgVelECEF, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -736,6 +778,8 @@ implemented). Defaults to 0.
     Number of satellites used in solution
   flags : int
     Status flags (reserved)
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgVelNED",
@@ -753,6 +797,9 @@ implemented). Defaults to 0.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgVelNED, self).__init__()
+      self.msg_type = SBP_MSG_VEL_NED
+      self.sender = kwargs.pop('sender', 0)
       self.tow = kwargs.pop('tow')
       self.n = kwargs.pop('n')
       self.e = kwargs.pop('e')
@@ -777,7 +824,7 @@ implemented). Defaults to 0.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgVelNED._parser.build(c)
     return self.pack()
 
@@ -791,6 +838,7 @@ implemented). Defaults to 0.
     return MsgVelNED(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgVelNED, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -17,7 +17,7 @@ Satellite observation messages from the device.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/observation.yaml with generate.py.
@@ -193,6 +193,8 @@ whole cycles and 8-bits of fractional cycles).
     Pseudorange and carrier phase observation for a
 satellite being tracked.
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgObs",
@@ -204,6 +206,9 @@ satellite being tracked.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgObs, self).__init__()
+      self.msg_type = SBP_MSG_OBS
+      self.sender = kwargs.pop('sender', 0)
       self.header = kwargs.pop('header')
       self.obs = kwargs.pop('obs')
 
@@ -222,7 +227,7 @@ satellite being tracked.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgObs._parser.build(c)
     return self.pack()
 
@@ -236,6 +241,7 @@ satellite being tracked.
     return MsgObs(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgObs, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -267,6 +273,8 @@ error in the pseudo-absolute position output.
     Longitude
   height : double
     Height
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgBasePos",
@@ -279,6 +287,9 @@ error in the pseudo-absolute position output.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgBasePos, self).__init__()
+      self.msg_type = SBP_MSG_BASE_POS
+      self.sender = kwargs.pop('sender', 0)
       self.lat = kwargs.pop('lat')
       self.lon = kwargs.pop('lon')
       self.height = kwargs.pop('height')
@@ -298,7 +309,7 @@ error in the pseudo-absolute position output.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgBasePos._parser.build(c)
     return self.pack()
 
@@ -312,6 +323,7 @@ error in the pseudo-absolute position output.
     return MsgBasePos(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgBasePos, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -389,6 +401,8 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     Satellite is healthy?
   prn : int
     PRN being tracked
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgEphemeris",
@@ -424,6 +438,9 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgEphemeris, self).__init__()
+      self.msg_type = SBP_MSG_EPHEMERIS
+      self.sender = kwargs.pop('sender', 0)
       self.tgd = kwargs.pop('tgd')
       self.crs = kwargs.pop('crs')
       self.crc = kwargs.pop('crc')
@@ -466,7 +483,7 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgEphemeris._parser.build(c)
     return self.pack()
 
@@ -480,6 +497,7 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     return MsgEphemeris(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgEphemeris, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -23,7 +23,7 @@ These messages are in the implementation-defined range
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/piksi.yaml with generate.py.
@@ -139,6 +139,10 @@ alamanac onto the Piksi's flash memory from the host.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgAlmanac, self).__init__()
+      self.msg_type = SBP_MSG_ALMANAC
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -163,6 +167,10 @@ time estimate sent by the host.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgSetTime, self).__init__()
+      self.msg_type = SBP_MSG_SET_TIME
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -187,6 +195,10 @@ bootloader.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgReset, self).__init__()
+      self.msg_type = SBP_MSG_RESET
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -212,6 +224,10 @@ removed in a future release.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgCwResults, self).__init__()
+      self.msg_type = SBP_MSG_CW_RESULTS
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -237,6 +253,10 @@ be removed in a future release.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgCwStart, self).__init__()
+      self.msg_type = SBP_MSG_CW_START
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -261,6 +281,8 @@ Ambiguity Resolution (IAR) process.
     SBP parent object to inherit from.
   filter : int
     Filter flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgResetFilters",
@@ -271,6 +293,9 @@ Ambiguity Resolution (IAR) process.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgResetFilters, self).__init__()
+      self.msg_type = SBP_MSG_RESET_FILTERS
+      self.sender = kwargs.pop('sender', 0)
       self.filter = kwargs.pop('filter')
 
   def __repr__(self):
@@ -288,7 +313,7 @@ Ambiguity Resolution (IAR) process.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgResetFilters._parser.build(c)
     return self.pack()
 
@@ -302,6 +327,7 @@ Ambiguity Resolution (IAR) process.
     return MsgResetFilters(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgResetFilters, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -329,6 +355,10 @@ observations between the two.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgInitBase, self).__init__()
+      self.msg_type = SBP_MSG_INIT_BASE
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -360,6 +390,8 @@ thread. The reported percentage values require to be normalized.
 
   stack_free : int
     Free stack space for this thread
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgThreadState",
@@ -372,6 +404,9 @@ thread. The reported percentage values require to be normalized.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgThreadState, self).__init__()
+      self.msg_type = SBP_MSG_THREAD_STATE
+      self.sender = kwargs.pop('sender', 0)
       self.name = kwargs.pop('name')
       self.cpu = kwargs.pop('cpu')
       self.stack_free = kwargs.pop('stack_free')
@@ -391,7 +426,7 @@ thread. The reported percentage values require to be normalized.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgThreadState._parser.build(c)
     return self.pack()
 
@@ -405,6 +440,7 @@ thread. The reported percentage values require to be normalized.
     return MsgThreadState(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgThreadState, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -438,6 +474,8 @@ future. The reported percentage values require to be normalized.
     State of UART FTDI (USB logger)
   latency : Latency
     UART communication latency
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgUartState",
@@ -451,6 +489,9 @@ future. The reported percentage values require to be normalized.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgUartState, self).__init__()
+      self.msg_type = SBP_MSG_UART_STATE
+      self.sender = kwargs.pop('sender', 0)
       self.uart_a = kwargs.pop('uart_a')
       self.uart_b = kwargs.pop('uart_b')
       self.uart_ftdi = kwargs.pop('uart_ftdi')
@@ -471,7 +512,7 @@ future. The reported percentage values require to be normalized.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgUartState._parser.build(c)
     return self.pack()
 
@@ -485,6 +526,7 @@ future. The reported percentage values require to be normalized.
     return MsgUartState(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgUartState, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -511,6 +553,8 @@ from satellite observations.
     SBP parent object to inherit from.
   num_hyps : int
     Number of integer ambiguity hypotheses remaining
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgIarState",
@@ -521,6 +565,9 @@ from satellite observations.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgIarState, self).__init__()
+      self.msg_type = SBP_MSG_IAR_STATE
+      self.sender = kwargs.pop('sender', 0)
       self.num_hyps = kwargs.pop('num_hyps')
 
   def __repr__(self):
@@ -538,7 +585,7 @@ from satellite observations.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgIarState._parser.build(c)
     return self.pack()
 
@@ -552,6 +599,7 @@ from satellite observations.
     return MsgIarState(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgIarState, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -24,7 +24,7 @@ https://github.com/swift-nav/piksi\_firmware/blob/master/docs/settings.pdf
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/settings.yaml with generate.py.
@@ -52,6 +52,8 @@ class MsgSettings(SBP):
 [SECTION_SETTING, SETTING, VALUE] on writes or a series of
 such strings on reads.
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgSettings",
@@ -62,6 +64,9 @@ such strings on reads.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgSettings, self).__init__()
+      self.msg_type = SBP_MSG_SETTINGS
+      self.sender = kwargs.pop('sender', 0)
       self.setting = kwargs.pop('setting')
 
   def __repr__(self):
@@ -79,7 +84,7 @@ such strings on reads.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgSettings._parser.build(c)
     return self.pack()
 
@@ -93,6 +98,7 @@ such strings on reads.
     return MsgSettings(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgSettings, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -117,6 +123,10 @@ configuration to its onboard flash memory file system.
     if sbp:
       self.__dict__.update(sbp.__dict__)
       self.payload = sbp.payload
+    else:
+      super( MsgSettingsSave, self).__init__()
+      self.msg_type = SBP_MSG_SETTINGS_SAVE
+      self.sender = kwargs.pop('sender', 0)
 
   def __repr__(self):
     return fmt_repr(self)
@@ -145,6 +155,8 @@ NULL-terminated and delimited string with contents
     An index into the device settings, with values ranging from
 0 to length(settings)
 
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgSettingsReadByIndex",
@@ -155,6 +167,9 @@ NULL-terminated and delimited string with contents
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgSettingsReadByIndex, self).__init__()
+      self.msg_type = SBP_MSG_SETTINGS_READ_BY_INDEX
+      self.sender = kwargs.pop('sender', 0)
       self.index = kwargs.pop('index')
 
   def __repr__(self):
@@ -172,7 +187,7 @@ NULL-terminated and delimited string with contents
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgSettingsReadByIndex._parser.build(c)
     return self.pack()
 
@@ -186,6 +201,7 @@ NULL-terminated and delimited string with contents
     return MsgSettingsReadByIndex(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgSettingsReadByIndex, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -17,7 +17,7 @@ Standardized system messages from Swift Navigation devices.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/system.yaml with generate.py.
@@ -45,6 +45,8 @@ or configuration requests.
     SBP parent object to inherit from.
   reserved : int
     Reserved
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgStartup",
@@ -55,6 +57,9 @@ or configuration requests.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgStartup, self).__init__()
+      self.msg_type = SBP_MSG_STARTUP
+      self.sender = kwargs.pop('sender', 0)
       self.reserved = kwargs.pop('reserved')
 
   def __repr__(self):
@@ -72,7 +77,7 @@ or configuration requests.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgStartup._parser.build(c)
     return self.pack()
 
@@ -86,6 +91,7 @@ or configuration requests.
     return MsgStartup(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgStartup, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -118,6 +124,8 @@ the remaining error flags should be inspected.
     SBP parent object to inherit from.
   flags : int
     Status flags
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgHeartbeat",
@@ -128,6 +136,9 @@ the remaining error flags should be inspected.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgHeartbeat, self).__init__()
+      self.msg_type = SBP_MSG_HEARTBEAT
+      self.sender = kwargs.pop('sender', 0)
       self.flags = kwargs.pop('flags')
 
   def __repr__(self):
@@ -145,7 +156,7 @@ the remaining error flags should be inspected.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgHeartbeat._parser.build(c)
     return self.pack()
 
@@ -159,6 +170,7 @@ the remaining error flags should be inspected.
     return MsgHeartbeat(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgHeartbeat, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -18,7 +18,7 @@ Satellite code and carrier-phase tracking messages from the device.
 from construct import *
 import json
 from sbp import SBP
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize
 import six
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/tracking.yaml with generate.py.
@@ -80,6 +80,8 @@ all tracked satellites.
     SBP parent object to inherit from.
   states : array
     Satellite tracking channel state
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgTrackingState",
@@ -90,6 +92,9 @@ all tracked satellites.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgTrackingState, self).__init__()
+      self.msg_type = SBP_MSG_TRACKING_STATE
+      self.sender = kwargs.pop('sender', 0)
       self.states = kwargs.pop('states')
 
   def __repr__(self):
@@ -107,7 +112,7 @@ all tracked satellites.
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgTrackingState._parser.build(c)
     return self.pack()
 
@@ -121,6 +126,7 @@ all tracked satellites.
     return MsgTrackingState(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgTrackingState, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
@@ -194,6 +200,8 @@ class MsgEphemerisOld(SBP):
     Satellite is healthy?
   prn : int
     PRN being tracked
+  sender : int
+    Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgEphemerisOld",
@@ -229,6 +237,9 @@ class MsgEphemerisOld(SBP):
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+      super( MsgEphemerisOld, self).__init__()
+      self.msg_type = SBP_MSG_EPHEMERIS_OLD
+      self.sender = kwargs.pop('sender', 0)
       self.tgd = kwargs.pop('tgd')
       self.crs = kwargs.pop('crs')
       self.crc = kwargs.pop('crc')
@@ -271,7 +282,7 @@ class MsgEphemerisOld(SBP):
     """Produce a framed/packed SBP message.
 
     """
-    c = Container(**exclude_fields(self))
+    c = containerize(exclude_fields(self))
     self.payload = MsgEphemerisOld._parser.build(c)
     return self.pack()
 
@@ -285,6 +296,7 @@ class MsgEphemerisOld(SBP):
     return MsgEphemerisOld(sbp)
 
   def to_json_dict(self):
+    self.to_binary()
     d = super( MsgEphemerisOld, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -14,7 +14,7 @@ Utilities for running YAML-defined unit tests.
 """
 
 from sbp import SBP
-from sbp.table import dispatch
+from sbp.table import dispatch, _SBP_TABLE
 import base64
 import json
 import yaml
@@ -106,6 +106,17 @@ def _assert_msg_roundtrip_json(msg, raw_json):
   assert json.loads(msg.to_json()) == json.loads(raw_json)
   assert msg == msg.from_json(raw_json)
 
+def _assert_materialization(msg, sbp, raw_json):
+  """Asserts that a message materialized will get serialized into the
+  right JSON object.
+
+  """
+  fields = msg['fields']
+  fields.update({'sender': sbp.sender})
+  live_msg = _SBP_TABLE[sbp.msg_type](**fields)
+  assert isinstance(live_msg.to_json_dict(), dict)
+  assert live_msg.to_json_dict() == json.loads(raw_json)
+
 def _assert_sane_package(pkg_name, pkg):
   """
   Sanity check the package collection of tests before actually
@@ -147,3 +158,4 @@ def assert_package(test_filename, pkg_name):
       _assert_msg(dispatch(sbp), test_case['msg'])
       _assert_msg_roundtrip(dispatch(sbp), test_case['raw_packet'])
       _assert_msg_roundtrip_json(dispatch(sbp), test_case['raw_json'])
+      _assert_materialization(test_case['msg'], sbp, test_case['raw_json'])


### PR DESCRIPTION
Oh joy! Apparently, instantiating an SBP message and then attempting
to serialize results in an error from the parent SBP object, which
hasn't been backfilled (crc, etc.). This adds an __update call to
children objects to update these fields.

/cc @fnoble @mfine