### PR TITLE
Don't pull CRC field from JSON.

### DIFF
--- a/python/sbp/msg.py
+++ b/python/sbp/msg.py
@@ -169,7 +169,6 @@ class SBP(object):
     sbp.sender = d.pop('sender')
     sbp.length = d.pop('length')
     sbp.payload = base64.standard_b64decode(d.pop('payload'))
-    sbp.crc = d.pop('crc')
     return sbp
 
   def to_json_dict(self):


### PR DESCRIPTION
The CRC field is missing from the Android JSONLogger and it's easier to fix it here.

/cc @mookerji @mfine 