### PR TITLE
Deprecate bootloader handshake +  send SBP protocol version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ sbp_out.*
 
 # Virtual Envs
 /*env
+
+RELEASE-VERSION

--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -45,12 +45,13 @@
  * The handshake message response from the device establishes a
  * handshake between the device bootloader and the host. The
  * request from the host is MSG_BOOTLOADER_HANDSHAKE_HOST.  The
- * payload string contains the bootloader version number, but
- * returns an empty string for earlier versions.
+ * payload contains the bootloader version number and the SBP
+ * protocol version number.
  */
-#define SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE 0x00B0
+#define SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE 0x00B4
 typedef struct __attribute__((packed)) {
-  u8 handshake[0]; /**< Version number string (not NULL terminated) */
+  u32 flags;      /**< Bootloader flags */
+  char* version;    /**< Bootloader version number */
 } msg_bootloader_handshake_device_t;
 
 

--- a/c/include/libsbp/deprecated.h
+++ b/c/include/libsbp/deprecated.h
@@ -26,11 +26,25 @@
 #include "common.h"
 
 
+/** Bootloading handshake response (host <= device)
+ *
+ * The handshake message response from the device establishes a
+ * handshake between the device bootloader and the host. The
+ * request from the host is MSG_BOOTLOADER_HANDSHAKE_HOST.  The
+ * payload string contains the bootloader version number, but
+ * returns an empty string for earlier versions.
+ */
+#define SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED 0x00B0
+typedef struct __attribute__((packed)) {
+  u8 handshake[0]; /**< Version number string (not NULL terminated) */
+} msg_bootloader_handshake_deprecated_t;
+
+
 /** Deprecated
  *
 * Deprecated.
  */
-#define SBP_MSG_EPHEMERIS_DEPRECATED 0x001A
+#define SBP_MSG_EPHEMERIS_DEPRECATED            0x001A
 typedef struct __attribute__((packed)) {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */

--- a/python/MANIFEST.IN
+++ b/python/MANIFEST.IN
@@ -7,6 +7,7 @@ include *.txt
 include .coveragerc
 include .gitignore
 include LICENSE
+include RELEASE-VERSION
 include tox.ini
 recursive-include sbp/ *.py
 prune docs/_build

--- a/python/MANIFEST.IN
+++ b/python/MANIFEST.IN
@@ -7,7 +7,6 @@ include *.txt
 include .coveragerc
 include .gitignore
 include LICENSE
-include RELEASE-VERSION
 include tox.ini
 recursive-include sbp/ *.py
 prune docs/_build

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -59,9 +59,9 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_DEVICE.
     return fmt_repr(self)
  
     
-SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE = 0x00B0
+SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE = 0x00B4
 class MsgBootloaderHandshakeDevice(SBP):
-  """SBP class for message MSG_BOOTLOADER_HANDSHAKE_DEVICE (0x00B0).
+  """SBP class for message MSG_BOOTLOADER_HANDSHAKE_DEVICE (0x00B4).
 
   You can have MSG_BOOTLOADER_HANDSHAKE_DEVICE inherent its fields directly
   from an inherited SBP object, or construct it inline using a dict
@@ -71,22 +71,25 @@ class MsgBootloaderHandshakeDevice(SBP):
   The handshake message response from the device establishes a
 handshake between the device bootloader and the host. The
 request from the host is MSG_BOOTLOADER_HANDSHAKE_HOST.  The
-payload string contains the bootloader version number, but
-returns an empty string for earlier versions.
+payload contains the bootloader version number and the SBP
+protocol version number.
 
 
   Parameters
   ----------
   sbp : SBP
     SBP parent object to inherit from.
-  handshake : array
-    Version number string (not NULL terminated)
+  flags : int
+    Bootloader flags
+  version : string
+    Bootloader version number
   sender : int
     Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgBootloaderHandshakeDevice",
-                   OptionalGreedyRange(ULInt8('handshake')),)
+                   ULInt32('flags'),
+                   CString('version', six.b('\n')),)
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -96,7 +99,8 @@ returns an empty string for earlier versions.
       super( MsgBootloaderHandshakeDevice, self).__init__()
       self.msg_type = SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE
       self.sender = kwargs.pop('sender', 0)
-      self.handshake = kwargs.pop('handshake')
+      self.flags = kwargs.pop('flags')
+      self.version = kwargs.pop('version')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -315,7 +319,7 @@ on the right.
 
 msg_classes = {
   0x00B3: MsgBootloaderHandshakeHost,
-  0x00B0: MsgBootloaderHandshakeDevice,
+  0x00B4: MsgBootloaderHandshakeDevice,
   0x00B1: MsgBootloaderJumpToApp,
   0x00DE: MsgNapDeviceDnaHost,
   0x00DD: MsgNapDeviceDnaDevice,

--- a/python/sbp/deprecated.py
+++ b/python/sbp/deprecated.py
@@ -24,6 +24,80 @@ import six
 # Please do not hand edit!
 
 
+SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED = 0x00B0
+class MsgBootloaderHandshakeDeprecated(SBP):
+  """SBP class for message MSG_BOOTLOADER_HANDSHAKE_DEPRECATED (0x00B0).
+
+  You can have MSG_BOOTLOADER_HANDSHAKE_DEPRECATED inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
+  
+  The handshake message response from the device establishes a
+handshake between the device bootloader and the host. The
+request from the host is MSG_BOOTLOADER_HANDSHAKE_HOST.  The
+payload string contains the bootloader version number, but
+returns an empty string for earlier versions.
+
+
+  Parameters
+  ----------
+  sbp : SBP
+    SBP parent object to inherit from.
+  handshake : array
+    Version number string (not NULL terminated)
+  sender : int
+    Optional sender ID, defaults to 0
+
+  """
+  _parser = Struct("MsgBootloaderHandshakeDeprecated",
+                   OptionalGreedyRange(ULInt8('handshake')),)
+
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      super( MsgBootloaderHandshakeDeprecated, self).__init__()
+      self.msg_type = SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED
+      self.sender = kwargs.pop('sender', 0)
+      self.handshake = kwargs.pop('handshake')
+
+  def __repr__(self):
+    return fmt_repr(self)
+ 
+  def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
+    p = MsgBootloaderHandshakeDeprecated._parser.parse(d)
+    self.__dict__.update(dict(p.viewitems()))
+
+  def to_binary(self):
+    """Produce a framed/packed SBP message.
+
+    """
+    c = containerize(exclude_fields(self))
+    self.payload = MsgBootloaderHandshakeDeprecated._parser.build(c)
+    return self.pack()
+
+  @staticmethod
+  def from_json(s):
+    """Given a JSON-encoded string s, build a message object.
+
+    """
+    d = json.loads(s)
+    sbp = SBP.from_json_dict(d)
+    return MsgBootloaderHandshakeDeprecated(sbp)
+
+  def to_json_dict(self):
+    self.to_binary()
+    d = super( MsgBootloaderHandshakeDeprecated, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return d
+    
 SBP_MSG_EPHEMERIS_DEPRECATED = 0x001A
 class MsgEphemerisDeprecated(SBP):
   """SBP class for message MSG_EPHEMERIS_DEPRECATED (0x001A).
@@ -195,5 +269,6 @@ class MsgEphemerisDeprecated(SBP):
     
 
 msg_classes = {
+  0x00B0: MsgBootloaderHandshakeDeprecated,
   0x001A: MsgEphemerisDeprecated,
 }

--- a/python/sbp/version.py
+++ b/python/sbp/version.py
@@ -75,7 +75,7 @@ def get_git_version():
     version = call_git_describe()
 
     # Take off the leading if present.
-    if version[0] == 'v':
+    if version is not None and version[0] == 'v':
       version = version[1:]
 
     #adapt to PEP 386 compatible versioning scheme

--- a/python/sbp/version.py
+++ b/python/sbp/version.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Douglas Creager <dcreager@dcreager.net>
+# This file is placed into the public domain.
+# Adapted from Gist: https://gist.github.com/3067886
+
+# Calculates the current version number.  If possible, this is the
+# output of “git describe”, modified to conform to the versioning
+# scheme that setuptools uses.  If “git describe” returns an error
+# (most likely because we're in an unpacked copy of a release tarball,
+# rather than in a git working copy), then we fall back on reading the
+# contents of the RELEASE-VERSION file.
+#
+# To use this script, simply import it your setup.py file, and use the
+# results of get_git_version() as your package version:
+#
+# from version import *
+#
+# setup(
+#     version=get_git_version(),
+#     .
+#     .
+#     .
+# )
+#
+# This will automatically update the RELEASE-VERSION file, if
+# necessary.  Note that the RELEASE-VERSION file should *not* be
+# checked into git; please add it to your top-level .gitignore file.
+#
+# You'll probably want to distribute the RELEASE-VERSION file in your
+# sdist tarballs; to do this, just create a MANIFEST.in file that
+# contains the following line:
+#
+#   include RELEASE-VERSION
+
+__all__ = ("get_git_version")
+
+from subprocess import Popen, PIPE
+import os
+
+def call_git_describe():
+    try:
+        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+    except:
+        return None
+
+
+def read_release_version():
+    try:
+        f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "r")
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+        finally:
+            f.close()
+    except:
+        return None
+
+
+def write_release_version(version):
+    f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "w")
+    f.write("%s\n" % version)
+    f.close()
+
+
+def get_git_version():
+    # Read in the version that's currently in RELEASE-VERSION.
+    release_version = read_release_version()
+
+    # First try to get the current version using “git describe”.
+    version = call_git_describe()
+
+    # Take off the leading if present.
+    if version[0] == 'v':
+      version = version[1:]
+
+    #adapt to PEP 386 compatible versioning scheme
+    version = pep386adapt(version)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+    if version is None:
+        raise ValueError("Cannot find the version number!")
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+    return version
+
+
+def pep386adapt(version):
+    if version is not None and '-' in version:
+        # adapt git-describe version to be in line with PEP 386
+        # Break PEP 386 a bit here and append the Git hash
+        parts = version.split('-')
+        if len(parts) > 2:
+          version = '%s.post%s-%s' % (
+              parts[0], parts[1],
+              '-'.join(parts[2:])
+          )
+        return version
+    else:
+        return version
+
+VERSION = get_git_version()
+
+if __name__ == "__main__":
+    print get_git_version()
+

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 import os
 
-VERSION = "0.43"
+VERSION = "0.44"
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,81 +1,8 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from subprocess import Popen, PIPE
 import os
-
-def call_git_describe():
-    try:
-        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
-                  stdout=PIPE, stderr=PIPE)
-        p.stderr.close()
-        line = p.stdout.readlines()[0]
-        return line.strip()
-    except:
-        return None
-
-def read_release_version():
-    try:
-        f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "r")
-        try:
-            version = f.readlines()[0]
-            return version.strip()
-        finally:
-            f.close()
-    except:
-        return None
-
-def write_release_version(version):
-    f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "w")
-    f.write("%s\n" % version)
-    f.close()
-
-def pep386adapt(version):
-    if version is not None and '-' in version:
-        # adapt git-describe version to be in line with PEP 386
-        # Break PEP 386 a bit here and append the Git hash
-        parts = version.split('-')
-        if len(parts) > 2:
-          version = '%s.post%s-%s' % (
-              parts[0], parts[1],
-              '-'.join(parts[2:])
-          )
-        return version
-    else:
-        return version
-
-def get_git_version():
-    # Read in the version that's currently in RELEASE-VERSION.
-    release_version = read_release_version()
-
-    # First try to get the current version using 'git describe'.
-    version = call_git_describe()
-
-    # Take off the leading if present.
-    if version[0] == 'v':
-      version = version[1:]
-
-    #adapt to PEP 386 compatible versioning scheme
-    version = pep386adapt(version)
-
-    # If that doesn't work, fall back on the value that's in
-    # RELEASE-VERSION.
-    if version is None:
-        version = release_version
-
-    # If we still don't have anything, that's an error.
-    if version is None:
-        raise ValueError("Cannot find the version number!")
-
-    # If the current version is different from what's in the
-    # RELEASE-VERSION file, update the file to be current.
-    if version != release_version:
-        write_release_version(version)
-
-    # Finally, return the current version.
-    return version
-
-VERSION = get_git_version()
+from sbp.version import VERSION
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',
@@ -102,6 +29,10 @@ PLATFORMS = [
   'win32',
 ]
 
+PACKAGE_DATA = { 'sbp' : [
+  'RELEASE-VERSION',
+] }
+
 cwd = os.path.abspath(os.path.dirname(__file__))
 with open(cwd + '/README.rst') as f:
   readme = f.read()
@@ -119,6 +50,7 @@ setup(name='sbp',
       classifiers=CLASSIFIERS,
       packages=PACKAGES,
       platforms=PLATFORMS,
+      package_data=PACKAGE_DATA,
       install_requires=INSTALL_REQUIRES,
       use_2to3=False,
       zip_safe=False)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,9 +1,81 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from subprocess import Popen, PIPE
 import os
 
-VERSION = "0.44"
+def call_git_describe():
+    try:
+        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+    except:
+        return None
+
+def read_release_version():
+    try:
+        f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "r")
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+        finally:
+            f.close()
+    except:
+        return None
+
+def write_release_version(version):
+    f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "w")
+    f.write("%s\n" % version)
+    f.close()
+
+def pep386adapt(version):
+    if version is not None and '-' in version:
+        # adapt git-describe version to be in line with PEP 386
+        # Break PEP 386 a bit here and append the Git hash
+        parts = version.split('-')
+        if len(parts) > 2:
+          version = '%s.post%s-%s' % (
+              parts[0], parts[1],
+              '-'.join(parts[2:])
+          )
+        return version
+    else:
+        return version
+
+def get_git_version():
+    # Read in the version that's currently in RELEASE-VERSION.
+    release_version = read_release_version()
+
+    # First try to get the current version using 'git describe'.
+    version = call_git_describe()
+
+    # Take off the leading if present.
+    if version[0] == 'v':
+      version = version[1:]
+
+    #adapt to PEP 386 compatible versioning scheme
+    version = pep386adapt(version)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+    if version is None:
+        raise ValueError("Cannot find the version number!")
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+    return version
+
+VERSION = get_git_version()
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -34,7 +34,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 51
+  number_of_messages = 52
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/spec/tests/yaml/swiftnav/sbp/test_bootload.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_bootload.yaml
@@ -1,31 +1,25 @@
 ---
-description: Unit tests for swiftnav.sbp.bootload v0.29.
+description: Unit tests for swiftnav.sbp.bootload v0.42.
 generated_on: 2015-04-12 20:15:47.084788
 package: sbp.bootload
 tests:
 
 - msg:
     fields:
-      handshake: [118, 49, 46, 50] # 'v1.2'
+      flags: 0
+      version: v1.2
     module: sbp.bootload
     name: MsgBootloaderHandshakeDevice
-  msg_type: '0xb0'
-  raw_packet: VbAAwwQEdjEuMgHO
-  raw_json: '{
-    "handshake": [118, 49, 46, 50],
-    "crc": 52737,
-    "length": 4,
-    "msg_type": 176,
-    "payload": "djEuMg==",
-    "preamble": 85,
-    "sender": 1219
-  }'
+  msg_type: '0xb4'
+  raw_json: '{"sender": 0, "msg_type": 180, "crc": 457, "length": 9, "version": "v1.2",
+    "flags": 0, "preamble": 85, "payload": "AAAAAHYxLjIK"}'
+  raw_packet: VbQAAAAJAAAAAHYxLjIKyQE=
   sbp:
-    crc: '0xce01'
-    length: 4
-    msg_type: '0xb0'
-    payload: djEuMg==
+    crc: '0x1c9'
+    length: 9
+    msg_type: '0xb4'
+    payload: AAAAAHYxLjIK
     preamble: '0x55'
-    sender: '0x4c3'
-version: '0.29'
+    sender: '0x0'
+version: '0.42'
 ...

--- a/spec/tests/yaml/swiftnav/sbp/test_deprecated.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/test_deprecated.yaml
@@ -6,6 +6,30 @@ tests:
 
 - msg:
     fields:
+      handshake: [118, 49, 46, 50] # 'v1.2'
+    module: sbp.bootload
+    name: MsgBootloaderHandshakeDeprecated
+  msg_type: '0xb0'
+  raw_packet: VbAAwwQEdjEuMgHO
+  raw_json: '{
+    "handshake": [118, 49, 46, 50],
+    "crc": 52737,
+    "length": 4,
+    "msg_type": 176,
+    "payload": "djEuMg==",
+    "preamble": 85,
+    "sender": 1219
+  }'
+  sbp:
+    crc: '0xce01'
+    length: 4
+    msg_type: '0xb0'
+    payload: djEuMg==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+- msg:
+    fields:
       af0: -1.035025343298912e-05
       af1: -9.094947017729282e-13
       af2: 0.0

--- a/spec/yaml/swiftnav/sbp/bootload.yaml
+++ b/spec/yaml/swiftnav/sbp/bootload.yaml
@@ -42,9 +42,6 @@ definitions:
       payload contains the bootloader version number and the SBP
       protocol version number.
     fields:
-      - version:
-          type: string
-          desc: Bootloader version number
       - flags:
           type: u32
           desc: Bootloader flags
@@ -55,6 +52,9 @@ definitions:
                 desc: SBP minor protocol version number
             - 0-7:
                 desc: SBP major protocol version number
+      - version:
+          type: string
+          desc: Bootloader version number
 
  - MSG_BOOTLOADER_JUMP_TO_APP:
     id: 0x00B1

--- a/spec/yaml/swiftnav/sbp/bootload.yaml
+++ b/spec/yaml/swiftnav/sbp/bootload.yaml
@@ -45,9 +45,14 @@ definitions:
       - version:
           type: string
           desc: Bootloader version number
-      - protocol:
-          type: string
-          desc: SBP protocol version number
+      - flags:
+          type: u32
+          desc: Bootloader flags
+          fields:
+            - 24-31:
+                desc: Reserved
+            - 0-23:
+                desc: SBP protocol version number
 
  - MSG_BOOTLOADER_JUMP_TO_APP:
     id: 0x00B1

--- a/spec/yaml/swiftnav/sbp/bootload.yaml
+++ b/spec/yaml/swiftnav/sbp/bootload.yaml
@@ -32,20 +32,22 @@ definitions:
       response from the device is MSG_BOOTLOADER_HANDSHAKE_DEVICE.
 
  - MSG_BOOTLOADER_HANDSHAKE_DEVICE:
-    id: 0x00B0
+    id: 0x00B4
     public: True
     short_desc: Bootloading handshake response (host <= device)
     desc: |
       The handshake message response from the device establishes a
       handshake between the device bootloader and the host. The
       request from the host is MSG_BOOTLOADER_HANDSHAKE_HOST.  The
-      payload string contains the bootloader version number, but
-      returns an empty string for earlier versions.
+      payload contains the bootloader version number and the SBP
+      protocol version number.
     fields:
-      - handshake:
-          type: array
-          fill: u8
-          desc: Version number string (not NULL terminated)
+      - version:
+          type: string
+          desc: Bootloader version number
+      - protocol:
+          type: string
+          desc: SBP protocol version number
 
  - MSG_BOOTLOADER_JUMP_TO_APP:
     id: 0x00B1

--- a/spec/yaml/swiftnav/sbp/bootload.yaml
+++ b/spec/yaml/swiftnav/sbp/bootload.yaml
@@ -49,10 +49,12 @@ definitions:
           type: u32
           desc: Bootloader flags
           fields:
-            - 24-31:
+            - 16-31:
                 desc: Reserved
-            - 0-23:
-                desc: SBP protocol version number
+            - 8-15:
+                desc: SBP minor protocol version number
+            - 0-7:
+                desc: SBP major protocol version number
 
  - MSG_BOOTLOADER_JUMP_TO_APP:
     id: 0x00B1

--- a/spec/yaml/swiftnav/sbp/deprecated.yaml
+++ b/spec/yaml/swiftnav/sbp/deprecated.yaml
@@ -11,7 +11,7 @@
 package: swiftnav.sbp.deprecated
 description: Deprecated SBP messages.
 stable: False
-public: False
+public: True
 include:
   - types.yaml
 definitions:
@@ -34,6 +34,7 @@ definitions:
 
  - MSG_EPHEMERIS_DEPRECATED:
     id: 0x001A
+    public: False
     short_desc: Deprecated
     desc: Deprecated.
     replaced_by:

--- a/spec/yaml/swiftnav/sbp/deprecated.yaml
+++ b/spec/yaml/swiftnav/sbp/deprecated.yaml
@@ -16,6 +16,22 @@ include:
   - types.yaml
 definitions:
 
+ - MSG_BOOTLOADER_HANDSHAKE_DEPRECATED:
+    id: 0x00B0
+    public: True
+    short_desc: Bootloading handshake response (host <= device)
+    desc: |
+      The handshake message response from the device establishes a
+      handshake between the device bootloader and the host. The
+      request from the host is MSG_BOOTLOADER_HANDSHAKE_HOST.  The
+      payload string contains the bootloader version number, but
+      returns an empty string for earlier versions.
+    fields:
+      - handshake:
+          type: array
+          fill: u8
+          desc: Version number string (not NULL terminated)
+
  - MSG_EPHEMERIS_DEPRECATED:
     id: 0x001A
     short_desc: Deprecated

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -55,8 +55,10 @@ definitions:
                   values:
                       - 0: No external antenna detected
                       - 1: External antenna is present
-              - 3-30:
+              - 27-30:
                   desc: Reserved
+              - 3-26:
+                  desc: SBP protocol version number
               - 2:
                   desc: SwiftNAP Error
               - 1:
@@ -66,6 +68,3 @@ definitions:
                   values:
                       - 0: System Healthy
                       - 1: An error has occurred
-        - protocol:
-            type: string
-            desc: SBP protocol version number

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -55,10 +55,14 @@ definitions:
                   values:
                       - 0: No external antenna detected
                       - 1: External antenna is present
-              - 27-30:
+              - 24-30:
                   desc: Reserved
-              - 3-26:
-                  desc: SBP protocol version number
+              - 16-23:
+                  desc: SBP minor protocol version number
+              - 8-15:
+                  desc: SBP major protocol version number
+              - 3-7:
+                  desc: Reserved
               - 2:
                   desc: SwiftNAP Error
               - 1:

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -66,3 +66,6 @@ definitions:
                   values:
                       - 0: System Healthy
                       - 1: An error has occurred
+        - protocol:
+            type: string
+            desc: SBP protocol version number


### PR DESCRIPTION
Setup a new bootloader message from the device, containing both the bootloader version and the SBP protocol version as strings. Also add SBP protocol version as a string to the heartbeat.

There's a lot more changes that need to happen on top of this - collecting feedback before embarking on those changes.

/cc @fnoble @cbeighley @mookerji 

<!---
@huboard:{"order":417.0}
-->
