### PR TITLE
Allow the logger to inject tags into the logs

### DIFF
--- a/python/sbp/client/loggers/base_logger.py
+++ b/python/sbp/client/loggers/base_logger.py
@@ -23,10 +23,11 @@ class BaseLogger(object):
   filename : string
     File to log to.
   """
-  def __init__(self, filename, mode="w", dispatcher=dispatch):
+  def __init__(self, filename, mode="w", tags=None, dispatcher=dispatch):
     self.handle = open(filename, mode)
     self.dispatcher = dispatcher
     self.base_time = time.time()
+    self.tags = dict([tuple(t.split('=')) for t in tags.split(',')]) if tags else {}
 
   def __enter__(self):
     return self

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -33,9 +33,10 @@ class JSONLogger(BaseLogger):
       data = self.dispatcher(msg).to_json_dict()
     except KeyError:
       data = msg.to_json_dict()
-    msg = {"delta": self.delta(), "timestamp": self.timestamp(), "data": data}
-    msg.update(self.tags)
-    return msg
+    return {"delta": self.delta(),
+            "timestamp": self.timestamp(),
+            "data": data,
+            "metadata": self.tags}
 
   def call(self, msg):
     try:

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -33,9 +33,9 @@ class JSONLogger(BaseLogger):
       data = self.dispatcher(msg).to_json_dict()
     except KeyError:
       data = msg.to_json_dict()
-    return {"delta": self.delta(),
-            "timestamp": self.timestamp(),
-            "data": data}
+    msg = {"delta": self.delta(), "timestamp": self.timestamp(), "data": data}
+    msg.update(self.tags)
+    return msg
 
   def call(self, msg):
     try:


### PR DESCRIPTION
Add a tags parameter to Base logger and use it in JSON logger. It's a string of tags separated by commas used to decorate the logs with. This results in something like:

```
tags=WUT=now,HI=hater
```

generates:

```json
{"timestamp": 1431022699, "WUT": "now", "HI": "hater", "data": ...
```

This will be used to inject session data into the logs, namely `session_id`. There's some questions here on whether to nest these tags and metadata - we can update that as necessary.

/cc @mookerji 