### PR TITLE
Make add and remove callbacks take lists of message for convenience

### DIFF
--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -185,7 +185,7 @@ class Handler(object):
       List type adds the callback to all the message types.
     """
     try:
-      for mt in msg_type:
+      for mt in iter(msg_type):
         self.callbacks[mt].add(callback)
     except TypeError:
       self.callbacks[msg_type].add(callback)
@@ -203,7 +203,7 @@ class Handler(object):
       List type removes the callback from all the message types.
     """
     try:
-      for mt in msg_type:
+      for mt in iter(msg_type):
         self.callbacks[mt].remove(callback)
     except TypeError:
       self.callbacks[msg_type].remove(callback)

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -180,15 +180,15 @@ class Handler(object):
     ----------
     callback : fn
       Callback function
-    msg_type : int | list
+    msg_type : int | iterable
       Message type to register callback against. Default `None` means global callback.
       List type adds the callback to all the message types.
     """
-    if not isinstance(msg_type, list):
-      self.callbacks[msg_type].add(callback)
-    else:
+    try:
       for mt in msg_type:
         self.callbacks[mt].add(callback)
+    except TypeError:
+      self.callbacks[msg_type].add(callback)
 
   def remove_callback(self, callback, msg_type=None):
     """
@@ -202,11 +202,11 @@ class Handler(object):
       Message type to remove callback from. Default `None` means global callback.
       List type removes the callback from all the message types.
     """
-    if not isinstance(msg_type, list):
-      self.callbacks[msg_type].remove(callback)
-    else:
+    try:
       for mt in msg_type:
         self.callbacks[mt].remove(callback)
+    except TypeError:
+      self.callbacks[msg_type].remove(callback)
 
   def get_callbacks(self, msg_type):
     """

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -198,7 +198,7 @@ class Handler(object):
     ----------
     callback : fn
       Callback function
-    msg_type : int | list
+    msg_type : int | iterable
       Message type to remove callback from. Default `None` means global callback.
       List type removes the callback from all the message types.
     """

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -182,7 +182,7 @@ class Handler(object):
       Callback function
     msg_type : int | iterable
       Message type to register callback against. Default `None` means global callback.
-      List type adds the callback to all the message types.
+      Iterable type adds the callback to all the message types.
     """
     try:
       for mt in iter(msg_type):
@@ -200,7 +200,7 @@ class Handler(object):
       Callback function
     msg_type : int | iterable
       Message type to remove callback from. Default `None` means global callback.
-      List type removes the callback from all the message types.
+      Iterable type removes the callback from all the message types.
     """
     try:
       for mt in iter(msg_type):

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -180,10 +180,15 @@ class Handler(object):
     ----------
     callback : fn
       Callback function
-    msg_type : int
+    msg_type : int | list
       Message type to register callback against. Default `None` means global callback.
+      List type adds the callback to all the message types.
     """
-    self.callbacks[msg_type].add(callback)
+    if not isinstance(msg_type, list):
+      self.callbacks[msg_type].add(callback)
+    else:
+      for mt in msg_type:
+        self.callbacks[mt].add(callback)
 
   def remove_callback(self, callback, msg_type=None):
     """
@@ -193,10 +198,15 @@ class Handler(object):
     ----------
     callback : fn
       Callback function
-    msg_type : int
+    msg_type : int | list
       Message type to remove callback from. Default `None` means global callback.
+      List type removes the callback from all the message types.
     """
-    self.callbacks[msg_type].remove(callback)
+    if not isinstance(msg_type, list):
+      self.callbacks[msg_type].remove(callback)
+    else:
+      for mt in msg_type:
+        self.callbacks[mt].remove(callback)
 
   def get_callbacks(self, msg_type):
     """

--- a/python/tests/sbp/client/test_handler.py
+++ b/python/tests/sbp/client/test_handler.py
@@ -101,3 +101,30 @@ def test_handler_callbacks():
   assert global_counter2.value == 2
   assert msg_type_counter1.value == 1
   assert msg_type_counter2.value == 0
+  handler.remove_callback(global_counter1)
+  handler.remove_callback(global_counter2)
+  handler.remove_callback(msg_type_counter1, 0x55)
+  handler.remove_callback(msg_type_counter2, 0x66)
+  handler.call(SBP(0x11, None, None, None, None))
+  handler.call(SBP(0x55, None, None, None, None))
+  assert global_counter1.value == 2
+  assert global_counter2.value == 2
+  assert msg_type_counter1.value == 1
+  assert msg_type_counter2.value == 0
+
+def test_multiple_handler_callbacks():
+  handler = Handler(None, None)
+  msg_type_counter1 = TestCallbackCounter()
+  msg_type_counter2 = TestCallbackCounter()
+  handler.add_callback(msg_type_counter1, [0x55, 0x66])
+  handler.add_callback(msg_type_counter2, [0x11, 0x55])
+  handler.call(SBP(0x11, None, None, None, None))
+  handler.call(SBP(0x55, None, None, None, None))
+  assert msg_type_counter1.value == 1
+  assert msg_type_counter2.value == 2
+  handler.remove_callback(msg_type_counter1, [0x55, 0x66])
+  handler.remove_callback(msg_type_counter2, [0x11, 0x55])
+  handler.call(SBP(0x11, None, None, None, None))
+  handler.call(SBP(0x55, None, None, None, None))
+  assert msg_type_counter1.value == 1
+  assert msg_type_counter2.value == 2


### PR DESCRIPTION
Check to see if the msg_type is a list, and then apply the callbacks to all the message types. Better way to do something like this?

/cc @fnoble @denniszollo 