### PR TITLE
Add a whitelist option to the javascript library. Can speed up dispatching substantially

### DIFF
--- a/javascript/benchmark_dispatch_whitelist.js
+++ b/javascript/benchmark_dispatch_whitelist.js
@@ -1,0 +1,46 @@
+// Benchmark how much time is saved in dispatch by ignoring some messages (in this case half)
+var Benchmark = require('benchmark');
+var stream = require('stream');
+var path = require('path');
+
+var dispatch = require(path.resolve(__dirname, './sbp/')).dispatch;
+var MsgPosLlh = require(path.resolve(__dirname, './sbp/navigation')).MsgPosLlh;
+
+var suite = new Benchmark.Suite();
+var Readable = stream.Readable;
+
+var msgLlhPayload = new Buffer('VQEC9tciFC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAOyL', 'base64');
+var msgVelEcefPayload = new Buffer('VQQC9tcUFC4nANoLAACG9f//o/z//wAACQBQ7A==', 'base64');
+
+function runDispatch (whitelist, deferred) {
+  var rs = new Readable();
+  rs.push(msgVelEcefPayload);
+  rs.push(msgLlhPayload);
+  rs.push(null);
+
+  var callbacks = 0;
+  dispatch(rs, whitelist, function (err, framedMessage) {
+    callbacks++;
+    if (whitelist && callbacks === 1) {
+      deferred.resolve();
+    } else if (!whitelist && callbacks === 2) {
+      deferred.resolve();
+    }
+  });
+}
+
+suite.add('dispatch without whitelist', {
+  defer: true,
+  fn: function (deferred) {
+    runDispatch(undefined, deferred);
+  }
+}).add('dispatch with whitelist', {
+  defer: true,
+  fn: function (deferred) {
+    runDispatch([MsgPosLlh.prototype.msg_type], deferred);
+  }
+}).on('cycle', function (event) {
+  console.log(String(event.target));
+}).on('complete', function () {
+  console.log('Fastest is ' + this.filter('fastest').map('name'));
+}).run({ async: false });

--- a/javascript/tests/test_dispatch.js
+++ b/javascript/tests/test_dispatch.js
@@ -14,6 +14,8 @@ var path = require('path');
 var assert = require('assert');
 var Readable = require('stream').Readable;
 var dispatch = require(path.resolve(__dirname, '../sbp/')).dispatch;
+var MsgPosLlh = require(path.resolve(__dirname, '../sbp/navigation')).MsgPosLlh;
+var MsgVelEcef = require(path.resolve(__dirname, '../sbp/navigation')).MsgVelEcef;
 
 var framedMessage =                 [0x55, 0x02, 0x02, 0xcc, 0x04, 0x14, 0x70, 0x3d, 0xd0, 0x18, 0xcf, 0xef, 0xff, 0xff, 0xef, 0xe8, 0xff, 0xff, 0xf0, 0x18, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x43, 0x94];
 var corruptedMessageTooShort =      [0x55, 0x02, 0x02, 0xcc, 0x04, 0x12, 0x70, 0x3d, 0xd0, 0x18, 0xcf, 0xef, 0xff, 0xff, 0xef, 0xe8, 0xff, 0xff, 0xf0, 0x18, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x43, 0x94];
@@ -131,6 +133,100 @@ describe('dispatcher', function () {
     var callbacks = 0;
     var validMessages = 0;
     dispatch(rs, function (err, framedMessage) {
+      if (framedMessage && framedMessage.fields && framedMessage.fields.tow) {
+        validMessages++;
+      }
+      if ((++callbacks) === 1) {
+        assert.equal(validMessages, 1);
+        done();
+      }
+    });
+  });
+
+  it('should whitelist messages properly - no whitelist', function (done) {
+    var msgLlhPayload = new Buffer('VQEC9tciFC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAOyL', 'base64');
+    var msgVelEcefPayload = new Buffer('VQQC9tcUFC4nANoLAACG9f//o/z//wAACQBQ7A==', 'base64');
+
+    var rs = new Readable();
+    rs.push(msgLlhPayload);
+    rs.push(msgVelEcefPayload);
+    rs.push(null);
+
+    var callbacks = 0;
+    var validMessages = 0;
+    dispatch(rs, function (err, framedMessage) {
+      if (framedMessage && framedMessage.fields && framedMessage.fields.tow) {
+        validMessages++;
+      }
+      if ((++callbacks) === 2) {
+        assert.equal(validMessages, 2);
+        done();
+      }
+    });
+  });
+
+  it('should whitelist messages properly - array whitelist', function (done) {
+    var msgLlhPayload = new Buffer('VQEC9tciFC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAOyL', 'base64');
+    var msgVelEcefPayload = new Buffer('VQQC9tcUFC4nANoLAACG9f//o/z//wAACQBQ7A==', 'base64');
+
+    var rs = new Readable();
+    rs.push(msgVelEcefPayload);
+    rs.push(msgLlhPayload);
+    rs.push(null);
+
+    var callbacks = 0;
+    var validMessages = 0;
+    dispatch(rs, [MsgPosLlh.prototype.msg_type], function (err, framedMessage) {
+      assert.equal(framedMessage.msg_type, MsgPosLlh.prototype.msg_type);
+      if (framedMessage && framedMessage.fields && framedMessage.fields.tow) {
+        validMessages++;
+      }
+      if ((++callbacks) === 1) {
+        assert.equal(validMessages, 1);
+        done();
+      }
+    });
+  });
+
+  it('should whitelist messages properly - mask whitelist', function (done) {
+    var msgLlhPayload = new Buffer('VQEC9tciFC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAOyL', 'base64');
+    var msgVelEcefPayload = new Buffer('VQQC9tcUFC4nANoLAACG9f//o/z//wAACQBQ7A==', 'base64');
+
+    var rs = new Readable();
+    rs.push(msgVelEcefPayload);
+    rs.push(msgLlhPayload);
+    rs.push(null);
+
+    var callbacks = 0;
+    var validMessages = 0;
+    dispatch(rs, ~MsgVelEcef.prototype.msg_type, function (err, framedMessage) {
+      assert.equal(framedMessage.msg_type, MsgPosLlh.prototype.msg_type);
+      if (framedMessage && framedMessage.fields && framedMessage.fields.tow) {
+        validMessages++;
+      }
+      if ((++callbacks) === 1) {
+        assert.equal(validMessages, 1);
+        done();
+      }
+    });
+  });
+
+  it('should whitelist messages properly - function whitelist', function (done) {
+    var msgLlhPayload = new Buffer('VQEC9tciFC4nAPod4rrrtkJAE8szxBiLXsAfnaDoenNRQAAAAAAJAOyL', 'base64');
+    var msgVelEcefPayload = new Buffer('VQQC9tcUFC4nANoLAACG9f//o/z//wAACQBQ7A==', 'base64');
+
+    var rs = new Readable();
+    rs.push(msgVelEcefPayload);
+    rs.push(msgLlhPayload);
+    rs.push(null);
+
+    var callbacks = 0;
+    var validMessages = 0;
+    var whitelist = function (msgType) {
+      return msgType === MsgVelEcef.prototype.msg_type;
+    };
+    dispatch(rs, whitelist, function (err, framedMessage) {
+      assert.equal(framedMessage.msg_type, MsgVelEcef.prototype.msg_type);
       if (framedMessage && framedMessage.fields && framedMessage.fields.tow) {
         validMessages++;
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.1",
-    "microtime": "^2.1.1",
     "mocha": "^2.4.5",
     "request": "^2.74.0",
     "serialport": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "js-yaml": "^3.4.3"
   },
   "devDependencies": {
+    "benchmark": "^2.1.1",
+    "microtime": "^2.1.1",
     "mocha": "^2.4.5",
     "request": "^2.74.0",
     "serialport": "^4.0.1"


### PR DESCRIPTION
Add a whitelist option to the javascript library. Can speed up decoding/dispatching substantially if you know you want to ignore some messages. Basically if there's a whitelist and a message is filtered out, it isn't fully decoded - saving some CPU cycles. 

Was dropping >90% of position messages previously at 10hz, now dropping 0% of the position messages. YMMV depending on how aggressively you're filtering. 