### PR TITLE
python forwarder: add context

### DIFF
--- a/python/sbp/client/forwarder.py
+++ b/python/sbp/client/forwarder.py
@@ -50,3 +50,9 @@ class Forwarder(Thread):
       self.sink.close()
     except:
       pass
+
+  def __enter__(self):
+    self.run()
+  
+  def __exit__(self):
+    self.stop()


### PR DESCRIPTION
Like the handler, I think we should use context management on the forwarder