### PR TITLE
Improvements to Makefile and Python generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,23 +145,35 @@ html:
 	@echo
 	@echo "Finished!"
 
-test:	java
+test: test-all-begin test-c test-java test-python test-all-end
+
+test-all-begin:
 	@echo
-	@echo "Run tests..."
+	@echo "Running all tests..."
+
+test-all-end:
+	@echo
+	@echo "Finished!"
+
+test-c: c
 	@echo
 	@echo "Running C tests..."
 	@echo
 	cd $(SWIFTNAV_ROOT)/c; \
 	mkdir -p build/ && cd build/; \
 	cmake ../; \
-	make test;
+	make test
+
+test-java: java
+	@echo
+	@echo "No Java tests - TODO"
+
+test-python: python
 	@echo
 	@echo "Running Python tests..."
 	@echo
 	cd $(SWIFTNAV_ROOT)/python/ && tox
-	cd $(SWIFTNAV_ROOT);
-	@echo
-	@echo "Finished!"
+	cd $(SWIFTNAV_ROOT)
 
 release:
 	@echo

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -128,6 +128,8 @@ class ((( m.identifier | classnameify )))(SBP):
                '((( f.identifier )))',
                ((*- endfor *))
               ]
+  ((*- else *))
+  __slots__ = []
   ((*- endif *))
 
   def __init__(self, sbp=None, **kwargs):

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -44,6 +44,7 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_RESP.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -240,6 +241,7 @@ and not related to the Piksi's serial number.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -652,6 +652,7 @@ ID in the payload.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -165,6 +165,7 @@ alamanac onto the Piksi's flash memory from the host.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -196,6 +197,7 @@ time estimate sent by the host.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -227,6 +229,7 @@ bootloader.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -259,6 +262,7 @@ removed in a future release.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -291,6 +295,7 @@ be removed in a future release.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -402,6 +407,7 @@ observations between the two.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -44,6 +44,7 @@ configuration to its onboard flash memory file system.
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -478,6 +479,7 @@ class MsgSettingsReadByIndexDone(SBP):
 
 
   """
+  __slots__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:


### PR DESCRIPTION
1. Split Makefile tests into separate targets.
2. Also ensure that `__slots…__` is generated for all Python classes, even if there aren't any fields for a given message.

@mookerji @gsmcmullin @mfine 