### PR TITLE
Add a write interface to the HTTP file-like handle.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,6 +6,7 @@ flake8==2.3.0
 httpretty
 requests>=2.8.1
 futures==2.2.0
+requests-futures>=0.9.5
 pep8==1.5.7
 pyftdi==0.6.3
 pylibftdi==0.14.2

--- a/python/sbp/client/forwarder.py
+++ b/python/sbp/client/forwarder.py
@@ -48,4 +48,3 @@ class Forwarder(Thread):
       self._source.breakiter()
     except:
       pass
-

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -269,4 +269,3 @@ class Handler(object):
        if self._broken and m is None:
          raise StopIteration
        return m
-


### PR DESCRIPTION
Add a write interface and refresh to the HTTP file-like handle.
Refactors the HTTP handle to work more like a session client that can
create a write/read stream on-demand. Main object keeps a threadpool
executor for PUTs so that streaming network connections don't hang up
the calling thread.

/cc @mfine @JoshuaGross