### PR TITLE
Pass reason with underlying client connection warnings.

### DIFF
--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -209,15 +209,21 @@ class HTTPDriver(BaseDriver):
       gen = (msg.pack() for msg, _ in self.source)
       self.write_session.put(self.url, data=gen, headers=headers)
       self.write_response = True
-    except requests.exceptions.ConnectionError:
-      msg = "Invalid request to %s with headers %s." % (self.url, headers)
+    except requests.exceptions.ConnectionError as err:
+      msg = "Client connection error to %s with headers %s: msg=%s" \
+            % (self.url, headers, err.message)
       warnings.warn(msg)
-    except requests.exceptions.ConnectTimeout:
-      pass
+    except requests.exceptions.ConnectTimeout as err:
+      msg = "Client connection timeout to %s with headers %s: msg=%s" \
+            % (self.url, headers, err.message)
+      warnings.warn(msg)
     except requests.exceptions.RetryError:
-      pass
+      msg = "Client retry error to %s with headers %s: msg=%s" \
+            % (self.url, headers, err.message)
+      warnings.warn(msg)
     except requests.exceptions.ReadTimeout:
-      msg = "Invalid request to %s with headers %s." % (self.url, headers)
+      msg = "Client read timeout to %s with headers %s: msg=%s" \
+            % (self.url, headers, err.message)
       warnings.warn(msg)
     return self.write_ok
 

--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -210,19 +210,19 @@ class HTTPDriver(BaseDriver):
       self.write_session.put(self.url, data=gen, headers=headers)
       self.write_response = True
     except requests.exceptions.ConnectionError as err:
-      msg = "Client connection error to %s with headers %s: msg=%s" \
+      msg = "Client connection error to %s with [PUT] headers %s: msg=%s" \
             % (self.url, headers, err.message)
       warnings.warn(msg)
     except requests.exceptions.ConnectTimeout as err:
-      msg = "Client connection timeout to %s with headers %s: msg=%s" \
+      msg = "Client connection timeout to %s with [PUT] headers %s: msg=%s" \
             % (self.url, headers, err.message)
       warnings.warn(msg)
     except requests.exceptions.RetryError:
-      msg = "Client retry error to %s with headers %s: msg=%s" \
+      msg = "Client retry error to %s with [PUT] headers %s: msg=%s" \
             % (self.url, headers, err.message)
       warnings.warn(msg)
     except requests.exceptions.ReadTimeout:
-      msg = "Client read timeout to %s with headers %s: msg=%s" \
+      msg = "Client read timeout to %s with [PUT] headers %s: msg=%s" \
             % (self.url, headers, err.message)
       warnings.warn(msg)
     return self.write_ok
@@ -275,15 +275,21 @@ class HTTPDriver(BaseDriver):
                                                  stream=True,
                                                  headers=headers,
                                                  timeout=self.timeout)
-    except requests.exceptions.ConnectionError:
-      msg = "Invalid request to %s with headers %s." % (self.url, headers)
+    except requests.exceptions.ConnectionError as err:
+      msg = "Client connection error to %s with [GET] headers %s: msg=%s" \
+            % (self.url, headers, err.message)
       warnings.warn(msg)
-    except requests.exceptions.ConnectTimeout:
-      pass
+    except requests.exceptions.ConnectTimeout as err:
+      msg = "Client connection timeout to %s with [GET] headers %s: msg=%s" \
+            % (self.url, headers, err.message)
+      warnings.warn(msg)
     except requests.exceptions.RetryError:
-      pass
+      msg = "Client retry error to %s with [GET] headers %s: msg=%s" \
+            % (self.url, headers, err.message)
+      warnings.warn(msg)
     except requests.exceptions.ReadTimeout:
-      msg = "Invalid request to %s with headers %s." % (self.url, headers)
+      msg = "Client read timeout to %s with [GET] headers %s: msg=%s" \
+            % (self.url, headers, err.message)
       warnings.warn(msg)
     return self.read_ok
 


### PR DESCRIPTION
Passes the message from a Requests connection exception, to be
reflected in the Console. Previously this context was dropped.

/cc @mfine