### PR TITLE
Device monitor message: Fix VIN scaling.

### DIFF
--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -292,7 +292,7 @@ definitions:
     fields:
         - dev_vin:
             type: s16
-            units: V / 11 * 1000
+            units: V * 1000
             desc: Device V_in
         - cpu_vint:
             type: s16


### PR DESCRIPTION
Realized this is board dependent and will be taken care of somewhere else. SBP message should be just a generic voltage level applicable to any device.

/cc @JoshuaGross