### PR TITLE
Give Haskell code better casing for GPSTime

### DIFF
--- a/generator/sbpg/targets/haskell.py
+++ b/generator/sbpg/targets/haskell.py
@@ -72,6 +72,9 @@ def to_global(s):
   """
   Format a global variable name.
   """
+  if s.startswith('GPSTime'):
+    s = 'Gps' + s[3:]
+
   if '_' in s:
     s = "".join([string.capitalize(i) for i in s.split("_")])
   return s[0].lower() + s[1:]
@@ -80,6 +83,9 @@ def to_data(s):
   """
   Format a data variable name.
   """
+  if s.startswith('GPSTime'):
+    s = 'Gps' + s[3:]
+
   if '_' in s:
     return "".join([string.capitalize(i) for i in s.split("_")])
   return s
@@ -89,6 +95,8 @@ def to_type(f, type_map=CONSTRUCT_CODE):
   Format a the proper type.
   """
   name = f.type_id
+  if name.startswith('GPSTime'):
+    name = 'Gps' + name[3:]
   if type_map.get(name, None):
     return type_map.get(name, None)
   elif name == 'array':
@@ -100,6 +108,8 @@ def to_type(f, type_map=CONSTRUCT_CODE):
 
 def to_get(f, type_map=GET_CONSTRUCT_CODE):
   name = f.type_id
+  if name.startswith('GPSTime'):
+    name = 'Gps' + name[3:]
   if type_map.get(name, None):
     return type_map.get(name, None)
   elif name == 'string' and f.options.get('size', None):
@@ -121,6 +131,8 @@ def to_get(f, type_map=GET_CONSTRUCT_CODE):
 
 def to_put(f, type_map=PUT_CONSTRUCT_CODE):
   name = f.type_id
+  if name.startswith('GPSTime'):
+    name = 'Gps' + name[3:]
   if type_map.get(name, None):
     return type_map.get(name, None)
   elif name == 'array':

--- a/haskell/src/SwiftNav/SBP/Gnss.hs
+++ b/haskell/src/SwiftNav/SBP/Gnss.hs
@@ -58,25 +58,25 @@ $(makeLenses ''GnssSignal)
 --
 -- A wire-appropriate GPS time, defined as the number of milliseconds since
 -- beginning of the week on the Saturday/Sunday transition.
-data GPSTime = GPSTime
-  { _gPSTime_tow :: Word32
+data GpsTime = GpsTime
+  { _gpsTime_tow :: Word32
     -- ^ Milliseconds since start of GPS week
-  , _gPSTime_wn :: Word16
+  , _gpsTime_wn :: Word16
     -- ^ GPS week number
   } deriving ( Show, Read, Eq )
 
-instance Binary GPSTime where
+instance Binary GpsTime where
   get = do
-    _gPSTime_tow <- getWord32le
-    _gPSTime_wn <- getWord16le
-    return GPSTime {..}
+    _gpsTime_tow <- getWord32le
+    _gpsTime_wn <- getWord16le
+    return GpsTime {..}
 
-  put GPSTime {..} = do
-    putWord32le _gPSTime_tow
-    putWord16le _gPSTime_wn
-$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_gPSTime_" . stripPrefix "_gPSTime_"}
-             ''GPSTime)
-$(makeLenses ''GPSTime)
+  put GpsTime {..} = do
+    putWord32le _gpsTime_tow
+    putWord16le _gpsTime_wn
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_gpsTime_" . stripPrefix "_gpsTime_"}
+             ''GpsTime)
+$(makeLenses ''GpsTime)
 
 -- | CarrierPhase.
 --

--- a/haskell/src/SwiftNav/SBP/Observation.hs
+++ b/haskell/src/SwiftNav/SBP/Observation.hs
@@ -32,7 +32,7 @@ import SwiftNav.SBP.Gnss
 --
 -- Header of a GPS observation message.
 data ObservationHeader = ObservationHeader
-  { _observationHeader_t   :: GPSTime
+  { _observationHeader_t   :: GpsTime
     -- ^ GPS time of this observation
   , _observationHeader_n_obs :: Word8
     -- ^ Total number of observations. First nibble is the size of the sequence
@@ -201,7 +201,7 @@ $(makeLenses ''MsgBasePosEcef)
 data EphemerisCommonContent = EphemerisCommonContent
   { _ephemerisCommonContent_sid        :: GnssSignal
     -- ^ GNSS signal identifier
-  , _ephemerisCommonContent_toe        :: GPSTime
+  , _ephemerisCommonContent_toe        :: GpsTime
     -- ^ Time of Ephemerides
   , _ephemerisCommonContent_ura        :: Double
     -- ^ User Range Accuracy
@@ -289,7 +289,7 @@ data MsgEphemerisGps = MsgEphemerisGps
     -- ^ Polynomial clock correction coefficient (clock drift)
   , _msgEphemerisGps_af2    :: Double
     -- ^ Polynomial clock correction coefficient (rate of clock drift)
-  , _msgEphemerisGps_toc    :: GPSTime
+  , _msgEphemerisGps_toc    :: GpsTime
     -- ^ Clock reference
   , _msgEphemerisGps_iode   :: Word8
     -- ^ Issue of ephemeris data
@@ -1166,7 +1166,7 @@ msgIono = 0x0090
 -- utilize the ionospheric model for computation of the ionospheric delay.
 -- Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
 data MsgIono = MsgIono
-  { _msgIono_t_nmct :: GPSTime
+  { _msgIono_t_nmct :: GpsTime
     -- ^ Navigation Message Correction Table Valitidy Time
   , _msgIono_a0   :: Double
   , _msgIono_a1   :: Double
@@ -1215,7 +1215,7 @@ msgSvConfigurationGps = 0x0091
 --
 -- Please see ICD-GPS-200 (Chapter 20.3.3.5.1.4) for more details.
 data MsgSvConfigurationGps = MsgSvConfigurationGps
-  { _msgSvConfigurationGps_t_nmct :: GPSTime
+  { _msgSvConfigurationGps_t_nmct :: GpsTime
     -- ^ Navigation Message Correction Table Valitidy Time
   , _msgSvConfigurationGps_l2c_mask :: Word32
     -- ^ L2C capability mask, SV32 bit being MSB, SV1 bit being LSB
@@ -1244,7 +1244,7 @@ msgGroupDelay = 0x0092
 --
 -- Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
 data MsgGroupDelay = MsgGroupDelay
-  { _msgGroupDelay_t_op   :: GPSTime
+  { _msgGroupDelay_t_op   :: GpsTime
     -- ^ Data Predict Time of Week
   , _msgGroupDelay_prn    :: Word8
     -- ^ Satellite number

--- a/haskell/src/SwiftNav/SBP/Tracking.hs
+++ b/haskell/src/SwiftNav/SBP/Tracking.hs
@@ -38,7 +38,7 @@ msgTrackingStateDetailed = 0x0011
 data MsgTrackingStateDetailed = MsgTrackingStateDetailed
   { _msgTrackingStateDetailed_recv_time  :: Word64
     -- ^ Receiver clock time.
-  , _msgTrackingStateDetailed_tot        :: GPSTime
+  , _msgTrackingStateDetailed_tot        :: GpsTime
     -- ^ Time of transmission of signal from satellite.
   , _msgTrackingStateDetailed_P          :: Word32
     -- ^ Pseudorange observation.


### PR DESCRIPTION
This is pretty ugly fix, but `gPSTime_tow` was pretty bad.
