### PR TITLE
UDP logger for SBP

### DIFF
--- a/python/sbp/client/examples/udp.py
+++ b/python/sbp/client/examples/udp.py
@@ -15,9 +15,8 @@ messages from a serial port and sending them to a UDP socket.
 
 from sbp.client.drivers.pyserial_driver import PySerialDriver
 from sbp.client.handler import Handler
+from sbp.client.loggers import UdpLogger
 
-from contextlib import closing
-import socket
 import struct
 import time
 
@@ -49,23 +48,15 @@ def get_args():
                       help="specify the baud rate to use.")
   return parser.parse_args()
 
-def send_udp_callback_generator(udp, args):
-  def send_udp_callback(msg):
-    s = ""
-    s += struct.pack("<BHHB", 0x55, msg.msg_type, msg.sender, msg.length)
-    s += msg.payload
-    s += struct.pack("<H", msg.crc)
-    udp.sendto(s, (args.address[0], args.udp_port[0]))
-
-  return send_udp_callback
-
 def main():
   args = get_args()
+  address = args.address[0]
+  udp_port = args.udp_port[0]
 
   with PySerialDriver(args.serial_port[0], args.baud[0]) as driver:
     with Handler(driver.read, driver.write) as handler:
-      with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as udp:
-        handler.add_callback(send_udp_callback_generator(udp, args))
+      with UdpLogger(address, udp_port) as udp:
+        handler.add_callback(udp)
 
         try:
           while True:

--- a/python/sbp/client/examples/udp.py
+++ b/python/sbp/client/examples/udp.py
@@ -14,8 +14,8 @@ messages from a serial port and sending them to a UDP socket.
 """
 
 from sbp.client.drivers.pyserial_driver import PySerialDriver
-from sbp.client.handler import Handler
-from sbp.client.loggers import UdpLogger
+from sbp.client.handler            import Handler
+from sbp.client.loggers.udp_logger import UdpLogger
 
 import struct
 import time

--- a/python/sbp/client/loggers/udp_logger.py
+++ b/python/sbp/client/loggers/udp_logger.py
@@ -41,5 +41,8 @@ class UdpLogger(BaseLogger):
     s += struct.pack("<H", msg.crc)
     return s
 
+  def flush(self):
+    pass
+
   def call(self, msg):
     self.handle.sendto(self.fmt_msg(msg), (self.address, self.port))

--- a/python/sbp/client/loggers/udp_logger.py
+++ b/python/sbp/client/loggers/udp_logger.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Mark Fine <mark@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import socket
+import struct
+
+from .base_logger import BaseLogger
+
+class UdpLogger(BaseLogger):
+  """
+  UdpLogger
+
+  The :class:`UdpLogger` logs SBP messages over UDP.
+
+  Parameters
+  ----------
+  address : string
+    IP Address to send UDP packets to.
+  port : int
+    IP Port to send UDP packets to.
+  """
+  def __init__(self, address, port):
+    self.handle = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    self.address = address
+    self.port = port
+
+  def __call__(self, msg):
+    self.call(msg)
+
+  def fmt_msg(self, msg):
+    s = ""
+    s += struct.pack("<BHHB", 0x55, msg.msg_type, msg.sender, msg.length)
+    s += msg.payload
+    s += struct.pack("<H", msg.crc)
+    return s
+
+  def call(self, msg):
+    self.handle.sendto(self.fmt_msg(msg), (self.address, self.port))

--- a/python/tests/sbp/client/test_udp_logger.py
+++ b/python/tests/sbp/client/test_udp_logger.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+def test_udp_logger():
+  pass


### PR DESCRIPTION
A simple UDP logger. Sends messages over a UDP address:port pair. There should be some library help around framing out the message instead of doing it explicitly here. Haven't tried this out yet.

/cc @fnoble @denniszollo 