### PR TITLE
Tweak stack.yaml for Hackage compatibility

### DIFF
--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -3,3 +3,4 @@ flags: {}
 packages:
   - '.'
 extra-deps: []
+pvp-bounds: both


### PR DESCRIPTION
This will transparently add upper and lower bounds to all package dependencies not currently having them, based on the snapshot in use, when the package is uploaded via either `stack upload` or `stack sdist`.

See https://www.fpcomplete.com/blog/2015/09/stack-pvp