### PR TITLE
add CDC driver

### DIFF
--- a/python/sbp/client/drivers/cdc_driver.py
+++ b/python/sbp/client/drivers/cdc_driver.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2016 Swift Navigation Inc.
+# Contact: Dennis Zollo <dzollo@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from .base_driver import BaseDriver
+
+class CdcDriver(BaseDriver):
+  """
+  CdcDriver
+  The :class:`CdcDriver` class wraps IO sources of SBP messages and provides
+  context management.  It is intended for the devices that use the USB Gadget
+  CDC ACM drivers and is preferred over PySerial for these devices.
+
+  Parameters
+  ----------
+  handle : port
+    Stream of bytes to read from and write to.
+  """
+
+  def read(self, size):
+    """
+    Read wrapper.
+
+    Parameters
+    ----------
+    size : int
+      Number of bytes to read.
+    """
+    try:
+      return_val = self.handle.read(size)
+      if return_val == '':
+        print
+        print "Piksi disconnected"
+        print
+        raise IOError
+      return return_val
+    except OSError:
+      print
+      print "Piksi disconnected"
+      print
+      raise IOError
+
+  def write(self, s):
+    """
+    Write wrapper.
+
+    Parameters
+    ----------
+    s : bytes
+      Bytes to write
+    """
+    try:
+      return self.handle.write(s)
+    except OSError:
+      print
+      print "Piksi disconnected"
+      print
+      raise IOError
+
+  def close(self):
+    """
+    Close wrapper.
+    """
+    try:
+      self.handle.close()
+    except OSError, IOError:
+      pass


### PR DESCRIPTION
This adds a CDC driver primarily to support CDC AMC devices on OSX versions past Yosemite.

The "base driver" didn't handle disconnection out of the box
the "pyserial driver" didn't work on any OSX versions past Yosemite. 

I determine that the device is disconnected based upon when reads from the device return nothing.  I'm not sure if this is the best method, but it's the only thing I could get to work without a more sophisticated driver.  Referrd to [posix read](http://pubs.opengroup.org/onlinepubs/009695399/functions/read.html), the [fread in stdlib]([url](http://www.cplusplus.com/reference/cstdio/fread/)) and [python file.read()](https://docs.python.org/2/library/stdtypes.html#bltin-file-objects) to decide on the empty string comparison.  IOError is tested to be thrown when the port is disconnected or the CDC device goes offline.

/cc @fnoble @mfine