### PR TITLE
Remove the janky 0xFF terminator on read dir requests

### DIFF
--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -74,9 +74,8 @@ typedef struct __attribute__((packed)) {
  * used to skip the first n elements of the file list. Returns a
  * MSG_FILEIO_READ_DIR_RESP message containing the directory
  * listings as a NULL delimited list. The listing is chunked over
- * multiple SBP packets and the end of the list is identified by an
- * entry containing just the character 0xFF. The sequence number in
- * the request will be returned in the response.
+ * multiple SBP packets. The sequence number in the request will be
+ * returned in the response.
  */
 #define SBP_MSG_FILEIO_READ_DIR_REQ  0x00A9
 typedef struct __attribute__((packed)) {

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -227,9 +227,8 @@ device's onboard flash file system.  The offset parameter can be
 used to skip the first n elements of the file list. Returns a
 MSG_FILEIO_READ_DIR_RESP message containing the directory
 listings as a NULL delimited list. The listing is chunked over
-multiple SBP packets and the end of the list is identified by an
-entry containing just the character 0xFF. The sequence number in
-the request will be returned in the response.
+multiple SBP packets. The sequence number in the request will be
+returned in the response.
 
 
   Parameters

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -78,9 +78,8 @@ definitions:
       used to skip the first n elements of the file list. Returns a
       MSG_FILEIO_READ_DIR_RESP message containing the directory
       listings as a NULL delimited list. The listing is chunked over
-      multiple SBP packets and the end of the list is identified by an
-      entry containing just the character 0xFF. The sequence number in
-      the request will be returned in the response.
+      multiple SBP packets. The sequence number in the request will be
+      returned in the response.
     fields:
       - sequence:
           type: u32


### PR DESCRIPTION
Pull out the 0xFF terminator. End of dir entries will come via an an empty response.

/cc @gsmcmullin 