### PR TITLE
C array declarations - how do they work?

### DIFF
--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -51,7 +51,7 @@
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE 0x00B4
 typedef struct __attribute__((packed)) {
   u32 flags;      /**< Bootloader flags */
-  char[0] version;    /**< Bootloader version number */
+  char version[0]; /**< Bootloader version number */
 } msg_bootloader_handshake_device_t;
 
 

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -35,7 +35,7 @@
  */
 #define SBP_MSG_PRINT     0x0010
 typedef struct __attribute__((packed)) {
-  char[0] text;    /**< Human-readable string */
+  char text[0]; /**< Human-readable string */
 } msg_print_t;
 
 

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -39,7 +39,7 @@
  */
 #define SBP_MSG_SETTINGS               0x00A0
 typedef struct __attribute__((packed)) {
-  char[0] setting;    /**< A NULL-terminated and delimited string with contents
+  char setting[0]; /**< A NULL-terminated and delimited string with contents
 [SECTION_SETTING, SETTING, VALUE] on writes or a series of
 such strings on reads.
  */

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -53,10 +53,8 @@ def mk_id(field):
   """Builds an identifier from a field.
   """
   name = field.type_id
-  if name == "string" and field.options.get('size', None):
+  if name == "string":
     return "%s" % ("char")
-  elif name == "string":
-    return "%s[0]" % ("char")
   elif name == "array" and field.size:
     if field.options['fill'].value not in CONSTRUCT_CODE:
       return "%s" % convert(field.options['fill'].value)
@@ -76,7 +74,7 @@ def mk_size(field):
   if name == "string" and field.options.get('size', None):
     return "%s[%d];" % (field.identifier, field.options.get('size').value)
   elif name == "string":
-    return "%s;" % field.identifier
+    return "%s[0];" % field.identifier
   elif name == "array" and field.options.get('size', None):
     return "%s[%d];" % (field.identifier, field.options.get('size').value)
   elif name == "array":


### PR DESCRIPTION
Woops. Put the size after the name. Get rid of the special case in `mk_id`.

/cc @mookerji 