### PR TITLE
fix directory path in build instructions in c/README.md

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -18,11 +18,10 @@ sudo apt-get install build-essential pkg-config cmake
 On other systems, you can obtain CMake from your operating system
 package manager or from http://www.cmake.org/.
 
-Once you have the dependencies installed,
+Once you have the dependencies installed, from this (the libsbp/c directory)
 create a build directory where the library will be built:
 
 ```shell
-cd libsbp/c
 mkdir build
 cd build
 ```

--- a/c/README.md
+++ b/c/README.md
@@ -18,10 +18,11 @@ sudo apt-get install build-essential pkg-config cmake
 On other systems, you can obtain CMake from your operating system
 package manager or from http://www.cmake.org/.
 
-Once you have the dependencies installed, From the libsbp root
-directory, create a build directory where the library will be built:
+Once you have the dependencies installed,
+create a build directory where the library will be built:
 
 ```shell
+cd libsbp/c
 mkdir build
 cd build
 ```


### PR DESCRIPTION
The instructions currently say to make the build subdirectory in the libsbp root directory. This is incorrect - it should be made in the c subdirectory.