### PR TITLE
make handler callable threadsafe, Catch pyserial writeTimeoutErrors

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -87,8 +87,12 @@ class PySerialDriver(BaseDriver):
     """
     try:
       return self.handle.write(s)
-    except (OSError, serial.SerialException):
-      print
-      print "Piksi disconnected"
-      print
-      raise IOError
+    except (OSError, serial.SerialException, serial.writeTimeoutError) as e:
+      if e == serial.writeTimeoutError:
+        print "sbp pyserial_driver: writeTimeoutError"
+        return 0
+      else:
+        print
+        print "Piksi disconnected"
+        print
+        raise IOError

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -38,6 +38,7 @@ class Handler(object):
     self._receive_thread.daemon = True
     self._sinks = [] # This is a list of weakrefs to upstream iterators
     self._dead = False
+    self._write_lock = threading.Lock()
 
   def _recv_thread(self):
     """
@@ -241,7 +242,8 @@ class Handler(object):
     self.remove_callback(cb, msg_type)
 
   def __call__(self, msg, **metadata):
-    self._source(msg, **metadata)
+    with self._write_lock:
+      self._source(msg, **metadata)
 
   class _SBPQueueIterator(object):
     """


### PR DESCRIPTION
When using skylark on the console, lately we have seen this problem when you try and write something else to the serial port concurrently. 

Here we put a mutex around writing to the framer.  This fixes our interaction between skylark and other stuff in the console.  After a review and any comments we can try and cut an sbp release.  Potentially we could do instead this with some kind of queue rather than blocking writes to avoid holding up other threads, but I think this approach is acceptable.

/cc @jkretzmer @mfine @switanis 