### PR TITLE
New file_io messages

### DIFF
--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -64,6 +64,7 @@ typedef struct __attribute__((packed)) {
   u32 offset;        /**< File offset [bytes] */
   u8 chunk_size;    /**< Chunk size read [bytes] */
   char filename[20];  /**< Name of the file read from (NULL padded) */
+  u8 contents[0];   /**< Contents of read file */
 } msg_fileio_read_response_t;
 
 
@@ -98,9 +99,10 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_FILEIO_READ_DIR_RESPONSE 0x00AA
 typedef struct __attribute__((packed)) {
-  u32 offset;     /**< The offset to skip the first n elements of the file list
+  u32 offset;      /**< The offset to skip the first n elements of the file list
  */
   char dirname[20]; /**< Name of the directory to list (NULL padded) */
+  u8 contents[0]; /**< Contents of read directory */
 } msg_fileio_read_dir_response_t;
 
 

--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -35,41 +35,73 @@
 #include "common.h"
 
 
-/** Read file from the file system (host <=> device)
+/** Read file from the file system (host => device)
  *
  * The file read message reads a certain length (up to 255 bytes)
  * from a given offset into a file, and returns the data in a
- * MSG_FILEIO_READ message where the message length field indicates
- * how many bytes were succesfully read. If the message is invalid,
- * a followup MSG_PRINT message will print "Invalid fileio read
- * message".
+ * MSG_FILEIO_READ_RESPONSE message where the message length field
+ * indicates how many bytes were succesfully read. If the message is
+ * invalid, a followup MSG_PRINT message will print "Invalid fileio
+ * read message".
  */
-#define SBP_MSG_FILEIO_READ     0x00A8
+#define SBP_MSG_FILEIO_READ_REQUEST      0x00A8
 typedef struct __attribute__((packed)) {
   u32 offset;        /**< File offset [bytes] */
   u8 chunk_size;    /**< Chunk size to read [bytes] */
   char filename[20];  /**< Name of the file to read from (NULL padded) */
-} msg_fileio_read_t;
+} msg_fileio_read_request_t;
 
 
-/** List files in a directory (host <=> device)
+/** File read from the file system (host <= device)
+ *
+ * The file read message reads a certain length (up to 255 bytes)
+ * from a given offset into a file, and returns the data in a
+ * message where the message length field indicates how many bytes
+ * were succesfully read.
+ */
+#define SBP_MSG_FILEIO_READ_RESPONSE     0x00A3
+typedef struct __attribute__((packed)) {
+  u32 offset;        /**< File offset [bytes] */
+  u8 chunk_size;    /**< Chunk size read [bytes] */
+  char filename[20];  /**< Name of the file read from (NULL padded) */
+} msg_fileio_read_response_t;
+
+
+/** List files in a directory (host => device)
  *
  * The read directory message lists the files in a directory on the
  * device's onboard flash file system.  The offset parameter can be
  * used to skip the first n elements of the file list. Returns a
- * MSG_FILEIO_READ_DIR message containing the directory listings as
- * a NULL delimited list. The listing is chunked over multiple SBP
- * packets and the end of the list is identified by an entry
- * containing just the character 0xFF. If message is invalid, a
+ * MSG_FILEIO_READ_DIR_RESPONSE message containing the directory
+ * listings as a NULL delimited list. The listing is chunked over
+ * multiple SBP packets and the end of the list is identified by an
+ * entry containing just the character 0xFF. If message is invalid, a
  * followup MSG_PRINT message will print "Invalid fileio read
  * message".
  */
-#define SBP_MSG_FILEIO_READ_DIR 0x00A9
+#define SBP_MSG_FILEIO_READ_DIR_REQUEST  0x00A9
 typedef struct __attribute__((packed)) {
   u32 offset;     /**< The offset to skip the first n elements of the file list
  */
   char dirname[20]; /**< Name of the directory to list (NULL padded) */
-} msg_fileio_read_dir_t;
+} msg_fileio_read_dir_request_t;
+
+
+/** Files listed in a directory (host <= device)
+ *
+ * The read directory message lists the files in a directory on the
+ * device's onboard flash file system.  The offset parameter can be
+ * used to skip the first n elements of the file list. Message contains
+ * the directory listings as a NULL delimited list. The listing is
+ * chunked over multiple SBP packets and the end of the list is
+ * identified by an entry containing just the character 0xFF.
+ */
+#define SBP_MSG_FILEIO_READ_DIR_RESPONSE 0x00AA
+typedef struct __attribute__((packed)) {
+  u32 offset;     /**< The offset to skip the first n elements of the file list
+ */
+  char dirname[20]; /**< Name of the directory to list (NULL padded) */
+} msg_fileio_read_dir_response_t;
 
 
 /** Delete a file from the file system (host => device)
@@ -78,26 +110,41 @@ typedef struct __attribute__((packed)) {
  * message is invalid, a followup MSG_PRINT message will print
  * "Invalid fileio remove message".
  */
-#define SBP_MSG_FILEIO_REMOVE   0x00AC
+#define SBP_MSG_FILEIO_REMOVE            0x00AC
 typedef struct __attribute__((packed)) {
   char filename[20]; /**< Name of the file to delete (NULL padded) */
 } msg_fileio_remove_t;
 
 
-/** Write to file (host <=> device)
+/** Write to file (host => device)
  *
  * The file write message writes a certain length (up to 255 bytes)
  * of data to a file at a given offset. Returns a copy of the
- * original MSG_FILEIO_WRITE message to check integrity of the
- * write. If message is invalid, a followup MSG_PRINT message will
- * print "Invalid fileio write message".
+ * original MSG_FILEIO_WRITE_RESPONSE message to check integrity of
+ * the write. If message is invalid, a followup MSG_PRINT message
+ * will print "Invalid fileio write message".
  */
-#define SBP_MSG_FILEIO_WRITE    0x00AD
+#define SBP_MSG_FILEIO_WRITE_REQUEST     0x00AD
 typedef struct __attribute__((packed)) {
   char filename[20]; /**< Name of the file to write to (NULL padded) */
   u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
   u8 data[0];     /**< Variable-length array of data to write */
-} msg_fileio_write_t;
+} msg_fileio_write_request_t;
+
+
+/** File written to (host <= device)
+ *
+ * The file write message writes a certain length (up to 255 bytes)
+ * of data to a file at a given offset. The message is a copy of the
+ * original MSG_FILEIO_WRITE_REQUEST message to check integrity of the
+ * write.
+ */
+#define SBP_MSG_FILEIO_WRITE_RESPONSE    0x00AB
+typedef struct __attribute__((packed)) {
+  char filename[20]; /**< Name of the file to write to (NULL padded) */
+  u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
+  u8 data[0];     /**< Variable-length array of data to write */
+} msg_fileio_write_response_t;
 
 
 /** \} */

--- a/c/include/libsbp/version.h
+++ b/c/include/libsbp/version.h
@@ -23,7 +23,7 @@
 /** Protocol major version. */
 #define SBP_MAJOR_VERSION 0
 /** Protocol minor version. */
-#define SBP_MINOR_VERSION 45
+#define SBP_MINOR_VERSION 47
 
 /** \} */
 

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -34,21 +34,21 @@ import six
 # Please do not hand edit!
 
 
-SBP_MSG_FILEIO_READ = 0x00A8
-class MsgFileioRead(SBP):
-  """SBP class for message MSG_FILEIO_READ (0x00A8).
+SBP_MSG_FILEIO_READ_REQUEST = 0x00A8
+class MsgFileioReadRequest(SBP):
+  """SBP class for message MSG_FILEIO_READ_REQUEST (0x00A8).
 
-  You can have MSG_FILEIO_READ inherent its fields directly
+  You can have MSG_FILEIO_READ_REQUEST inherent its fields directly
   from an inherited SBP object, or construct it inline using a dict
   of its fields.
 
   
   The file read message reads a certain length (up to 255 bytes)
 from a given offset into a file, and returns the data in a
-MSG_FILEIO_READ message where the message length field indicates
-how many bytes were succesfully read. If the message is invalid,
-a followup MSG_PRINT message will print "Invalid fileio read
-message".
+MSG_FILEIO_READ_RESPONSE message where the message length field
+indicates how many bytes were succesfully read. If the message is
+invalid, a followup MSG_PRINT message will print "Invalid fileio
+read message".
 
 
   Parameters
@@ -65,7 +65,7 @@ message".
     Optional sender ID, defaults to SENDER_ID (see sbp/msg.py).
 
   """
-  _parser = Struct("MsgFileioRead",
+  _parser = Struct("MsgFileioReadRequest",
                    ULInt32('offset'),
                    ULInt8('chunk_size'),
                    String('filename', 20),)
@@ -75,8 +75,89 @@ message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
-      super( MsgFileioRead, self).__init__()
-      self.msg_type = SBP_MSG_FILEIO_READ
+      super( MsgFileioReadRequest, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_READ_REQUEST
+      self.sender = kwargs.pop('sender', 0)
+      self.offset = kwargs.pop('offset')
+      self.chunk_size = kwargs.pop('chunk_size')
+      self.filename = kwargs.pop('filename')
+
+  def __repr__(self):
+    return fmt_repr(self)
+ 
+  def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
+    p = MsgFileioReadRequest._parser.parse(d)
+    self.__dict__.update(dict(p.viewitems()))
+
+  def to_binary(self):
+    """Produce a framed/packed SBP message.
+
+    """
+    c = containerize(exclude_fields(self))
+    self.payload = MsgFileioReadRequest._parser.build(c)
+    return self.pack()
+
+  @staticmethod
+  def from_json(s):
+    """Given a JSON-encoded string s, build a message object.
+
+    """
+    d = json.loads(s)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioReadRequest(sbp)
+
+  def to_json_dict(self):
+    self.to_binary()
+    d = super( MsgFileioReadRequest, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return d
+    
+SBP_MSG_FILEIO_READ_RESPONSE = 0x00A3
+class MsgFileioReadResponse(SBP):
+  """SBP class for message MSG_FILEIO_READ_RESPONSE (0x00A3).
+
+  You can have MSG_FILEIO_READ_RESPONSE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
+  
+  The file read message reads a certain length (up to 255 bytes)
+from a given offset into a file, and returns the data in a
+message where the message length field indicates how many bytes
+were succesfully read.
+
+
+  Parameters
+  ----------
+  sbp : SBP
+    SBP parent object to inherit from.
+  offset : int
+    File offset
+  chunk_size : int
+    Chunk size read
+  filename : string
+    Name of the file read from (NULL padded)
+  sender : int
+    Optional sender ID, defaults to 0
+
+  """
+  _parser = Struct("MsgFileioReadResponse",
+                   ULInt32('offset'),
+                   ULInt8('chunk_size'),
+                   String('filename', 20),)
+
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      super( MsgFileioReadResponse, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_READ_RESPONSE
       self.sender = kwargs.pop('sender', SENDER_ID)
       self.offset = kwargs.pop('offset')
       self.chunk_size = kwargs.pop('chunk_size')
@@ -90,7 +171,7 @@ message".
     the message.
 
     """
-    p = MsgFileioRead._parser.parse(d)
+    p = MsgFileioReadResponse._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
@@ -98,7 +179,7 @@ message".
 
     """
     c = containerize(exclude_fields(self))
-    self.payload = MsgFileioRead._parser.build(c)
+    self.payload = MsgFileioReadResponse._parser.build(c)
     return self.pack()
 
   @staticmethod
@@ -108,20 +189,20 @@ message".
     """
     d = json.loads(s)
     sbp = SBP.from_json_dict(d)
-    return MsgFileioRead(sbp)
+    return MsgFileioReadResponse(sbp)
 
   def to_json_dict(self):
     self.to_binary()
-    d = super( MsgFileioRead, self).to_json_dict()
+    d = super( MsgFileioReadResponse, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
     return d
     
-SBP_MSG_FILEIO_READ_DIR = 0x00A9
-class MsgFileioReadDir(SBP):
-  """SBP class for message MSG_FILEIO_READ_DIR (0x00A9).
+SBP_MSG_FILEIO_READ_DIR_REQUEST = 0x00A9
+class MsgFileioReadDirRequest(SBP):
+  """SBP class for message MSG_FILEIO_READ_DIR_REQUEST (0x00A9).
 
-  You can have MSG_FILEIO_READ_DIR inherent its fields directly
+  You can have MSG_FILEIO_READ_DIR_REQUEST inherent its fields directly
   from an inherited SBP object, or construct it inline using a dict
   of its fields.
 
@@ -129,10 +210,10 @@ class MsgFileioReadDir(SBP):
   The read directory message lists the files in a directory on the
 device's onboard flash file system.  The offset parameter can be
 used to skip the first n elements of the file list. Returns a
-MSG_FILEIO_READ_DIR message containing the directory listings as
-a NULL delimited list. The listing is chunked over multiple SBP
-packets and the end of the list is identified by an entry
-containing just the character 0xFF. If message is invalid, a
+MSG_FILEIO_READ_DIR_RESPONSE message containing the directory
+listings as a NULL delimited list. The listing is chunked over
+multiple SBP packets and the end of the list is identified by an
+entry containing just the character 0xFF. If message is invalid, a
 followup MSG_PRINT message will print "Invalid fileio read
 message".
 
@@ -150,7 +231,7 @@ message".
     Optional sender ID, defaults to SENDER_ID (see sbp/msg.py).
 
   """
-  _parser = Struct("MsgFileioReadDir",
+  _parser = Struct("MsgFileioReadDirRequest",
                    ULInt32('offset'),
                    String('dirname', 20),)
 
@@ -159,9 +240,15 @@ message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+<<<<<<< HEAD
       super( MsgFileioReadDir, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_READ_DIR
       self.sender = kwargs.pop('sender', SENDER_ID)
+=======
+      super( MsgFileioReadDirRequest, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_READ_DIR_REQUEST
+      self.sender = kwargs.pop('sender', 0)
+>>>>>>> New file_io messages remove bi-dir.
       self.offset = kwargs.pop('offset')
       self.dirname = kwargs.pop('dirname')
 
@@ -173,7 +260,7 @@ message".
     the message.
 
     """
-    p = MsgFileioReadDir._parser.parse(d)
+    p = MsgFileioReadDirRequest._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
@@ -181,7 +268,7 @@ message".
 
     """
     c = containerize(exclude_fields(self))
-    self.payload = MsgFileioReadDir._parser.build(c)
+    self.payload = MsgFileioReadDirRequest._parser.build(c)
     return self.pack()
 
   @staticmethod
@@ -191,11 +278,91 @@ message".
     """
     d = json.loads(s)
     sbp = SBP.from_json_dict(d)
-    return MsgFileioReadDir(sbp)
+    return MsgFileioReadDirRequest(sbp)
 
   def to_json_dict(self):
     self.to_binary()
-    d = super( MsgFileioReadDir, self).to_json_dict()
+    d = super( MsgFileioReadDirRequest, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return d
+    
+SBP_MSG_FILEIO_READ_DIR_RESPONSE = 0x00AA
+class MsgFileioReadDirResponse(SBP):
+  """SBP class for message MSG_FILEIO_READ_DIR_RESPONSE (0x00AA).
+
+  You can have MSG_FILEIO_READ_DIR_RESPONSE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
+  
+  The read directory message lists the files in a directory on the
+device's onboard flash file system.  The offset parameter can be
+used to skip the first n elements of the file list. Message contains
+the directory listings as a NULL delimited list. The listing is
+chunked over multiple SBP packets and the end of the list is
+identified by an entry containing just the character 0xFF.
+
+
+  Parameters
+  ----------
+  sbp : SBP
+    SBP parent object to inherit from.
+  offset : int
+    The offset to skip the first n elements of the file list
+
+  dirname : string
+    Name of the directory to list (NULL padded)
+  sender : int
+    Optional sender ID, defaults to 0
+
+  """
+  _parser = Struct("MsgFileioReadDirResponse",
+                   ULInt32('offset'),
+                   String('dirname', 20),)
+
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      super( MsgFileioReadDirResponse, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_READ_DIR_RESPONSE
+      self.sender = kwargs.pop('sender', 0)
+      self.offset = kwargs.pop('offset')
+      self.dirname = kwargs.pop('dirname')
+
+  def __repr__(self):
+    return fmt_repr(self)
+ 
+  def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
+    p = MsgFileioReadDirResponse._parser.parse(d)
+    self.__dict__.update(dict(p.viewitems()))
+
+  def to_binary(self):
+    """Produce a framed/packed SBP message.
+
+    """
+    c = containerize(exclude_fields(self))
+    self.payload = MsgFileioReadDirResponse._parser.build(c)
+    return self.pack()
+
+  @staticmethod
+  def from_json(s):
+    """Given a JSON-encoded string s, build a message object.
+
+    """
+    d = json.loads(s)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioReadDirResponse(sbp)
+
+  def to_json_dict(self):
+    self.to_binary()
+    d = super( MsgFileioReadDirResponse, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
     return d
@@ -272,20 +439,101 @@ message is invalid, a followup MSG_PRINT message will print
     d.update(j)
     return d
     
-SBP_MSG_FILEIO_WRITE = 0x00AD
-class MsgFileioWrite(SBP):
-  """SBP class for message MSG_FILEIO_WRITE (0x00AD).
+SBP_MSG_FILEIO_WRITE_REQUEST = 0x00AD
+class MsgFileioWriteRequest(SBP):
+  """SBP class for message MSG_FILEIO_WRITE_REQUEST (0x00AD).
 
-  You can have MSG_FILEIO_WRITE inherent its fields directly
+  You can have MSG_FILEIO_WRITE_REQUEST inherent its fields directly
   from an inherited SBP object, or construct it inline using a dict
   of its fields.
 
   
   The file write message writes a certain length (up to 255 bytes)
 of data to a file at a given offset. Returns a copy of the
-original MSG_FILEIO_WRITE message to check integrity of the
-write. If message is invalid, a followup MSG_PRINT message will
-print "Invalid fileio write message".
+original MSG_FILEIO_WRITE_RESPONSE message to check integrity of
+the write. If message is invalid, a followup MSG_PRINT message
+will print "Invalid fileio write message".
+
+
+  Parameters
+  ----------
+  sbp : SBP
+    SBP parent object to inherit from.
+  filename : string
+    Name of the file to write to (NULL padded)
+  offset : int
+    Offset into the file at which to start writing in bytes
+  data : array
+    Variable-length array of data to write
+  sender : int
+    Optional sender ID, defaults to 0
+
+  """
+  _parser = Struct("MsgFileioWriteRequest",
+                   String('filename', 20),
+                   ULInt32('offset'),
+                   OptionalGreedyRange(ULInt8('data')),)
+
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      self.__dict__.update(sbp.__dict__)
+      self.from_binary(sbp.payload)
+    else:
+      super( MsgFileioWriteRequest, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_WRITE_REQUEST
+      self.sender = kwargs.pop('sender', 0)
+      self.filename = kwargs.pop('filename')
+      self.offset = kwargs.pop('offset')
+      self.data = kwargs.pop('data')
+
+  def __repr__(self):
+    return fmt_repr(self)
+ 
+  def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
+    p = MsgFileioWriteRequest._parser.parse(d)
+    self.__dict__.update(dict(p.viewitems()))
+
+  def to_binary(self):
+    """Produce a framed/packed SBP message.
+
+    """
+    c = containerize(exclude_fields(self))
+    self.payload = MsgFileioWriteRequest._parser.build(c)
+    return self.pack()
+
+  @staticmethod
+  def from_json(s):
+    """Given a JSON-encoded string s, build a message object.
+
+    """
+    d = json.loads(s)
+    sbp = SBP.from_json_dict(d)
+    return MsgFileioWriteRequest(sbp)
+
+  def to_json_dict(self):
+    self.to_binary()
+    d = super( MsgFileioWriteRequest, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return d
+    
+SBP_MSG_FILEIO_WRITE_RESPONSE = 0x00AB
+class MsgFileioWriteResponse(SBP):
+  """SBP class for message MSG_FILEIO_WRITE_RESPONSE (0x00AB).
+
+  You can have MSG_FILEIO_WRITE_RESPONSE inherent its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
+  
+  The file write message writes a certain length (up to 255 bytes)
+of data to a file at a given offset. The message is a copy of the
+original MSG_FILEIO_WRITE_REQUEST message to check integrity of the
+write.
 
 
   Parameters
@@ -302,7 +550,7 @@ print "Invalid fileio write message".
     Optional sender ID, defaults to SENDER_ID (see sbp/msg.py).
 
   """
-  _parser = Struct("MsgFileioWrite",
+  _parser = Struct("MsgFileioWriteResponse",
                    String('filename', 20),
                    ULInt32('offset'),
                    OptionalGreedyRange(ULInt8('data')),)
@@ -312,9 +560,15 @@ print "Invalid fileio write message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
+<<<<<<< HEAD
       super( MsgFileioWrite, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_WRITE
       self.sender = kwargs.pop('sender', SENDER_ID)
+=======
+      super( MsgFileioWriteResponse, self).__init__()
+      self.msg_type = SBP_MSG_FILEIO_WRITE_RESPONSE
+      self.sender = kwargs.pop('sender', 0)
+>>>>>>> New file_io messages remove bi-dir.
       self.filename = kwargs.pop('filename')
       self.offset = kwargs.pop('offset')
       self.data = kwargs.pop('data')
@@ -327,7 +581,7 @@ print "Invalid fileio write message".
     the message.
 
     """
-    p = MsgFileioWrite._parser.parse(d)
+    p = MsgFileioWriteResponse._parser.parse(d)
     self.__dict__.update(dict(p.viewitems()))
 
   def to_binary(self):
@@ -335,7 +589,7 @@ print "Invalid fileio write message".
 
     """
     c = containerize(exclude_fields(self))
-    self.payload = MsgFileioWrite._parser.build(c)
+    self.payload = MsgFileioWriteResponse._parser.build(c)
     return self.pack()
 
   @staticmethod
@@ -345,19 +599,22 @@ print "Invalid fileio write message".
     """
     d = json.loads(s)
     sbp = SBP.from_json_dict(d)
-    return MsgFileioWrite(sbp)
+    return MsgFileioWriteResponse(sbp)
 
   def to_json_dict(self):
     self.to_binary()
-    d = super( MsgFileioWrite, self).to_json_dict()
+    d = super( MsgFileioWriteResponse, self).to_json_dict()
     j = walk_json_dict(exclude_fields(self))
     d.update(j)
     return d
     
 
 msg_classes = {
-  0x00A8: MsgFileioRead,
-  0x00A9: MsgFileioReadDir,
+  0x00A8: MsgFileioReadRequest,
+  0x00A3: MsgFileioReadResponse,
+  0x00A9: MsgFileioReadDirRequest,
+  0x00AA: MsgFileioReadDirResponse,
   0x00AC: MsgFileioRemove,
-  0x00AD: MsgFileioWrite,
+  0x00AD: MsgFileioWriteRequest,
+  0x00AB: MsgFileioWriteResponse,
 }

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -77,7 +77,7 @@ read message".
     else:
       super( MsgFileioReadRequest, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_READ_REQUEST
-      self.sender = kwargs.pop('sender', 0)
+      self.sender = kwargs.pop('sender', SENDER_ID)
       self.offset = kwargs.pop('offset')
       self.chunk_size = kwargs.pop('chunk_size')
       self.filename = kwargs.pop('filename')
@@ -244,15 +244,9 @@ message".
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
-<<<<<<< HEAD
-      super( MsgFileioReadDir, self).__init__()
-      self.msg_type = SBP_MSG_FILEIO_READ_DIR
-      self.sender = kwargs.pop('sender', SENDER_ID)
-=======
       super( MsgFileioReadDirRequest, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_READ_DIR_REQUEST
-      self.sender = kwargs.pop('sender', 0)
->>>>>>> New file_io messages remove bi-dir.
+      self.sender = kwargs.pop('sender', SENDER_ID)
       self.offset = kwargs.pop('offset')
       self.dirname = kwargs.pop('dirname')
 
@@ -335,7 +329,7 @@ identified by an entry containing just the character 0xFF.
     else:
       super( MsgFileioReadDirResponse, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_READ_DIR_RESPONSE
-      self.sender = kwargs.pop('sender', 0)
+      self.sender = kwargs.pop('sender', SENDER_ID)
       self.offset = kwargs.pop('offset')
       self.dirname = kwargs.pop('dirname')
       self.contents = kwargs.pop('contents')
@@ -489,7 +483,7 @@ will print "Invalid fileio write message".
     else:
       super( MsgFileioWriteRequest, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_WRITE_REQUEST
-      self.sender = kwargs.pop('sender', 0)
+      self.sender = kwargs.pop('sender', SENDER_ID)
       self.filename = kwargs.pop('filename')
       self.offset = kwargs.pop('offset')
       self.data = kwargs.pop('data')
@@ -568,15 +562,9 @@ write.
       self.__dict__.update(sbp.__dict__)
       self.from_binary(sbp.payload)
     else:
-<<<<<<< HEAD
-      super( MsgFileioWrite, self).__init__()
-      self.msg_type = SBP_MSG_FILEIO_WRITE
-      self.sender = kwargs.pop('sender', SENDER_ID)
-=======
       super( MsgFileioWriteResponse, self).__init__()
       self.msg_type = SBP_MSG_FILEIO_WRITE_RESPONSE
-      self.sender = kwargs.pop('sender', 0)
->>>>>>> New file_io messages remove bi-dir.
+      self.sender = kwargs.pop('sender', SENDER_ID)
       self.filename = kwargs.pop('filename')
       self.offset = kwargs.pop('offset')
       self.data = kwargs.pop('data')

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -142,6 +142,8 @@ were succesfully read.
     Chunk size read
   filename : string
     Name of the file read from (NULL padded)
+  contents : array
+    Contents of read file
   sender : int
     Optional sender ID, defaults to 0
 
@@ -149,7 +151,8 @@ were succesfully read.
   _parser = Struct("MsgFileioReadResponse",
                    ULInt32('offset'),
                    ULInt8('chunk_size'),
-                   String('filename', 20),)
+                   String('filename', 20),
+                   OptionalGreedyRange(ULInt8('contents')),)
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -162,6 +165,7 @@ were succesfully read.
       self.offset = kwargs.pop('offset')
       self.chunk_size = kwargs.pop('chunk_size')
       self.filename = kwargs.pop('filename')
+      self.contents = kwargs.pop('contents')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -313,13 +317,16 @@ identified by an entry containing just the character 0xFF.
 
   dirname : string
     Name of the directory to list (NULL padded)
+  contents : array
+    Contents of read directory
   sender : int
     Optional sender ID, defaults to 0
 
   """
   _parser = Struct("MsgFileioReadDirResponse",
                    ULInt32('offset'),
-                   String('dirname', 20),)
+                   String('dirname', 20),
+                   OptionalGreedyRange(ULInt8('contents')),)
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -331,6 +338,7 @@ identified by an entry containing just the character 0xFF.
       self.sender = kwargs.pop('sender', 0)
       self.offset = kwargs.pop('offset')
       self.dirname = kwargs.pop('dirname')
+      self.contents = kwargs.pop('contents')
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -34,7 +34,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 57
+  number_of_messages = 58
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -34,7 +34,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 55
+  number_of_messages = 57
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -71,6 +71,10 @@ definitions:
           type: string
           size: 20
           desc: Name of the file read from (NULL padded)
+      - contents:
+          type: array
+          fill: u8
+          desc: Contents of read file
 
  - MSG_FILEIO_READ_DIR_REQUEST:
     id: 0x00A9
@@ -114,6 +118,10 @@ definitions:
           type: string
           size: 20
           desc: Name of the directory to list (NULL padded)
+      - contents:
+          type: array
+          fill: u8
+          desc: Contents of read directory
 
  - MSG_FILEIO_REMOVE:
     id: 0x00AC

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -26,17 +26,16 @@ include:
   - types.yaml
 definitions:
 
- - MSG_FILEIO_READ:
+ - MSG_FILEIO_READ_REQUEST:
     id: 0x00A8
-    public: True
-    short_desc: Read file from the file system (host <=> device)
+    short_desc: Read file from the file system (host => device)
     desc: |
       The file read message reads a certain length (up to 255 bytes)
       from a given offset into a file, and returns the data in a
-      MSG_FILEIO_READ message where the message length field indicates
-      how many bytes were succesfully read. If the message is invalid,
-      a followup MSG_PRINT message will print "Invalid fileio read
-      message".
+      MSG_FILEIO_READ_RESPONSE message where the message length field
+      indicates how many bytes were succesfully read. If the message is
+      invalid, a followup MSG_PRINT message will print "Invalid fileio
+      read message".
     fields:
       - offset:
           type: u32
@@ -51,18 +50,39 @@ definitions:
           size: 20
           desc: Name of the file to read from (NULL padded)
 
- - MSG_FILEIO_READ_DIR:
+ - MSG_FILEIO_READ_RESPONSE:
+    id: 0x00A3
+    short_desc: File read from the file system (host <= device)
+    desc: |
+      The file read message reads a certain length (up to 255 bytes)
+      from a given offset into a file, and returns the data in a
+      message where the message length field indicates how many bytes
+      were succesfully read.
+    fields:
+      - offset:
+          type: u32
+          units: bytes
+          desc: File offset
+      - chunk_size:
+          type: u8
+          units: bytes
+          desc: Chunk size read
+      - filename:
+          type: string
+          size: 20
+          desc: Name of the file read from (NULL padded)
+
+ - MSG_FILEIO_READ_DIR_REQUEST:
     id: 0x00A9
-    public: True
-    short_desc: List files in a directory (host <=> device)
+    short_desc: List files in a directory (host => device)
     desc: |
       The read directory message lists the files in a directory on the
       device's onboard flash file system.  The offset parameter can be
       used to skip the first n elements of the file list. Returns a
-      MSG_FILEIO_READ_DIR message containing the directory listings as
-      a NULL delimited list. The listing is chunked over multiple SBP
-      packets and the end of the list is identified by an entry
-      containing just the character 0xFF. If message is invalid, a
+      MSG_FILEIO_READ_DIR_RESPONSE message containing the directory
+      listings as a NULL delimited list. The listing is chunked over
+      multiple SBP packets and the end of the list is identified by an
+      entry containing just the character 0xFF. If message is invalid, a
       followup MSG_PRINT message will print "Invalid fileio read
       message".
     fields:
@@ -75,9 +95,28 @@ definitions:
           size: 20
           desc: Name of the directory to list (NULL padded)
 
+ - MSG_FILEIO_READ_DIR_RESPONSE:
+    id: 0x00AA
+    short_desc: Files listed in a directory (host <= device)
+    desc: |
+      The read directory message lists the files in a directory on the
+      device's onboard flash file system.  The offset parameter can be
+      used to skip the first n elements of the file list. Message contains
+      the directory listings as a NULL delimited list. The listing is
+      chunked over multiple SBP packets and the end of the list is
+      identified by an entry containing just the character 0xFF.
+    fields:
+      - offset:
+          type: u32
+          desc: |
+            The offset to skip the first n elements of the file list
+      - dirname:
+          type: string
+          size: 20
+          desc: Name of the directory to list (NULL padded)
+
  - MSG_FILEIO_REMOVE:
     id: 0x00AC
-    public: True
     short_desc: Delete a file from the file system (host => device)
     desc: |
       The file remove message deletes a file from the file system. If
@@ -89,16 +128,37 @@ definitions:
           size: 20
           desc: Name of the file to delete (NULL padded)
 
- - MSG_FILEIO_WRITE:
+ - MSG_FILEIO_WRITE_REQUEST:
     id: 0x00AD
-    public: True
-    short_desc: Write to file (host <=> device)
+    short_desc: Write to file (host => device)
     desc: |
       The file write message writes a certain length (up to 255 bytes)
       of data to a file at a given offset. Returns a copy of the
-      original MSG_FILEIO_WRITE message to check integrity of the
-      write. If message is invalid, a followup MSG_PRINT message will
-      print "Invalid fileio write message".
+      original MSG_FILEIO_WRITE_RESPONSE message to check integrity of
+      the write. If message is invalid, a followup MSG_PRINT message
+      will print "Invalid fileio write message".
+    fields:
+      - filename:
+          type: string
+          size: 20
+          desc: Name of the file to write to (NULL padded)
+      - offset:
+          type: u32
+          units: bytes
+          desc: Offset into the file at which to start writing in bytes
+      - data:
+          type: array
+          fill: u8
+          desc: Variable-length array of data to write
+
+ - MSG_FILEIO_WRITE_RESPONSE:
+    id: 0x00AB
+    short_desc: File written to (host <= device)
+    desc: |
+      The file write message writes a certain length (up to 255 bytes)
+      of data to a file at a given offset. The message is a copy of the
+      original MSG_FILEIO_WRITE_REQUEST message to check integrity of the
+      write.
     fields:
       - filename:
           type: string


### PR DESCRIPTION
Remove bi-directionality. Request, response all the things. No deprecation necessary. Were there more changes to these messages we wanted? A `dir_done` message vs. the 0xff thing might be nice. Thoughts?

/cc @fnoble @mookerji @denniszollo 