### PR TITLE
Add fullBuffer to dispatch callback arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "binary-parser": "git://github.com/JoshuaGross/binary-parser.git#jgross-greedy-string",
     "js-yaml": "^3.4.3"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5"
   }
 }


### PR DESCRIPTION
If you want to forward SBP messages to another destination it's useful to
have both the parsed and raw versions on hand.  This change passes the
raw Buffer to the user callback after the parsed one.