### PR TITLE
SBP TCP subscriptions.

### DIFF
--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from .base_driver import BaseDriver
+import socket
+import sys
+import threading
+
+# TODO (Buro): Consider making a basic, standard library async tcp
+# client: http://pymotw.com/2/asyncore/.
+
+DEFAULT_RECV_SIZE = 1024
+
+class TCPDriver(BaseDriver):
+  """TCPDriver
+
+  The :class:`TCPDriver` class reads SBP messages to and from a TCP
+  socket.
+
+  Parameters
+  ----------
+  port : string
+    Path to port to read SBP messages from.
+  baud : int
+    Baud rate of serial port.
+
+  """
+  def __init__(self, host, port, size=DEFAULT_RECV_SIZE):
+    self.handle = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    self.handle.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+      self.handle.connect((host, port))
+    except socket.error, msg:
+      err = "%s for %s:%s!\n" % (msg.strerror, host, port)
+      sys.stderr.write(err)
+      raise SystemExit
+    super(TCPDriver, self).__init__(self.handle)
+    self._write_lock = threading.Lock()
+    self.recv_size = size
+
+  def read(self, size=None):
+    """
+    Read wrapper.
+
+    Parameters
+    ----------
+    size : int
+      Number of bytes to read
+    """
+    try:
+      data = self.handle.recv(self.recv_size)
+      return data
+    except socket.error, msg:
+      sys.stderr.write(msg.strerror)
+      sys.stderr.write("\n")
+      raise SystemExit
+
+  def flush(self):
+    pass
+
+  def write(self, s):
+    """
+    Write wrapper.
+
+    Parameters
+    ----------
+    s : bytes
+      Bytes to write
+    """
+    try:
+      self._write_lock.acquire()
+      self.handle.sendall(s)
+    except socket.error, msg:
+      sys.stderr.write(msg.strerror)
+      sys.stderr.write("\n")
+      raise SystemExit
+    finally:
+      self._write_lock.release()

--- a/python/sbp/client/loggers/null_logger.py
+++ b/python/sbp/client/loggers/null_logger.py
@@ -20,5 +20,17 @@ class NullLogger(object):
   def __enter__(self):
     return self
 
+  def flush(self):
+    pass
+
+  def read(self, s=None):
+    pass
+
+  def write(self, s=None):
+    pass
+
+  def close(self):
+    pass
+
   def __exit__(self, *args):
     pass

--- a/python/sbp/client/loggers/udp_logger.py
+++ b/python/sbp/client/loggers/udp_logger.py
@@ -8,10 +8,9 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-import socket
-import struct
-
 from .base_logger import BaseLogger
+import socket
+
 
 class UdpLogger(BaseLogger):
   """
@@ -35,11 +34,7 @@ class UdpLogger(BaseLogger):
     self.call(msg)
 
   def fmt_msg(self, msg):
-    s = ""
-    s += struct.pack("<BHHB", 0x55, msg.msg_type, msg.sender, msg.length)
-    s += msg.payload
-    s += struct.pack("<H", msg.crc)
-    return s
+    return msg.pack()
 
   def flush(self):
     pass

--- a/python/tests/sbp/client/test_driver.py
+++ b/python/tests/sbp/client/test_driver.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from sbp.client.drivers.pyserial_driver import PySerialDriver
+from sbp.client.handler import Handler
+from sbp.logging import MsgPrint
+import SocketServer
+import threading
+import time
+
+def tcp_handler(data):
+  class MockRequestHandler(SocketServer.BaseRequestHandler):
+    def handle(self):
+      self.request.sendall(data)
+  return MockRequestHandler
+
+class MockServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+  pass
+
+def tcp_server(handler):
+  server = MockServer(("localhost", 0), handler)
+  ip, port = server.server_address
+  server_thread = threading.Thread(target=server.serve_forever)
+  server_thread.daemon = True
+  server_thread.start()
+  return (ip, port)
+
+def test_tcp_logger():
+  handler = tcp_handler(MsgPrint(text='abc').to_binary())
+  ip, port = tcp_server(handler)
+  port = "socket://%s:%s" % (ip, port)
+  baud = 115200
+  t0 = time.time()
+  sleep = 0.1
+  def assert_logger(s):
+    assert s.preamble==0x55
+    assert s.msg_type==0x10
+    assert s.sender==66
+    assert s.length==3
+    assert s.payload=='abc'
+    assert s.crc==0xDAEE
+  with PySerialDriver(port, baud) as driver:
+    with Handler(driver.read, driver.write, verbose=False) as link:
+      link.add_callback(assert_logger)
+      while True:
+        if (time.time() - t0) < sleep:
+          break


### PR DESCRIPTION
SBP TCP subscriptions.

0. A first run at a TCP client driver.
1. serial driver now accepts pyserial's full range of URIs. You can now point serial_link at any socket carrying SBP and read results.
2. Something stupid that links a logger and a driver.

Open to any refactoring suggestions, now or for the future.

/cc @mfine @fnoble @denniszollo @henryhallam