### PR TITLE
Per-message test YAML

### DIFF
--- a/python/tests/sbp/build_test_data.py
+++ b/python/tests/sbp/build_test_data.py
@@ -89,48 +89,25 @@ def dump_modules_to_yaml(test_map, version):
   Parameters
   ----------
   test_map : dict
-    Dictionary mapping SBP message type to instances of SBP object to be used
+    Dictionary mapping SBP message name to instances of SBP object to be used
     for making unit test cases.
 
   """
   for k, v in test_map.iteritems():
-    item = {'package': k,
-            'description': "Unit tests for swiftnav.%s v%s." % (k, version),
+    if not v:
+      continue
+    package = v[0]['msg']['module']
+    item = {'package': package,
+            'description': "Unit tests for swiftnav.%s %s v%s." % (package, k, version),
             'generated_on': datetime.datetime.now(),
             'version': version,
             'tests': v}
     d = yaml.dump(item, explicit_start=True,
                   default_flow_style=False,
                   explicit_end=True)
-    filename = "test_"+k.split(".")[-1]+".yaml"
+    filename = "test_"+k+".yaml"
     with open(filename, 'w') as f:
       f.write(d.replace('\n- ', '\n\n- '))
-
-def gather_by_module(test_table):
-  """
-  Join accumulated unit test data by module.
-
-  Parameters
-  ----------
-  test_table : dict
-    A dict mapping an SBP message type to a list of parsed SBP
-    objects.
-
-  Returns
-  ----------
-  A dict mapping an SBP module to a list of parsed SBP objects.
-
-  """
-  output = {}
-  for k, v in test_table.iteritems():
-    if not v:
-      continue
-    module = v[0]['msg']['module']
-    if output.get(module, None):
-      output[module] += v
-    else:
-      output[module] = v
-  return output
 
 def mk_readable_msg(msg):
   """
@@ -218,12 +195,12 @@ def main():
       # hopefully unique cases. Assume that messages that are likely
       # to be identical are consecutive, so coompare any new message
       # with the most recent one.
-      if len(test_table[msg.msg_type]) <= num_test_cases:
-        if len(test_table[msg.msg_type]) == 0:
-          test_table[msg.msg_type].append(i)
-        elif test_table[msg.msg_type][-1] != i:
-          test_table[msg.msg_type].append(i)
-  dump_modules_to_yaml(gather_by_module(test_table), version)
+      name = i['msg']['name']
+      if not name in test_table:
+        test_table[name] = [i];      
+      elif len(test_table[name]) < num_test_cases and test_table[name][-1] != i:
+        test_table[name].append(i)
+  dump_modules_to_yaml(test_table, version)
 
 if __name__ == "__main__":
   main()

--- a/python/tests/sbp/build_test_data.py
+++ b/python/tests/sbp/build_test_data.py
@@ -19,7 +19,7 @@ Running this command from the top level,
 
   python tests/sbp/build_test_data.py --log_file <log_file>,
 
-produces test_<module name>.yaml files in directory the command is
+produces <module_name>/test_<message_name>.yaml files in directory the command is
 written. The produced file looks like:
 
 description: Unit tests for swiftnav.sbp.acquisition v0.23.
@@ -59,6 +59,7 @@ import base64
 import datetime
 import warnings
 import yaml
+import os
 
 def _to_readable_dict(msg):
   """
@@ -84,7 +85,9 @@ def _to_readable_dict(msg):
 def dump_modules_to_yaml(test_map, version):
   """
   Take unit test data data from test, format as YAML, and write to
-  local files.
+  local files. Each file is stored in a directory structure consisting
+  of components of its package name, 
+  e.g. sbp/acquisition/test_MsgAcqResult.yaml
 
   Parameters
   ----------
@@ -105,8 +108,18 @@ def dump_modules_to_yaml(test_map, version):
     d = yaml.dump(item, explicit_start=True,
                   default_flow_style=False,
                   explicit_end=True)
+
+    path = ""
+    components = package.split(".")
+    for component in components:
+      path = os.path.join(path, component)
+      if not os.path.isdir(path):
+        os.makedirs(path)
+
+
     filename = "test_"+k+".yaml"
-    with open(filename, 'w') as f:
+    filepath = os.path.join(path, filename)
+    with open(filepath, 'w') as f:
       f.write(d.replace('\n- ', '\n\n- '))
 
 def mk_readable_msg(msg):

--- a/spec/tests/yaml/swiftnav/sbp/acquisition/test_MsgAcqResult.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/acquisition/test_MsgAcqResult.yaml
@@ -1,0 +1,112 @@
+---
+description: Unit tests for swiftnav.sbp.acquisition MsgAcqResult v0.51.
+generated_on: 2015-11-09 11:34:21.384812
+package: sbp.acquisition
+tests:
+
+- msg:
+    fields:
+      cf: 4995.1171875
+      cp: 322.0
+      sid: 9
+      snr: 36.66360855102539
+    module: sbp.acquisition
+    name: MsgAcqResult
+  msg_type: '0x14'
+  raw_json: '{"sender": 55286, "msg_type": 20, "cf": 4995.1171875, "crc": 50000, "length":
+    16, "snr": 36.66360855102539, "sid": 9, "cp": 322.0, "preamble": 85, "payload":
+    "iacSQgAAoUPwGJxFCQAAAA=="}'
+  raw_packet: VRQA9tcQiacSQgAAoUPwGJxFCQAAAFDD
+  sbp:
+    crc: '0xc350'
+    length: 16
+    msg_type: '0x14'
+    payload: iacSQgAAoUPwGJxFCQAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cf: -8241.943359375
+      cp: 843.0
+      sid: 3
+      snr: 36.16875457763672
+    module: sbp.acquisition
+    name: MsgAcqResult
+  msg_type: '0x14'
+  raw_json: '{"sender": 55286, "msg_type": 20, "cf": -8241.943359375, "crc": 36757,
+    "length": 16, "snr": 36.16875457763672, "sid": 3, "cp": 843.0, "preamble": 85,
+    "payload": "zqwQQgDAUkTGxwDGAwAAAA=="}'
+  raw_packet: VRQA9tcQzqwQQgDAUkTGxwDGAwAAAJWP
+  sbp:
+    crc: '0x8f95'
+    length: 16
+    msg_type: '0x14'
+    payload: zqwQQgDAUkTGxwDGAwAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cf: 4745.361328125
+      cp: 794.0
+      sid: 18
+      snr: 35.77723693847656
+    module: sbp.acquisition
+    name: MsgAcqResult
+  msg_type: '0x14'
+  raw_json: '{"sender": 55286, "msg_type": 20, "cf": 4745.361328125, "crc": 39859,
+    "length": 16, "snr": 35.77723693847656, "sid": 18, "cp": 794.0, "preamble": 85,
+    "payload": "5BsPQgCARkTkSpRFEgAAAA=="}'
+  raw_packet: VRQA9tcQ5BsPQgCARkTkSpRFEgAAALOb
+  sbp:
+    crc: '0x9bb3'
+    length: 16
+    msg_type: '0x14'
+    payload: 5BsPQgCARkTkSpRFEgAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cf: 2497.55859375
+      cp: 258.5
+      sid: 17
+      snr: 35.69451141357422
+    module: sbp.acquisition
+    name: MsgAcqResult
+  msg_type: '0x14'
+  raw_json: '{"sender": 55286, "msg_type": 20, "cf": 2497.55859375, "crc": 46354,
+    "length": 16, "snr": 35.69451141357422, "sid": 17, "cp": 258.5, "preamble": 85,
+    "payload": "LscOQgBAgUPwGBxFEQAAAA=="}'
+  raw_packet: VRQA9tcQLscOQgBAgUPwGBxFEQAAABK1
+  sbp:
+    crc: '0xb512'
+    length: 16
+    msg_type: '0x14'
+    payload: LscOQgBAgUPwGBxFEQAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cf: -499.5117492675781
+      cp: 522.0
+      sid: 5
+      snr: 35.52417755126953
+    module: sbp.acquisition
+    name: MsgAcqResult
+  msg_type: '0x14'
+  raw_json: '{"sender": 55286, "msg_type": 20, "cf": -499.5117492675781, "crc": 52003,
+    "length": 16, "snr": 35.52417755126953, "sid": 5, "cp": 522.0, "preamble": 85,
+    "payload": "whgOQgCAAkSBwfnDBQAAAA=="}'
+  raw_packet: VRQA9tcQwhgOQgCAAkSBwfnDBQAAACPL
+  sbp:
+    crc: '0xcb23'
+    length: 16
+    msg_type: '0x14'
+    payload: whgOQgCAAkSBwfnDBQAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgBaselineECEF.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgBaselineECEF.yaml
@@ -1,0 +1,127 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgBaselineECEF v0.51.
+generated_on: 2015-11-09 11:34:21.287537
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2567700
+      x: -53227
+      y: -35532
+      z: -76840
+    module: sbp.navigation
+    name: MsgBaselineECEF
+  msg_type: '0x202'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 514, "tow": 2567700, "crc":
+    35122, "length": 20, "flags": 1, "y": -35532, "x": -53227, "z": -76840, "preamble":
+    85, "payload": "FC4nABUw//80df//2NP+/wAACQE=", "accuracy": 0}'
+  raw_packet: VQIC9tcUFC4nABUw//80df//2NP+/wAACQEyiQ==
+  sbp:
+    crc: '0x8932'
+    length: 20
+    msg_type: '0x202'
+    payload: FC4nABUw//80df//2NP+/wAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2567800
+      x: -52934
+      y: -35791
+      z: -76922
+    module: sbp.navigation
+    name: MsgBaselineECEF
+  msg_type: '0x202'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 514, "tow": 2567800, "crc":
+    39907, "length": 20, "flags": 1, "y": -35791, "x": -52934, "z": -76922, "preamble":
+    85, "payload": "eC4nADox//8xdP//htP+/wAACQE=", "accuracy": 0}'
+  raw_packet: VQIC9tcUeC4nADox//8xdP//htP+/wAACQHjmw==
+  sbp:
+    crc: '0x9be3'
+    length: 20
+    msg_type: '0x202'
+    payload: eC4nADox//8xdP//htP+/wAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2567900
+      x: -52639
+      y: -36049
+      z: -77004
+    module: sbp.navigation
+    name: MsgBaselineECEF
+  msg_type: '0x202'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 514, "tow": 2567900, "crc":
+    32317, "length": 20, "flags": 1, "y": -36049, "x": -52639, "z": -77004, "preamble":
+    85, "payload": "3C4nAGEy//8vc///NNP+/wAACQE=", "accuracy": 0}'
+  raw_packet: VQIC9tcU3C4nAGEy//8vc///NNP+/wAACQE9fg==
+  sbp:
+    crc: '0x7e3d'
+    length: 20
+    msg_type: '0x202'
+    payload: 3C4nAGEy//8vc///NNP+/wAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2568000
+      x: -52344
+      y: -36307
+      z: -77084
+    module: sbp.navigation
+    name: MsgBaselineECEF
+  msg_type: '0x202'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 514, "tow": 2568000, "crc":
+    20424, "length": 20, "flags": 1, "y": -36307, "x": -52344, "z": -77084, "preamble":
+    85, "payload": "QC8nAIgz//8tcv//5NL+/wAACQE=", "accuracy": 0}'
+  raw_packet: VQIC9tcUQC8nAIgz//8tcv//5NL+/wAACQHITw==
+  sbp:
+    crc: '0x4fc8'
+    length: 20
+    msg_type: '0x202'
+    payload: QC8nAIgz//8tcv//5NL+/wAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2568100
+      x: -52048
+      y: -36564
+      z: -77163
+    module: sbp.navigation
+    name: MsgBaselineECEF
+  msg_type: '0x202'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 514, "tow": 2568100, "crc":
+    6248, "length": 20, "flags": 1, "y": -36564, "x": -52048, "z": -77163, "preamble":
+    85, "payload": "pC8nALA0//8scf//ldL+/wAACQE=", "accuracy": 0}'
+  raw_packet: VQIC9tcUpC8nALA0//8scf//ldL+/wAACQFoGA==
+  sbp:
+    crc: '0x1868'
+    length: 20
+    msg_type: '0x202'
+    payload: pC8nALA0//8scf//ldL+/wAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgBaselineNED.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgBaselineNED.yaml
@@ -1,0 +1,137 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgBaselineNED v0.51.
+generated_on: 2015-11-09 11:34:21.340285
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      d: 0
+      e: -26134
+      flags: 1
+      h_accuracy: 0
+      n: -96525
+      n_sats: 9
+      tow: 2567700
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgBaselineNED
+  msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": -26134, "sender": 55286, "msg_type": 515, "tow":
+    2567700, "n": -96525, "crc": 49501, "length": 22, "flags": 1, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "FC4nAPOG/v/qmf//AAAAAAAAAAAJAQ==", "d":
+    0}'
+  raw_packet: VQMC9tcWFC4nAPOG/v/qmf//AAAAAAAAAAAJAV3B
+  sbp:
+    crc: '0xc15d'
+    length: 22
+    msg_type: '0x203'
+    payload: FC4nAPOG/v/qmf//AAAAAAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: -25747
+      flags: 1
+      h_accuracy: 0
+      n: -96629
+      n_sats: 9
+      tow: 2567800
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgBaselineNED
+  msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": -25747, "sender": 55286, "msg_type": 515, "tow":
+    2567800, "n": -96629, "crc": 10022, "length": 22, "flags": 1, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "eC4nAIuG/v9tm///AAAAAAAAAAAJAQ==", "d":
+    0}'
+  raw_packet: VQMC9tcWeC4nAIuG/v9tm///AAAAAAAAAAAJASYn
+  sbp:
+    crc: '0x2726'
+    length: 22
+    msg_type: '0x203'
+    payload: eC4nAIuG/v9tm///AAAAAAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: -25360
+      flags: 1
+      h_accuracy: 0
+      n: -96731
+      n_sats: 9
+      tow: 2567900
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgBaselineNED
+  msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": -25360, "sender": 55286, "msg_type": 515, "tow":
+    2567900, "n": -96731, "crc": 34106, "length": 22, "flags": 1, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "3C4nACWG/v/wnP//AAAAAAAAAAAJAQ==", "d":
+    0}'
+  raw_packet: VQMC9tcW3C4nACWG/v/wnP//AAAAAAAAAAAJATqF
+  sbp:
+    crc: '0x853a'
+    length: 22
+    msg_type: '0x203'
+    payload: 3C4nACWG/v/wnP//AAAAAAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: -24973
+      flags: 1
+      h_accuracy: 0
+      n: -96831
+      n_sats: 9
+      tow: 2568000
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgBaselineNED
+  msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": -24973, "sender": 55286, "msg_type": 515, "tow":
+    2568000, "n": -96831, "crc": 54840, "length": 22, "flags": 1, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "QC8nAMGF/v9znv//AAAAAAAAAAAJAQ==", "d":
+    0}'
+  raw_packet: VQMC9tcWQC8nAMGF/v9znv//AAAAAAAAAAAJATjW
+  sbp:
+    crc: '0xd638'
+    length: 22
+    msg_type: '0x203'
+    payload: QC8nAMGF/v9znv//AAAAAAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: -24586
+      flags: 1
+      h_accuracy: 0
+      n: -96931
+      n_sats: 9
+      tow: 2568100
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgBaselineNED
+  msg_type: '0x203'
+  raw_json: '{"v_accuracy": 0, "e": -24586, "sender": 55286, "msg_type": 515, "tow":
+    2568100, "n": -96931, "crc": 62698, "length": 22, "flags": 1, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "pC8nAF2F/v/2n///AAAAAAAAAAAJAQ==", "d":
+    0}'
+  raw_packet: VQMC9tcWpC8nAF2F/v/2n///AAAAAAAAAAAJAer0
+  sbp:
+    crc: '0xf4ea'
+    length: 22
+    msg_type: '0x203'
+    payload: pC8nAF2F/v/2n///AAAAAAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgDops.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgDops.yaml
@@ -1,0 +1,76 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgDops v0.51.
+generated_on: 2015-11-09 11:34:21.395837
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      gdop: 180
+      hdop: 160
+      pdop: 190
+      tdop: 170
+      tow: 2568200
+      vdop: 150
+    module: sbp.navigation
+    name: MsgDops
+  msg_type: '0x206'
+  raw_json: '{"gdop": 180, "tdop": 170, "vdop": 150, "sender": 55286, "msg_type":
+    518, "pdop": 190, "tow": 2568200, "crc": 43641, "length": 14, "preamble": 85,
+    "payload": "CDAnALQAvgCqAKAAlgA=", "hdop": 160}'
+  raw_packet: VQYC9tcOCDAnALQAvgCqAKAAlgB5qg==
+  sbp:
+    crc: '0xaa79'
+    length: 14
+    msg_type: '0x206'
+    payload: CDAnALQAvgCqAKAAlgA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      gdop: 180
+      hdop: 160
+      pdop: 190
+      tdop: 170
+      tow: 2569200
+      vdop: 150
+    module: sbp.navigation
+    name: MsgDops
+  msg_type: '0x206'
+  raw_json: '{"gdop": 180, "tdop": 170, "vdop": 150, "sender": 55286, "msg_type":
+    518, "pdop": 190, "tow": 2569200, "crc": 43342, "length": 14, "preamble": 85,
+    "payload": "8DMnALQAvgCqAKAAlgA=", "hdop": 160}'
+  raw_packet: VQYC9tcO8DMnALQAvgCqAKAAlgBOqQ==
+  sbp:
+    crc: '0xa94e'
+    length: 14
+    msg_type: '0x206'
+    payload: 8DMnALQAvgCqAKAAlgA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      gdop: 180
+      hdop: 160
+      pdop: 190
+      tdop: 170
+      tow: 2570200
+      vdop: 150
+    module: sbp.navigation
+    name: MsgDops
+  msg_type: '0x206'
+  raw_json: '{"gdop": 180, "tdop": 170, "vdop": 150, "sender": 55286, "msg_type":
+    518, "pdop": 190, "tow": 2570200, "crc": 55879, "length": 14, "preamble": 85,
+    "payload": "2DcnALQAvgCqAKAAlgA=", "hdop": 160}'
+  raw_packet: VQYC9tcO2DcnALQAvgCqAKAAlgBH2g==
+  sbp:
+    crc: '0xda47'
+    length: 14
+    msg_type: '0x206'
+    payload: 2DcnALQAvgCqAKAAlgA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgGPSTime.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgGPSTime.yaml
@@ -1,0 +1,107 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgGPSTime v0.51.
+generated_on: 2015-11-09 11:34:21.279013
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      flags: 0
+      ns: 0
+      tow: 2567800
+      wn: 1787
+    module: sbp.navigation
+    name: MsgGPSTime
+  msg_type: '0x100'
+  raw_json: '{"sender": 55286, "msg_type": 256, "wn": 1787, "tow": 2567800, "crc":
+    9349, "length": 11, "flags": 0, "ns": 0, "preamble": 85, "payload": "+wZ4LicAAAAAAAA="}'
+  raw_packet: VQAB9tcL+wZ4LicAAAAAAACFJA==
+  sbp:
+    crc: '0x2485'
+    length: 11
+    msg_type: '0x100'
+    payload: +wZ4LicAAAAAAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 0
+      ns: 0
+      tow: 2567900
+      wn: 1787
+    module: sbp.navigation
+    name: MsgGPSTime
+  msg_type: '0x100'
+  raw_json: '{"sender": 55286, "msg_type": 256, "wn": 1787, "tow": 2567900, "crc":
+    40996, "length": 11, "flags": 0, "ns": 0, "preamble": 85, "payload": "+wbcLicAAAAAAAA="}'
+  raw_packet: VQAB9tcL+wbcLicAAAAAAAAkoA==
+  sbp:
+    crc: '0xa024'
+    length: 11
+    msg_type: '0x100'
+    payload: +wbcLicAAAAAAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 0
+      ns: 0
+      tow: 2568000
+      wn: 1787
+    module: sbp.navigation
+    name: MsgGPSTime
+  msg_type: '0x100'
+  raw_json: '{"sender": 55286, "msg_type": 256, "wn": 1787, "tow": 2568000, "crc":
+    48811, "length": 11, "flags": 0, "ns": 0, "preamble": 85, "payload": "+wZALycAAAAAAAA="}'
+  raw_packet: VQAB9tcL+wZALycAAAAAAACrvg==
+  sbp:
+    crc: '0xbeab'
+    length: 11
+    msg_type: '0x100'
+    payload: +wZALycAAAAAAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 0
+      ns: 0
+      tow: 2568100
+      wn: 1787
+    module: sbp.navigation
+    name: MsgGPSTime
+  msg_type: '0x100'
+  raw_json: '{"sender": 55286, "msg_type": 256, "wn": 1787, "tow": 2568100, "crc":
+    26067, "length": 11, "flags": 0, "ns": 0, "preamble": 85, "payload": "+wakLycAAAAAAAA="}'
+  raw_packet: VQAB9tcL+wakLycAAAAAAADTZQ==
+  sbp:
+    crc: '0x65d3'
+    length: 11
+    msg_type: '0x100'
+    payload: +wakLycAAAAAAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 0
+      ns: 0
+      tow: 2568200
+      wn: 1787
+    module: sbp.navigation
+    name: MsgGPSTime
+  msg_type: '0x100'
+  raw_json: '{"sender": 55286, "msg_type": 256, "wn": 1787, "tow": 2568200, "crc":
+    11515, "length": 11, "flags": 0, "ns": 0, "preamble": 85, "payload": "+wYIMCcAAAAAAAA="}'
+  raw_packet: VQAB9tcL+wYIMCcAAAAAAAD7LA==
+  sbp:
+    crc: '0x2cfb'
+    length: 11
+    msg_type: '0x100'
+    payload: +wYIMCcAAAAAAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosECEF.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosECEF.yaml
@@ -1,0 +1,132 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgPosECEF v0.51.
+generated_on: 2015-11-09 11:34:21.253104
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2567700
+      x: -2700354.5912927105
+      y: -4292510.764041577
+      z: 3855357.977260149
+    module: sbp.navigation
+    name: MsgPosECEF
+  msg_type: '0x200'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 512, "tow": 2567700, "crc":
+    22029, "length": 32, "flags": 0, "y": -4292510.764041577, "x": -2700354.5912927105,
+    "z": 3855357.977260149, "preamble": 85, "payload": "FC4nAMN6r0shmkTBpA7msOdfUMFO3Bb9/mlNQQAACQA=",
+    "accuracy": 0}'
+  raw_packet: VQAC9tcgFC4nAMN6r0shmkTBpA7msOdfUMFO3Bb9/mlNQQAACQANVg==
+  sbp:
+    crc: '0x560d'
+    length: 32
+    msg_type: '0x200'
+    payload: FC4nAMN6r0shmkTBpA7msOdfUMFO3Bb9/mlNQQAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2567700
+      x: -2700356.3285146747
+      y: -4292509.928737887
+      z: 3855357.5011712564
+    module: sbp.navigation
+    name: MsgPosECEF
+  msg_type: '0x200'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 512, "tow": 2567700, "crc":
+    36683, "length": 32, "flags": 1, "y": -4292509.928737887, "x": -2700356.3285146747,
+    "z": 3855357.5011712564, "preamble": 85, "payload": "FC4nANTEDCoimkTBCXFwe+dfUME2YSbA/mlNQQAACQE=",
+    "accuracy": 0}'
+  raw_packet: VQAC9tcgFC4nANTEDCoimkTBCXFwe+dfUME2YSbA/mlNQQAACQFLjw==
+  sbp:
+    crc: '0x8f4b'
+    length: 32
+    msg_type: '0x200'
+    payload: FC4nANTEDCoimkTBCXFwe+dfUME2YSbA/mlNQQAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2567800
+      x: -2700357.485576801
+      y: -4292509.80414865
+      z: 3855356.517968082
+    module: sbp.navigation
+    name: MsgPosECEF
+  msg_type: '0x200'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 512, "tow": 2567800, "crc":
+    29132, "length": 32, "flags": 0, "y": -4292509.80414865, "x": -2700357.485576801,
+    "z": 3855356.517968082, "preamble": 85, "payload": "eC4nAHBhJ74imkTB5it3c+dfUMEyx0xC/mlNQQAACQA=",
+    "accuracy": 0}'
+  raw_packet: VQAC9tcgeC4nAHBhJ74imkTB5it3c+dfUMEyx0xC/mlNQQAACQDMcQ==
+  sbp:
+    crc: '0x71cc'
+    length: 32
+    msg_type: '0x200'
+    payload: eC4nAHBhJ74imkTB5it3c+dfUMEyx0xC/mlNQQAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 1
+      n_sats: 9
+      tow: 2567800
+      x: -2700356.0349524925
+      y: -4292510.187605589
+      z: 3855357.4185667858
+    module: sbp.navigation
+    name: MsgPosECEF
+  msg_type: '0x200'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 512, "tow": 2567800, "crc":
+    18273, "length": 32, "flags": 1, "y": -4292510.187605589, "x": -2700356.0349524925,
+    "z": 3855357.4185667858, "preamble": 85, "payload": "eC4nAMJSeQQimkTB37oBjOdfUMGwmJO1/mlNQQAACQE=",
+    "accuracy": 0}'
+  raw_packet: VQAC9tcgeC4nAMJSeQQimkTB37oBjOdfUMGwmJO1/mlNQQAACQFhRw==
+  sbp:
+    crc: '0x4761'
+    length: 32
+    msg_type: '0x200'
+    payload: eC4nAMJSeQQimkTB37oBjOdfUMGwmJO1/mlNQQAACQE=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2567900
+      x: -2700355.9913074784
+      y: -4292509.946935424
+      z: 3855359.0924900775
+    module: sbp.navigation
+    name: MsgPosECEF
+  msg_type: '0x200'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 512, "tow": 2567900, "crc":
+    25095, "length": 32, "flags": 0, "y": -4292509.946935424, "x": -2700355.9913074784,
+    "z": 3855359.0924900775, "preamble": 85, "payload": "3C4nANgp4/4hmkTBCZeafOdfUMEBt9aL/2lNQQAACQA=",
+    "accuracy": 0}'
+  raw_packet: VQAC9tcg3C4nANgp4/4hmkTBCZeafOdfUMEBt9aL/2lNQQAACQAHYg==
+  sbp:
+    crc: '0x6207'
+    length: 32
+    msg_type: '0x200'
+    payload: 3C4nANgp4/4hmkTBCZeafOdfUMEBt9aL/2lNQQAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosLLH.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosLLH.yaml
@@ -1,0 +1,137 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgPosLLH v0.51.
+generated_on: 2015-11-09 11:34:21.360715
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      flags: 0
+      h_accuracy: 0
+      height: 69.80437675175607
+      lat: 37.42906890908121
+      lon: -122.17338662202773
+      n_sats: 9
+      tow: 2567700
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgPosLLH
+  msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 9, "sender": 55286, "msg_type": 513, "lon":
+    -122.17338662202773, "tow": 2567700, "height": 69.80437675175607, "crc": 35820,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.42906890908121, "preamble":
+    85, "payload": "FC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAA=="}'
+  raw_packet: VQEC9tciFC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAOyL
+  sbp:
+    crc: '0x8bec'
+    length: 34
+    msg_type: '0x201'
+    payload: FC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 1
+      h_accuracy: 0
+      height: 69.68814067715354
+      lat: 37.42906430885274
+      lon: -122.17340826071865
+      n_sats: 9
+      tow: 2567700
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgPosLLH
+  msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 9, "sender": 55286, "msg_type": 513, "lon":
+    -122.17340826071865, "tow": 2567700, "height": 69.68814067715354, "crc": 29977,
+    "length": 34, "flags": 1, "h_accuracy": 0, "lat": 37.42906430885274, "preamble":
+    85, "payload": "FC4nAKEzS5TrtkJAJCn2HhmLXsD+2jF/CmxRQAAAAAAJAQ=="}'
+  raw_packet: VQEC9tciFC4nAKEzS5TrtkJAJCn2HhmLXsD+2jF/CmxRQAAAAAAJARl1
+  sbp:
+    crc: '0x7519'
+    length: 34
+    msg_type: '0x201'
+    payload: FC4nAKEzS5TrtkJAJCn2HhmLXsD+2jF/CmxRQAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 0
+      h_accuracy: 0
+      height: 69.49608854815264
+      lat: 37.42905447764173
+      lon: -122.17342007549469
+      n_sats: 9
+      tow: 2567800
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgPosLLH
+  msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 9, "sender": 55286, "msg_type": 513, "lon":
+    -122.17342007549469, "tow": 2567800, "height": 69.49608854815264, "crc": 27054,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.42905447764173, "preamble":
+    85, "payload": "eC4nADjW0kHrtkJADS6EUBmLXsAWjy7qv19RQAAAAAAJAA=="}'
+  raw_packet: VQEC9tcieC4nADjW0kHrtkJADS6EUBmLXsAWjy7qv19RQAAAAAAJAK5p
+  sbp:
+    crc: '0x69ae'
+    length: 34
+    msg_type: '0x201'
+    payload: eC4nADjW0kHrtkJADS6EUBmLXsAWjy7qv19RQAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 1
+      h_accuracy: 0
+      height: 69.68780458819901
+      lat: 37.429063373925565
+      lon: -122.17340389594972
+      n_sats: 9
+      tow: 2567800
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgPosLLH
+  msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 9, "sender": 55286, "msg_type": 513, "lon":
+    -122.17340389594972, "tow": 2567800, "height": 69.68780458819901, "crc": 32634,
+    "length": 34, "flags": 1, "h_accuracy": 0, "lat": 37.429063373925565, "preamble":
+    85, "payload": "eC4nAPt1c4zrtkJAmIanDBmLXsCgFon9BGxRQAAAAAAJAQ=="}'
+  raw_packet: VQEC9tcieC4nAPt1c4zrtkJAmIanDBmLXsCgFon9BGxRQAAAAAAJAXp/
+  sbp:
+    crc: '0x7f7a'
+    length: 34
+    msg_type: '0x201'
+    payload: eC4nAPt1c4zrtkJAmIanDBmLXsCgFon9BGxRQAAAAAAJAQ==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      flags: 0
+      h_accuracy: 0
+      height: 70.5249547317965
+      lat: 37.42907659359516
+      lon: -122.17340492645452
+      n_sats: 9
+      tow: 2567900
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgPosLLH
+  msg_type: '0x201'
+  raw_json: '{"v_accuracy": 0, "n_sats": 9, "sender": 55286, "msg_type": 513, "lon":
+    -122.17340492645452, "tow": 2567900, "height": 70.5249547317965, "crc": 40642,
+    "length": 34, "flags": 0, "h_accuracy": 0, "lat": 37.42907659359516, "preamble":
+    85, "payload": "3C4nADN8WPvrtkJAmQX6EBmLXsCSPLvbmKFRQAAAAAAJAA=="}'
+  raw_packet: VQEC9tci3C4nADN8WPvrtkJAmQX6EBmLXsCSPLvbmKFRQAAAAAAJAMKe
+  sbp:
+    crc: '0x9ec2'
+    length: 34
+    msg_type: '0x201'
+    payload: 3C4nADN8WPvrtkJAmQX6EBmLXsCSPLvbmKFRQAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelECEF.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelECEF.yaml
@@ -1,0 +1,127 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgVelECEF v0.51.
+generated_on: 2015-11-09 11:34:21.372291
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2567700
+      x: 3034
+      y: -2682
+      z: -861
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 516, "tow": 2567700, "crc":
+    60496, "length": 20, "flags": 0, "y": -2682, "x": 3034, "z": -861, "preamble":
+    85, "payload": "FC4nANoLAACG9f//o/z//wAACQA=", "accuracy": 0}'
+  raw_packet: VQQC9tcUFC4nANoLAACG9f//o/z//wAACQBQ7A==
+  sbp:
+    crc: '0xec50'
+    length: 20
+    msg_type: '0x204'
+    payload: FC4nANoLAACG9f//o/z//wAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2567800
+      x: 2884
+      y: -2536
+      z: -804
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 516, "tow": 2567800, "crc":
+    35576, "length": 20, "flags": 0, "y": -2536, "x": 2884, "z": -804, "preamble":
+    85, "payload": "eC4nAEQLAAAY9v//3Pz//wAACQA=", "accuracy": 0}'
+  raw_packet: VQQC9tcUeC4nAEQLAAAY9v//3Pz//wAACQD4ig==
+  sbp:
+    crc: '0x8af8'
+    length: 20
+    msg_type: '0x204'
+    payload: eC4nAEQLAAAY9v//3Pz//wAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2567900
+      x: 2837
+      y: -2483
+      z: -777
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 516, "tow": 2567900, "crc":
+    44569, "length": 20, "flags": 0, "y": -2483, "x": 2837, "z": -777, "preamble":
+    85, "payload": "3C4nABULAABN9v//9/z//wAACQA=", "accuracy": 0}'
+  raw_packet: VQQC9tcU3C4nABULAABN9v//9/z//wAACQAZrg==
+  sbp:
+    crc: '0xae19'
+    length: 20
+    msg_type: '0x204'
+    payload: 3C4nABULAABN9v//9/z//wAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2568000
+      x: 2937
+      y: -2558
+      z: -790
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 516, "tow": 2568000, "crc":
+    58563, "length": 20, "flags": 0, "y": -2558, "x": 2937, "z": -790, "preamble":
+    85, "payload": "QC8nAHkLAAAC9v//6vz//wAACQA=", "accuracy": 0}'
+  raw_packet: VQQC9tcUQC8nAHkLAAAC9v//6vz//wAACQDD5A==
+  sbp:
+    crc: '0xe4c3'
+    length: 20
+    msg_type: '0x204'
+    payload: QC8nAHkLAAAC9v//6vz//wAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      accuracy: 0
+      flags: 0
+      n_sats: 9
+      tow: 2568100
+      x: 2847
+      y: -2467
+      z: -752
+    module: sbp.navigation
+    name: MsgVelECEF
+  msg_type: '0x204'
+  raw_json: '{"n_sats": 9, "sender": 55286, "msg_type": 516, "tow": 2568100, "crc":
+    42203, "length": 20, "flags": 0, "y": -2467, "x": 2847, "z": -752, "preamble":
+    85, "payload": "pC8nAB8LAABd9v//EP3//wAACQA=", "accuracy": 0}'
+  raw_packet: VQQC9tcUpC8nAB8LAABd9v//EP3//wAACQDbpA==
+  sbp:
+    crc: '0xa4db'
+    length: 20
+    msg_type: '0x204'
+    payload: pC8nAB8LAABd9v//EP3//wAACQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelNED.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelNED.yaml
@@ -1,0 +1,134 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgVelNED v0.51.
+generated_on: 2015-11-09 11:34:21.267364
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      d: 0
+      e: 3996
+      flags: 0
+      h_accuracy: 0
+      n: -1082
+      n_sats: 9
+      tow: 2567700
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 3996, "sender": 55286, "msg_type": 517, "tow":
+    2567700, "n": -1082, "crc": 23713, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "FC4nAMb7//+cDwAAAAAAAAAAAAAJAA==", "d":
+    0}'
+  raw_packet: VQUC9tcWFC4nAMb7//+cDwAAAAAAAAAAAAAJAKFc
+  sbp:
+    crc: '0x5ca1'
+    length: 22
+    msg_type: '0x205'
+    payload: FC4nAMb7//+cDwAAAAAAAAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: 3791
+      flags: 0
+      h_accuracy: 0
+      n: -1010
+      n_sats: 9
+      tow: 2567800
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 3791, "sender": 55286, "msg_type": 517, "tow":
+    2567800, "n": -1010, "crc": 41085, "length": 22, "flags": 0, "h_accuracy": 0,
+    "n_sats": 9, "preamble": 85, "payload": "eC4nAA78///PDgAAAAAAAAAAAAAJAA==", "d":
+    0}'
+  raw_packet: VQUC9tcWeC4nAA78///PDgAAAAAAAAAAAAAJAH2g
+  sbp:
+    crc: '0xa07d'
+    length: 22
+    msg_type: '0x205'
+    payload: eC4nAA78///PDgAAAAAAAAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: 3724
+      flags: 0
+      h_accuracy: 0
+      n: -976
+      n_sats: 9
+      tow: 2567900
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 3724, "sender": 55286, "msg_type": 517, "tow":
+    2567900, "n": -976, "crc": 34739, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats":
+    9, "preamble": 85, "payload": "3C4nADD8//+MDgAAAAAAAAAAAAAJAA==", "d": 0}'
+  raw_packet: VQUC9tcW3C4nADD8//+MDgAAAAAAAAAAAAAJALOH
+  sbp:
+    crc: '0x87b3'
+    length: 22
+    msg_type: '0x205'
+    payload: 3C4nADD8//+MDgAAAAAAAAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: 3848
+      flags: 0
+      h_accuracy: 0
+      n: -992
+      n_sats: 9
+      tow: 2568000
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 3848, "sender": 55286, "msg_type": 517, "tow":
+    2568000, "n": -992, "crc": 45363, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats":
+    9, "preamble": 85, "payload": "QC8nACD8//8IDwAAAAAAAAAAAAAJAA==", "d": 0}'
+  raw_packet: VQUC9tcWQC8nACD8//8IDwAAAAAAAAAAAAAJADOx
+  sbp:
+    crc: '0xb133'
+    length: 22
+    msg_type: '0x205'
+    payload: QC8nACD8//8IDwAAAAAAAAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      d: 0
+      e: 3724
+      flags: 0
+      h_accuracy: 0
+      n: -944
+      n_sats: 9
+      tow: 2568100
+      v_accuracy: 0
+    module: sbp.navigation
+    name: MsgVelNED
+  msg_type: '0x205'
+  raw_json: '{"v_accuracy": 0, "e": 3724, "sender": 55286, "msg_type": 517, "tow":
+    2568100, "n": -944, "crc": 23, "length": 22, "flags": 0, "h_accuracy": 0, "n_sats":
+    9, "preamble": 85, "payload": "pC8nAFD8//+MDgAAAAAAAAAAAAAJAA==", "d": 0}'
+  raw_packet: VQUC9tcWpC8nAFD8//+MDgAAAAAAAAAAAAAJABcA
+  sbp:
+    crc: '0x17'
+    length: 22
+    msg_type: '0x205'
+    payload: pC8nAFD8//+MDgAAAAAAAAAAAAAJAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgObs.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgObs.yaml
@@ -1,0 +1,314 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgObs v0.51.
+generated_on: 2015-11-09 11:34:21.300570
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      header:
+        n_obs: 32
+        t:
+          tow: 2567800
+          wn: 1787
+      obs:
+      - L:
+          f: 27
+          i: 117913055
+        P: 2243669940
+        cn0: 157
+        lock: 0
+        sid: 202
+      - L:
+          f: 175
+          i: 129899608
+        P: 2471857210
+        cn0: 144
+        lock: 0
+        sid: 203
+      - L:
+          f: 135
+          i: 122531024
+        P: 2331544796
+        cn0: 151
+        lock: 0
+        sid: 208
+      - L:
+          f: 242
+          i: 119280243
+        P: 2269692589
+        cn0: 156
+        lock: 0
+        sid: 212
+      - L:
+          f: 120
+          i: 109691922
+        P: 2087293092
+        cn0: 168
+        lock: 0
+        sid: 217
+      - L:
+          f: 87
+          i: 123340754
+        P: 2347034654
+        cn0: 150
+        lock: 0
+        sid: 218
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x43'
+  raw_json: '{"sender": 55286, "msg_type": 67, "header": {"n_obs": 32, "t": {"wn":
+    1787, "tow": 2567800}}, "obs": [{"lock": 0, "sid": 202, "L": {"i": 117913055,
+    "f": 27}, "cn0": 157, "P": 2243669940}, {"lock": 0, "sid": 203, "L": {"i": 129899608,
+    "f": 175}, "cn0": 144, "P": 2471857210}, {"lock": 0, "sid": 208, "L": {"i": 122531024,
+    "f": 135}, "cn0": 151, "P": 2331544796}, {"lock": 0, "sid": 212, "L": {"i": 119280243,
+    "f": 242}, "cn0": 156, "P": 2269692589}, {"lock": 0, "sid": 217, "L": {"i": 109691922,
+    "f": 120}, "cn0": 168, "P": 2087293092}, {"lock": 0, "sid": 218, "L": {"i": 123340754,
+    "f": 87}, "cn0": 150, "P": 2347034654}], "crc": 21929, "length": 103, "preamble":
+    85, "payload": "eC4nAPsGILSvu4XfNQcHG50AAMoAAAA6jFWTWBy+B6+QAADLAAAA3Iz4itCsTQeHlwAA0AAAAK3CSIdzEhwH8pwAANQAAACkkGl8EsSJBnioAADZAAAAHujki9IHWgdXlgAA2gAAAA=="}'
+  raw_packet: VUMA9tdneC4nAPsGILSvu4XfNQcHG50AAMoAAAA6jFWTWBy+B6+QAADLAAAA3Iz4itCsTQeHlwAA0AAAAK3CSIdzEhwH8pwAANQAAACkkGl8EsSJBnioAADZAAAAHujki9IHWgdXlgAA2gAAAKlV
+  sbp:
+    crc: '0x55a9'
+    length: 103
+    msg_type: '0x43'
+    payload: eC4nAPsGILSvu4XfNQcHG50AAMoAAAA6jFWTWBy+B6+QAADLAAAA3Iz4itCsTQeHlwAA0AAAAK3CSIdzEhwH8pwAANQAAACkkGl8EsSJBnioAADZAAAAHujki9IHWgdXlgAA2gAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      header:
+        n_obs: 33
+        t:
+          tow: 2567800
+          wn: 1787
+      obs:
+      - L:
+          f: 219
+          i: 120256389
+        P: 2288371524
+        cn0: 154
+        lock: 0
+        sid: 220
+      - L:
+          f: 235
+          i: 117692256
+        P: 2239434459
+        cn0: 156
+        lock: 0
+        sid: 222
+      - L:
+          f: 174
+          i: 107851013
+        P: 2052171351
+        cn0: 170
+        lock: 0
+        sid: 225
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x43'
+  raw_json: '{"sender": 55286, "msg_type": 67, "header": {"n_obs": 33, "t": {"wn":
+    1787, "tow": 2567800}}, "obs": [{"lock": 0, "sid": 220, "L": {"i": 120256389,
+    "f": 219}, "cn0": 154, "P": 2288371524}, {"lock": 0, "sid": 222, "L": {"i": 117692256,
+    "f": 235}, "cn0": 156, "P": 2239434459}, {"lock": 0, "sid": 225, "L": {"i": 107851013,
+    "f": 174}, "cn0": 170, "P": 2052171351}], "crc": 59659, "length": 55, "preamble":
+    85, "payload": "eC4nAPsGIUTHZYiF9yoH25oAANwAAADbDnuFYNcDB+ucAADeAAAAV6ZRegWtbQauqgAA4QAAAA=="}'
+  raw_packet: VUMA9tc3eC4nAPsGIUTHZYiF9yoH25oAANwAAADbDnuFYNcDB+ucAADeAAAAV6ZRegWtbQauqgAA4QAAAAvp
+  sbp:
+    crc: '0xe90b'
+    length: 55
+    msg_type: '0x43'
+    payload: eC4nAPsGIUTHZYiF9yoH25oAANwAAADbDnuFYNcDB+ucAADeAAAAV6ZRegWtbQauqgAA4QAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      header:
+        n_obs: 32
+        t:
+          tow: 2568000
+          wn: 1787
+      obs:
+      - L:
+          f: 94
+          i: 117912556
+        P: 2243658852
+        cn0: 156
+        lock: 0
+        sid: 202
+      - L:
+          f: 40
+          i: 129900210
+        P: 2471868513
+        cn0: 140
+        lock: 0
+        sid: 203
+      - L:
+          f: 2
+          i: 122530650
+        P: 2331537287
+        cn0: 150
+        lock: 0
+        sid: 208
+      - L:
+          f: 241
+          i: 119280830
+        P: 2269703860
+        cn0: 155
+        lock: 0
+        sid: 212
+      - L:
+          f: 153
+          i: 109691996
+        P: 2087295247
+        cn0: 168
+        lock: 0
+        sid: 217
+      - L:
+          f: 41
+          i: 123340176
+        P: 2347022641
+        cn0: 150
+        lock: 0
+        sid: 218
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x43'
+  raw_json: '{"sender": 55286, "msg_type": 67, "header": {"n_obs": 32, "t": {"wn":
+    1787, "tow": 2568000}}, "obs": [{"lock": 0, "sid": 202, "L": {"i": 117912556,
+    "f": 94}, "cn0": 156, "P": 2243658852}, {"lock": 0, "sid": 203, "L": {"i": 129900210,
+    "f": 40}, "cn0": 140, "P": 2471868513}, {"lock": 0, "sid": 208, "L": {"i": 122530650,
+    "f": 2}, "cn0": 150, "P": 2331537287}, {"lock": 0, "sid": 212, "L": {"i": 119280830,
+    "f": 241}, "cn0": 155, "P": 2269703860}, {"lock": 0, "sid": 217, "L": {"i": 109691996,
+    "f": 153}, "cn0": 168, "P": 2087295247}, {"lock": 0, "sid": 218, "L": {"i": 123340176,
+    "f": 41}, "cn0": 150, "P": 2347022641}], "crc": 25329, "length": 103, "preamble":
+    85, "payload": "QC8nAPsGIGSEu4XsMwcHXpwAAMoAAABhuFWTsh6+ByiMAADLAAAAh2/4ilqrTQcClgAA0AAAALTuSIe+FBwH8ZsAANQAAAAPmWl8XMSJBpmoAADZAAAAMbnki5AFWgcplgAA2gAAAA=="}'
+  raw_packet: VUMA9tdnQC8nAPsGIGSEu4XsMwcHXpwAAMoAAABhuFWTsh6+ByiMAADLAAAAh2/4ilqrTQcClgAA0AAAALTuSIe+FBwH8ZsAANQAAAAPmWl8XMSJBpmoAADZAAAAMbnki5AFWgcplgAA2gAAAPFi
+  sbp:
+    crc: '0x62f1'
+    length: 103
+    msg_type: '0x43'
+    payload: QC8nAPsGIGSEu4XsMwcHXpwAAMoAAABhuFWTsh6+ByiMAADLAAAAh2/4ilqrTQcClgAA0AAAALTuSIe+FBwH8ZsAANQAAAAPmWl8XMSJBpmoAADZAAAAMbnki5AFWgcplgAA2gAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      header:
+        n_obs: 33
+        t:
+          tow: 2568000
+          wn: 1787
+      obs:
+      - L:
+          f: 20
+          i: 120255759
+        P: 2288358634
+        cn0: 154
+        lock: 0
+        sid: 220
+      - L:
+          f: 38
+          i: 117691920
+        P: 2239428560
+        cn0: 156
+        lock: 0
+        sid: 222
+      - L:
+          f: 7
+          i: 107850774
+        P: 2052167183
+        cn0: 172
+        lock: 0
+        sid: 225
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x43'
+  raw_json: '{"sender": 55286, "msg_type": 67, "header": {"n_obs": 33, "t": {"wn":
+    1787, "tow": 2568000}}, "obs": [{"lock": 0, "sid": 220, "L": {"i": 120255759,
+    "f": 20}, "cn0": 154, "P": 2288358634}, {"lock": 0, "sid": 222, "L": {"i": 117691920,
+    "f": 38}, "cn0": 156, "P": 2239428560}, {"lock": 0, "sid": 225, "L": {"i": 107850774,
+    "f": 7}, "cn0": 172, "P": 2052167183}], "crc": 3529, "length": 55, "preamble":
+    85, "payload": "QC8nAPsGIeqUZYgP9SoHFJoAANwAAADQ93qFENYDByacAADeAAAAD5ZRehasbQYHrAAA4QAAAA=="}'
+  raw_packet: VUMA9tc3QC8nAPsGIeqUZYgP9SoHFJoAANwAAADQ93qFENYDByacAADeAAAAD5ZRehasbQYHrAAA4QAAAMkN
+  sbp:
+    crc: '0xdc9'
+    length: 55
+    msg_type: '0x43'
+    payload: QC8nAPsGIeqUZYgP9SoHFJoAANwAAADQ93qFENYDByacAADeAAAAD5ZRehasbQYHrAAA4QAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      header:
+        n_obs: 32
+        t:
+          tow: 2568200
+          wn: 1787
+      obs:
+      - L:
+          f: 165
+          i: 117912057
+        P: 2243649790
+        cn0: 156
+        lock: 0
+        sid: 202
+      - L:
+          f: 106
+          i: 129900811
+        P: 2471880049
+        cn0: 143
+        lock: 0
+        sid: 203
+      - L:
+          f: 159
+          i: 122530275
+        P: 2331530678
+        cn0: 150
+        lock: 0
+        sid: 208
+      - L:
+          f: 7
+          i: 119281418
+        P: 2269714449
+        cn0: 156
+        lock: 0
+        sid: 212
+      - L:
+          f: 186
+          i: 109692070
+        P: 2087295852
+        cn0: 170
+        lock: 0
+        sid: 217
+      - L:
+          f: 236
+          i: 123339597
+        P: 2347011798
+        cn0: 151
+        lock: 0
+        sid: 218
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x43'
+  raw_json: '{"sender": 55286, "msg_type": 67, "header": {"n_obs": 32, "t": {"wn":
+    1787, "tow": 2568200}}, "obs": [{"lock": 0, "sid": 202, "L": {"i": 117912057,
+    "f": 165}, "cn0": 156, "P": 2243649790}, {"lock": 0, "sid": 203, "L": {"i": 129900811,
+    "f": 106}, "cn0": 143, "P": 2471880049}, {"lock": 0, "sid": 208, "L": {"i": 122530275,
+    "f": 159}, "cn0": 150, "P": 2331530678}, {"lock": 0, "sid": 212, "L": {"i": 119281418,
+    "f": 7}, "cn0": 156, "P": 2269714449}, {"lock": 0, "sid": 217, "L": {"i": 109692070,
+    "f": 186}, "cn0": 170, "P": 2087295852}, {"lock": 0, "sid": 218, "L": {"i": 123339597,
+    "f": 236}, "cn0": 151, "P": 2347011798}], "crc": 30267, "length": 103, "preamble":
+    85, "payload": "CDAnAPsGIP5gu4X5MQcHpZwAAMoAAABx5VWTCyG+B2qPAADLAAAAtlX4iuOpTQeflgAA0AAAABEYSYcKFxwHB5wAANQAAABsm2l8psSJBrqqAADZAAAA1o7ki00DWgfslwAA2gAAAA=="}'
+  raw_packet: VUMA9tdnCDAnAPsGIP5gu4X5MQcHpZwAAMoAAABx5VWTCyG+B2qPAADLAAAAtlX4iuOpTQeflgAA0AAAABEYSYcKFxwHB5wAANQAAABsm2l8psSJBrqqAADZAAAA1o7ki00DWgfslwAA2gAAADt2
+  sbp:
+    crc: '0x763b'
+    length: 103
+    msg_type: '0x43'
+    payload: CDAnAPsGIP5gu4X5MQcHpZwAAMoAAABx5VWTCyG+B2qPAADLAAAAtlX4iuOpTQeflgAA0AAAABEYSYcKFxwHB5wAANQAAABsm2l8psSJBrqqAADZAAAA1o7ki00DWgfslwAA2gAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/piksi/test_MsgIarState.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/piksi/test_MsgIarState.yaml
@@ -1,0 +1,24 @@
+---
+description: Unit tests for swiftnav.sbp.piksi MsgIarState v0.51.
+generated_on: 2015-11-09 11:34:21.337881
+package: sbp.piksi
+tests:
+
+- msg:
+    fields:
+      num_hyps: 1
+    module: sbp.piksi
+    name: MsgIarState
+  msg_type: '0x19'
+  raw_json: '{"sender": 55286, "msg_type": 25, "num_hyps": 1, "crc": 36056, "length":
+    4, "preamble": 85, "payload": "AQAAAA=="}'
+  raw_packet: VRkA9tcEAQAAANiM
+  sbp:
+    crc: '0x8cd8'
+    length: 4
+    msg_type: '0x19'
+    payload: AQAAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/piksi/test_MsgThreadState.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/piksi/test_MsgThreadState.yaml
@@ -1,0 +1,107 @@
+---
+description: Unit tests for swiftnav.sbp.piksi MsgThreadState v0.51.
+generated_on: 2015-11-09 11:34:21.327613
+package: sbp.piksi
+tests:
+
+- msg:
+    fields:
+      cpu: 0
+      name: "main\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+      stack_free: 2460
+    module: sbp.piksi
+    name: MsgThreadState
+  msg_type: '0x17'
+  raw_json: '{"sender": 55286, "msg_type": 23, "cpu": 0, "crc": 35401, "length": 26,
+    "stack_free": 2460, "preamble": 85, "payload": "bWFpbgAAAAAAAAAAAAAAAAAAAAAAAJwJAAA=",
+    "name": "main\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
+  raw_packet: VRcA9tcabWFpbgAAAAAAAAAAAAAAAAAAAAAAAJwJAABJig==
+  sbp:
+    crc: '0x8a49'
+    length: 26
+    msg_type: '0x17'
+    payload: bWFpbgAAAAAAAAAAAAAAAAAAAAAAAJwJAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cpu: 595
+      name: "idle\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+      stack_free: 36
+    module: sbp.piksi
+    name: MsgThreadState
+  msg_type: '0x17'
+  raw_json: '{"sender": 55286, "msg_type": 23, "cpu": 595, "crc": 5271, "length":
+    26, "stack_free": 36, "preamble": 85, "payload": "aWRsZQAAAAAAAAAAAAAAAAAAAABTAiQAAAA=",
+    "name": "idle\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
+  raw_packet: VRcA9tcaaWRsZQAAAAAAAAAAAAAAAAAAAABTAiQAAACXFA==
+  sbp:
+    crc: '0x1497'
+    length: 26
+    msg_type: '0x17'
+    payload: aWRsZQAAAAAAAAAAAAAAAAAAAABTAiQAAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cpu: 14
+      name: "NAP ISR\0\0\0\0\0\0\0\0\0\0\0\0\0"
+      stack_free: 1140
+    module: sbp.piksi
+    name: MsgThreadState
+  msg_type: '0x17'
+  raw_json: '{"sender": 55286, "msg_type": 23, "cpu": 14, "crc": 15586, "length":
+    26, "stack_free": 1140, "preamble": 85, "payload": "TkFQIElTUgAAAAAAAAAAAAAAAAAOAHQEAAA=",
+    "name": "NAP ISR\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
+  raw_packet: VRcA9tcaTkFQIElTUgAAAAAAAAAAAAAAAAAOAHQEAADiPA==
+  sbp:
+    crc: '0x3ce2'
+    length: 26
+    msg_type: '0x17'
+    payload: TkFQIElTUgAAAAAAAAAAAAAAAAAOAHQEAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cpu: 1
+      name: "SBP\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+      stack_free: 5060
+    module: sbp.piksi
+    name: MsgThreadState
+  msg_type: '0x17'
+  raw_json: '{"sender": 55286, "msg_type": 23, "cpu": 1, "crc": 43354, "length": 26,
+    "stack_free": 5060, "preamble": 85, "payload": "U0JQAAAAAAAAAAAAAAAAAAAAAAABAMQTAAA=",
+    "name": "SBP\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
+  raw_packet: VRcA9tcaU0JQAAAAAAAAAAAAAAAAAAAAAAABAMQTAABaqQ==
+  sbp:
+    crc: '0xa95a'
+    length: 26
+    msg_type: '0x17'
+    payload: U0JQAAAAAAAAAAAAAAAAAAAAAAABAMQTAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      cpu: 7
+      name: "manage acq\0\0\0\0\0\0\0\0\0\0"
+      stack_free: 2324
+    module: sbp.piksi
+    name: MsgThreadState
+  msg_type: '0x17'
+  raw_json: '{"sender": 55286, "msg_type": 23, "cpu": 7, "crc": 19247, "length": 26,
+    "stack_free": 2324, "preamble": 85, "payload": "bWFuYWdlIGFjcQAAAAAAAAAAAAAHABQJAAA=",
+    "name": "manage acq\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}'
+  raw_packet: VRcA9tcabWFuYWdlIGFjcQAAAAAAAAAAAAAHABQJAAAvSw==
+  sbp:
+    crc: '0x4b2f'
+    length: 26
+    msg_type: '0x17'
+    payload: bWFuYWdlIGFjcQAAAAAAAAAAAAAHABQJAAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/piksi/test_MsgUartState.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/piksi/test_MsgUartState.yaml
@@ -1,0 +1,103 @@
+---
+description: Unit tests for swiftnav.sbp.piksi MsgUartState v0.51.
+generated_on: 2015-11-09 11:34:21.429274
+package: sbp.piksi
+tests:
+
+- msg:
+    fields:
+      latency:
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
+      uart_a:
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 24
+        tx_throughput: 0.8661972284317017
+      uart_b:
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 40
+        tx_throughput: 2.9718310832977295
+      uart_ftdi:
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 1
+        rx_throughput: 0.035211268812417984
+        tx_buffer_level: 81
+        tx_throughput: 5.063380241394043
+    module: sbp.piksi
+    name: MsgUartState
+  msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    55286, "msg_type": 24, "crc": 31815, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 40, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 2.9718310832977295}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    24, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.8661972284317017}, "preamble": 85, "payload": "Gr9dPwAAAAAAAAAAGAB7Mj5AAAAAAAAAAAAoADYHokCxORA9AAAAAFEB/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 1, "tx_buffer_level": 81, "rx_throughput": 0.035211268812417984,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 5.063380241394043}}'
+  raw_packet: VRgA9tc6Gr9dPwAAAAAAAAAAGAB7Mj5AAAAAAAAAAAAoADYHokCxORA9AAAAAFEB/////wAAAAAAAAAA/////0d8
+  sbp:
+    crc: '0x7c47'
+    length: 58
+    msg_type: '0x18'
+    payload: Gr9dPwAAAAAAAAAAGAB7Mj5AAAAAAAAAAAAoADYHokCxORA9AAAAAFEB/////wAAAAAAAAAA/////w==
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      latency:
+        avg: -1
+        current: -1
+        lmax: 0
+        lmin: 0
+      uart_a:
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 24
+        tx_throughput: 0.8746479153633118
+      uart_b:
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 0
+        rx_throughput: 0.0
+        tx_buffer_level: 40
+        tx_throughput: 2.995774745941162
+      uart_ftdi:
+        crc_error_count: 0
+        io_error_count: 0
+        rx_buffer_level: 1
+        rx_throughput: 0.35211268067359924
+        tx_buffer_level: 85
+        tx_throughput: 6.7901411056518555
+    module: sbp.piksi
+    name: MsgUartState
+  msg_type: '0x18'
+  raw_json: '{"latency": {"current": -1, "lmax": 0, "avg": -1, "lmin": 0}, "sender":
+    55286, "msg_type": 24, "crc": 63641, "length": 58, "uart_b": {"rx_buffer_level":
+    0, "tx_buffer_level": 40, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count":
+    0, "tx_throughput": 2.995774745941162}, "uart_a": {"rx_buffer_level": 0, "tx_buffer_level":
+    24, "rx_throughput": 0.0, "crc_error_count": 0, "io_error_count": 0, "tx_throughput":
+    0.8746479153633118}, "preamble": 85, "payload": "7ehfPwAAAAAAAAAAGADGuj9AAAAAAAAAAAAoANZI2UAdSLQ+AAAAAFUB/////wAAAAAAAAAA/////w==",
+    "uart_ftdi": {"rx_buffer_level": 1, "tx_buffer_level": 85, "rx_throughput": 0.35211268067359924,
+    "crc_error_count": 0, "io_error_count": 0, "tx_throughput": 6.7901411056518555}}'
+  raw_packet: VRgA9tc67ehfPwAAAAAAAAAAGADGuj9AAAAAAAAAAAAoANZI2UAdSLQ+AAAAAFUB/////wAAAAAAAAAA/////5n4
+  sbp:
+    crc: '0xf899'
+    length: 58
+    msg_type: '0x18'
+    payload: 7ehfPwAAAAAAAAAAGADGuj9AAAAAAAAAAAAoANZI2UAdSLQ+AAAAAFUB/////wAAAAAAAAAA/////w==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/settings/test_MsgSettingsReadByIndexDone.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/settings/test_MsgSettingsReadByIndexDone.yaml
@@ -1,0 +1,23 @@
+---
+description: Unit tests for swiftnav.sbp.settings MsgSettingsReadByIndexDone v0.51.
+generated_on: 2015-11-09 11:34:21.382905
+package: sbp.settings
+tests:
+
+- msg:
+    fields: null
+    module: sbp.settings
+    name: MsgSettingsReadByIndexDone
+  msg_type: '0xa6'
+  raw_json: '{"sender": 55286, "msg_type": 166, "crc": 15011, "length": 0, "preamble":
+    85, "payload": ""}'
+  raw_packet: VaYA9tcAozo=
+  sbp:
+    crc: '0x3aa3'
+    length: 0
+    msg_type: '0xa6'
+    payload: ''
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/settings/test_MsgSettingsReadByIndexResp.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/settings/test_MsgSettingsReadByIndexResp.yaml
@@ -1,0 +1,102 @@
+---
+description: Unit tests for swiftnav.sbp.settings MsgSettingsReadByIndexResp v0.51.
+generated_on: 2015-11-09 11:34:21.351510
+package: sbp.settings
+tests:
+
+- msg:
+    fields:
+      index: 0
+      setting: "telemetry_radio\0configuration_string\0AT&F,ATS1=115,ATS2=128,ATS5=0,AT&W,ATZ\0"
+    module: sbp.settings
+    name: MsgSettingsReadByIndexResp
+  msg_type: '0xa7'
+  raw_json: '{"index": 0, "sender": 55286, "msg_type": 167, "crc": 59896, "length":
+    78, "setting": "telemetry_radio\u0000configuration_string\u0000AT&F,ATS1=115,ATS2=128,ATS5=0,AT&W,ATZ\u0000",
+    "preamble": 85, "payload": "AAB0ZWxlbWV0cnlfcmFkaW8AY29uZmlndXJhdGlvbl9zdHJpbmcAQVQmRixBVFMxPTExNSxBVFMyPTEyOCxBVFM1PTAsQVQmVyxBVFoA"}'
+  raw_packet: VacA9tdOAAB0ZWxlbWV0cnlfcmFkaW8AY29uZmlndXJhdGlvbl9zdHJpbmcAQVQmRixBVFMxPTExNSxBVFMyPTEyOCxBVFM1PTAsQVQmVyxBVFoA+Ok=
+  sbp:
+    crc: '0xe9f8'
+    length: 78
+    msg_type: '0xa7'
+    payload: AAB0ZWxlbWV0cnlfcmFkaW8AY29uZmlndXJhdGlvbl9zdHJpbmcAQVQmRixBVFMxPTExNSxBVFMyPTEyOCxBVFM1PTAsQVQmVyxBVFoA
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      index: 1
+      setting: "uart_ftdi\0mode\0SBP\0enum:SBP,NMEA\0"
+    module: sbp.settings
+    name: MsgSettingsReadByIndexResp
+  msg_type: '0xa7'
+  raw_json: '{"index": 1, "sender": 55286, "msg_type": 167, "crc": 62375, "length":
+    35, "setting": "uart_ftdi\u0000mode\u0000SBP\u0000enum:SBP,NMEA\u0000", "preamble":
+    85, "payload": "AQB1YXJ0X2Z0ZGkAbW9kZQBTQlAAZW51bTpTQlAsTk1FQQA="}'
+  raw_packet: VacA9tcjAQB1YXJ0X2Z0ZGkAbW9kZQBTQlAAZW51bTpTQlAsTk1FQQCn8w==
+  sbp:
+    crc: '0xf3a7'
+    length: 35
+    msg_type: '0xa7'
+    payload: AQB1YXJ0X2Z0ZGkAbW9kZQBTQlAAZW51bTpTQlAsTk1FQQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      index: 2
+      setting: "uart_ftdi\0sbp_message_mask\065535\0"
+    module: sbp.settings
+    name: MsgSettingsReadByIndexResp
+  msg_type: '0xa7'
+  raw_json: '{"index": 2, "sender": 55286, "msg_type": 167, "crc": 14340, "length":
+    35, "setting": "uart_ftdi\u0000sbp_message_mask\u000065535\u0000", "preamble":
+    85, "payload": "AgB1YXJ0X2Z0ZGkAc2JwX21lc3NhZ2VfbWFzawA2NTUzNQA="}'
+  raw_packet: VacA9tcjAgB1YXJ0X2Z0ZGkAc2JwX21lc3NhZ2VfbWFzawA2NTUzNQAEOA==
+  sbp:
+    crc: '0x3804'
+    length: 35
+    msg_type: '0xa7'
+    payload: AgB1YXJ0X2Z0ZGkAc2JwX21lc3NhZ2VfbWFzawA2NTUzNQA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      index: 3
+      setting: "uart_ftdi\0baudrate\01000000\0"
+    module: sbp.settings
+    name: MsgSettingsReadByIndexResp
+  msg_type: '0xa7'
+  raw_json: '{"index": 3, "sender": 55286, "msg_type": 167, "crc": 37618, "length":
+    29, "setting": "uart_ftdi\u0000baudrate\u00001000000\u0000", "preamble": 85, "payload":
+    "AwB1YXJ0X2Z0ZGkAYmF1ZHJhdGUAMTAwMDAwMAA="}'
+  raw_packet: VacA9tcdAwB1YXJ0X2Z0ZGkAYmF1ZHJhdGUAMTAwMDAwMADykg==
+  sbp:
+    crc: '0x92f2'
+    length: 29
+    msg_type: '0xa7'
+    payload: AwB1YXJ0X2Z0ZGkAYmF1ZHJhdGUAMTAwMDAwMAA=
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      index: 4
+      setting: "uart_uarta\0mode\0SBP\0enum:SBP,NMEA\0"
+    module: sbp.settings
+    name: MsgSettingsReadByIndexResp
+  msg_type: '0xa7'
+  raw_json: '{"index": 4, "sender": 55286, "msg_type": 167, "crc": 1046, "length":
+    36, "setting": "uart_uarta\u0000mode\u0000SBP\u0000enum:SBP,NMEA\u0000", "preamble":
+    85, "payload": "BAB1YXJ0X3VhcnRhAG1vZGUAU0JQAGVudW06U0JQLE5NRUEA"}'
+  raw_packet: VacA9tckBAB1YXJ0X3VhcnRhAG1vZGUAU0JQAGVudW06U0JQLE5NRUEAFgQ=
+  sbp:
+    crc: '0x416'
+    length: 36
+    msg_type: '0xa7'
+    payload: BAB1YXJ0X3VhcnRhAG1vZGUAU0JQAGVudW06U0JQLE5NRUEA
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/system/test_MsgHeartbeat.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/system/test_MsgHeartbeat.yaml
@@ -1,0 +1,24 @@
+---
+description: Unit tests for swiftnav.sbp.system MsgHeartbeat v0.51.
+generated_on: 2015-11-09 11:34:21.298571
+package: sbp.system
+tests:
+
+- msg:
+    fields:
+      flags: 12800
+    module: sbp.system
+    name: MsgHeartbeat
+  msg_type: '0xffff'
+  raw_json: '{"sender": 55286, "msg_type": 65535, "crc": 55545, "length": 4, "flags":
+    12800, "preamble": 85, "payload": "ADIAAA=="}'
+  raw_packet: Vf//9tcEADIAAPnY
+  sbp:
+    crc: '0xd8f9'
+    length: 4
+    msg_type: '0xffff'
+    payload: ADIAAA==
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...

--- a/spec/tests/yaml/swiftnav/sbp/tracking/test_MsgTrackingState.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/tracking/test_MsgTrackingState.yaml
@@ -1,0 +1,291 @@
+---
+description: Unit tests for swiftnav.sbp.tracking MsgTrackingState v0.51.
+generated_on: 2015-11-09 11:34:21.401841
+package: sbp.tracking
+tests:
+
+- msg:
+    fields:
+      states:
+      - cn0: 39.24782180786133
+        sid: 202
+        state: 1
+      - cn0: 36.09756088256836
+        sid: 203
+        state: 1
+      - cn0: 37.62678527832031
+        sid: 208
+        state: 1
+      - cn0: 39.020729064941406
+        sid: 212
+        state: 1
+      - cn0: 42.03290557861328
+        sid: 217
+        state: 1
+      - cn0: 37.43546676635742
+        sid: 218
+        state: 1
+      - cn0: 38.4229621887207
+        sid: 220
+        state: 1
+      - cn0: 38.91520309448242
+        sid: 222
+        state: 1
+      - cn0: 42.62259292602539
+        sid: 225
+        state: 1
+      - cn0: -1.0
+        sid: 0
+        state: 0
+      - cn0: -1.0
+        sid: 0
+        state: 0
+    module: sbp.tracking
+    name: MsgTrackingState
+  msg_type: '0x13'
+  raw_json: '{"sender": 55286, "msg_type": 19, "states": [{"state": 1, "cn0": 39.24782180786133,
+    "sid": 202}, {"state": 1, "cn0": 36.09756088256836, "sid": 203}, {"state": 1,
+    "cn0": 37.62678527832031, "sid": 208}, {"state": 1, "cn0": 39.020729064941406,
+    "sid": 212}, {"state": 1, "cn0": 42.03290557861328, "sid": 217}, {"state": 1,
+    "cn0": 37.43546676635742, "sid": 218}, {"state": 1, "cn0": 38.4229621887207, "sid":
+    220}, {"state": 1, "cn0": 38.91520309448242, "sid": 222}, {"state": 1, "cn0":
+    42.62259292602539, "sid": 225}, {"state": 0, "cn0": -1.0, "sid": 0}, {"state":
+    0, "cn0": -1.0, "sid": 0}], "crc": 25054, "length": 99, "preamble": 85, "payload":
+    "AcoAAADF/RxCAcsAAADnYxBCAdAAAADUgRZCAdQAAAA6FRxCAdkAAACyIShCAdoAAADrvRVCAdwAAAAdsRlCAd4AAAArqRtCAeEAAACJfSpCAAAAAAAAAIC/AAAAAAAAAIC/"}'
+  raw_packet: VRMA9tdjAcoAAADF/RxCAcsAAADnYxBCAdAAAADUgRZCAdQAAAA6FRxCAdkAAACyIShCAdoAAADrvRVCAdwAAAAdsRlCAd4AAAArqRtCAeEAAACJfSpCAAAAAAAAAIC/AAAAAAAAAIC/3mE=
+  sbp:
+    crc: '0x61de'
+    length: 99
+    msg_type: '0x13'
+    payload: AcoAAADF/RxCAcsAAADnYxBCAdAAAADUgRZCAdQAAAA6FRxCAdkAAACyIShCAdoAAADrvRVCAdwAAAAdsRlCAd4AAAArqRtCAeEAAACJfSpCAAAAAAAAAIC/AAAAAAAAAIC/
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      states:
+      - cn0: 38.994117736816406
+        sid: 202
+        state: 1
+      - cn0: 34.889801025390625
+        sid: 203
+        state: 1
+      - cn0: 37.44603729248047
+        sid: 208
+        state: 1
+      - cn0: 38.72849655151367
+        sid: 212
+        state: 1
+      - cn0: 41.983219146728516
+        sid: 217
+        state: 1
+      - cn0: 37.46448516845703
+        sid: 218
+        state: 1
+      - cn0: 38.44300079345703
+        sid: 220
+        state: 1
+      - cn0: 39.03423309326172
+        sid: 222
+        state: 1
+      - cn0: 42.89944839477539
+        sid: 225
+        state: 1
+      - cn0: -1.0
+        sid: 0
+        state: 0
+      - cn0: -1.0
+        sid: 0
+        state: 0
+    module: sbp.tracking
+    name: MsgTrackingState
+  msg_type: '0x13'
+  raw_json: '{"sender": 55286, "msg_type": 19, "states": [{"state": 1, "cn0": 38.994117736816406,
+    "sid": 202}, {"state": 1, "cn0": 34.889801025390625, "sid": 203}, {"state": 1,
+    "cn0": 37.44603729248047, "sid": 208}, {"state": 1, "cn0": 38.72849655151367,
+    "sid": 212}, {"state": 1, "cn0": 41.983219146728516, "sid": 217}, {"state": 1,
+    "cn0": 37.46448516845703, "sid": 218}, {"state": 1, "cn0": 38.44300079345703,
+    "sid": 220}, {"state": 1, "cn0": 39.03423309326172, "sid": 222}, {"state": 1,
+    "cn0": 42.89944839477539, "sid": 225}, {"state": 0, "cn0": -1.0, "sid": 0}, {"state":
+    0, "cn0": -1.0, "sid": 0}], "crc": 7956, "length": 99, "preamble": 85, "payload":
+    "AcoAAAD6+RtCAcsAAAAojwtCAdAAAAC+yBVCAdQAAAD76RpCAdkAAADR7idCAdoAAACi2xVCAdwAAACixRlCAd4AAAAOIxxCAeEAAAAJmStCAAAAAAAAAIC/AAAAAAAAAIC/"}'
+  raw_packet: VRMA9tdjAcoAAAD6+RtCAcsAAAAojwtCAdAAAAC+yBVCAdQAAAD76RpCAdkAAADR7idCAdoAAACi2xVCAdwAAACixRlCAd4AAAAOIxxCAeEAAAAJmStCAAAAAAAAAIC/AAAAAAAAAIC/FB8=
+  sbp:
+    crc: '0x1f14'
+    length: 99
+    msg_type: '0x13'
+    payload: AcoAAAD6+RtCAcsAAAAojwtCAdAAAAC+yBVCAdQAAAD76RpCAdkAAADR7idCAdoAAACi2xVCAdwAAACixRlCAd4AAAAOIxxCAeEAAAAJmStCAAAAAAAAAIC/AAAAAAAAAIC/
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      states:
+      - cn0: 38.95457077026367
+        sid: 202
+        state: 1
+      - cn0: 35.813316345214844
+        sid: 203
+        state: 1
+      - cn0: 37.553924560546875
+        sid: 208
+        state: 1
+      - cn0: 38.88901901245117
+        sid: 212
+        state: 1
+      - cn0: 42.4013557434082
+        sid: 217
+        state: 1
+      - cn0: 37.63916015625
+        sid: 218
+        state: 1
+      - cn0: 37.919986724853516
+        sid: 220
+        state: 1
+      - cn0: 39.25254440307617
+        sid: 222
+        state: 1
+      - cn0: 42.59827423095703
+        sid: 225
+        state: 1
+      - cn0: -1.0
+        sid: 0
+        state: 0
+      - cn0: -1.0
+        sid: 0
+        state: 0
+    module: sbp.tracking
+    name: MsgTrackingState
+  msg_type: '0x13'
+  raw_json: '{"sender": 55286, "msg_type": 19, "states": [{"state": 1, "cn0": 38.95457077026367,
+    "sid": 202}, {"state": 1, "cn0": 35.813316345214844, "sid": 203}, {"state": 1,
+    "cn0": 37.553924560546875, "sid": 208}, {"state": 1, "cn0": 38.88901901245117,
+    "sid": 212}, {"state": 1, "cn0": 42.4013557434082, "sid": 217}, {"state": 1, "cn0":
+    37.63916015625, "sid": 218}, {"state": 1, "cn0": 37.919986724853516, "sid": 220},
+    {"state": 1, "cn0": 39.25254440307617, "sid": 222}, {"state": 1, "cn0": 42.59827423095703,
+    "sid": 225}, {"state": 0, "cn0": -1.0, "sid": 0}, {"state": 0, "cn0": -1.0, "sid":
+    0}], "crc": 18409, "length": 99, "preamble": 85, "payload": "AcoAAAB70RtCAcsAAADWQA9CAdAAAAA4NxZCAdQAAABbjhtCAdkAAAD9milCAdoAAACAjhZCAdwAAAARrhdCAd4AAACbAh1CAeEAAACiZCpCAAAAAAAAAIC/AAAAAAAAAIC/"}'
+  raw_packet: VRMA9tdjAcoAAAB70RtCAcsAAADWQA9CAdAAAAA4NxZCAdQAAABbjhtCAdkAAAD9milCAdoAAACAjhZCAdwAAAARrhdCAd4AAACbAh1CAeEAAACiZCpCAAAAAAAAAIC/AAAAAAAAAIC/6Uc=
+  sbp:
+    crc: '0x47e9'
+    length: 99
+    msg_type: '0x13'
+    payload: AcoAAAB70RtCAcsAAADWQA9CAdAAAAA4NxZCAdQAAABbjhtCAdkAAAD9milCAdoAAACAjhZCAdwAAAARrhdCAd4AAACbAh1CAeEAAACiZCpCAAAAAAAAAIC/AAAAAAAAAIC/
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      states:
+      - cn0: 39.369598388671875
+        sid: 202
+        state: 1
+      - cn0: 36.52173614501953
+        sid: 203
+        state: 1
+      - cn0: 38.15976333618164
+        sid: 208
+        state: 1
+      - cn0: 39.19989776611328
+        sid: 212
+        state: 1
+      - cn0: 41.55845642089844
+        sid: 217
+        state: 1
+      - cn0: 37.026981353759766
+        sid: 218
+        state: 1
+      - cn0: 38.1049690246582
+        sid: 220
+        state: 1
+      - cn0: 39.04584503173828
+        sid: 222
+        state: 1
+      - cn0: 42.37783432006836
+        sid: 225
+        state: 1
+      - cn0: -1.0
+        sid: 0
+        state: 0
+      - cn0: -1.0
+        sid: 0
+        state: 0
+    module: sbp.tracking
+    name: MsgTrackingState
+  msg_type: '0x13'
+  raw_json: '{"sender": 55286, "msg_type": 19, "states": [{"state": 1, "cn0": 39.369598388671875,
+    "sid": 202}, {"state": 1, "cn0": 36.52173614501953, "sid": 203}, {"state": 1,
+    "cn0": 38.15976333618164, "sid": 208}, {"state": 1, "cn0": 39.19989776611328,
+    "sid": 212}, {"state": 1, "cn0": 41.55845642089844, "sid": 217}, {"state": 1,
+    "cn0": 37.026981353759766, "sid": 218}, {"state": 1, "cn0": 38.1049690246582,
+    "sid": 220}, {"state": 1, "cn0": 39.04584503173828, "sid": 222}, {"state": 1,
+    "cn0": 42.37783432006836, "sid": 225}, {"state": 0, "cn0": -1.0, "sid": 0}, {"state":
+    0, "cn0": -1.0, "sid": 0}], "crc": 49481, "length": 99, "preamble": 85, "payload":
+    "AcoAAAB4eh1CAcsAAABCFhJCAdAAAACZoxhCAdQAAACyzBxCAdkAAADcOyZCAdoAAAChGxRCAdwAAAB9axhCAd4AAADyLhxCAeEAAADngilCAAAAAAAAAIC/AAAAAAAAAIC/"}'
+  raw_packet: VRMA9tdjAcoAAAB4eh1CAcsAAABCFhJCAdAAAACZoxhCAdQAAACyzBxCAdkAAADcOyZCAdoAAAChGxRCAdwAAAB9axhCAd4AAADyLhxCAeEAAADngilCAAAAAAAAAIC/AAAAAAAAAIC/ScE=
+  sbp:
+    crc: '0xc149'
+    length: 99
+    msg_type: '0x13'
+    payload: AcoAAAB4eh1CAcsAAABCFhJCAdAAAACZoxhCAdQAAACyzBxCAdkAAADcOyZCAdoAAAChGxRCAdwAAAB9axhCAd4AAADyLhxCAeEAAADngilCAAAAAAAAAIC/AAAAAAAAAIC/
+    preamble: '0x55'
+    sender: '0xd7f6'
+
+- msg:
+    fields:
+      states:
+      - cn0: 39.70351791381836
+        sid: 202
+        state: 1
+      - cn0: 36.52388381958008
+        sid: 203
+        state: 1
+      - cn0: 37.169708251953125
+        sid: 208
+        state: 1
+      - cn0: 38.81692886352539
+        sid: 212
+        state: 1
+      - cn0: 42.05073165893555
+        sid: 217
+        state: 1
+      - cn0: 37.807498931884766
+        sid: 218
+        state: 1
+      - cn0: 37.71632385253906
+        sid: 220
+        state: 1
+      - cn0: 38.5289192199707
+        sid: 222
+        state: 1
+      - cn0: 42.27101516723633
+        sid: 225
+        state: 1
+      - cn0: -1.0
+        sid: 0
+        state: 0
+      - cn0: -1.0
+        sid: 0
+        state: 0
+    module: sbp.tracking
+    name: MsgTrackingState
+  msg_type: '0x13'
+  raw_json: '{"sender": 55286, "msg_type": 19, "states": [{"state": 1, "cn0": 39.70351791381836,
+    "sid": 202}, {"state": 1, "cn0": 36.52388381958008, "sid": 203}, {"state": 1,
+    "cn0": 37.169708251953125, "sid": 208}, {"state": 1, "cn0": 38.81692886352539,
+    "sid": 212}, {"state": 1, "cn0": 42.05073165893555, "sid": 217}, {"state": 1,
+    "cn0": 37.807498931884766, "sid": 218}, {"state": 1, "cn0": 37.71632385253906,
+    "sid": 220}, {"state": 1, "cn0": 38.5289192199707, "sid": 222}, {"state": 1, "cn0":
+    42.27101516723633, "sid": 225}, {"state": 0, "cn0": -1.0, "sid": 0}, {"state":
+    0, "cn0": -1.0, "sid": 0}], "crc": 12158, "length": 99, "preamble": 85, "payload":
+    "AcoAAABn0B5CAcsAAAB1GBJCAdAAAADIrRRCAdQAAACJRBtCAdkAAADzMyhCAdoAAADhOhdCAdwAAACE3RZCAd4AAACdHRpCAeEAAACFFSlCAAAAAAAAAIC/AAAAAAAAAIC/"}'
+  raw_packet: VRMA9tdjAcoAAABn0B5CAcsAAAB1GBJCAdAAAADIrRRCAdQAAACJRBtCAdkAAADzMyhCAdoAAADhOhdCAdwAAACE3RZCAd4AAACdHRpCAeEAAACFFSlCAAAAAAAAAIC/AAAAAAAAAIC/fi8=
+  sbp:
+    crc: '0x2f7e'
+    length: 99
+    msg_type: '0x13'
+    payload: AcoAAABn0B5CAcsAAAB1GBJCAdAAAADIrRRCAdQAAACJRBtCAdkAAADzMyhCAdoAAADhOhdCAdwAAACE3RZCAd4AAACdHRpCAeEAAACFFSlCAAAAAAAAAIC/AAAAAAAAAIC/
+    preamble: '0x55'
+    sender: '0xd7f6'
+version: '0.51'
+...


### PR DESCRIPTION
Generate a test YAML file for each message separately (instead of grouping by package). 
Store files in subdirs named by package, e.g. acquisition/test_MsgAcqResult.yaml. 
Add test data for many current message types.

Separating by message type makes it much easier to add test cases for new message types without modifying existing tests.