### PR TITLE
Unfixed strings, remove null termination

### DIFF
--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -40,15 +40,15 @@
  * The file read message reads a certain length (up to 255 bytes)
  * from a given offset into a file, and returns the data in a
  * MSG_FILEIO_READ_RESPONSE message where the message length field
- * indicates how many bytes were succesfully read. If the message is
- * invalid, a followup MSG_PRINT message will print "Invalid fileio
- * read message".
+ * indicates how many bytes were succesfully read.The sequence
+ * number in the request will be returned in the response.
  */
 #define SBP_MSG_FILEIO_READ_REQUEST      0x00A8
 typedef struct __attribute__((packed)) {
+  u32 sequence;      /**< Read sequence number */
   u32 offset;        /**< File offset [bytes] */
   u8 chunk_size;    /**< Chunk size to read [bytes] */
-  char filename[20];  /**< Name of the file to read from (NULL padded) */
+  char filename[0];   /**< Name of the file to read from */
 } msg_fileio_read_request_t;
 
 
@@ -57,14 +57,13 @@ typedef struct __attribute__((packed)) {
  * The file read message reads a certain length (up to 255 bytes)
  * from a given offset into a file, and returns the data in a
  * message where the message length field indicates how many bytes
- * were succesfully read.
+ * were succesfully read. The sequence number in the response is
+ * preserved from the request.
  */
 #define SBP_MSG_FILEIO_READ_RESPONSE     0x00A3
 typedef struct __attribute__((packed)) {
-  u32 offset;        /**< File offset [bytes] */
-  u8 chunk_size;    /**< Chunk size read [bytes] */
-  char filename[20];  /**< Name of the file read from (NULL padded) */
-  u8 contents[0];   /**< Contents of read file */
+  u32 sequence;    /**< Read sequence number */
+  u8 contents[0]; /**< Contents of read file */
 } msg_fileio_read_response_t;
 
 
@@ -76,45 +75,41 @@ typedef struct __attribute__((packed)) {
  * MSG_FILEIO_READ_DIR_RESPONSE message containing the directory
  * listings as a NULL delimited list. The listing is chunked over
  * multiple SBP packets and the end of the list is identified by an
- * entry containing just the character 0xFF. If message is invalid, a
- * followup MSG_PRINT message will print "Invalid fileio read
- * message".
+ * entry containing just the character 0xFF. The sequence number in
+ * the request will be returned in the response.
  */
 #define SBP_MSG_FILEIO_READ_DIR_REQUEST  0x00A9
 typedef struct __attribute__((packed)) {
-  u32 offset;     /**< The offset to skip the first n elements of the file list
+  u32 sequence;    /**< Read sequence number */
+  u32 offset;      /**< The offset to skip the first n elements of the file list
  */
-  char dirname[20]; /**< Name of the directory to list (NULL padded) */
+  char dirname[0];  /**< Name of the directory to list */
 } msg_fileio_read_dir_request_t;
 
 
 /** Files listed in a directory (host <= device)
  *
  * The read directory message lists the files in a directory on the
- * device's onboard flash file system.  The offset parameter can be
- * used to skip the first n elements of the file list. Message contains
- * the directory listings as a NULL delimited list. The listing is
- * chunked over multiple SBP packets and the end of the list is
- * identified by an entry containing just the character 0xFF.
+ * device's onboard flash file system. Message contains the directory
+ * listings as a NULL delimited list. The listing is chunked over
+ * multiple SBP packets and the end of the list is identified by an
+ * entry containing just the character 0xFF. The sequence number in
+ * the response is preserved from the request.
  */
 #define SBP_MSG_FILEIO_READ_DIR_RESPONSE 0x00AA
 typedef struct __attribute__((packed)) {
-  u32 offset;      /**< The offset to skip the first n elements of the file list
- */
-  char dirname[20]; /**< Name of the directory to list (NULL padded) */
+  u32 sequence;    /**< Read sequence number */
   u8 contents[0]; /**< Contents of read directory */
 } msg_fileio_read_dir_response_t;
 
 
 /** Delete a file from the file system (host => device)
  *
- * The file remove message deletes a file from the file system. If
- * message is invalid, a followup MSG_PRINT message will print
- * "Invalid fileio remove message".
+ * The file remove message deletes a file from the file system.
  */
 #define SBP_MSG_FILEIO_REMOVE            0x00AC
 typedef struct __attribute__((packed)) {
-  char filename[20]; /**< Name of the file to delete (NULL padded) */
+  char filename[0]; /**< Name of the file to delete */
 } msg_fileio_remove_t;
 
 
@@ -123,13 +118,14 @@ typedef struct __attribute__((packed)) {
  * The file write message writes a certain length (up to 255 bytes)
  * of data to a file at a given offset. Returns a copy of the
  * original MSG_FILEIO_WRITE_RESPONSE message to check integrity of
- * the write. If message is invalid, a followup MSG_PRINT message
- * will print "Invalid fileio write message".
+ * the write. The sequence number in the request will be returned
+ * in the response.
  */
 #define SBP_MSG_FILEIO_WRITE_REQUEST     0x00AD
 typedef struct __attribute__((packed)) {
-  char filename[20]; /**< Name of the file to write to (NULL padded) */
+  u32 sequence;    /**< Write sequence number */
   u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
+  char filename[0]; /**< Name of the file to write to */
   u8 data[0];     /**< Variable-length array of data to write */
 } msg_fileio_write_request_t;
 
@@ -139,13 +135,11 @@ typedef struct __attribute__((packed)) {
  * The file write message writes a certain length (up to 255 bytes)
  * of data to a file at a given offset. The message is a copy of the
  * original MSG_FILEIO_WRITE_REQUEST message to check integrity of the
- * write.
+ * write. The sequence number in the response is preserved from the request.
  */
 #define SBP_MSG_FILEIO_WRITE_RESPONSE    0x00AB
 typedef struct __attribute__((packed)) {
-  char filename[20]; /**< Name of the file to write to (NULL padded) */
-  u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
-  u8 data[0];     /**< Variable-length array of data to write */
+  u32 sequence;    /**< Write sequence number */
 } msg_fileio_write_response_t;
 
 

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -75,6 +75,8 @@ def fmt_repr(obj):
   items = ["%s = %r" % (k, v) for k, v in exclude_fields(obj).items()]
   return "<%s: {%s}>" % (obj.__class__.__name__, ', '.join(items))
 
+# TODO: Once https://github.com/construct/construct/pull/59 is published
+#       to pypi, remove this in favor of construct.GreedyString
 def greedy_string(name):
   """
   Variable-length string field.

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -35,8 +35,12 @@ definitions:
       MSG_FILEIO_READ_RESPONSE message where the message length field
       indicates how many bytes were succesfully read. If the message is
       invalid, a followup MSG_PRINT message will print "Invalid fileio
-      read message".
+      read message". The sequence number in the request will be returned
+      in the response.
     fields:
+      - sequence:
+          type: u32
+          desc: Read sequence number
       - offset:
           type: u32
           units: bytes
@@ -47,8 +51,7 @@ definitions:
           desc: Chunk size to read
       - filename:
           type: string
-          size: 20
-          desc: Name of the file to read from (NULL padded)
+          desc: Name of the file to read from
 
  - MSG_FILEIO_READ_RESPONSE:
     id: 0x00A3
@@ -57,20 +60,12 @@ definitions:
       The file read message reads a certain length (up to 255 bytes)
       from a given offset into a file, and returns the data in a
       message where the message length field indicates how many bytes
-      were succesfully read.
+      were succesfully read. The sequence number in the response is
+      preserved from the request.
     fields:
-      - offset:
+      - sequence:
           type: u32
-          units: bytes
-          desc: File offset
-      - chunk_size:
-          type: u8
-          units: bytes
-          desc: Chunk size read
-      - filename:
-          type: string
-          size: 20
-          desc: Name of the file read from (NULL padded)
+          desc: Read sequence number
       - contents:
           type: array
           fill: u8
@@ -88,36 +83,34 @@ definitions:
       multiple SBP packets and the end of the list is identified by an
       entry containing just the character 0xFF. If message is invalid, a
       followup MSG_PRINT message will print "Invalid fileio read
-      message".
+      message". The sequence number in the request will be returned in
+      the response.
     fields:
+      - sequence:
+          type: u32
+          desc: Read sequence number
       - offset:
           type: u32
           desc: |
             The offset to skip the first n elements of the file list
       - dirname:
           type: string
-          size: 20
-          desc: Name of the directory to list (NULL padded)
+          desc: Name of the directory to list
 
  - MSG_FILEIO_READ_DIR_RESPONSE:
     id: 0x00AA
     short_desc: Files listed in a directory (host <= device)
     desc: |
       The read directory message lists the files in a directory on the
-      device's onboard flash file system.  The offset parameter can be
-      used to skip the first n elements of the file list. Message contains
-      the directory listings as a NULL delimited list. The listing is
-      chunked over multiple SBP packets and the end of the list is
-      identified by an entry containing just the character 0xFF.
+      device's onboard flash file system. Message contains the directory
+      listings as a NULL delimited list. The listing is chunked over
+      multiple SBP packets and the end of the list is identified by an
+      entry containing just the character 0xFF. The sequence number in
+      the response is preserved from the request.
     fields:
-      - offset:
+      - sequence:
           type: u32
-          desc: |
-            The offset to skip the first n elements of the file list
-      - dirname:
-          type: string
-          size: 20
-          desc: Name of the directory to list (NULL padded)
+          desc: Read sequence number
       - contents:
           type: array
           fill: u8
@@ -133,8 +126,7 @@ definitions:
     fields:
       - filename:
           type: string
-          size: 20
-          desc: Name of the file to delete (NULL padded)
+          desc: Name of the file to delete
 
  - MSG_FILEIO_WRITE_REQUEST:
     id: 0x00AD
@@ -144,16 +136,19 @@ definitions:
       of data to a file at a given offset. Returns a copy of the
       original MSG_FILEIO_WRITE_RESPONSE message to check integrity of
       the write. If message is invalid, a followup MSG_PRINT message
-      will print "Invalid fileio write message".
+      will print "Invalid fileio write message". The sequence number in
+      the request will be returned in the response.
     fields:
-      - filename:
-          type: string
-          size: 20
-          desc: Name of the file to write to (NULL padded)
+      - sequence:
+          type: u32
+          desc: Write sequence number
       - offset:
           type: u32
           units: bytes
           desc: Offset into the file at which to start writing in bytes
+      - filename:
+          type: string
+          desc: Name of the file to write to
       - data:
           type: array
           fill: u8
@@ -166,17 +161,8 @@ definitions:
       The file write message writes a certain length (up to 255 bytes)
       of data to a file at a given offset. The message is a copy of the
       original MSG_FILEIO_WRITE_REQUEST message to check integrity of the
-      write.
+      write. The sequence number in the response is preserved from the request.
     fields:
-      - filename:
-          type: string
-          size: 20
-          desc: Name of the file to write to (NULL padded)
-      - offset:
+      - sequence:
           type: u32
-          units: bytes
-          desc: Offset into the file at which to start writing in bytes
-      - data:
-          type: array
-          fill: u8
-          desc: Variable-length array of data to write
+          desc: Write sequence number

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -33,10 +33,8 @@ definitions:
       The file read message reads a certain length (up to 255 bytes)
       from a given offset into a file, and returns the data in a
       MSG_FILEIO_READ_RESPONSE message where the message length field
-      indicates how many bytes were succesfully read. If the message is
-      invalid, a followup MSG_PRINT message will print "Invalid fileio
-      read message". The sequence number in the request will be returned
-      in the response.
+      indicates how many bytes were succesfully read.The sequence
+      number in the request will be returned in the response.
     fields:
       - sequence:
           type: u32
@@ -81,10 +79,8 @@ definitions:
       MSG_FILEIO_READ_DIR_RESPONSE message containing the directory
       listings as a NULL delimited list. The listing is chunked over
       multiple SBP packets and the end of the list is identified by an
-      entry containing just the character 0xFF. If message is invalid, a
-      followup MSG_PRINT message will print "Invalid fileio read
-      message". The sequence number in the request will be returned in
-      the response.
+      entry containing just the character 0xFF. The sequence number in
+      the request will be returned in the response.
     fields:
       - sequence:
           type: u32
@@ -120,9 +116,7 @@ definitions:
     id: 0x00AC
     short_desc: Delete a file from the file system (host => device)
     desc: |
-      The file remove message deletes a file from the file system. If
-      message is invalid, a followup MSG_PRINT message will print
-      "Invalid fileio remove message".
+      The file remove message deletes a file from the file system.
     fields:
       - filename:
           type: string
@@ -135,9 +129,8 @@ definitions:
       The file write message writes a certain length (up to 255 bytes)
       of data to a file at a given offset. Returns a copy of the
       original MSG_FILEIO_WRITE_RESPONSE message to check integrity of
-      the write. If message is invalid, a followup MSG_PRINT message
-      will print "Invalid fileio write message". The sequence number in
-      the request will be returned in the response.
+      the write. The sequence number in the request will be returned
+      in the response.
     fields:
       - sequence:
           type: u32


### PR DESCRIPTION
Remove the fixed strings in fileio.  Remove the null termination description in settings.

/cc @fnoble @gsmcmullin @mookerji @denniszollo 