### PR TITLE
SBP misc. cleanup.

### DIFF
--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -148,6 +148,8 @@ class ((( m.identifier | classnameify )))(SBP):
       ((*- for f in m.fields *))
       self.(((f.identifier))) = kwargs.pop('(((f.identifier)))')
       ((*- endfor *))
+    ((*- else *))
+      self.payload = ""
     ((*- endif *))
 
   def __repr__(self):

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -55,6 +55,7 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_RESP.
       super( MsgBootloaderHandshakeReq, self).__init__()
       self.msg_type = SBP_MSG_BOOTLOADER_HANDSHAKE_REQ
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -250,6 +251,7 @@ and not related to the Piksi's serial number.
       super( MsgNapDeviceDnaReq, self).__init__()
       self.msg_type = SBP_MSG_NAP_DEVICE_DNA_REQ
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -18,6 +18,7 @@ import struct
 import threading
 
 from ..msg import crc16, SBP, SBP_PREAMBLE
+from sbp.piksi import MsgReset
 
 class Framer(object):
   """
@@ -63,16 +64,13 @@ class Framer(object):
       if self.verbose:
         print "Host Side Unhandled byte: 0x%02x" % ord(preamble)
       return None
-
     # hdr
     hdr = self.readall(5)
     msg_crc = crc16(hdr)
     msg_type, sender, msg_len = struct.unpack("<HHB", hdr)
-
     # data
     data = self.readall(msg_len)
     msg_crc = crc16(data, msg_crc)
-
     # crc
     crc = self.readall(2)
     crc, = struct.unpack("<H", crc)
@@ -247,6 +245,12 @@ class Handler(object):
     Return whether the processes thread is alive.
     """
     return self.receive_thread.is_alive()
+
+  def reset(self):
+    """
+    Reset the Piksi via a MSG_RESET.
+    """
+    self.send_msg(MsgReset())
 
   def send(self, msg_type, data, sender=0x42):
     """

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -62,12 +62,6 @@ class JSONLogIterator(LogIterator):
     Path to file to read SBP messages from.
 
   """
-  def _process(self, data):
-    delta = data['delta']
-    timestamp = data['timestamp']
-    item = SBP.from_json_dict(data['data'])
-    msg = self.dispatch(msg)
-    yield (delta, timestamp, msg)
 
   def next(self):
     """

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -663,6 +663,7 @@ ID in the payload.
       super( MsgStmUniqueIdReq, self).__init__()
       self.msg_type = SBP_MSG_STM_UNIQUE_ID_REQ
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -176,6 +176,7 @@ alamanac onto the Piksi's flash memory from the host.
       super( MsgAlmanac, self).__init__()
       self.msg_type = SBP_MSG_ALMANAC
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -206,6 +207,7 @@ time estimate sent by the host.
       super( MsgSetTime, self).__init__()
       self.msg_type = SBP_MSG_SET_TIME
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -236,6 +238,7 @@ bootloader.
       super( MsgReset, self).__init__()
       self.msg_type = SBP_MSG_RESET
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -267,6 +270,7 @@ removed in a future release.
       super( MsgCwResults, self).__init__()
       self.msg_type = SBP_MSG_CW_RESULTS
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -298,6 +302,7 @@ be removed in a future release.
       super( MsgCwStart, self).__init__()
       self.msg_type = SBP_MSG_CW_START
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -408,6 +413,7 @@ observations between the two.
       super( MsgInitBase, self).__init__()
       self.msg_type = SBP_MSG_INIT_BASE
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -55,6 +55,7 @@ configuration to its onboard flash memory file system.
       super( MsgSettingsSave, self).__init__()
       self.msg_type = SBP_MSG_SETTINGS_SAVE
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)
@@ -484,6 +485,7 @@ class MsgSettingsReadByIndexDone(SBP):
       super( MsgSettingsReadByIndexDone, self).__init__()
       self.msg_type = SBP_MSG_SETTINGS_READ_BY_INDEX_DONE
       self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
 
   def __repr__(self):
     return fmt_repr(self)


### PR DESCRIPTION
When materializing SBP messages without fields, the parent payload
field was uninitialized, which threw an exception while packing binary
for the serial buffer.

/cc @fnoble @mfine