### PR TITLE
Field constructor update for non-SBP structs.

### DIFF
--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -54,11 +54,18 @@ class ((( m.identifier )))(object):
                      ((*- endfor *))))
   ((*- endif *))
 
-  def __init__(self, payload):
+  def __init__(self, payload=None, **kwargs):
+    if payload:
       ((*- if m.fields *))
-    self.from_binary(payload)
+      self.from_binary(payload)
       ((*- else *))
-    self.payload = payload
+      self.payload = payload
+      ((*- endif *))
+      ((*- if m.fields *))
+    else:
+        ((*- for f in m.fields *))
+      self.(((f.identifier))) = kwargs.pop('(((f.identifier)))')
+        ((*- endfor *))
       ((*- endif *))
 
   def __repr__(self):

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -44,8 +44,12 @@ transition.
                      ULInt32('tow'),
                      ULInt16('wn'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.tow = kwargs.pop('tow')
+      self.wn = kwargs.pop('wn')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -77,8 +81,12 @@ cycles and 8-bits of fractional cycles.
                      SLInt32('i'),
                      ULInt8('f'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.i = kwargs.pop('i')
+      self.f = kwargs.pop('f')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -110,8 +118,12 @@ counter (ith packet of n)
                      Struct('t', ObsGPSTime._parser),
                      ULInt8('n_obs'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.t = kwargs.pop('t')
+      self.n_obs = kwargs.pop('n_obs')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -154,8 +166,15 @@ carrier phase ambiguity may have changed.
                      ULInt16('lock'),
                      ULInt8('prn'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.P = kwargs.pop('P')
+      self.L = kwargs.pop('L')
+      self.cn0 = kwargs.pop('cn0')
+      self.lock = kwargs.pop('lock')
+      self.prn = kwargs.pop('prn')
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -66,8 +66,16 @@ be normalized.
                      ULInt8('tx_buffer_level'),
                      ULInt8('rx_buffer_level'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.tx_throughput = kwargs.pop('tx_throughput')
+      self.rx_throughput = kwargs.pop('rx_throughput')
+      self.crc_error_count = kwargs.pop('crc_error_count')
+      self.io_error_count = kwargs.pop('io_error_count')
+      self.tx_buffer_level = kwargs.pop('tx_buffer_level')
+      self.rx_buffer_level = kwargs.pop('rx_buffer_level')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -107,8 +115,14 @@ communication latency in the system.
                      SLInt32('lmax'),
                      SLInt32('current'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.avg = kwargs.pop('avg')
+      self.lmin = kwargs.pop('lmin')
+      self.lmax = kwargs.pop('lmax')
+      self.current = kwargs.pop('current')
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -47,8 +47,13 @@ signal power.
                      ULInt8('prn'),
                      LFloat32('cn0'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.state = kwargs.pop('state')
+      self.prn = kwargs.pop('prn')
+      self.cn0 = kwargs.pop('cn0')
 
   def __repr__(self):
     return fmt_repr(self)
@@ -78,8 +83,12 @@ class TrackingChannelCorrelation(object):
                      SLInt32('I'),
                      SLInt32('Q'),))
 
-  def __init__(self, payload):
-    self.from_binary(payload)
+  def __init__(self, payload=None, **kwargs):
+    if payload:
+      self.from_binary(payload)
+    else:
+      self.I = kwargs.pop('I')
+      self.Q = kwargs.pop('Q')
 
   def __repr__(self):
     return fmt_repr(self)


### PR DESCRIPTION
Creating non-SBP message structs still required binary payloads to be
created. Updates code generation template so non-SBP constructor
pattern follows SBP constructor pattern.

Closes #192.

/cc @mfine