### PR TITLE
Start to improve the module imports/exports

### DIFF
--- a/generator/sbpg/targets/resources/SbpTemplate.hs
+++ b/generator/sbpg/targets/resources/SbpTemplate.hs
@@ -8,7 +8,13 @@
 --
 -- SBP message containers and serialization utilities.
 
-module SwiftNav.SBP where
+module SwiftNav.SBP
+  ( Msg
+  , SBPMsg (..)
+((*- for m in modules *))
+  , module (((m)))
+((*- endfor *))
+  ) where
 
 import BasicPrelude hiding (lookup)
 import Control.Lens hiding ((.=))

--- a/haskell/src/SwiftNav/SBP.hs
+++ b/haskell/src/SwiftNav/SBP.hs
@@ -8,7 +8,22 @@
 --
 -- SBP message containers and serialization utilities.
 
-module SwiftNav.SBP where
+module SwiftNav.SBP
+  ( Msg
+  , SBPMsg (..)
+  , module SwiftNav.SBP.Acquisition
+  , module SwiftNav.SBP.Bootload
+  , module SwiftNav.SBP.ExtEvents
+  , module SwiftNav.SBP.FileIo
+  , module SwiftNav.SBP.Flash
+  , module SwiftNav.SBP.Logging
+  , module SwiftNav.SBP.Navigation
+  , module SwiftNav.SBP.Observation
+  , module SwiftNav.SBP.Piksi
+  , module SwiftNav.SBP.Settings
+  , module SwiftNav.SBP.System
+  , module SwiftNav.SBP.Tracking
+  ) where
 
 import BasicPrelude hiding (lookup)
 import Control.Lens hiding ((.=))


### PR DESCRIPTION
We should start to improve the imports situation so that the library is more pleasant to use. Here's one stab that re-exports all the module plus `Msg` and `SBPMsg` - just import `SwiftNav.SBP` and go.

/cc @mookerji 