### PR TITLE
Crc namespace collision

### DIFF
--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -124,12 +124,12 @@ typedef struct __attribute__((packed)) {
 #define SBP_MSG_EPHEMERIS 0x0046
 typedef struct __attribute__((packed)) {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
-  double crs;         /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
-  double crc;         /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
-  double cuc;         /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
-  double cus;         /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
-  double cic;         /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
-  double cis;         /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
+  double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
+  double c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
+  double c_uc;        /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
+  double c_us;        /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
+  double c_ic;        /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
+  double c_is;        /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
   double dn;          /**< Mean motion difference [rad/s] */
   double m0;          /**< Mean anomaly at reference time [radians] */
   double ecc;         /**< Eccentricity of satellite orbit */

--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -57,12 +57,12 @@ typedef struct __attribute__((packed)) {
 #define SBP_MSG_EPHEMERIS_OLD  0x001A
 typedef struct __attribute__((packed)) {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
-  double crs;         /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
-  double crc;         /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
-  double cuc;         /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
-  double cus;         /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
-  double cic;         /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
-  double cis;         /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
+  double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
+  double c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
+  double c_uc;        /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
+  double c_us;        /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
+  double c_ic;        /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
+  double c_is;        /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
   double dn;          /**< Mean motion difference [rad/s] */
   double m0;          /**< Mean anomaly at reference time [radians] */
   double ecc;         /**< Eccentricity of satellite orbit */

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -351,17 +351,17 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     SBP parent object to inherit from.
   tgd : double
     Group delay differential between L1 and L2
-  crs : double
+  c_rs : double
     Amplitude of the sine harmonic correction term to the orbit radius
-  crc : double
+  c_rc : double
     Amplitude of the cosine harmonic correction term to the orbit radius
-  cuc : double
+  c_uc : double
     Amplitude of the cosine harmonic correction term to the argument of latitude
-  cus : double
+  c_us : double
     Amplitude of the sine harmonic correction term to the argument of latitude
-  cic : double
+  c_ic : double
     Amplitude of the cosine harmonic correction term to the angle of inclination
-  cis : double
+  c_is : double
     Amplitude of the sine harmonic correction term to the angle of inclination
   dn : double
     Mean motion difference
@@ -407,12 +407,12 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
   """
   _parser = Struct("MsgEphemeris",
                    LFloat64('tgd'),
-                   LFloat64('crs'),
-                   LFloat64('crc'),
-                   LFloat64('cuc'),
-                   LFloat64('cus'),
-                   LFloat64('cic'),
-                   LFloat64('cis'),
+                   LFloat64('c_rs'),
+                   LFloat64('c_rc'),
+                   LFloat64('c_uc'),
+                   LFloat64('c_us'),
+                   LFloat64('c_ic'),
+                   LFloat64('c_is'),
                    LFloat64('dn'),
                    LFloat64('m0'),
                    LFloat64('ecc'),
@@ -442,12 +442,12 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
       self.msg_type = SBP_MSG_EPHEMERIS
       self.sender = kwargs.pop('sender', 0)
       self.tgd = kwargs.pop('tgd')
-      self.crs = kwargs.pop('crs')
-      self.crc = kwargs.pop('crc')
-      self.cuc = kwargs.pop('cuc')
-      self.cus = kwargs.pop('cus')
-      self.cic = kwargs.pop('cic')
-      self.cis = kwargs.pop('cis')
+      self.c_rs = kwargs.pop('c_rs')
+      self.c_rc = kwargs.pop('c_rc')
+      self.c_uc = kwargs.pop('c_uc')
+      self.c_us = kwargs.pop('c_us')
+      self.c_ic = kwargs.pop('c_ic')
+      self.c_is = kwargs.pop('c_is')
       self.dn = kwargs.pop('dn')
       self.m0 = kwargs.pop('m0')
       self.ecc = kwargs.pop('ecc')

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -150,17 +150,17 @@ class MsgEphemerisOld(SBP):
     SBP parent object to inherit from.
   tgd : double
     Group delay differential between L1 and L2
-  crs : double
+  c_rs : double
     Amplitude of the sine harmonic correction term to the orbit radius
-  crc : double
+  c_rc : double
     Amplitude of the cosine harmonic correction term to the orbit radius
-  cuc : double
+  c_uc : double
     Amplitude of the cosine harmonic correction term to the argument of latitude
-  cus : double
+  c_us : double
     Amplitude of the sine harmonic correction term to the argument of latitude
-  cic : double
+  c_ic : double
     Amplitude of the cosine harmonic correction term to the angle of inclination
-  cis : double
+  c_is : double
     Amplitude of the sine harmonic correction term to the angle of inclination
   dn : double
     Mean motion difference
@@ -206,12 +206,12 @@ class MsgEphemerisOld(SBP):
   """
   _parser = Struct("MsgEphemerisOld",
                    LFloat64('tgd'),
-                   LFloat64('crs'),
-                   LFloat64('crc'),
-                   LFloat64('cuc'),
-                   LFloat64('cus'),
-                   LFloat64('cic'),
-                   LFloat64('cis'),
+                   LFloat64('c_rs'),
+                   LFloat64('c_rc'),
+                   LFloat64('c_uc'),
+                   LFloat64('c_us'),
+                   LFloat64('c_ic'),
+                   LFloat64('c_is'),
                    LFloat64('dn'),
                    LFloat64('m0'),
                    LFloat64('ecc'),
@@ -241,12 +241,12 @@ class MsgEphemerisOld(SBP):
       self.msg_type = SBP_MSG_EPHEMERIS_OLD
       self.sender = kwargs.pop('sender', 0)
       self.tgd = kwargs.pop('tgd')
-      self.crs = kwargs.pop('crs')
-      self.crc = kwargs.pop('crc')
-      self.cuc = kwargs.pop('cuc')
-      self.cus = kwargs.pop('cus')
-      self.cic = kwargs.pop('cic')
-      self.cis = kwargs.pop('cis')
+      self.c_rs = kwargs.pop('c_rs')
+      self.c_rc = kwargs.pop('c_rc')
+      self.c_uc = kwargs.pop('c_uc')
+      self.c_us = kwargs.pop('c_us')
+      self.c_ic = kwargs.pop('c_ic')
+      self.c_is = kwargs.pop('c_is')
       self.dn = kwargs.pop('dn')
       self.m0 = kwargs.pop('m0')
       self.ecc = kwargs.pop('ecc')

--- a/spec/tests/yaml/swiftnav/sbp/test_observation.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_observation.yaml
@@ -1,6 +1,6 @@
 ---
 description: Unit tests for swiftnav.sbp.observation v0.29.
-generated_on: 2015-04-12 20:15:47.093026
+generated_on: 2015-04-29 09:15:25.778090
 package: sbp.observation
 tests:
 
@@ -347,6 +347,306 @@ tests:
     length: 72
     msg_type: '0x45'
     payload: KKNEGC4HEIRr2XkOlP//ASyvkwCBQsh9lB3+/5kpDrEDgLL4iI9C/v/eEriFDZ41soYqGwIA7R4hYBYmU1Z2qG///y040Fge
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: -1.035025343298912e-05
+      af1: -9.094947017729282e-13
+      af2: 0.0
+      c_ic: 6.332993507385254e-08
+      c_is: -1.564621925354004e-07
+      c_rc: 234.375
+      c_rs: -74.90625
+      c_uc: -3.937631845474243e-06
+      c_us: 6.9122761487960815e-06
+      dn: 4.8884179079418005e-09
+      ecc: 0.011132609914056957
+      healthy: 1
+      inc: 0.9395524830579087
+      inc_dot: -3.296565886629854e-10
+      m0: 2.467348395627239
+      omega0: -0.9468985437479658
+      omegadot: -8.201055892610478e-09
+      prn: 3
+      sqrta: 5153.714303970337
+      tgd: -6.51925802230835e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: 1.0525047200405302
+    module: sbp.observation
+    name: MsgEphemeris
+  msg_type: '0x46'
+  raw_json: '{"msg_type": 70, "c_rs": -74.90625, "toe_wn": 1838, "prn": 3, "inc_dot":
+    -3.296565886629854e-10, "tgd": -6.51925802230835e-09, "c_rc": 234.375, "ecc":
+    0.011132609914056957, "sqrta": 5153.714303970337, "payload": "AAAAAAAAPL4AAAAAALpSwAAAAAAATG1AAAAAAACE0L4AAAAAAP7cPgAAAAAAAHE+AAAAAAAAhb4cJBlR3/40Ptx02CchvQNAAAAAnLHMhj8AAKDctiG0QJjhwCz+TO6/KZYYApScQb78WncwD9fwP3x/c17QEO4/pXM0SmGn9r0AAAAAwLTlvgAAAAAAAHC9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAw==",
+    "inc": 0.9395524830579087, "toe_tow": 410400.0, "c_uc": -3.937631845474243e-06,
+    "c_us": 6.9122761487960815e-06, "valid": 1, "m0": 2.467348395627239, "toc_tow":
+    410400.0, "dn": 4.8884179079418005e-09, "omegadot": -8.201055892610478e-09, "toc_wn":
+    1838, "c_ic": 6.332993507385254e-08, "c_is": -1.564621925354004e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -9.094947017729282e-13, "crc": 49112,
+    "length": 175, "w": 1.0525047200405302, "af0": -1.035025343298912e-05, "omega0":
+    -0.9468985437479658, "af2": 0.0}'
+  raw_packet: VUYAwwSvAAAAAAAAPL4AAAAAALpSwAAAAAAATG1AAAAAAACE0L4AAAAAAP7cPgAAAAAAAHE+AAAAAAAAhb4cJBlR3/40Ptx02CchvQNAAAAAnLHMhj8AAKDctiG0QJjhwCz+TO6/KZYYApScQb78WncwD9fwP3x/c17QEO4/pXM0SmGn9r0AAAAAwLTlvgAAAAAAAHC9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBA9i/
+  sbp:
+    crc: '0xbfd8'
+    length: 175
+    msg_type: '0x46'
+    payload: AAAAAAAAPL4AAAAAALpSwAAAAAAATG1AAAAAAACE0L4AAAAAAP7cPgAAAAAAAHE+AAAAAAAAhb4cJBlR3/40Ptx02CchvQNAAAAAnLHMhj8AAKDctiG0QJjhwCz+TO6/KZYYApScQb78WncwD9fwP3x/c17QEO4/pXM0SmGn9r0AAAAAwLTlvgAAAAAAAHC9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAw==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: 7.384549826383591e-05
+      af1: -2.8421709430404007e-12
+      af2: 0.0
+      c_ic: 1.341104507446289e-07
+      c_is: 1.1920928955078125e-07
+      c_rc: 315.78125
+      c_rs: 36.5625
+      c_uc: 2.0638108253479004e-06
+      c_us: 3.4142285585403442e-06
+      dn: 4.86198823561129e-09
+      ecc: 0.007922741584479809
+      healthy: 1
+      inc: 0.9669012918227122
+      inc_dot: 2.6251093463412166e-10
+      m0: -1.588160855720083
+      omega0: 1.237919941568746
+      omegadot: -8.295702692172441e-09
+      prn: 13
+      sqrta: 5153.57085609436
+      tgd: -9.313225746154785e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -1.9736022837941165
+    module: sbp.observation
+    name: MsgEphemeris
+  msg_type: '0x46'
+  raw_json: '{"msg_type": 70, "c_rs": 36.5625, "toe_wn": 1838, "prn": 13, "inc_dot":
+    2.6251093463412166e-10, "tgd": -9.313225746154785e-09, "c_rc": 315.78125, "ecc":
+    0.007922741584479809, "sqrta": 5153.57085609436, "payload": "AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==",
+    "inc": 0.9669012918227122, "toe_tow": 410400.0, "c_uc": 2.0638108253479004e-06,
+    "c_us": 3.4142285585403442e-06, "valid": 1, "m0": -1.588160855720083, "toc_tow":
+    410400.0, "dn": 4.86198823561129e-09, "omegadot": -8.295702692172441e-09, "toc_wn":
+    1838, "c_ic": 1.341104507446289e-07, "c_is": 1.1920928955078125e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -2.8421709430404007e-12, "crc": 17695,
+    "length": 175, "w": -1.9736022837941165, "af0": 7.384549826383591e-05, "omega0":
+    1.237919941568746, "af2": 0.0}'
+  raw_packet: VUYAwwSvAAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDR9F
+  sbp:
+    crc: '0x451f'
+    length: 175
+    msg_type: '0x46'
+    payload: AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: -7.249414920806885e-06
+      af1: 4.547473508864641e-13
+      af2: 0.0
+      c_ic: -4.6566128730773926e-08
+      c_is: -2.60770320892334e-08
+      c_rc: 236.03125
+      c_rs: -68.625
+      c_uc: -3.470107913017273e-06
+      c_us: 7.461756467819214e-06
+      dn: 4.4637573619826565e-09
+      ecc: 0.004040417145006359
+      healthy: 1
+      inc: 0.9619021920701416
+      inc_dot: -3.3644258561271105e-10
+      m0: 2.7055255058713295
+      omega0: -0.9258770941316397
+      omegadot: -8.082122367123182e-09
+      prn: 0
+      sqrta: 5153.669353485107
+      tgd: 5.587935447692871e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: 0.37873566614641857
+    module: sbp.observation
+    name: MsgEphemeris
+  msg_type: '0x46'
+  raw_json: '{"msg_type": 70, "c_rs": -68.625, "toe_wn": 1838, "prn": 0, "inc_dot":
+    -3.3644258561271105e-10, "tgd": 5.587935447692871e-09, "c_rc": 236.03125, "ecc":
+    0.004040417145006359, "sqrta": 5153.669353485107, "payload": "AAAAAAAAOD4AAAAAAChRwAAAAAAAgW1AAAAAAAAczb4AAAAAAEzfPgAAAAAAAGm+AAAAAAAAXL6God//8yszPpKwcY7qpAVAAAAAOK+McD8AAMBaqyG0QCQm7f/IoO2/zFw/mjFbQb59XvuEND3YPwKLHBvnx+4/fLcEtMIe970AAAAAAGjevgAAAAAAAGA9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAA==",
+    "inc": 0.9619021920701416, "toe_tow": 410400.0, "c_uc": -3.470107913017273e-06,
+    "c_us": 7.461756467819214e-06, "valid": 1, "m0": 2.7055255058713295, "toc_tow":
+    410400.0, "dn": 4.4637573619826565e-09, "omegadot": -8.082122367123182e-09, "toc_wn":
+    1838, "c_ic": -4.6566128730773926e-08, "c_is": -2.60770320892334e-08, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": 4.547473508864641e-13, "crc": 27959,
+    "length": 175, "w": 0.37873566614641857, "af0": -7.249414920806885e-06, "omega0":
+    -0.9258770941316397, "af2": 0.0}'
+  raw_packet: VUYAwwSvAAAAAAAAOD4AAAAAAChRwAAAAAAAgW1AAAAAAAAczb4AAAAAAEzfPgAAAAAAAGm+AAAAAAAAXL6God//8yszPpKwcY7qpAVAAAAAOK+McD8AAMBaqyG0QCQm7f/IoO2/zFw/mjFbQb59XvuEND3YPwKLHBvnx+4/fLcEtMIe970AAAAAAGjevgAAAAAAAGA9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBADdt
+  sbp:
+    crc: '0x6d37'
+    length: 175
+    msg_type: '0x46'
+    payload: AAAAAAAAOD4AAAAAAChRwAAAAAAAgW1AAAAAAAAczb4AAAAAAEzfPgAAAAAAAGm+AAAAAAAAXL6God//8yszPpKwcY7qpAVAAAAAOK+McD8AAMBaqyG0QCQm7f/IoO2/zFw/mjFbQb59XvuEND3YPwKLHBvnx+4/fLcEtMIe970AAAAAAGjevgAAAAAAAGA9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAA==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: 7.384549826383591e-05
+      af1: -2.8421709430404007e-12
+      af2: 0.0
+      c_ic: 1.341104507446289e-07
+      c_is: 1.1920928955078125e-07
+      c_rc: 315.78125
+      c_rs: 36.5625
+      c_uc: 2.0638108253479004e-06
+      c_us: 3.4142285585403442e-06
+      dn: 4.86198823561129e-09
+      ecc: 0.007922741584479809
+      healthy: 1
+      inc: 0.9669012918227122
+      inc_dot: 2.6251093463412166e-10
+      m0: -1.588160855720083
+      omega0: 1.237919941568746
+      omegadot: -8.295702692172441e-09
+      prn: 13
+      sqrta: 5153.57085609436
+      tgd: -9.313225746154785e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -1.9736022837941165
+    module: sbp.observation
+    name: MsgEphemeris
+  msg_type: '0x46'
+  raw_json: '{"msg_type": 70, "c_rs": 36.5625, "toe_wn": 1838, "prn": 13, "inc_dot":
+    2.6251093463412166e-10, "tgd": -9.313225746154785e-09, "c_rc": 315.78125, "ecc":
+    0.007922741584479809, "sqrta": 5153.57085609436, "payload": "AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==",
+    "inc": 0.9669012918227122, "toe_tow": 410400.0, "c_uc": 2.0638108253479004e-06,
+    "c_us": 3.4142285585403442e-06, "valid": 1, "m0": -1.588160855720083, "toc_tow":
+    410400.0, "dn": 4.86198823561129e-09, "omegadot": -8.295702692172441e-09, "toc_wn":
+    1838, "c_ic": 1.341104507446289e-07, "c_is": 1.1920928955078125e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -2.8421709430404007e-12, "crc": 17695,
+    "length": 175, "w": -1.9736022837941165, "af0": 7.384549826383591e-05, "omega0":
+    1.237919941568746, "af2": 0.0}'
+  raw_packet: VUYAwwSvAAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDR9F
+  sbp:
+    crc: '0x451f'
+    length: 175
+    msg_type: '0x46'
+    payload: AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: -9.925523772835732e-05
+      af1: -2.5011104298755527e-12
+      af2: 0.0
+      c_ic: -3.166496753692627e-08
+      c_is: -2.0675361156463623e-07
+      c_rc: 305.21875
+      c_rs: 43.21875
+      c_uc: 2.1010637283325195e-06
+      c_us: 3.766268491744995e-06
+      dn: 5.26057626697412e-09
+      ecc: 0.009923744946718216
+      healthy: 1
+      inc: 0.9487513221807672
+      inc_dot: 3.000124967247105e-10
+      m0: -2.666160271911327
+      omega0: 1.1669551972594425
+      omegadot: -8.45999524990264e-09
+      prn: 22
+      sqrta: 5153.636667251587
+      tgd: -2.0023435354232788e-08
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -2.7021241452652935
+    module: sbp.observation
+    name: MsgEphemeris
+  msg_type: '0x46'
+  raw_json: '{"msg_type": 70, "c_rs": 43.21875, "toe_wn": 1838, "prn": 22, "inc_dot":
+    3.000124967247105e-10, "tgd": -2.0023435354232788e-08, "c_rc": 305.21875, "ecc":
+    0.009923744946718216, "sqrta": 5153.636667251587, "payload": "AAAAAACAVb4AAAAAAJxFQAAAAACAE3NAAAAAAACgwT4AAAAAAJjPPgAAAAAAAGG+AAAAAADAi74aGg2VEJg2PmgHLtZLVAXAAAAAgOZShD8AAKD8oiG0QEkGgjbZq/I/UeCje+4qQr7OK41D850FwHGzmbsrXO4//uwfK+Cd9D0AAAAA6AQavwAAAAAAAIa9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBFg==",
+    "inc": 0.9487513221807672, "toe_tow": 410400.0, "c_uc": 2.1010637283325195e-06,
+    "c_us": 3.766268491744995e-06, "valid": 1, "m0": -2.666160271911327, "toc_tow":
+    410400.0, "dn": 5.26057626697412e-09, "omegadot": -8.45999524990264e-09, "toc_wn":
+    1838, "c_ic": -3.166496753692627e-08, "c_is": -2.0675361156463623e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -2.5011104298755527e-12, "crc": 28993,
+    "length": 175, "w": -2.7021241452652935, "af0": -9.925523772835732e-05, "omega0":
+    1.1669551972594425, "af2": 0.0}'
+  raw_packet: VUYAwwSvAAAAAACAVb4AAAAAAJxFQAAAAACAE3NAAAAAAACgwT4AAAAAAJjPPgAAAAAAAGG+AAAAAADAi74aGg2VEJg2PmgHLtZLVAXAAAAAgOZShD8AAKD8oiG0QEkGgjbZq/I/UeCje+4qQr7OK41D850FwHGzmbsrXO4//uwfK+Cd9D0AAAAA6AQavwAAAAAAAIa9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBFkFx
+  sbp:
+    crc: '0x7141'
+    length: 175
+    msg_type: '0x46'
+    payload: AAAAAACAVb4AAAAAAJxFQAAAAACAE3NAAAAAAACgwT4AAAAAAJjPPgAAAAAAAGG+AAAAAADAi74aGg2VEJg2PmgHLtZLVAXAAAAAgOZShD8AAKD8oiG0QEkGgjbZq/I/UeCje+4qQr7OK41D850FwHGzmbsrXO4//uwfK+Cd9D0AAAAA6AQavwAAAAAAAIa9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBFg==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: 0.0003196117468178272
+      af1: -1.0231815394945443e-12
+      af2: 0.0
+      c_ic: 9.12696123123169e-08
+      c_is: 5.21540641784668e-08
+      c_rc: 247.28125
+      c_rs: -77.90625
+      c_uc: -3.723427653312683e-06
+      c_us: 7.178634405136108e-06
+      dn: 4.400897600764146e-09
+      ecc: 0.008178644930012524
+      healthy: 1
+      inc: 0.9755122017245301
+      inc_dot: -5.882387882209502e-10
+      m0: 1.9401823459824192
+      omega0: 2.241868028927766
+      omegadot: -7.962474526167494e-09
+      prn: 30
+      sqrta: 5153.7539920806885
+      tgd: -1.3504177331924438e-08
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -0.5237901716088061
+    module: sbp.observation
+    name: MsgEphemeris
+  msg_type: '0x46'
+  raw_json: '{"msg_type": 70, "c_rs": -77.90625, "toe_wn": 1838, "prn": 30, "inc_dot":
+    -5.882387882209502e-10, "tgd": -1.3504177331924438e-08, "c_rc": 247.28125, "ecc":
+    0.008178644930012524, "sqrta": 5153.7539920806885, "payload": "AAAAAAAATb4AAAAAAHpTwAAAAAAA6W5AAAAAAAA8z74AAAAAABzePgAAAAAAgHg+AAAAAAAAbD4K5reM1uYyPjZWxKT8Cv8/AAAAJPe/gD8AAKAFwSG0QLqKUYFY7wFAXtJ4qmoZQb5n1SCb48Lgv5wvaF1lN+8/xFNk/jM2BL4AAAAAMvI0PwAAAAAAAHK9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBHg==",
+    "inc": 0.9755122017245301, "toe_tow": 410400.0, "c_uc": -3.723427653312683e-06,
+    "c_us": 7.178634405136108e-06, "valid": 1, "m0": 1.9401823459824192, "toc_tow":
+    410400.0, "dn": 4.400897600764146e-09, "omegadot": -7.962474526167494e-09, "toc_wn":
+    1838, "c_ic": 9.12696123123169e-08, "c_is": 5.21540641784668e-08, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -1.0231815394945443e-12, "crc": 38608,
+    "length": 175, "w": -0.5237901716088061, "af0": 0.0003196117468178272, "omega0":
+    2.241868028927766, "af2": 0.0}'
+  raw_packet: VUYAwwSvAAAAAAAATb4AAAAAAHpTwAAAAAAA6W5AAAAAAAA8z74AAAAAABzePgAAAAAAgHg+AAAAAAAAbD4K5reM1uYyPjZWxKT8Cv8/AAAAJPe/gD8AAKAFwSG0QLqKUYFY7wFAXtJ4qmoZQb5n1SCb48Lgv5wvaF1lN+8/xFNk/jM2BL4AAAAAMvI0PwAAAAAAAHK9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBHtCW
+  sbp:
+    crc: '0x96d0'
+    length: 175
+    msg_type: '0x46'
+    payload: AAAAAAAATb4AAAAAAHpTwAAAAAAA6W5AAAAAAAA8z74AAAAAABzePgAAAAAAgHg+AAAAAAAAbD4K5reM1uYyPjZWxKT8Cv8/AAAAJPe/gD8AAKAFwSG0QLqKUYFY7wFAXtJ4qmoZQb5n1SCb48Lgv5wvaF1lN+8/xFNk/jM2BL4AAAAAMvI0PwAAAAAAAHK9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBHg==
     preamble: '0x55'
     sender: '0x4c3'
 version: '0.29'

--- a/spec/tests/yaml/swiftnav/sbp/test_tracking.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_tracking.yaml
@@ -1,6 +1,6 @@
 ---
 description: Unit tests for swiftnav.sbp.tracking v0.29.
-generated_on: 2015-04-12 20:15:47.019143
+generated_on: 2015-04-29 09:15:25.687807
 package: sbp.tracking
 tests:
 
@@ -334,6 +334,306 @@ tests:
     length: 66
     msg_type: '0x16'
     payload: AQBiJ9tBAQIAADhAAQN5ewdBAAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/AAAAAIC/
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: -1.035025343298912e-05
+      af1: -9.094947017729282e-13
+      af2: 0.0
+      c_ic: 6.332993507385254e-08
+      c_is: -1.564621925354004e-07
+      c_rc: 234.375
+      c_rs: -74.90625
+      c_uc: -3.937631845474243e-06
+      c_us: 6.9122761487960815e-06
+      dn: 4.8884179079418005e-09
+      ecc: 0.011132609914056957
+      healthy: 1
+      inc: 0.9395524830579087
+      inc_dot: -3.296565886629854e-10
+      m0: 2.467348395627239
+      omega0: -0.9468985437479658
+      omegadot: -8.201055892610478e-09
+      prn: 3
+      sqrta: 5153.714303970337
+      tgd: -6.51925802230835e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: 1.0525047200405302
+    module: sbp.tracking
+    name: MsgEphemerisOld
+  msg_type: '0x1a'
+  raw_json: '{"msg_type": 26, "c_rs": -74.90625, "toe_wn": 1838, "prn": 3, "inc_dot":
+    -3.296565886629854e-10, "tgd": -6.51925802230835e-09, "c_rc": 234.375, "ecc":
+    0.011132609914056957, "sqrta": 5153.714303970337, "payload": "AAAAAAAAPL4AAAAAALpSwAAAAAAATG1AAAAAAACE0L4AAAAAAP7cPgAAAAAAAHE+AAAAAAAAhb4cJBlR3/40Ptx02CchvQNAAAAAnLHMhj8AAKDctiG0QJjhwCz+TO6/KZYYApScQb78WncwD9fwP3x/c17QEO4/pXM0SmGn9r0AAAAAwLTlvgAAAAAAAHC9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAw==",
+    "inc": 0.9395524830579087, "toe_tow": 410400.0, "c_uc": -3.937631845474243e-06,
+    "c_us": 6.9122761487960815e-06, "valid": 1, "m0": 2.467348395627239, "toc_tow":
+    410400.0, "dn": 4.8884179079418005e-09, "omegadot": -8.201055892610478e-09, "toc_wn":
+    1838, "c_ic": 6.332993507385254e-08, "c_is": -1.564621925354004e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -9.094947017729282e-13, "crc": 49854,
+    "length": 175, "w": 1.0525047200405302, "af0": -1.035025343298912e-05, "omega0":
+    -0.9468985437479658, "af2": 0.0}'
+  raw_packet: VRoAwwSvAAAAAAAAPL4AAAAAALpSwAAAAAAATG1AAAAAAACE0L4AAAAAAP7cPgAAAAAAAHE+AAAAAAAAhb4cJBlR3/40Ptx02CchvQNAAAAAnLHMhj8AAKDctiG0QJjhwCz+TO6/KZYYApScQb78WncwD9fwP3x/c17QEO4/pXM0SmGn9r0AAAAAwLTlvgAAAAAAAHC9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBA77C
+  sbp:
+    crc: '0xc2be'
+    length: 175
+    msg_type: '0x1a'
+    payload: AAAAAAAAPL4AAAAAALpSwAAAAAAATG1AAAAAAACE0L4AAAAAAP7cPgAAAAAAAHE+AAAAAAAAhb4cJBlR3/40Ptx02CchvQNAAAAAnLHMhj8AAKDctiG0QJjhwCz+TO6/KZYYApScQb78WncwD9fwP3x/c17QEO4/pXM0SmGn9r0AAAAAwLTlvgAAAAAAAHC9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAw==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: 7.384549826383591e-05
+      af1: -2.8421709430404007e-12
+      af2: 0.0
+      c_ic: 1.341104507446289e-07
+      c_is: 1.1920928955078125e-07
+      c_rc: 315.78125
+      c_rs: 36.5625
+      c_uc: 2.0638108253479004e-06
+      c_us: 3.4142285585403442e-06
+      dn: 4.86198823561129e-09
+      ecc: 0.007922741584479809
+      healthy: 1
+      inc: 0.9669012918227122
+      inc_dot: 2.6251093463412166e-10
+      m0: -1.588160855720083
+      omega0: 1.237919941568746
+      omegadot: -8.295702692172441e-09
+      prn: 13
+      sqrta: 5153.57085609436
+      tgd: -9.313225746154785e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -1.9736022837941165
+    module: sbp.tracking
+    name: MsgEphemerisOld
+  msg_type: '0x1a'
+  raw_json: '{"msg_type": 26, "c_rs": 36.5625, "toe_wn": 1838, "prn": 13, "inc_dot":
+    2.6251093463412166e-10, "tgd": -9.313225746154785e-09, "c_rc": 315.78125, "ecc":
+    0.007922741584479809, "sqrta": 5153.57085609436, "payload": "AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==",
+    "inc": 0.9669012918227122, "toe_tow": 410400.0, "c_uc": 2.0638108253479004e-06,
+    "c_us": 3.4142285585403442e-06, "valid": 1, "m0": -1.588160855720083, "toc_tow":
+    410400.0, "dn": 4.86198823561129e-09, "omegadot": -8.295702692172441e-09, "toc_wn":
+    1838, "c_ic": 1.341104507446289e-07, "c_is": 1.1920928955078125e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -2.8421709430404007e-12, "crc": 14457,
+    "length": 175, "w": -1.9736022837941165, "af0": 7.384549826383591e-05, "omega0":
+    1.237919941568746, "af2": 0.0}'
+  raw_packet: VRoAwwSvAAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDXk4
+  sbp:
+    crc: '0x3879'
+    length: 175
+    msg_type: '0x1a'
+    payload: AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: -7.249414920806885e-06
+      af1: 4.547473508864641e-13
+      af2: 0.0
+      c_ic: -4.6566128730773926e-08
+      c_is: -2.60770320892334e-08
+      c_rc: 236.03125
+      c_rs: -68.625
+      c_uc: -3.470107913017273e-06
+      c_us: 7.461756467819214e-06
+      dn: 4.4637573619826565e-09
+      ecc: 0.004040417145006359
+      healthy: 1
+      inc: 0.9619021920701416
+      inc_dot: -3.3644258561271105e-10
+      m0: 2.7055255058713295
+      omega0: -0.9258770941316397
+      omegadot: -8.082122367123182e-09
+      prn: 0
+      sqrta: 5153.669353485107
+      tgd: 5.587935447692871e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: 0.37873566614641857
+    module: sbp.tracking
+    name: MsgEphemerisOld
+  msg_type: '0x1a'
+  raw_json: '{"msg_type": 26, "c_rs": -68.625, "toe_wn": 1838, "prn": 0, "inc_dot":
+    -3.3644258561271105e-10, "tgd": 5.587935447692871e-09, "c_rc": 236.03125, "ecc":
+    0.004040417145006359, "sqrta": 5153.669353485107, "payload": "AAAAAAAAOD4AAAAAAChRwAAAAAAAgW1AAAAAAAAczb4AAAAAAEzfPgAAAAAAAGm+AAAAAAAAXL6God//8yszPpKwcY7qpAVAAAAAOK+McD8AAMBaqyG0QCQm7f/IoO2/zFw/mjFbQb59XvuEND3YPwKLHBvnx+4/fLcEtMIe970AAAAAAGjevgAAAAAAAGA9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAA==",
+    "inc": 0.9619021920701416, "toe_tow": 410400.0, "c_uc": -3.470107913017273e-06,
+    "c_us": 7.461756467819214e-06, "valid": 1, "m0": 2.7055255058713295, "toc_tow":
+    410400.0, "dn": 4.4637573619826565e-09, "omegadot": -8.082122367123182e-09, "toc_wn":
+    1838, "c_ic": -4.6566128730773926e-08, "c_is": -2.60770320892334e-08, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": 4.547473508864641e-13, "crc": 4177, "length":
+    175, "w": 0.37873566614641857, "af0": -7.249414920806885e-06, "omega0": -0.9258770941316397,
+    "af2": 0.0}'
+  raw_packet: VRoAwwSvAAAAAAAAOD4AAAAAAChRwAAAAAAAgW1AAAAAAAAczb4AAAAAAEzfPgAAAAAAAGm+AAAAAAAAXL6God//8yszPpKwcY7qpAVAAAAAOK+McD8AAMBaqyG0QCQm7f/IoO2/zFw/mjFbQb59XvuEND3YPwKLHBvnx+4/fLcEtMIe970AAAAAAGjevgAAAAAAAGA9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAFEQ
+  sbp:
+    crc: '0x1051'
+    length: 175
+    msg_type: '0x1a'
+    payload: AAAAAAAAOD4AAAAAAChRwAAAAAAAgW1AAAAAAAAczb4AAAAAAEzfPgAAAAAAAGm+AAAAAAAAXL6God//8yszPpKwcY7qpAVAAAAAOK+McD8AAMBaqyG0QCQm7f/IoO2/zFw/mjFbQb59XvuEND3YPwKLHBvnx+4/fLcEtMIe970AAAAAAGjevgAAAAAAAGA9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBAA==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: 7.384549826383591e-05
+      af1: -2.8421709430404007e-12
+      af2: 0.0
+      c_ic: 1.341104507446289e-07
+      c_is: 1.1920928955078125e-07
+      c_rc: 315.78125
+      c_rs: 36.5625
+      c_uc: 2.0638108253479004e-06
+      c_us: 3.4142285585403442e-06
+      dn: 4.86198823561129e-09
+      ecc: 0.007922741584479809
+      healthy: 1
+      inc: 0.9669012918227122
+      inc_dot: 2.6251093463412166e-10
+      m0: -1.588160855720083
+      omega0: 1.237919941568746
+      omegadot: -8.295702692172441e-09
+      prn: 13
+      sqrta: 5153.57085609436
+      tgd: -9.313225746154785e-09
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -1.9736022837941165
+    module: sbp.tracking
+    name: MsgEphemerisOld
+  msg_type: '0x1a'
+  raw_json: '{"msg_type": 26, "c_rs": 36.5625, "toe_wn": 1838, "prn": 13, "inc_dot":
+    2.6251093463412166e-10, "tgd": -9.313225746154785e-09, "c_rc": 315.78125, "ecc":
+    0.007922741584479809, "sqrta": 5153.57085609436, "payload": "AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==",
+    "inc": 0.9669012918227122, "toe_tow": 410400.0, "c_uc": 2.0638108253479004e-06,
+    "c_us": 3.4142285585403442e-06, "valid": 1, "m0": -1.588160855720083, "toc_tow":
+    410400.0, "dn": 4.86198823561129e-09, "omegadot": -8.295702692172441e-09, "toc_wn":
+    1838, "c_ic": 1.341104507446289e-07, "c_is": 1.1920928955078125e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -2.8421709430404007e-12, "crc": 14457,
+    "length": 175, "w": -1.9736022837941165, "af0": 7.384549826383591e-05, "omega0":
+    1.237919941568746, "af2": 0.0}'
+  raw_packet: VRoAwwSvAAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDXk4
+  sbp:
+    crc: '0x3879'
+    length: 175
+    msg_type: '0x1a'
+    payload: AAAAAAAARL4AAAAAAEhCQAAAAACAvHNAAAAAAABQwT4AAAAAAKTMPgAAAAAAAII+AAAAAAAAgD5ItX8G0OE0Pp6ugVsbafm/AAAAYMw5gD8AAKAjkiG0QPepASSFzvM/TwttXJzQQb5nTgP935P/v6TWWvra8O4/Xu+7JSQK8j0AAAAAsFsTPwAAAAAAAIm9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBDQ==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: -9.925523772835732e-05
+      af1: -2.5011104298755527e-12
+      af2: 0.0
+      c_ic: -3.166496753692627e-08
+      c_is: -2.0675361156463623e-07
+      c_rc: 305.21875
+      c_rs: 43.21875
+      c_uc: 2.1010637283325195e-06
+      c_us: 3.766268491744995e-06
+      dn: 5.26057626697412e-09
+      ecc: 0.009923744946718216
+      healthy: 1
+      inc: 0.9487513221807672
+      inc_dot: 3.000124967247105e-10
+      m0: -2.666160271911327
+      omega0: 1.1669551972594425
+      omegadot: -8.45999524990264e-09
+      prn: 22
+      sqrta: 5153.636667251587
+      tgd: -2.0023435354232788e-08
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -2.7021241452652935
+    module: sbp.tracking
+    name: MsgEphemerisOld
+  msg_type: '0x1a'
+  raw_json: '{"msg_type": 26, "c_rs": 43.21875, "toe_wn": 1838, "prn": 22, "inc_dot":
+    3.000124967247105e-10, "tgd": -2.0023435354232788e-08, "c_rc": 305.21875, "ecc":
+    0.009923744946718216, "sqrta": 5153.636667251587, "payload": "AAAAAACAVb4AAAAAAJxFQAAAAACAE3NAAAAAAACgwT4AAAAAAJjPPgAAAAAAAGG+AAAAAADAi74aGg2VEJg2PmgHLtZLVAXAAAAAgOZShD8AAKD8oiG0QEkGgjbZq/I/UeCje+4qQr7OK41D850FwHGzmbsrXO4//uwfK+Cd9D0AAAAA6AQavwAAAAAAAIa9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBFg==",
+    "inc": 0.9487513221807672, "toe_tow": 410400.0, "c_uc": 2.1010637283325195e-06,
+    "c_us": 3.766268491744995e-06, "valid": 1, "m0": -2.666160271911327, "toc_tow":
+    410400.0, "dn": 5.26057626697412e-09, "omegadot": -8.45999524990264e-09, "toc_wn":
+    1838, "c_ic": -3.166496753692627e-08, "c_is": -2.0675361156463623e-07, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -2.5011104298755527e-12, "crc": 3111,
+    "length": 175, "w": -2.7021241452652935, "af0": -9.925523772835732e-05, "omega0":
+    1.1669551972594425, "af2": 0.0}'
+  raw_packet: VRoAwwSvAAAAAACAVb4AAAAAAJxFQAAAAACAE3NAAAAAAACgwT4AAAAAAJjPPgAAAAAAAGG+AAAAAADAi74aGg2VEJg2PmgHLtZLVAXAAAAAgOZShD8AAKD8oiG0QEkGgjbZq/I/UeCje+4qQr7OK41D850FwHGzmbsrXO4//uwfK+Cd9D0AAAAA6AQavwAAAAAAAIa9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBFicM
+  sbp:
+    crc: '0xc27'
+    length: 175
+    msg_type: '0x1a'
+    payload: AAAAAACAVb4AAAAAAJxFQAAAAACAE3NAAAAAAACgwT4AAAAAAJjPPgAAAAAAAGG+AAAAAADAi74aGg2VEJg2PmgHLtZLVAXAAAAAgOZShD8AAKD8oiG0QEkGgjbZq/I/UeCje+4qQr7OK41D850FwHGzmbsrXO4//uwfK+Cd9D0AAAAA6AQavwAAAAAAAIa9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBFg==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
+      af0: 0.0003196117468178272
+      af1: -1.0231815394945443e-12
+      af2: 0.0
+      c_ic: 9.12696123123169e-08
+      c_is: 5.21540641784668e-08
+      c_rc: 247.28125
+      c_rs: -77.90625
+      c_uc: -3.723427653312683e-06
+      c_us: 7.178634405136108e-06
+      dn: 4.400897600764146e-09
+      ecc: 0.008178644930012524
+      healthy: 1
+      inc: 0.9755122017245301
+      inc_dot: -5.882387882209502e-10
+      m0: 1.9401823459824192
+      omega0: 2.241868028927766
+      omegadot: -7.962474526167494e-09
+      prn: 30
+      sqrta: 5153.7539920806885
+      tgd: -1.3504177331924438e-08
+      toc_tow: 410400.0
+      toc_wn: 1838
+      toe_tow: 410400.0
+      toe_wn: 1838
+      valid: 1
+      w: -0.5237901716088061
+    module: sbp.tracking
+    name: MsgEphemerisOld
+  msg_type: '0x1a'
+  raw_json: '{"msg_type": 26, "c_rs": -77.90625, "toe_wn": 1838, "prn": 30, "inc_dot":
+    -5.882387882209502e-10, "tgd": -1.3504177331924438e-08, "c_rc": 247.28125, "ecc":
+    0.008178644930012524, "sqrta": 5153.7539920806885, "payload": "AAAAAAAATb4AAAAAAHpTwAAAAAAA6W5AAAAAAAA8z74AAAAAABzePgAAAAAAgHg+AAAAAAAAbD4K5reM1uYyPjZWxKT8Cv8/AAAAJPe/gD8AAKAFwSG0QLqKUYFY7wFAXtJ4qmoZQb5n1SCb48Lgv5wvaF1lN+8/xFNk/jM2BL4AAAAAMvI0PwAAAAAAAHK9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBHg==",
+    "inc": 0.9755122017245301, "toe_tow": 410400.0, "c_uc": -3.723427653312683e-06,
+    "c_us": 7.178634405136108e-06, "valid": 1, "m0": 1.9401823459824192, "toc_tow":
+    410400.0, "dn": 4.400897600764146e-09, "omegadot": -7.962474526167494e-09, "toc_wn":
+    1838, "c_ic": 9.12696123123169e-08, "c_is": 5.21540641784668e-08, "preamble":
+    85, "sender": 1219, "healthy": 1, "af1": -1.0231815394945443e-12, "crc": 60342,
+    "length": 175, "w": -0.5237901716088061, "af0": 0.0003196117468178272, "omega0":
+    2.241868028927766, "af2": 0.0}'
+  raw_packet: VRoAwwSvAAAAAAAATb4AAAAAAHpTwAAAAAAA6W5AAAAAAAA8z74AAAAAABzePgAAAAAAgHg+AAAAAAAAbD4K5reM1uYyPjZWxKT8Cv8/AAAAJPe/gD8AAKAFwSG0QLqKUYFY7wFAXtJ4qmoZQb5n1SCb48Lgv5wvaF1lN+8/xFNk/jM2BL4AAAAAMvI0PwAAAAAAAHK9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBHrbr
+  sbp:
+    crc: '0xebb6'
+    length: 175
+    msg_type: '0x1a'
+    payload: AAAAAAAATb4AAAAAAHpTwAAAAAAA6W5AAAAAAAA8z74AAAAAABzePgAAAAAAgHg+AAAAAAAAbD4K5reM1uYyPjZWxKT8Cv8/AAAAJPe/gD8AAKAFwSG0QLqKUYFY7wFAXtJ4qmoZQb5n1SCb48Lgv5wvaF1lN+8/xFNk/jM2BL4AAAAAMvI0PwAAAAAAAHK9AAAAAAAAAAAAAAAAgAwZQS4HAAAAAIAMGUEuBwEBHg==
     preamble: '0x55'
     sender: '0x4c3'
 version: '0.29'

--- a/spec/yaml/swiftnav/sbp/observation.yaml
+++ b/spec/yaml/swiftnav/sbp/observation.yaml
@@ -154,27 +154,27 @@ definitions:
           type: double
           units: s
           desc: Group delay differential between L1 and L2
-      - crs:
+      - c_rs:
           type: double
           units: m
           desc: Amplitude of the sine harmonic correction term to the orbit radius
-      - crc:
+      - c_rc:
           type: double
           units: m
           desc: Amplitude of the cosine harmonic correction term to the orbit radius
-      - cuc:
+      - c_uc:
           type: double
           units: rad
           desc: Amplitude of the cosine harmonic correction term to the argument of latitude
-      - cus:
+      - c_us:
           type: double
           units: rad
           desc: Amplitude of the sine harmonic correction term to the argument of latitude
-      - cic:
+      - c_ic:
           type: double
           units: rad
           desc: Amplitude of the cosine harmonic correction term to the angle of inclination
-      - cis:
+      - c_is:
           type: double
           units: rad
           desc: Amplitude of the sine harmonic correction term to the angle of inclination

--- a/spec/yaml/swiftnav/sbp/tracking.yaml
+++ b/spec/yaml/swiftnav/sbp/tracking.yaml
@@ -68,27 +68,28 @@ definitions:
           type: double
           units: s
           desc: Group delay differential between L1 and L2
-      - crs:
+      - c_rs:
           type: double
           units: m
           desc: Amplitude of the sine harmonic correction term to the orbit radius
-      - crc:
+      - c_rc:
+
           type: double
           units: m
           desc: Amplitude of the cosine harmonic correction term to the orbit radius
-      - cuc:
+      - c_uc:
           type: double
           units: rad
           desc: Amplitude of the cosine harmonic correction term to the argument of latitude
-      - cus:
+      - c_us:
           type: double
           units: rad
           desc: Amplitude of the sine harmonic correction term to the argument of latitude
-      - cic:
+      - c_ic:
           type: double
           units: rad
           desc: Amplitude of the cosine harmonic correction term to the angle of inclination
-      - cis:
+      - c_is:
           type: double
           units: rad
           desc: Amplitude of the sine harmonic correction term to the angle of inclination


### PR DESCRIPTION
The "crc" term in the ephemeris message was colliding with the crc value from the inherited class.  This change should avoid the namespace collision by adding an "_" character to each of the amplitude fields.  It will break the following:
 -- piksi_firmware (when updated to latest libsbp)
 -- generated documentation

