### PR TITLE
Use a zero length array instead of a pointer

### DIFF
--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -51,7 +51,7 @@
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE 0x00B4
 typedef struct __attribute__((packed)) {
   u32 flags;      /**< Bootloader flags */
-  char* version;    /**< Bootloader version number */
+  char[0] version;    /**< Bootloader version number */
 } msg_bootloader_handshake_device_t;
 
 

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -35,7 +35,7 @@
  */
 #define SBP_MSG_PRINT     0x0010
 typedef struct __attribute__((packed)) {
-  char* text;    /**< Human-readable string */
+  char[0] text;    /**< Human-readable string */
 } msg_print_t;
 
 

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -39,7 +39,7 @@
  */
 #define SBP_MSG_SETTINGS               0x00A0
 typedef struct __attribute__((packed)) {
-  char* setting;    /**< A NULL-terminated and delimited string with contents
+  char[0] setting;    /**< A NULL-terminated and delimited string with contents
 [SECTION_SETTING, SETTING, VALUE] on writes or a series of
 such strings on reads.
  */

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -55,7 +55,7 @@ def mk_id(field):
   if name == "string" and field.options.get('size', None):
     return "%s" % ("char")
   elif name == "string":
-    return "%s*" % ("char")
+    return "%s[0]" % ("char")
   elif name == "array" and field.size:
     if field.options['fill'].value not in CONSTRUCT_CODE:
       return "%s" % convert(field.options['fill'].value)


### PR DESCRIPTION
Represent strings a 0 length arrays to avoid problems calculating message sizes. (is there a better way to represent this or is this acceptable?)

/cc @mookerji @fnoble @cbeighley 