### PR TITLE
Added libsbp C example.

### DIFF
--- a/c/example/CMakeLists.txt
+++ b/c/example/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8.9)
+project(libsbp_example)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Wno-unknown-warning-option -Werror -std=gnu99 ${CMAKE_C_FLAGS}")
+
+add_executable(libsbp_example example.c)
+
+find_package(PkgConfig)
+pkg_check_modules(LIBSERIALPORT libserialport)
+link_directories(${LIBSERIALPORT_LIBRARY_DIRS})
+include_directories(${LIBSERIALPORT_INCLUDE_DIRS})
+
+link_directories("/usr/local/lib/")
+include_directories("/usr/local/include/")
+
+target_link_libraries(libsbp_example serialport sbp)

--- a/c/example/README.md
+++ b/c/example/README.md
@@ -1,0 +1,48 @@
+## C example for libsbp
+
+An example C program, intended to be run on a host computer connected to
+the Piksi, that parses incoming SBP messages from the Piksi and prints some of
+them to the screen.
+
+## Installation
+
+On Debian-based systems (including Ubuntu 12.10 or later) you can get all
+the requirements with:
+
+```shell
+sudo apt-get install build-essential pkg-config cmake
+```
+
+On other systems, you can obtain CMake from your operating system
+package manager or from http://www.cmake.org/.
+
+You should also install libsbp and libserialport. For instructions please refer to:
+* [libsbp](https://github.com/swift-nav/libsbp/tree/master/c)
+* [libserialport](http://sigrok.org/wiki/Libserialport)
+
+Once you have the dependencies installed, create a build directory where the example will be built:
+
+```shell
+mkdir build
+cd build
+```
+
+Then invoke CMake to configure the build, and then build,
+
+```shell
+cmake ../
+make
+```
+
+## Usage
+
+```shell
+./libsbp_example
+usage: ./libsbp_example [-p serial port]
+```
+
+## LICENSE
+
+Copyright © 2015 Swift Navigation
+
+Distributed under LGPLv3.0.

--- a/c/example/example.c
+++ b/c/example/example.c
@@ -1,0 +1,137 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libserialport.h>
+
+#include <libsbp/sbp.h>
+#include <libsbp/system.h>
+
+char *serial_port_name = NULL;
+struct sp_port *piksi_port = NULL;
+static sbp_msg_callbacks_node_t heartbeat_callback_node;
+
+void usage(char *prog_name) {
+  fprintf(stderr, "usage: %s [-p serial port]\n", prog_name);
+}
+
+void setup_port()
+{
+  int result;
+
+  result = sp_set_baudrate(piksi_port, 1000000);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot set port baud rate!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  result = sp_set_flowcontrol(piksi_port, SP_FLOWCONTROL_NONE);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot set flow control!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  result = sp_set_bits(piksi_port, 8);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot set data bits!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  result = sp_set_parity(piksi_port, SP_PARITY_NONE);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot set parity!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  result = sp_set_stopbits(piksi_port, 1);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot set stop bits!\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void hearbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+{
+  (void)sender_id, (void)len, (void)msg, (void)context;
+  fprintf(stdout, "%s\n", __FUNCTION__);
+}
+
+u32 piksi_port_read(u8 *buff, u32 n, void *context)
+{
+  (void)context;
+  u32 result;
+
+  result = sp_blocking_read(piksi_port, buff, n, 0);
+
+  return result;
+}
+
+int main(int argc, char **argv)
+{
+  int opt;
+  int result = 0;
+
+  sbp_state_t s;
+
+  if (argc <= 1) {
+    usage(argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  while ((opt = getopt(argc, argv, "p:")) != -1) {
+    switch (opt) {
+      case 'p':
+        serial_port_name = (char *)calloc(strlen(optarg) + 1, sizeof(char));
+        if (!serial_port_name) {
+          fprintf(stderr, "Cannot allocate memory!\n");
+          exit(EXIT_FAILURE);
+        }
+        strcpy(serial_port_name, optarg);
+        break;
+      case 'h':
+        usage(argv[0]);
+        exit(EXIT_FAILURE);
+    }
+  }
+
+  if (!serial_port_name) {
+    fprintf(stderr, "Please supply the serial port path where the Piksi is " \
+                    "connected!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  result = sp_get_port_by_name(serial_port_name, &piksi_port);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot find provided serial port!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  result = sp_open(piksi_port, SP_MODE_READ);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot open %s for reading!\n", serial_port_name);
+    exit(EXIT_FAILURE);
+  }
+
+  setup_port();
+
+  sbp_state_init(&s);
+
+  sbp_register_callback(&s, SBP_MSG_HEARTBEAT, &hearbeat_callback, NULL,
+                        &heartbeat_callback_node);
+
+  while(1) {
+    sbp_process(&s, &piksi_port_read);
+  }
+
+  result = sp_close(piksi_port);
+  if (result != SP_OK) {
+    fprintf(stderr, "Cannot close %s properly!\n", serial_port_name);
+  }
+
+  sp_free_port(piksi_port);
+
+  free(serial_port_name);
+
+  return 0;
+}


### PR DESCRIPTION
Serial port library used is: http://sigrok.org/wiki/Libserialport. The example listens for heartbeat messages and prints a confirmation when one is received. It is built separately from libsbp not to introduce any dependency with libserialport.

Signed-off-by: Vlad Ungureanu <vvu@vdev.ro>

/cc: @fnoble @gsmcmullin 