### PR TITLE
Base64 encoded strings in Haskell's JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ sbp_out.*
 
 # Virtual Envs
 /*env
+*venv/
 
 RELEASE-VERSION
 

--- a/haskell/src/SwiftNav/SBP/Acquisition.hs
+++ b/haskell/src/SwiftNav/SBP/Acquisition.hs
@@ -187,9 +187,9 @@ instance Binary AcqSvProfile where
     _acqSvProfile_bin_width <- getWord16le
     _acqSvProfile_timestamp <- getWord32le
     _acqSvProfile_time_spent <- getWord32le
-    _acqSvProfile_cf_min <- liftM fromIntegral getWord32le
-    _acqSvProfile_cf_max <- liftM fromIntegral getWord32le
-    _acqSvProfile_cf <- liftM fromIntegral getWord32le
+    _acqSvProfile_cf_min <- fromIntegral <$> getWord32le
+    _acqSvProfile_cf_max <- fromIntegral <$> getWord32le
+    _acqSvProfile_cf <- fromIntegral <$> getWord32le
     _acqSvProfile_cp <- getWord32le
     return AcqSvProfile {..}
 
@@ -224,7 +224,7 @@ data MsgAcqSvProfile = MsgAcqSvProfile
 
 instance Binary MsgAcqSvProfile where
   get = do
-    _msgAcqSvProfile_acq_sv_profile <- whileM (liftM not isEmpty) get
+    _msgAcqSvProfile_acq_sv_profile <- whileM (not <$> isEmpty) get
     return MsgAcqSvProfile {..}
 
   put MsgAcqSvProfile {..} = do

--- a/haskell/src/SwiftNav/SBP/Bootload.hs
+++ b/haskell/src/SwiftNav/SBP/Bootload.hs
@@ -65,19 +65,19 @@ msgBootloaderHandshakeResp = 0x00B4
 data MsgBootloaderHandshakeResp = MsgBootloaderHandshakeResp
   { _msgBootloaderHandshakeResp_flags :: Word32
     -- ^ Bootloader flags
-  , _msgBootloaderHandshakeResp_version :: ByteString
+  , _msgBootloaderHandshakeResp_version :: Text
     -- ^ Bootloader version number
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgBootloaderHandshakeResp where
   get = do
     _msgBootloaderHandshakeResp_flags <- getWord32le
-    _msgBootloaderHandshakeResp_version <- liftM toStrict getRemainingLazyByteString
+    _msgBootloaderHandshakeResp_version <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgBootloaderHandshakeResp {..}
 
   put MsgBootloaderHandshakeResp {..} = do
     putWord32le _msgBootloaderHandshakeResp_flags
-    putByteString _msgBootloaderHandshakeResp_version
+    putByteString $ encodeUtf8 _msgBootloaderHandshakeResp_version
 
 $(deriveSBP 'msgBootloaderHandshakeResp ''MsgBootloaderHandshakeResp)
 
@@ -179,7 +179,7 @@ data MsgBootloaderHandshakeDepA = MsgBootloaderHandshakeDepA
 
 instance Binary MsgBootloaderHandshakeDepA where
   get = do
-    _msgBootloaderHandshakeDepA_handshake <- whileM (liftM not isEmpty) getWord8
+    _msgBootloaderHandshakeDepA_handshake <- whileM (not <$> isEmpty) getWord8
     return MsgBootloaderHandshakeDepA {..}
 
   put MsgBootloaderHandshakeDepA {..} = do

--- a/haskell/src/SwiftNav/SBP/ExtEvents.hs
+++ b/haskell/src/SwiftNav/SBP/ExtEvents.hs
@@ -53,7 +53,7 @@ instance Binary MsgExtEvent where
   get = do
     _msgExtEvent_wn <- getWord16le
     _msgExtEvent_tow <- getWord32le
-    _msgExtEvent_ns <- liftM fromIntegral getWord32le
+    _msgExtEvent_ns <- fromIntegral <$> getWord32le
     _msgExtEvent_flags <- getWord8
     _msgExtEvent_pin <- getWord8
     return MsgExtEvent {..}

--- a/haskell/src/SwiftNav/SBP/FileIo.hs
+++ b/haskell/src/SwiftNav/SBP/FileIo.hs
@@ -51,7 +51,7 @@ data MsgFileioReadReq = MsgFileioReadReq
     -- ^ File offset
   , _msgFileioReadReq_chunk_size :: Word8
     -- ^ Chunk size to read
-  , _msgFileioReadReq_filename :: ByteString
+  , _msgFileioReadReq_filename :: Text
     -- ^ Name of the file to read from
   } deriving ( Show, Read, Eq )
 
@@ -60,14 +60,14 @@ instance Binary MsgFileioReadReq where
     _msgFileioReadReq_sequence <- getWord32le
     _msgFileioReadReq_offset <- getWord32le
     _msgFileioReadReq_chunk_size <- getWord8
-    _msgFileioReadReq_filename <- liftM toStrict getRemainingLazyByteString
+    _msgFileioReadReq_filename <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgFileioReadReq {..}
 
   put MsgFileioReadReq {..} = do
     putWord32le _msgFileioReadReq_sequence
     putWord32le _msgFileioReadReq_offset
     putWord8 _msgFileioReadReq_chunk_size
-    putByteString _msgFileioReadReq_filename
+    putByteString $ encodeUtf8 _msgFileioReadReq_filename
 
 $(deriveSBP 'msgFileioReadReq ''MsgFileioReadReq)
 
@@ -94,7 +94,7 @@ data MsgFileioReadResp = MsgFileioReadResp
 instance Binary MsgFileioReadResp where
   get = do
     _msgFileioReadResp_sequence <- getWord32le
-    _msgFileioReadResp_contents <- whileM (liftM not isEmpty) getWord8
+    _msgFileioReadResp_contents <- whileM (not <$> isEmpty) getWord8
     return MsgFileioReadResp {..}
 
   put MsgFileioReadResp {..} = do
@@ -125,7 +125,7 @@ data MsgFileioReadDirReq = MsgFileioReadDirReq
     -- ^ Read sequence number
   , _msgFileioReadDirReq_offset :: Word32
     -- ^ The offset to skip the first n elements of the file list
-  , _msgFileioReadDirReq_dirname :: ByteString
+  , _msgFileioReadDirReq_dirname :: Text
     -- ^ Name of the directory to list
   } deriving ( Show, Read, Eq )
 
@@ -133,13 +133,13 @@ instance Binary MsgFileioReadDirReq where
   get = do
     _msgFileioReadDirReq_sequence <- getWord32le
     _msgFileioReadDirReq_offset <- getWord32le
-    _msgFileioReadDirReq_dirname <- liftM toStrict getRemainingLazyByteString
+    _msgFileioReadDirReq_dirname <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgFileioReadDirReq {..}
 
   put MsgFileioReadDirReq {..} = do
     putWord32le _msgFileioReadDirReq_sequence
     putWord32le _msgFileioReadDirReq_offset
-    putByteString _msgFileioReadDirReq_dirname
+    putByteString $ encodeUtf8 _msgFileioReadDirReq_dirname
 
 $(deriveSBP 'msgFileioReadDirReq ''MsgFileioReadDirReq)
 
@@ -167,7 +167,7 @@ data MsgFileioReadDirResp = MsgFileioReadDirResp
 instance Binary MsgFileioReadDirResp where
   get = do
     _msgFileioReadDirResp_sequence <- getWord32le
-    _msgFileioReadDirResp_contents <- whileM (liftM not isEmpty) getWord8
+    _msgFileioReadDirResp_contents <- whileM (not <$> isEmpty) getWord8
     return MsgFileioReadDirResp {..}
 
   put MsgFileioReadDirResp {..} = do
@@ -190,17 +190,17 @@ msgFileioRemove = 0x00AC
 -- message". A device will only process this message when it is received from
 -- sender ID 0x42.
 data MsgFileioRemove = MsgFileioRemove
-  { _msgFileioRemove_filename :: ByteString
+  { _msgFileioRemove_filename :: Text
     -- ^ Name of the file to delete
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgFileioRemove where
   get = do
-    _msgFileioRemove_filename <- liftM toStrict getRemainingLazyByteString
+    _msgFileioRemove_filename <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgFileioRemove {..}
 
   put MsgFileioRemove {..} = do
-    putByteString _msgFileioRemove_filename
+    putByteString $ encodeUtf8 _msgFileioRemove_filename
 
 $(deriveSBP 'msgFileioRemove ''MsgFileioRemove)
 
@@ -225,7 +225,7 @@ data MsgFileioWriteReq = MsgFileioWriteReq
     -- ^ Write sequence number
   , _msgFileioWriteReq_offset :: Word32
     -- ^ Offset into the file at which to start writing in bytes
-  , _msgFileioWriteReq_filename :: ByteString
+  , _msgFileioWriteReq_filename :: Text
     -- ^ Name of the file to write to
   , _msgFileioWriteReq_data   :: [Word8]
     -- ^ Variable-length array of data to write
@@ -235,14 +235,14 @@ instance Binary MsgFileioWriteReq where
   get = do
     _msgFileioWriteReq_sequence <- getWord32le
     _msgFileioWriteReq_offset <- getWord32le
-    _msgFileioWriteReq_filename <- liftM toStrict getRemainingLazyByteString
-    _msgFileioWriteReq_data <- whileM (liftM not isEmpty) getWord8
+    _msgFileioWriteReq_filename <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
+    _msgFileioWriteReq_data <- whileM (not <$> isEmpty) getWord8
     return MsgFileioWriteReq {..}
 
   put MsgFileioWriteReq {..} = do
     putWord32le _msgFileioWriteReq_sequence
     putWord32le _msgFileioWriteReq_offset
-    putByteString _msgFileioWriteReq_filename
+    putByteString $ encodeUtf8 _msgFileioWriteReq_filename
     mapM_ putWord8 _msgFileioWriteReq_data
 
 $(deriveSBP 'msgFileioWriteReq ''MsgFileioWriteReq)

--- a/haskell/src/SwiftNav/SBP/Flash.hs
+++ b/haskell/src/SwiftNav/SBP/Flash.hs
@@ -55,7 +55,7 @@ instance Binary MsgFlashProgram where
     _msgFlashProgram_target <- getWord8
     _msgFlashProgram_addr_start <- replicateM 3 getWord8
     _msgFlashProgram_addr_len <- getWord8
-    _msgFlashProgram_data <- whileM (liftM not isEmpty) getWord8
+    _msgFlashProgram_data <- whileM (not <$> isEmpty) getWord8
     return MsgFlashProgram {..}
 
   put MsgFlashProgram {..} = do

--- a/haskell/src/SwiftNav/SBP/Gnss.hs
+++ b/haskell/src/SwiftNav/SBP/Gnss.hs
@@ -92,7 +92,7 @@ data CarrierPhase = CarrierPhase
 
 instance Binary CarrierPhase where
   get = do
-    _carrierPhase_i <- liftM fromIntegral getWord32le
+    _carrierPhase_i <- fromIntegral <$> getWord32le
     _carrierPhase_f <- getWord8
     return CarrierPhase {..}
 

--- a/haskell/src/SwiftNav/SBP/Logging.hs
+++ b/haskell/src/SwiftNav/SBP/Logging.hs
@@ -38,19 +38,19 @@ msgLog = 0x0401
 data MsgLog = MsgLog
   { _msgLog_level :: Word8
     -- ^ Logging level
-  , _msgLog_text :: ByteString
+  , _msgLog_text :: Text
     -- ^ Human-readable string
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgLog where
   get = do
     _msgLog_level <- getWord8
-    _msgLog_text <- liftM toStrict getRemainingLazyByteString
+    _msgLog_text <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgLog {..}
 
   put MsgLog {..} = do
     putWord8 _msgLog_level
-    putByteString _msgLog_text
+    putByteString $ encodeUtf8 _msgLog_text
 
 $(deriveSBP 'msgLog ''MsgLog)
 
@@ -65,17 +65,17 @@ msgTweet = 0x0012
 --
 -- All the news fit to tweet.
 data MsgTweet = MsgTweet
-  { _msgTweet_tweet :: ByteString
+  { _msgTweet_tweet :: Text
     -- ^ Human-readable string
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgTweet where
   get = do
-    _msgTweet_tweet <- getByteString 140
+    _msgTweet_tweet <- decodeUtf8 <$> getByteString 140
     return MsgTweet {..}
 
   put MsgTweet {..} = do
-    putByteString _msgTweet_tweet
+    putByteString $ encodeUtf8 _msgTweet_tweet
 
 $(deriveSBP 'msgTweet ''MsgTweet)
 
@@ -90,17 +90,17 @@ msgPrintDep = 0x0010
 --
 -- Deprecated.
 data MsgPrintDep = MsgPrintDep
-  { _msgPrintDep_text :: ByteString
+  { _msgPrintDep_text :: Text
     -- ^ Human-readable string
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgPrintDep where
   get = do
-    _msgPrintDep_text <- liftM toStrict getRemainingLazyByteString
+    _msgPrintDep_text <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgPrintDep {..}
 
   put MsgPrintDep {..} = do
-    putByteString _msgPrintDep_text
+    putByteString $ encodeUtf8 _msgPrintDep_text
 
 $(deriveSBP 'msgPrintDep ''MsgPrintDep)
 

--- a/haskell/src/SwiftNav/SBP/Navigation.hs
+++ b/haskell/src/SwiftNav/SBP/Navigation.hs
@@ -65,7 +65,7 @@ instance Binary MsgGpsTime where
   get = do
     _msgGpsTime_wn <- getWord16le
     _msgGpsTime_tow <- getWord32le
-    _msgGpsTime_ns <- liftM fromIntegral getWord32le
+    _msgGpsTime_ns <- fromIntegral <$> getWord32le
     _msgGpsTime_flags <- getWord8
     return MsgGpsTime {..}
 
@@ -270,9 +270,9 @@ data MsgBaselineEcef = MsgBaselineEcef
 instance Binary MsgBaselineEcef where
   get = do
     _msgBaselineEcef_tow <- getWord32le
-    _msgBaselineEcef_x <- liftM fromIntegral getWord32le
-    _msgBaselineEcef_y <- liftM fromIntegral getWord32le
-    _msgBaselineEcef_z <- liftM fromIntegral getWord32le
+    _msgBaselineEcef_x <- fromIntegral <$> getWord32le
+    _msgBaselineEcef_y <- fromIntegral <$> getWord32le
+    _msgBaselineEcef_z <- fromIntegral <$> getWord32le
     _msgBaselineEcef_accuracy <- getWord16le
     _msgBaselineEcef_n_sats <- getWord8
     _msgBaselineEcef_flags <- getWord8
@@ -326,9 +326,9 @@ data MsgBaselineNed = MsgBaselineNed
 instance Binary MsgBaselineNed where
   get = do
     _msgBaselineNed_tow <- getWord32le
-    _msgBaselineNed_n <- liftM fromIntegral getWord32le
-    _msgBaselineNed_e <- liftM fromIntegral getWord32le
-    _msgBaselineNed_d <- liftM fromIntegral getWord32le
+    _msgBaselineNed_n <- fromIntegral <$> getWord32le
+    _msgBaselineNed_e <- fromIntegral <$> getWord32le
+    _msgBaselineNed_d <- fromIntegral <$> getWord32le
     _msgBaselineNed_h_accuracy <- getWord16le
     _msgBaselineNed_v_accuracy <- getWord16le
     _msgBaselineNed_n_sats <- getWord8
@@ -379,9 +379,9 @@ data MsgVelEcef = MsgVelEcef
 instance Binary MsgVelEcef where
   get = do
     _msgVelEcef_tow <- getWord32le
-    _msgVelEcef_x <- liftM fromIntegral getWord32le
-    _msgVelEcef_y <- liftM fromIntegral getWord32le
-    _msgVelEcef_z <- liftM fromIntegral getWord32le
+    _msgVelEcef_x <- fromIntegral <$> getWord32le
+    _msgVelEcef_y <- fromIntegral <$> getWord32le
+    _msgVelEcef_z <- fromIntegral <$> getWord32le
     _msgVelEcef_accuracy <- getWord16le
     _msgVelEcef_n_sats <- getWord8
     _msgVelEcef_flags <- getWord8
@@ -433,9 +433,9 @@ data MsgVelNed = MsgVelNed
 instance Binary MsgVelNed where
   get = do
     _msgVelNed_tow <- getWord32le
-    _msgVelNed_n <- liftM fromIntegral getWord32le
-    _msgVelNed_e <- liftM fromIntegral getWord32le
-    _msgVelNed_d <- liftM fromIntegral getWord32le
+    _msgVelNed_n <- fromIntegral <$> getWord32le
+    _msgVelNed_e <- fromIntegral <$> getWord32le
+    _msgVelNed_d <- fromIntegral <$> getWord32le
     _msgVelNed_h_accuracy <- getWord16le
     _msgVelNed_v_accuracy <- getWord16le
     _msgVelNed_n_sats <- getWord8

--- a/haskell/src/SwiftNav/SBP/Observation.hs
+++ b/haskell/src/SwiftNav/SBP/Observation.hs
@@ -112,7 +112,7 @@ data MsgObs = MsgObs
 instance Binary MsgObs where
   get = do
     _msgObs_header <- get
-    _msgObs_obs <- whileM (liftM not isEmpty) get
+    _msgObs_obs <- whileM (not <$> isEmpty) get
     return MsgObs {..}
 
   put MsgObs {..} = do
@@ -1010,7 +1010,7 @@ data CarrierPhaseDepA = CarrierPhaseDepA
 
 instance Binary CarrierPhaseDepA where
   get = do
-    _carrierPhaseDepA_i <- liftM fromIntegral getWord32le
+    _carrierPhaseDepA_i <- fromIntegral <$> getWord32le
     _carrierPhaseDepA_f <- getWord8
     return CarrierPhaseDepA {..}
 
@@ -1112,7 +1112,7 @@ data MsgObsDepA = MsgObsDepA
 instance Binary MsgObsDepA where
   get = do
     _msgObsDepA_header <- get
-    _msgObsDepA_obs <- whileM (liftM not isEmpty) get
+    _msgObsDepA_obs <- whileM (not <$> isEmpty) get
     return MsgObsDepA {..}
 
   put MsgObsDepA {..} = do
@@ -1144,7 +1144,7 @@ data MsgObsDepB = MsgObsDepB
 instance Binary MsgObsDepB where
   get = do
     _msgObsDepB_header <- get
-    _msgObsDepB_obs <- whileM (liftM not isEmpty) get
+    _msgObsDepB_obs <- whileM (not <$> isEmpty) get
     return MsgObsDepB {..}
 
   put MsgObsDepB {..} = do
@@ -1261,9 +1261,9 @@ instance Binary MsgGroupDelay where
     _msgGroupDelay_t_op <- get
     _msgGroupDelay_prn <- getWord8
     _msgGroupDelay_valid <- getWord8
-    _msgGroupDelay_tgd <- liftM fromIntegral getWord16le
-    _msgGroupDelay_isc_l1ca <- liftM fromIntegral getWord16le
-    _msgGroupDelay_isc_l2c <- liftM fromIntegral getWord16le
+    _msgGroupDelay_tgd <- fromIntegral <$> getWord16le
+    _msgGroupDelay_isc_l1ca <- fromIntegral <$> getWord16le
+    _msgGroupDelay_isc_l2c <- fromIntegral <$> getWord16le
     return MsgGroupDelay {..}
 
   put MsgGroupDelay {..} = do

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -206,7 +206,7 @@ msgThreadState = 0x0017
 -- (RTOS) thread usage statistics for the named thread. The reported percentage
 -- values must be normalized.
 data MsgThreadState = MsgThreadState
-  { _msgThreadState_name     :: ByteString
+  { _msgThreadState_name     :: Text
     -- ^ Thread name (NULL terminated)
   , _msgThreadState_cpu      :: Word16
     -- ^ Percentage cpu use for this thread. Values range from 0 - 1000 and needs
@@ -217,13 +217,13 @@ data MsgThreadState = MsgThreadState
 
 instance Binary MsgThreadState where
   get = do
-    _msgThreadState_name <- getByteString 20
+    _msgThreadState_name <- decodeUtf8 <$> getByteString 20
     _msgThreadState_cpu <- getWord16le
     _msgThreadState_stack_free <- getWord32le
     return MsgThreadState {..}
 
   put MsgThreadState {..} = do
-    putByteString _msgThreadState_name
+    putByteString $ encodeUtf8 _msgThreadState_name
     putWord16le _msgThreadState_cpu
     putWord32le _msgThreadState_stack_free
 
@@ -293,10 +293,10 @@ data Period = Period
 
 instance Binary Period where
   get = do
-    _period_avg <- liftM fromIntegral getWord32le
-    _period_pmin <- liftM fromIntegral getWord32le
-    _period_pmax <- liftM fromIntegral getWord32le
-    _period_current <- liftM fromIntegral getWord32le
+    _period_avg <- fromIntegral <$> getWord32le
+    _period_pmin <- fromIntegral <$> getWord32le
+    _period_pmax <- fromIntegral <$> getWord32le
+    _period_current <- fromIntegral <$> getWord32le
     return Period {..}
 
   put Period {..} = do
@@ -327,10 +327,10 @@ data Latency = Latency
 
 instance Binary Latency where
   get = do
-    _latency_avg <- liftM fromIntegral getWord32le
-    _latency_lmin <- liftM fromIntegral getWord32le
-    _latency_lmax <- liftM fromIntegral getWord32le
-    _latency_current <- liftM fromIntegral getWord32le
+    _latency_avg <- fromIntegral <$> getWord32le
+    _latency_lmin <- fromIntegral <$> getWord32le
+    _latency_lmax <- fromIntegral <$> getWord32le
+    _latency_current <- fromIntegral <$> getWord32le
     return Latency {..}
 
   put Latency {..} = do
@@ -507,11 +507,11 @@ data MsgDeviceMonitor = MsgDeviceMonitor
 
 instance Binary MsgDeviceMonitor where
   get = do
-    _msgDeviceMonitor_dev_vin <- liftM fromIntegral getWord16le
-    _msgDeviceMonitor_cpu_vint <- liftM fromIntegral getWord16le
-    _msgDeviceMonitor_cpu_vaux <- liftM fromIntegral getWord16le
-    _msgDeviceMonitor_cpu_temperature <- liftM fromIntegral getWord16le
-    _msgDeviceMonitor_fe_temperature <- liftM fromIntegral getWord16le
+    _msgDeviceMonitor_dev_vin <- fromIntegral <$> getWord16le
+    _msgDeviceMonitor_cpu_vint <- fromIntegral <$> getWord16le
+    _msgDeviceMonitor_cpu_vaux <- fromIntegral <$> getWord16le
+    _msgDeviceMonitor_cpu_temperature <- fromIntegral <$> getWord16le
+    _msgDeviceMonitor_fe_temperature <- fromIntegral <$> getWord16le
     return MsgDeviceMonitor {..}
 
   put MsgDeviceMonitor {..} = do

--- a/haskell/src/SwiftNav/SBP/Settings.hs
+++ b/haskell/src/SwiftNav/SBP/Settings.hs
@@ -61,7 +61,7 @@ msgSettingsWrite = 0x00A0
 --
 -- The setting message writes the device configuration.
 data MsgSettingsWrite = MsgSettingsWrite
-  { _msgSettingsWrite_setting :: ByteString
+  { _msgSettingsWrite_setting :: Text
     -- ^ A NULL-terminated and delimited string with contents [SECTION_SETTING,
     -- SETTING, VALUE]. A device will only process to this message when it is
     -- received from sender ID 0x42.
@@ -69,11 +69,11 @@ data MsgSettingsWrite = MsgSettingsWrite
 
 instance Binary MsgSettingsWrite where
   get = do
-    _msgSettingsWrite_setting <- liftM toStrict getRemainingLazyByteString
+    _msgSettingsWrite_setting <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgSettingsWrite {..}
 
   put MsgSettingsWrite {..} = do
-    putByteString _msgSettingsWrite_setting
+    putByteString $ encodeUtf8 _msgSettingsWrite_setting
 
 $(deriveSBP 'msgSettingsWrite ''MsgSettingsWrite)
 
@@ -88,7 +88,7 @@ msgSettingsReadReq = 0x00A4
 --
 -- The setting message reads the device configuration.
 data MsgSettingsReadReq = MsgSettingsReadReq
-  { _msgSettingsReadReq_setting :: ByteString
+  { _msgSettingsReadReq_setting :: Text
     -- ^ A NULL-terminated and delimited string with contents [SECTION_SETTING,
     -- SETTING]. A device will only respond to this message when it is received
     -- from sender ID 0x42.
@@ -96,11 +96,11 @@ data MsgSettingsReadReq = MsgSettingsReadReq
 
 instance Binary MsgSettingsReadReq where
   get = do
-    _msgSettingsReadReq_setting <- liftM toStrict getRemainingLazyByteString
+    _msgSettingsReadReq_setting <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgSettingsReadReq {..}
 
   put MsgSettingsReadReq {..} = do
-    putByteString _msgSettingsReadReq_setting
+    putByteString $ encodeUtf8 _msgSettingsReadReq_setting
 
 $(deriveSBP 'msgSettingsReadReq ''MsgSettingsReadReq)
 
@@ -115,18 +115,18 @@ msgSettingsReadResp = 0x00A5
 --
 -- The setting message reads the device configuration.
 data MsgSettingsReadResp = MsgSettingsReadResp
-  { _msgSettingsReadResp_setting :: ByteString
+  { _msgSettingsReadResp_setting :: Text
     -- ^ A NULL-terminated and delimited string with contents [SECTION_SETTING,
     -- SETTING, VALUE].
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgSettingsReadResp where
   get = do
-    _msgSettingsReadResp_setting <- liftM toStrict getRemainingLazyByteString
+    _msgSettingsReadResp_setting <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgSettingsReadResp {..}
 
   put MsgSettingsReadResp {..} = do
-    putByteString _msgSettingsReadResp_setting
+    putByteString $ encodeUtf8 _msgSettingsReadResp_setting
 
 $(deriveSBP 'msgSettingsReadResp ''MsgSettingsReadResp)
 
@@ -175,7 +175,7 @@ data MsgSettingsReadByIndexResp = MsgSettingsReadByIndexResp
   { _msgSettingsReadByIndexResp_index :: Word16
     -- ^ An index into the device settings, with values ranging from 0 to
     -- length(settings)
-  , _msgSettingsReadByIndexResp_setting :: ByteString
+  , _msgSettingsReadByIndexResp_setting :: Text
     -- ^ A NULL-terminated and delimited string with contents [SECTION_SETTING,
     -- SETTING, VALUE].
   } deriving ( Show, Read, Eq )
@@ -183,12 +183,12 @@ data MsgSettingsReadByIndexResp = MsgSettingsReadByIndexResp
 instance Binary MsgSettingsReadByIndexResp where
   get = do
     _msgSettingsReadByIndexResp_index <- getWord16le
-    _msgSettingsReadByIndexResp_setting <- liftM toStrict getRemainingLazyByteString
+    _msgSettingsReadByIndexResp_setting <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgSettingsReadByIndexResp {..}
 
   put MsgSettingsReadByIndexResp {..} = do
     putWord16le _msgSettingsReadByIndexResp_index
-    putByteString _msgSettingsReadByIndexResp_setting
+    putByteString $ encodeUtf8 _msgSettingsReadByIndexResp_setting
 
 $(deriveSBP 'msgSettingsReadByIndexResp ''MsgSettingsReadByIndexResp)
 
@@ -227,18 +227,18 @@ msgSettingsRegister = 0x00AE
 -- settings daemon.  The host should reply with MSG_SETTINGS_WRITE for this
 -- setting to set the initial value.
 data MsgSettingsRegister = MsgSettingsRegister
-  { _msgSettingsRegister_setting :: ByteString
+  { _msgSettingsRegister_setting :: Text
     -- ^ A NULL-terminated and delimited string with contents [SECTION_SETTING,
     -- SETTING, VALUE].
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgSettingsRegister where
   get = do
-    _msgSettingsRegister_setting <- liftM toStrict getRemainingLazyByteString
+    _msgSettingsRegister_setting <- decodeUtf8 . toStrict <$> getRemainingLazyByteString
     return MsgSettingsRegister {..}
 
   put MsgSettingsRegister {..} = do
-    putByteString _msgSettingsRegister_setting
+    putByteString $ encodeUtf8 _msgSettingsRegister_setting
 
 $(deriveSBP 'msgSettingsRegister ''MsgSettingsRegister)
 

--- a/haskell/src/SwiftNav/SBP/Tracking.hs
+++ b/haskell/src/SwiftNav/SBP/Tracking.hs
@@ -94,7 +94,7 @@ instance Binary MsgTrackingStateDetailed where
     _msgTrackingStateDetailed_cn0 <- getWord8
     _msgTrackingStateDetailed_lock <- getWord16le
     _msgTrackingStateDetailed_sid <- get
-    _msgTrackingStateDetailed_doppler <- liftM fromIntegral getWord32le
+    _msgTrackingStateDetailed_doppler <- fromIntegral <$> getWord32le
     _msgTrackingStateDetailed_doppler_std <- getWord16le
     _msgTrackingStateDetailed_uptime <- getWord32le
     _msgTrackingStateDetailed_clock_offset <- getWord16le
@@ -181,7 +181,7 @@ data MsgTrackingState = MsgTrackingState
 
 instance Binary MsgTrackingState where
   get = do
-    _msgTrackingState_states <- whileM (liftM not isEmpty) get
+    _msgTrackingState_states <- whileM (not <$> isEmpty) get
     return MsgTrackingState {..}
 
   put MsgTrackingState {..} = do
@@ -205,8 +205,8 @@ data TrackingChannelCorrelation = TrackingChannelCorrelation
 
 instance Binary TrackingChannelCorrelation where
   get = do
-    _trackingChannelCorrelation_I <- liftM fromIntegral getWord32le
-    _trackingChannelCorrelation_Q <- liftM fromIntegral getWord32le
+    _trackingChannelCorrelation_I <- fromIntegral <$> getWord32le
+    _trackingChannelCorrelation_Q <- fromIntegral <$> getWord32le
     return TrackingChannelCorrelation {..}
 
   put TrackingChannelCorrelation {..} = do
@@ -290,7 +290,7 @@ data MsgTrackingStateDepA = MsgTrackingStateDepA
 
 instance Binary MsgTrackingStateDepA where
   get = do
-    _msgTrackingStateDepA_states <- whileM (liftM not isEmpty) get
+    _msgTrackingStateDepA_states <- whileM (not <$> isEmpty) get
     return MsgTrackingStateDepA {..}
 
   put MsgTrackingStateDepA {..} = do

--- a/haskell/src/SwiftNav/SBP/User.hs
+++ b/haskell/src/SwiftNav/SBP/User.hs
@@ -41,7 +41,7 @@ data MsgUserData = MsgUserData
 
 instance Binary MsgUserData where
   get = do
-    _msgUserData_contents <- whileM (liftM not isEmpty) getWord8
+    _msgUserData_contents <- whileM (not <$> isEmpty) getWord8
     return MsgUserData {..}
 
   put MsgUserData {..} = do

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.4
+resolver: lts-6.22
 flags: {}
 packages:
   - '.'


### PR DESCRIPTION
All of the strings in Haskell's JSON were being base64 encoded. This was because the strings used `ByteString` and picked up the base64-encoding implementation we provide for `ByteString`. This change switches strings to `Text` and avoids this issue.

/cc @mookerji 