### PR TITLE
C: include files with libsbp in path

### DIFF
--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB libsbp_HEADERS "${PROJECT_SOURCE_DIR}/include/libsbp/*.h")
 include_directories("${PROJECT_SOURCE_DIR}/CBLAS/include")
 include_directories("${PROJECT_SOURCE_DIR}/clapack-3.2.1-CMAKE/INCLUDE")
 include_directories("${PROJECT_SOURCE_DIR}/lapacke/include")
-include_directories("${PROJECT_SOURCE_DIR}/include/libsbp")
+include_directories("${PROJECT_SOURCE_DIR}/include")
 
 set(libsbp_SRCS
   edc.c

--- a/c/src/edc.c
+++ b/c/src/edc.c
@@ -10,7 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "edc.h"
+#include "libsbp/edc.h"
 
 /** \defgroup edc Error Detection and Correction
  * Error detection and correction functions.

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -10,8 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "edc.h"
-#include "sbp.h"
+#include "libsbp/edc.h"
+#include "libsbp/sbp.h"
 
 #define SBP_PREAMBLE 0x55
 


### PR DESCRIPTION
In order to make it easier to directly use the C files in other projects, don't make it necessary to add all header files in include/libsbp to the include dirs....