### PR TITLE
SBP C: Introduce "global" callback that will handle all message types

### DIFF
--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -36,6 +36,9 @@
 /** Default sender ID. Intended for messages sent from the host to the device. */
 #define SBP_SENDER_ID 0x42
 
+/** Fake message id that indicates a handler should be invoked for every message type. */
+#define SBP_GLOBAL_CALLBACK 0x00
+
 /** SBP callback function prototype definition. */
 typedef void (*sbp_msg_callback_t)(u16 sender_id, u8 len, u8 msg[], void *context);
 

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -231,7 +231,7 @@ sbp_msg_callbacks_node_t* sbp_find_callback(sbp_state_t *s, u16 msg_type)
    */
   sbp_msg_callbacks_node_t *p = s->sbp_msg_callbacks_head;
   do
-    if (p->msg_type == msg_type)
+    if (p->msg_type == msg_type || p->msg_type == SBP_GLOBAL_CALLBACK)
       return p;
 
   while ((p = p->next));

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -151,7 +151,7 @@
  * Register a callback that is called when a message
  * with type msg_type is received.
  *
- * To handle all message types, pass SBP_GLOBAL_CALLBACK as msg_type.
+ * To handle all message types, pass `SBP_GLOBAL_CALLBACK` (0x00) as msg_type.
  * NOTE: This should be the first and only callback you register. Behavior
  * with multiple callbacks registered along with the global callback will
  * be considered "undefined."

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -151,6 +151,11 @@
  * Register a callback that is called when a message
  * with type msg_type is received.
  *
+ * To handle all message types, pass SBP_GLOBAL_CALLBACK as msg_type.
+ * NOTE: This should be the first and only callback you register. Behavior
+ * with multiple callbacks registered along with the global callback will
+ * be considered "undefined."
+ *
  * \param msg_type Message type associated with callback
  * \param cb       Pointer to message callback function
  * \param context  Pointer to context for callback function


### PR DESCRIPTION
Sometimes you just want to handle all message types and you don't want to
to give libsbp a giant whitelist. This review introduces a "global"
callback type: simply pass SBP_GLOBAL_CALLBACK (0x00) as the msg_type in
sbp_register_callback and the callback will be invoked for all messages.

/cc @swift-nav/skylark @fnoble @gsmcmullin @jacobmcnamee 