### PR TITLE
add note about what sender id of 0x42 represents

### DIFF
--- a/generator/sbpg/targets/resources/sbp_base.tex
+++ b/generator/sbpg/targets/resources/sbp_base.tex
@@ -129,7 +129,7 @@ detection\footnote{CCITT 16-bit CRC Implementation uses parameters
     \midrule
     $0$ & $1$ & {Preamble} & Denotes the start of frame transmission. Always 0x55. \\
     $1$ & $2$ & {Message Type} & Identifies the payload contents. \\
-    $3$ & $2$ & {Sender} & \hangindent=0.5em{A unique identifier of the sender. On the Piksi, this is set to the 2 least significant bytes of the device serial number. A stream of SBP messages may also included sender IDs for forwarded messages.} \\
+    $3$ & $2$ & {Sender} & \hangindent=0.5em{A unique identifier of the sender. On the Piksi, this is set to the 2 least significant bytes of the device serial number. A stream of SBP messages may also included sender IDs for forwarded messages. By default, clients of `libsbp` use a sender id value of `0x42`.  Sender id '0x42' is used to represent device controllers such as the Piksi Console.} \\
     $5$ & $1$ & {Length} & Length (bytes) of the {Payload} field. \\
     $6$ & $N$ & {Payload} & Binary message contents. \\
     $N+6$ & $2$ & {CRC} & \hangindent=0.5em{Cyclic Redundancy Check of the frame's binary data from the Message Type up to the end of Payload (does not include the Preamble).} \\

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -35,6 +35,9 @@ definitions:
       MSG_FILEIO_READ_RESP message where the message length field
       indicates how many bytes were succesfully read.The sequence
       number in the request will be returned in the response.
+      If the message is invalid, a followup MSG_PRINT message will
+      print "Invalid fileio read message". A device will only respond
+      to this message when it is received from sender ID 0x42.
     fields:
       - sequence:
           type: u32
@@ -79,7 +82,10 @@ definitions:
       MSG_FILEIO_READ_DIR_RESP message containing the directory
       listings as a NULL delimited list. The listing is chunked over
       multiple SBP packets. The sequence number in the request will be
-      returned in the response.
+      returned in the response.  If message is invalid, a followup
+      MSG_PRINT message will print "Invalid fileio read message".
+      A device will only respond to this message when it is received
+      from sender ID 0x42.
     fields:
       - sequence:
           type: u32
@@ -116,6 +122,9 @@ definitions:
     short_desc: Delete a file from the file system (host => device)
     desc: |
       The file remove message deletes a file from the file system.
+      If the message is invalid, a followup MSG_PRINT message will
+      print "Invalid fileio remove message". A device will only
+      process this message when it is received from sender ID 0x42.
     fields:
       - filename:
           type: string
@@ -129,7 +138,10 @@ definitions:
       of data to a file at a given offset. Returns a copy of the
       original MSG_FILEIO_WRITE_RESP message to check integrity of
       the write. The sequence number in the request will be returned
-      in the response.
+      in the response. If message is invalid, a followup MSG_PRINT
+      message will print "Invalid fileio write message". A device will
+      only  process this message when it is received from sender ID
+      0x42.
     fields:
       - sequence:
           type: u32

--- a/spec/yaml/swiftnav/sbp/settings.yaml
+++ b/spec/yaml/swiftnav/sbp/settings.yaml
@@ -39,7 +39,9 @@ definitions:
           type: string
           desc: |
             A NULL-terminated and delimited string with contents
-            [SECTION_SETTING, SETTING, VALUE].
+            [SECTION_SETTING, SETTING, VALUE]. A device will only
+            process to this message when it is received from
+            sender ID 0x42.
 
  - MSG_SETTINGS_READ_REQ:
     id: 0x00A4
@@ -50,7 +52,8 @@ definitions:
           type: string
           desc: |
             A NULL-terminated and delimited string with contents
-            [SECTION_SETTING, SETTING].
+            [SECTION_SETTING, SETTING]. A device will only
+            respond to this message when it is received from sender ID 0x42.
 
  - MSG_SETTINGS_READ_RESP:
     id: 0x00A5
@@ -70,7 +73,8 @@ definitions:
       The settings message for iterating through the settings
       values. It will read the setting at an index, returning a
       NULL-terminated and delimited string with contents
-      [SECTION_SETTING, SETTING, VALUE].
+      [SECTION_SETTING, SETTING, VALUE]. A device will only respond to this message
+      when it is received from sender ID 0x42.
     fields:
       - index:
           type: u16


### PR DESCRIPTION
@mfine  What do you think about adding this to the spec to note what 0x42 represents?