### PR TITLE
Handle failing parsing

### DIFF
--- a/python/data/serial_link_log_20150428-084729.log.dat
+++ b/python/data/serial_link_log_20150428-084729.log.dat
@@ -1,0 +1,1 @@
+{"timestamp": 1430236173, "data": {"sender": 1226, "msg_type": 16, "crc": 48120, "length": 26, "preamble": 85, "payload": "SU5GTzogTmV3IHRydXN0ZWQgZXBoZW1lcmk="}, "delta": 123742}

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -11,6 +11,7 @@
 from ... import SBP
 from ...table import dispatch
 from .base_logger import BaseLogger, LogIterator
+from construct.core import ConstructError
 import json
 import warnings
 from boto.s3.connection import S3Connection
@@ -87,7 +88,9 @@ class JSONLogIterator(LogIterator):
         item = SBP.from_json_dict(data['data'])
         try:
           yield (delta, timestamp, self.dispatcher(item))
-        except KeyError:
+        except (KeyError, ConstructError):
+          warn = "Bad message parsing for line %s" % line
+          warnings.warn(warn, RuntimeWarning)
           yield (delta, timestamp, item)
       except ValueError:
         warn = "Bad JSON decoding for line %s" % line

--- a/python/tests/sbp/client/test_logger.py
+++ b/python/tests/sbp/client/test_logger.py
@@ -142,8 +142,12 @@ def test_msg_print():
   """
   """
   log_datafile = "./data/serial_link_log_20150428-084729.log.dat"
-  with LogIterator(log_datafile) as log:
-    with pytest.raises(NotImplementedError) as exc_info:
+  with JSONLogIterator(log_datafile) as log:
+    with warnings.catch_warnings(record=True) as w:
       for delta, timestamp, msg in log.next():
         pass
-  assert exc_info.value.message == "next() not implemented!"
+      warnings.simplefilter("always")
+      # Check for warnings.
+      assert len(w) == 1
+      assert issubclass(w[0].category, RuntimeWarning)
+      assert str(w[0].message).startswith('Bad message parsing for line')

--- a/python/tests/sbp/client/test_logger.py
+++ b/python/tests/sbp/client/test_logger.py
@@ -137,3 +137,13 @@ def test_multi_json_log():
       warnings.simplefilter("always")
       assert len(w) == 0
   assert count == 2650 + 1451
+
+def test_msg_print():
+  """
+  """
+  log_datafile = "./data/serial_link_log_20150428-084729.log.dat"
+  with LogIterator(log_datafile) as log:
+    with pytest.raises(NotImplementedError) as exc_info:
+      for delta, timestamp, msg in log.next():
+        pass
+  assert exc_info.value.message == "next() not implemented!"


### PR DESCRIPTION
Wrap the failing parse with a warning and allow to continue on. See also #135.

/cc @mookerji 