### PR TITLE
`require` dependencies properly when there are dependencies between SBP parsers in different packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ javascript:
                        -r $(SBP_MAJOR_VERSION).$(SBP_MINOR_VERSION) \
 		       --javascript;\
 	cd $(SWIFTNAV_ROOT);
-	- npm version "v$(SBP_MAJOR_VERSION).$(SBP_MINOR_VERSION).$(SBP_PATCH_VERSION)" --no-git-tag-version
+	@echo "Bumping NPM version. You can ignore the following error, if any."
+	@- npm version "v$(SBP_MAJOR_VERSION).$(SBP_MINOR_VERSION).$(SBP_PATCH_VERSION)" --no-git-tag-version >/dev/null 2>&1
 	@echo
 	@echo "Finished! Please check $(SWIFTNAV_ROOT)/javascript/sbp."
 

--- a/generator/sbpg/targets/javascript.py
+++ b/generator/sbpg/targets/javascript.py
@@ -171,8 +171,9 @@ def render_source(output_dir, package_spec, jenv=JENV):
   destination_filename = "%s/%s.js" % (directory, name)
   py_template = jenv.get_template(TEMPLATE_NAME)
   module_path = ".".join(package_spec.identifier.split(".")[1:-1])
+  includeMap = {'signal':'SBPSignal'}
   includes = [".".join(i.split(".")[:-1]) for i in package_spec.includes]
-  includes = [i for i in includes if i != "types"]
+  includes = [(i, includeMap.get(i)) for i in includes if i != "types"]
   with open(destination_filename, 'w') as f:
     f.write(py_template.render(msgs=package_spec.definitions,
                                filepath="/".join(package_spec.filepath) + ".yaml",

--- a/generator/sbpg/targets/resources/sbp_js.js.j2
+++ b/generator/sbpg/targets/resources/sbp_js.js.j2
@@ -20,8 +20,8 @@
 
 var SBP = require('./sbp');
 var Parser = require('binary-parser').Parser;
-((*- for i in include *))
-//var dep = require("(((module_path))).(((i)))");
+((*- for (file, ident) in include *))
+var (((ident))) = require("./(((file)))").(((ident)));
 ((*- endfor *))
 
 ((*- for m in msgs *))
@@ -72,6 +72,8 @@ module.exports = {
 ((*- for m in msgs *))
   ((*- if m.sbp_id *))
   ((('0x%04X'|format(m.sbp_id)))): ((( m.identifier | js_classnameify ))),
+  ((*- else *))
+  ((( m.identifier | js_classnameify ))): ((( m.identifier | js_classnameify ))),
   ((*- endif*))
 ((*- endfor *))
 }

--- a/javascript/sbp/msg.js
+++ b/javascript/sbp/msg.js
@@ -198,7 +198,10 @@ module.exports = {
       stream.pause();
       try {
         streamBuffer = Buffer.concat([streamBuffer, data]);
-        callback(null, getFramedMessage());
+        if (streamBuffer.length < 2) {
+          return;
+        }
+        var framedMessage = getFramedMessage();
 
         // If there is data left to process after a successful parse, process again
         if (streamBuffer.length > 0) {
@@ -206,6 +209,8 @@ module.exports = {
             processData(new Buffer(0));
           }, 0);
         }
+
+        callback(null, framedMessage);
       } catch (e) {
         // If the buffer was corrupt but there's more in the stream, try again immediately
         if (e instanceof BufferCorruptError && streamBuffer.length > 0) {

--- a/javascript/sbp/msg.js
+++ b/javascript/sbp/msg.js
@@ -84,7 +84,13 @@ var packages = ["acquisition", "bootload", "ext_events", "file_io", "flash", "lo
 var sbpTable = packages.map(function (pkg) {
   return require(path.resolve(__dirname, "./" + pkg + ".js"));
 }).reduce(function (prev, curr) {
-  return mergeDict(prev, curr);
+  var numericKeysDict = {};
+  Object.keys(curr).map(function (key) {
+    if (parseInt(key) == key) {
+      numericKeysDict[key] = curr[key];
+    }
+  });
+  return mergeDict(prev, numericKeysDict);
 }, {});
 
 var parser = new Parser()

--- a/javascript/sbp/observation.js
+++ b/javascript/sbp/observation.js
@@ -596,10 +596,15 @@ MsgObsDepA.prototype.fieldSpec.push(['header', ObservationHeader.prototype.field
 MsgObsDepA.prototype.fieldSpec.push(['obs', 'array', PackedObsContentDepA.prototype.fieldSpec, function () { return this.fields.array.length; }]);
 
 module.exports = {
+  ObsGPSTime: ObsGPSTime,
+  CarrierPhase: CarrierPhase,
+  ObservationHeader: ObservationHeader,
+  PackedObsContent: PackedObsContent,
   0x0043: MsgObs,
   0x0044: MsgBasePos,
   0x0047: MsgEphemeris,
   0x001A: MsgEphemerisDepA,
   0x0046: MsgEphemerisDepB,
+  PackedObsContentDepA: PackedObsContentDepA,
   0x0045: MsgObsDepA,
 }

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -393,6 +393,8 @@ module.exports = {
   0x0022: MsgResetFilters,
   0x0023: MsgInitBase,
   0x0017: MsgThreadState,
+  UARTChannel: UARTChannel,
+  Latency: Latency,
   0x0018: MsgUartState,
   0x0019: MsgIarState,
   0x001B: MsgMaskSatellite,

--- a/javascript/sbp/signal.js
+++ b/javascript/sbp/signal.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Joshua Gross <josh@swift-nav.com>
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**********************
+ * Automatically generated from piksi/yaml/swiftnav/sbp/signal.yaml with generate.py.
+ * Don't edit this by hand!
+ **********************
+ * Package description:
+ *
+ * Struct to represent the signal (constellation, band, satellite identifier).
+***********************/
+
+var SBP = require('./sbp');
+var Parser = require('binary-parser').Parser;
+
+/**
+ * SBP class for message fragment SBPSignal
+ *
+ * Signal identifier containing constellation, band, and satellite identifier
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field sat number (unsigned 16-bit int, 2 bytes) Constellation-specific satellite identifier
+ * @field band number (unsigned 8-bit int, 1 byte) Signal band
+ * @field constellation number (unsigned 8-bit int, 1 byte) Constellation to which the satellite belongs
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var SBPSignal = function (sbp) {
+  SBP.call(this, sbp);
+  this.messageType = "SBPSignal";
+  this.fields = this.parser.parse(sbp.payload);
+
+  return this;
+};
+SBPSignal.prototype = Object.create(SBP.prototype);
+SBPSignal.prototype.constructor = SBPSignal;
+SBPSignal.prototype.parser = new Parser()
+  .endianess('little')
+  .uint16('sat')
+  .uint8('band')
+  .uint8('constellation');
+SBPSignal.prototype.fieldSpec = [];
+SBPSignal.prototype.fieldSpec.push(['sat', 'writeUInt16LE', 2]);
+SBPSignal.prototype.fieldSpec.push(['band', 'writeUInt8', 1]);
+SBPSignal.prototype.fieldSpec.push(['constellation', 'writeUInt8', 1]);
+
+module.exports = {
+  SBPSignal: SBPSignal,
+}

--- a/javascript/sbp/tracking.js
+++ b/javascript/sbp/tracking.js
@@ -197,7 +197,10 @@ MsgTrackingStateDepA.prototype.fieldSpec = [];
 MsgTrackingStateDepA.prototype.fieldSpec.push(['states', 'array', TrackingChannelStateDepA.prototype.fieldSpec, function () { return this.fields.array.length; }]);
 
 module.exports = {
+  TrackingChannelState: TrackingChannelState,
   0x0013: MsgTrackingState,
+  TrackingChannelCorrelation: TrackingChannelCorrelation,
   0x001C: MsgTrackingIq,
+  TrackingChannelStateDepA: TrackingChannelStateDepA,
   0x0016: MsgTrackingStateDepA,
 }

--- a/python/README.rst
+++ b/python/README.rst
@@ -48,6 +48,10 @@ To run the tests and check for coverage::
 
   $  py.test -v --cov sbp tests/
 
+To run the tests without suppressing stdout output:
+
+  $  py.test -v -s --cov sbp tests/
+
 License
 -------
 


### PR DESCRIPTION
1. Increase buffer size for bad preamble tests. 2. `require` dependencies properly