### PR TITLE
Make SBP and SBP-struct object attributes static.

### DIFF
--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -52,6 +52,10 @@ class ((( m.identifier )))(object):
                      ((*- for f in m.fields *))
                      ((( f | construct ))),
                      ((*- endfor *))))
+  __slots__ = [((* for f in m.fields *))
+               '((( f.identifier )))',
+               ((*- endfor *))
+              ]
   ((*- endif *))
 
   def __init__(self, payload=None, **kwargs):
@@ -73,10 +77,12 @@ class ((( m.identifier )))(object):
   ((* if m.fields *))
   def from_binary(self, d):
     p = ((( m.identifier )))._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return ((( m.identifier ))).build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return ((( m.identifier ))).build(d)
   ((*- endif *))
     ((* endif *))
   ((*- endif *))
@@ -119,11 +125,17 @@ class ((( m.identifier | classnameify )))(SBP):
                    ((*- for f in m.fields *))
                    ((( f | construct ))),
                    ((*- endfor *)))
+  __slots__ = [((* for f in m.fields *))
+               '((( f.identifier )))',
+               ((*- endfor *))
+              ]
   ((*- endif *))
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( ((( m.identifier | classnameify ))),
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       ((*- if m.fields *))
       self.from_binary(sbp.payload)
       ((*- else *))
@@ -148,7 +160,8 @@ class ((( m.identifier | classnameify )))(SBP):
 
     """
     p = ((( m.identifier | classnameify )))._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/bench/memory.py
+++ b/python/bench/memory.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from guppy import hpy
+
+def sbp_nav():
+  import sbp.navigation as nav
+  ll = []
+  for i in range(0, 100000):
+    ll.append(nav.MsgBaselineECEF(sender=0x42,
+                                  tow=100,
+                                  x=10,
+                                  y=10,
+                                  z=10,
+                                  accuracy=0,
+                                  n_sats=10,
+                                  flags=1))
+  print len(ll)
+  h = hpy()
+  print h.heap()
+
+if __name__ == '__main__':
+  sbp_nav()

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -65,10 +65,18 @@ acquisition was attempted
                    LFloat32('cp'),
                    LFloat32('cf'),
                    ULInt8('prn'),)
+  __slots__ = [
+               'snr',
+               'cp',
+               'cf',
+               'prn',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgAcqResult,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgAcqResult, self).__init__()
@@ -88,7 +96,8 @@ acquisition was attempted
 
     """
     p = MsgAcqResult._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -48,7 +48,9 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_RESPONSE.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBootloaderHandshakeRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgBootloaderHandshakeRequest, self).__init__()
@@ -90,10 +92,16 @@ protocol version number.
   _parser = Struct("MsgBootloaderHandshakeResponse",
                    ULInt32('flags'),
                    CString('version', six.b('\n')),)
+  __slots__ = [
+               'flags',
+               'version',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBootloaderHandshakeResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgBootloaderHandshakeResponse, self).__init__()
@@ -111,7 +119,8 @@ protocol version number.
 
     """
     p = MsgBootloaderHandshakeResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -161,10 +170,15 @@ class MsgBootloaderJumpToApp(SBP):
   """
   _parser = Struct("MsgBootloaderJumpToApp",
                    ULInt8('jump'),)
+  __slots__ = [
+               'jump',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBootloaderJumpToApp,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgBootloaderJumpToApp, self).__init__()
@@ -181,7 +195,8 @@ class MsgBootloaderJumpToApp(SBP):
 
     """
     p = MsgBootloaderJumpToApp._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -228,7 +243,9 @@ and not related to the Piksi's serial number.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgNapDeviceDnaRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgNapDeviceDnaRequest, self).__init__()
@@ -270,10 +287,15 @@ on the right.
   """
   _parser = Struct("MsgNapDeviceDnaResponse",
                    Struct('dna', Array(8, ULInt8('dna'))),)
+  __slots__ = [
+               'dna',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgNapDeviceDnaResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgNapDeviceDnaResponse, self).__init__()
@@ -290,7 +312,8 @@ on the right.
 
     """
     p = MsgNapDeviceDnaResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/deprecated.py
+++ b/python/sbp/deprecated.py
@@ -52,10 +52,15 @@ returns an empty string for earlier versions.
   """
   _parser = Struct("MsgBootloaderHandshakeDeprecated",
                    OptionalGreedyRange(ULInt8('handshake')),)
+  __slots__ = [
+               'handshake',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBootloaderHandshakeDeprecated,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgBootloaderHandshakeDeprecated, self).__init__()
@@ -72,7 +77,8 @@ returns an empty string for earlier versions.
 
     """
     p = MsgBootloaderHandshakeDeprecated._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -196,10 +202,40 @@ class MsgEphemerisDeprecated(SBP):
                    ULInt8('valid'),
                    ULInt8('healthy'),
                    ULInt8('prn'),)
+  __slots__ = [
+               'tgd',
+               'c_rs',
+               'c_rc',
+               'c_uc',
+               'c_us',
+               'c_ic',
+               'c_is',
+               'dn',
+               'm0',
+               'ecc',
+               'sqrta',
+               'omega0',
+               'omegadot',
+               'w',
+               'inc',
+               'inc_dot',
+               'af0',
+               'af1',
+               'af2',
+               'toe_tow',
+               'toe_wn',
+               'toc_tow',
+               'toc_wn',
+               'valid',
+               'healthy',
+               'prn',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgEphemerisDeprecated,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgEphemerisDeprecated, self).__init__()
@@ -241,7 +277,8 @@ class MsgEphemerisDeprecated(SBP):
 
     """
     p = MsgEphemerisDeprecated._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -65,10 +65,19 @@ from -500000 to 500000)
                    SLInt32('ns'),
                    ULInt8('flags'),
                    ULInt8('pin'),)
+  __slots__ = [
+               'wn',
+               'tow',
+               'ns',
+               'flags',
+               'pin',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgExtEvent,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgExtEvent, self).__init__()
@@ -89,7 +98,8 @@ from -500000 to 500000)
 
     """
     p = MsgExtEvent._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -69,10 +69,17 @@ read message".
                    ULInt32('offset'),
                    ULInt8('chunk_size'),
                    String('filename', 20),)
+  __slots__ = [
+               'offset',
+               'chunk_size',
+               'filename',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioReadRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioReadRequest, self).__init__()
@@ -91,7 +98,8 @@ read message".
 
     """
     p = MsgFileioReadRequest._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -153,10 +161,18 @@ were succesfully read.
                    ULInt8('chunk_size'),
                    String('filename', 20),
                    OptionalGreedyRange(ULInt8('contents')),)
+  __slots__ = [
+               'offset',
+               'chunk_size',
+               'filename',
+               'contents',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioReadResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioReadResponse, self).__init__()
@@ -176,7 +192,8 @@ were succesfully read.
 
     """
     p = MsgFileioReadResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -238,10 +255,16 @@ message".
   _parser = Struct("MsgFileioReadDirRequest",
                    ULInt32('offset'),
                    String('dirname', 20),)
+  __slots__ = [
+               'offset',
+               'dirname',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioReadDirRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioReadDirRequest, self).__init__()
@@ -259,7 +282,8 @@ message".
 
     """
     p = MsgFileioReadDirRequest._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -321,10 +345,17 @@ identified by an entry containing just the character 0xFF.
                    ULInt32('offset'),
                    String('dirname', 20),
                    OptionalGreedyRange(ULInt8('contents')),)
+  __slots__ = [
+               'offset',
+               'dirname',
+               'contents',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioReadDirResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioReadDirResponse, self).__init__()
@@ -343,7 +374,8 @@ identified by an entry containing just the character 0xFF.
 
     """
     p = MsgFileioReadDirResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -395,10 +427,15 @@ message is invalid, a followup MSG_PRINT message will print
   """
   _parser = Struct("MsgFileioRemove",
                    String('filename', 20),)
+  __slots__ = [
+               'filename',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioRemove,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioRemove, self).__init__()
@@ -415,7 +452,8 @@ message is invalid, a followup MSG_PRINT message will print
 
     """
     p = MsgFileioRemove._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -475,10 +513,17 @@ will print "Invalid fileio write message".
                    String('filename', 20),
                    ULInt32('offset'),
                    OptionalGreedyRange(ULInt8('data')),)
+  __slots__ = [
+               'filename',
+               'offset',
+               'data',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioWriteRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioWriteRequest, self).__init__()
@@ -497,7 +542,8 @@ will print "Invalid fileio write message".
 
     """
     p = MsgFileioWriteRequest._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -556,10 +602,17 @@ write.
                    String('filename', 20),
                    ULInt32('offset'),
                    OptionalGreedyRange(ULInt8('data')),)
+  __slots__ = [
+               'filename',
+               'offset',
+               'data',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFileioWriteResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFileioWriteResponse, self).__init__()
@@ -578,7 +631,8 @@ write.
 
     """
     p = MsgFileioWriteResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -71,10 +71,18 @@ starting address
                    Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),
                    OptionalGreedyRange(ULInt8('data')),)
+  __slots__ = [
+               'target',
+               'addr_start',
+               'addr_len',
+               'data',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFlashProgram,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFlashProgram, self).__init__()
@@ -94,7 +102,8 @@ starting address
 
     """
     p = MsgFlashProgram._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -147,10 +156,15 @@ MSG_FLASH_PROGRAM, may return this message on failure.
   """
   _parser = Struct("MsgFlashDone",
                    ULInt8('response'),)
+  __slots__ = [
+               'response',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFlashDone,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFlashDone, self).__init__()
@@ -167,7 +181,8 @@ MSG_FLASH_PROGRAM, may return this message on failure.
 
     """
     p = MsgFlashDone._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -231,10 +246,17 @@ starting address
                    ULInt8('target'),
                    Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),)
+  __slots__ = [
+               'target',
+               'addr_start',
+               'addr_len',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFlashReadRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFlashReadRequest, self).__init__()
@@ -253,7 +275,8 @@ starting address
 
     """
     p = MsgFlashReadRequest._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -317,10 +340,17 @@ starting address
                    ULInt8('target'),
                    Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),)
+  __slots__ = [
+               'target',
+               'addr_start',
+               'addr_len',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFlashReadResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFlashReadResponse, self).__init__()
@@ -339,7 +369,8 @@ starting address
 
     """
     p = MsgFlashReadResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -398,10 +429,16 @@ the M25)
   _parser = Struct("MsgFlashErase",
                    ULInt8('target'),
                    ULInt32('sector_num'),)
+  __slots__ = [
+               'target',
+               'sector_num',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgFlashErase,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgFlashErase, self).__init__()
@@ -419,7 +456,8 @@ the M25)
 
     """
     p = MsgFlashErase._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -470,10 +508,15 @@ memory. The device replies with a MSG_FLASH_DONE message.
   """
   _parser = Struct("MsgStmFlashLockSector",
                    ULInt32('sector'),)
+  __slots__ = [
+               'sector',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgStmFlashLockSector,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgStmFlashLockSector, self).__init__()
@@ -490,7 +533,8 @@ memory. The device replies with a MSG_FLASH_DONE message.
 
     """
     p = MsgStmFlashLockSector._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -541,10 +585,15 @@ memory. The device replies with a MSG_FLASH_DONE message.
   """
   _parser = Struct("MsgStmFlashUnlockSector",
                    ULInt32('sector'),)
+  __slots__ = [
+               'sector',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgStmFlashUnlockSector,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgStmFlashUnlockSector, self).__init__()
@@ -561,7 +610,8 @@ memory. The device replies with a MSG_FLASH_DONE message.
 
     """
     p = MsgStmFlashUnlockSector._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -606,7 +656,9 @@ ID in the payload.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgStmUniqueIdRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgStmUniqueIdRequest, self).__init__()
@@ -644,10 +696,15 @@ ID in the payload..
   """
   _parser = Struct("MsgStmUniqueIdResponse",
                    Struct('stm_id', Array(12, ULInt8('stm_id'))),)
+  __slots__ = [
+               'stm_id',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgStmUniqueIdResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgStmUniqueIdResponse, self).__init__()
@@ -664,7 +721,8 @@ ID in the payload..
 
     """
     p = MsgStmUniqueIdResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -715,10 +773,15 @@ register. The device replies with a MSG_FLASH_DONE message.
   """
   _parser = Struct("MsgM25FlashWriteStatus",
                    Struct('status', Array(1, ULInt8('status'))),)
+  __slots__ = [
+               'status',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgM25FlashWriteStatus,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgM25FlashWriteStatus, self).__init__()
@@ -735,7 +798,8 @@ register. The device replies with a MSG_FLASH_DONE message.
 
     """
     p = MsgM25FlashWriteStatus._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -52,10 +52,15 @@ ERROR, WARNING, DEBUG, INFO logging levels.
   """
   _parser = Struct("MsgPrint",
                    CString('text', six.b('\n')),)
+  __slots__ = [
+               'text',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgPrint,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgPrint, self).__init__()
@@ -72,7 +77,8 @@ ERROR, WARNING, DEBUG, INFO logging levels.
 
     """
     p = MsgPrint._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -121,10 +127,15 @@ class MsgTweet(SBP):
   """
   _parser = Struct("MsgTweet",
                    String('tweet', 140),)
+  __slots__ = [
+               'tweet',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgTweet,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgTweet, self).__init__()
@@ -141,7 +152,8 @@ class MsgTweet(SBP):
 
     """
     p = MsgTweet._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -82,10 +82,18 @@ from -500000 to 500000)
                    ULInt32('tow'),
                    SLInt32('ns'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'wn',
+               'tow',
+               'ns',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgGPSTime,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgGPSTime, self).__init__()
@@ -105,7 +113,8 @@ from -500000 to 500000)
 
     """
     p = MsgGPSTime._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -172,10 +181,20 @@ precision.
                    ULInt16('tdop'),
                    ULInt16('hdop'),
                    ULInt16('vdop'),)
+  __slots__ = [
+               'tow',
+               'gdop',
+               'pdop',
+               'tdop',
+               'hdop',
+               'vdop',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgDops,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgDops, self).__init__()
@@ -197,7 +216,8 @@ precision.
 
     """
     p = MsgDops._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -274,10 +294,21 @@ to 0.
                    ULInt16('accuracy'),
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'tow',
+               'x',
+               'y',
+               'z',
+               'accuracy',
+               'n_sats',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgPosECEF,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgPosECEF, self).__init__()
@@ -300,7 +331,8 @@ to 0.
 
     """
     p = MsgPosECEF._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -382,10 +414,22 @@ implemented). Defaults to 0.
                    ULInt16('v_accuracy'),
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'tow',
+               'lat',
+               'lon',
+               'height',
+               'h_accuracy',
+               'v_accuracy',
+               'n_sats',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgPosLLH,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgPosLLH, self).__init__()
@@ -409,7 +453,8 @@ implemented). Defaults to 0.
 
     """
     p = MsgPosLLH._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -483,10 +528,21 @@ to 0.
                    ULInt16('accuracy'),
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'tow',
+               'x',
+               'y',
+               'z',
+               'accuracy',
+               'n_sats',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBaselineECEF,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgBaselineECEF, self).__init__()
@@ -509,7 +565,8 @@ to 0.
 
     """
     p = MsgBaselineECEF._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -589,10 +646,22 @@ implemented). Defaults to 0.
                    ULInt16('v_accuracy'),
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'tow',
+               'n',
+               'e',
+               'd',
+               'h_accuracy',
+               'v_accuracy',
+               'n_sats',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBaselineNED,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgBaselineNED, self).__init__()
@@ -616,7 +685,8 @@ implemented). Defaults to 0.
 
     """
     p = MsgBaselineNED._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -688,10 +758,21 @@ to 0.
                    ULInt16('accuracy'),
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'tow',
+               'x',
+               'y',
+               'z',
+               'accuracy',
+               'n_sats',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgVelECEF,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgVelECEF, self).__init__()
@@ -714,7 +795,8 @@ to 0.
 
     """
     p = MsgVelECEF._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -791,10 +873,22 @@ implemented). Defaults to 0.
                    ULInt16('v_accuracy'),
                    ULInt8('n_sats'),
                    ULInt8('flags'),)
+  __slots__ = [
+               'tow',
+               'n',
+               'e',
+               'd',
+               'h_accuracy',
+               'v_accuracy',
+               'n_sats',
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgVelNED,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgVelNED, self).__init__()
@@ -818,7 +912,8 @@ implemented). Defaults to 0.
 
     """
     p = MsgVelNED._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -43,6 +43,10 @@ transition.
   _parser = Embedded(Struct("ObsGPSTime",
                      ULInt32('tow'),
                      ULInt16('wn'),))
+  __slots__ = [
+               'tow',
+               'wn',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -56,10 +60,12 @@ transition.
   
   def from_binary(self, d):
     p = ObsGPSTime._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return ObsGPSTime.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return ObsGPSTime.build(d)
     
 class CarrierPhase(object):
   """CarrierPhase.
@@ -80,6 +86,10 @@ cycles and 8-bits of fractional cycles.
   _parser = Embedded(Struct("CarrierPhase",
                      SLInt32('i'),
                      ULInt8('f'),))
+  __slots__ = [
+               'i',
+               'f',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -93,10 +103,12 @@ cycles and 8-bits of fractional cycles.
   
   def from_binary(self, d):
     p = CarrierPhase._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return CarrierPhase.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return CarrierPhase.build(d)
     
 class ObservationHeader(object):
   """ObservationHeader.
@@ -117,6 +129,10 @@ counter (ith packet of n)
   _parser = Embedded(Struct("ObservationHeader",
                      Struct('t', ObsGPSTime._parser),
                      ULInt8('n_obs'),))
+  __slots__ = [
+               't',
+               'n_obs',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -130,10 +146,12 @@ counter (ith packet of n)
   
   def from_binary(self, d):
     p = ObservationHeader._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return ObservationHeader.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return ObservationHeader.build(d)
     
 class PackedObsContent(object):
   """PackedObsContent.
@@ -165,6 +183,13 @@ carrier phase ambiguity may have changed.
                      ULInt8('cn0'),
                      ULInt16('lock'),
                      ULInt8('prn'),))
+  __slots__ = [
+               'P',
+               'L',
+               'cn0',
+               'lock',
+               'prn',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -181,10 +206,12 @@ carrier phase ambiguity may have changed.
   
   def from_binary(self, d):
     p = PackedObsContent._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return PackedObsContent.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return PackedObsContent.build(d)
     
 SBP_MSG_OBS = 0x0045
 class MsgObs(SBP):
@@ -219,10 +246,16 @@ satellite being tracked.
   _parser = Struct("MsgObs",
                    Struct('header', ObservationHeader._parser),
                    OptionalGreedyRange(Struct('obs', PackedObsContent._parser)),)
+  __slots__ = [
+               'header',
+               'obs',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgObs,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgObs, self).__init__()
@@ -240,7 +273,8 @@ satellite being tracked.
 
     """
     p = MsgObs._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -300,10 +334,17 @@ error in the pseudo-absolute position output.
                    LFloat64('lat'),
                    LFloat64('lon'),
                    LFloat64('height'),)
+  __slots__ = [
+               'lat',
+               'lon',
+               'height',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgBasePos,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgBasePos, self).__init__()
@@ -322,7 +363,8 @@ error in the pseudo-absolute position output.
 
     """
     p = MsgBasePos._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -454,10 +496,41 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                    ULInt8('healthy'),
                    ULInt8('prn'),
                    ULInt8('iode'),)
+  __slots__ = [
+               'tgd',
+               'c_rs',
+               'c_rc',
+               'c_uc',
+               'c_us',
+               'c_ic',
+               'c_is',
+               'dn',
+               'm0',
+               'ecc',
+               'sqrta',
+               'omega0',
+               'omegadot',
+               'w',
+               'inc',
+               'inc_dot',
+               'af0',
+               'af1',
+               'af2',
+               'toe_tow',
+               'toe_wn',
+               'toc_tow',
+               'toc_wn',
+               'valid',
+               'healthy',
+               'prn',
+               'iode',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgEphemeris,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgEphemeris, self).__init__()
@@ -500,7 +573,8 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
 
     """
     p = MsgEphemeris._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -65,6 +65,14 @@ be normalized.
                      ULInt16('io_error_count'),
                      ULInt8('tx_buffer_level'),
                      ULInt8('rx_buffer_level'),))
+  __slots__ = [
+               'tx_throughput',
+               'rx_throughput',
+               'crc_error_count',
+               'io_error_count',
+               'tx_buffer_level',
+               'rx_buffer_level',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -82,10 +90,12 @@ be normalized.
   
   def from_binary(self, d):
     p = UARTChannel._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return UARTChannel.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return UARTChannel.build(d)
     
 class Latency(object):
   """Latency.
@@ -114,6 +124,12 @@ communication latency in the system.
                      SLInt32('lmin'),
                      SLInt32('lmax'),
                      SLInt32('current'),))
+  __slots__ = [
+               'avg',
+               'lmin',
+               'lmax',
+               'current',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -129,10 +145,12 @@ communication latency in the system.
   
   def from_binary(self, d):
     p = Latency._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return Latency.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return Latency.build(d)
     
 SBP_MSG_ALMANAC = 0x0069
 class MsgAlmanac(SBP):
@@ -151,7 +169,9 @@ alamanac onto the Piksi's flash memory from the host.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgAlmanac,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgAlmanac, self).__init__()
@@ -179,7 +199,9 @@ time estimate sent by the host.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSetTime,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgSetTime, self).__init__()
@@ -207,7 +229,9 @@ bootloader.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgReset,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgReset, self).__init__()
@@ -236,7 +260,9 @@ removed in a future release.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgCwResults,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgCwResults, self).__init__()
@@ -265,7 +291,9 @@ be removed in a future release.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgCwStart,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgCwStart, self).__init__()
@@ -301,10 +329,15 @@ Ambiguity Resolution (IAR) process.
   """
   _parser = Struct("MsgResetFilters",
                    ULInt8('filter'),)
+  __slots__ = [
+               'filter',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgResetFilters,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgResetFilters, self).__init__()
@@ -321,7 +354,8 @@ Ambiguity Resolution (IAR) process.
 
     """
     p = MsgResetFilters._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -367,7 +401,9 @@ observations between the two.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgInitBase,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgInitBase, self).__init__()
@@ -412,10 +448,17 @@ thread. The reported percentage values require to be normalized.
                    String('name', 20),
                    ULInt16('cpu'),
                    ULInt32('stack_free'),)
+  __slots__ = [
+               'name',
+               'cpu',
+               'stack_free',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgThreadState,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgThreadState, self).__init__()
@@ -434,7 +477,8 @@ thread. The reported percentage values require to be normalized.
 
     """
     p = MsgThreadState._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -497,10 +541,18 @@ future. The reported percentage values require to be normalized.
                    Struct('uart_b', UARTChannel._parser),
                    Struct('uart_ftdi', UARTChannel._parser),
                    Struct('latency', Latency._parser),)
+  __slots__ = [
+               'uart_a',
+               'uart_b',
+               'uart_ftdi',
+               'latency',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgUartState,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgUartState, self).__init__()
@@ -520,7 +572,8 @@ future. The reported percentage values require to be normalized.
 
     """
     p = MsgUartState._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -573,10 +626,15 @@ from satellite observations.
   """
   _parser = Struct("MsgIarState",
                    ULInt32('num_hyps'),)
+  __slots__ = [
+               'num_hyps',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgIarState,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgIarState, self).__init__()
@@ -593,7 +651,8 @@ from satellite observations.
 
     """
     p = MsgIarState._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -647,10 +706,16 @@ from being used in various Piksi subsystems.
   _parser = Struct("MsgMaskSatellite",
                    ULInt8('mask'),
                    ULInt8('prn'),)
+  __slots__ = [
+               'mask',
+               'prn',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgMaskSatellite,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgMaskSatellite, self).__init__()
@@ -668,7 +733,8 @@ from being used in various Piksi subsystems.
 
     """
     p = MsgMaskSatellite._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -48,7 +48,9 @@ configuration to its onboard flash memory file system.
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsSave,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgSettingsSave, self).__init__()
@@ -84,10 +86,15 @@ class MsgSettingsWrite(SBP):
   """
   _parser = Struct("MsgSettingsWrite",
                    CString('setting', six.b('\n')),)
+  __slots__ = [
+               'setting',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsWrite,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgSettingsWrite, self).__init__()
@@ -104,7 +111,8 @@ class MsgSettingsWrite(SBP):
 
     """
     p = MsgSettingsWrite._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -155,10 +163,15 @@ class MsgSettingsReadRequest(SBP):
   """
   _parser = Struct("MsgSettingsReadRequest",
                    CString('setting', six.b('\n')),)
+  __slots__ = [
+               'setting',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsReadRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgSettingsReadRequest, self).__init__()
@@ -175,7 +188,8 @@ class MsgSettingsReadRequest(SBP):
 
     """
     p = MsgSettingsReadRequest._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -226,10 +240,15 @@ class MsgSettingsReadResponse(SBP):
   """
   _parser = Struct("MsgSettingsReadResponse",
                    CString('setting', six.b('\n')),)
+  __slots__ = [
+               'setting',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsReadResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgSettingsReadResponse, self).__init__()
@@ -246,7 +265,8 @@ class MsgSettingsReadResponse(SBP):
 
     """
     p = MsgSettingsReadResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -301,10 +321,15 @@ NULL-terminated and delimited string with contents
   """
   _parser = Struct("MsgSettingsReadByIndexRequest",
                    ULInt16('index'),)
+  __slots__ = [
+               'index',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsReadByIndexRequest,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgSettingsReadByIndexRequest, self).__init__()
@@ -321,7 +346,8 @@ NULL-terminated and delimited string with contents
 
     """
     p = MsgSettingsReadByIndexRequest._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -381,10 +407,16 @@ NULL-terminated and delimited string with contents
   _parser = Struct("MsgSettingsReadByIndexResponse",
                    ULInt16('index'),
                    CString('setting', six.b('\n')),)
+  __slots__ = [
+               'index',
+               'setting',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsReadByIndexResponse,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgSettingsReadByIndexResponse, self).__init__()
@@ -402,7 +434,8 @@ NULL-terminated and delimited string with contents
 
     """
     p = MsgSettingsReadByIndexResponse._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -444,7 +477,9 @@ class MsgSettingsReadByIndexDone(SBP):
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgSettingsReadByIndexDone,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.payload = sbp.payload
     else:
       super( MsgSettingsReadByIndexDone, self).__init__()

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -51,10 +51,15 @@ or configuration requests.
   """
   _parser = Struct("MsgStartup",
                    ULInt32('reserved'),)
+  __slots__ = [
+               'reserved',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgStartup,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgStartup, self).__init__()
@@ -71,7 +76,8 @@ or configuration requests.
 
     """
     p = MsgStartup._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -130,10 +136,15 @@ the remaining error flags should be inspected.
   """
   _parser = Struct("MsgHeartbeat",
                    ULInt32('flags'),)
+  __slots__ = [
+               'flags',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgHeartbeat,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgHeartbeat, self).__init__()
@@ -150,7 +161,8 @@ the remaining error flags should be inspected.
 
     """
     p = MsgHeartbeat._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -46,6 +46,11 @@ signal power.
                      ULInt8('state'),
                      ULInt8('prn'),
                      LFloat32('cn0'),))
+  __slots__ = [
+               'state',
+               'prn',
+               'cn0',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -60,10 +65,12 @@ signal power.
   
   def from_binary(self, d):
     p = TrackingChannelState._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return TrackingChannelState.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return TrackingChannelState.build(d)
     
 class TrackingChannelCorrelation(object):
   """TrackingChannelCorrelation.
@@ -82,6 +89,10 @@ class TrackingChannelCorrelation(object):
   _parser = Embedded(Struct("TrackingChannelCorrelation",
                      SLInt32('I'),
                      SLInt32('Q'),))
+  __slots__ = [
+               'I',
+               'Q',
+              ]
 
   def __init__(self, payload=None, **kwargs):
     if payload:
@@ -95,10 +106,12 @@ class TrackingChannelCorrelation(object):
   
   def from_binary(self, d):
     p = TrackingChannelCorrelation._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
-    return TrackingChannelCorrelation.build(self.__dict__)
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return TrackingChannelCorrelation.build(d)
     
 SBP_MSG_TRACKING_STATE = 0x0016
 class MsgTrackingState(SBP):
@@ -126,10 +139,15 @@ all tracked satellites.
   """
   _parser = Struct("MsgTrackingState",
                    OptionalGreedyRange(Struct('states', TrackingChannelState._parser)),)
+  __slots__ = [
+               'states',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgTrackingState,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgTrackingState, self).__init__()
@@ -146,7 +164,8 @@ all tracked satellites.
 
     """
     p = MsgTrackingState._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -203,10 +222,17 @@ update interval.
                    ULInt8('channel'),
                    ULInt32('sid'),
                    Struct('corrs', Array(3, Struct('corrs', TrackingChannelCorrelation._parser))),)
+  __slots__ = [
+               'channel',
+               'sid',
+               'corrs',
+              ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
-      self.__dict__.update(sbp.__dict__)
+      super( MsgTrackingIq,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
       self.from_binary(sbp.payload)
     else:
       super( MsgTrackingIq, self).__init__()
@@ -225,7 +251,8 @@ update interval.
 
     """
     p = MsgTrackingIq._parser.parse(d)
-    self.__dict__.update(dict(p.viewitems()))
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -22,7 +22,7 @@ def exclude_fields(obj, exclude=EXCLUDE):
   """
   Return dict of object without parent attrs.
   """
-  return {k: v for k, v in obj.__dict__.items() if k not in exclude}
+  return dict([(k, getattr(obj, k)) for k in obj.__slots__ if k not in exclude])
 
 
 def walk_json_dict(coll):

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -78,9 +78,9 @@ def _assert_msg(msg, test_case):
   assert msg.__class__.__name__ == test_case['name']
   if test_case['fields']:
     for field_name, field_value in test_case['fields'].iteritems():
-      assert field_eq(msg.__dict__[field_name], field_value), \
+      assert field_eq(getattr(msg, field_name), field_value), \
         "Unequal field values: got %s, but expected %s!" \
-        % (msg.__dict__[field_name], field_value)
+        % (getattr(msg, field_name), field_value)
 
 def _assert_msg_roundtrip(msg, raw_packet):
   """


### PR DESCRIPTION
This defines a __slots__ attribute for each SBP message (and non-SBP
struct) object, which fixes memory for a fixed set of attributes
instead of allocating a dynamic __dict__. Reduces memory overhead on
using the libsbp's Python bindings when we're instantiating 1k's of
objects. Anecdotal 7x decrease in heap usage:

Partition of a set of 240058 objects. Total size = 117214528 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 100000  42 104800000  89 104800000  89 dict of sbp.navigation.MsgBaselineECEF
     1 100000  42  6400000   5 111200000  95 sbp.navigation.MsgBaselineECEF

Partition of a set of 140393 objects. Total size = 21265240 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 100000  71 15200000  71  15200000  71 sbp.navigation.MsgBaselineECEF

Closes #95.

/cc @mfine @fnoble

<!---
@huboard:{"milestone_order":195.0}
-->
