### PR TITLE
Export PYTHONPATH from the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SWIFTNAV_ROOT := $(shell pwd)
 MAKEFLAGS += SWIFTNAV_ROOT=$(SWIFTNAV_ROOT)
 SBP_SPEC_DIR := $(SWIFTNAV_ROOT)/spec/yaml/swiftnav/sbp/
 SBP_GEN_BIN := python sbpg/generator.py
+export PYTHONPATH := .
 
 .PHONY: help all c python docs pdf html test
 


### PR DESCRIPTION
Fixes this non-descriptive problem when running make:
```
Traceback (most recent call last):
  File "sbpg/generator.py", line 20, in <module>
    import sbpg.specs.yaml2 as yaml
ImportError: No module named sbpg.specs.yaml2
```
