### PR TITLE
pyserial: Show actual error when open fails.

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -42,9 +42,11 @@ class PySerialDriver(BaseDriver):
       handle.baudrate = baud
       handle.timeout = 1
       super(PySerialDriver, self).__init__(handle)
-    except (OSError, serial.SerialException):
+    except (OSError, serial.SerialException) as e:
       print
-      print "Serial device '%s' not found" % port
+      print "Error opening serial device '%s':" % port
+      print e
+      print
       print "The following serial devices were detected:"
       print
       for (name, desc, _) in serial.tools.list_ports.comports():


### PR DESCRIPTION
Fixes swift-nav/piksi_tools#241.

```
gareth@lmde:~/Projects/piksi_tools/piksi_tools/console$ ./console.py -p /dev/ttyUSB0

Error opening serial device '/dev/ttyUSB0':
[Errno 13] Permission denied: '/dev/ttyUSB0'

The following serial devices were detected:

	/dev/ttyUSB0 (FTDI Single RS232-HS )
	/dev/ttyACM1 (Black Magic UART Port)
	/dev/ttyACM0 (Black Magic GDB Server)
```

/cc @ljbade 