### PR TITLE
Remove filename - use filehandles

### DIFF
--- a/python/sbp/client/loggers/base_logger.py
+++ b/python/sbp/client/loggers/base_logger.py
@@ -23,9 +23,8 @@ class BaseLogger(object):
   filename : string
     File to log to.
   """
-  def __init__(self, filename, mode="w", tags={}, dispatcher=None):
-    if filename:
-      self.handle = open(filename, mode)
+  def __init__(self, handle, tags={}, dispatcher=None):
+    self.handle = handle
     self.dispatcher = dispatcher
     self.tags = tags
 
@@ -70,8 +69,8 @@ class LogIterator(object):
     Path to file to read SBP messages from.
 
   """
-  def __init__(self, filename, dispatcher=dispatch):
-    self.handle = open(filename, "r")
+  def __init__(self, handle, dispatcher=dispatch):
+    self.handle = handle
     self.dispatcher = dispatcher
 
   def __enter__(self):

--- a/python/sbp/client/loggers/base_logger.py
+++ b/python/sbp/client/loggers/base_logger.py
@@ -20,7 +20,7 @@ class BaseLogger(object):
 
   Parameters
   ----------
-  filename : string
+  handle : filehandle
     File to log to.
   """
   def __init__(self, handle, tags={}, dispatcher=None):
@@ -65,8 +65,8 @@ class LogIterator(object):
 
   Parameters
   ----------
-  filename : string
-    Path to file to read SBP messages from.
+  handle : filehandle
+    File to read SBP messages from.
 
   """
   def __init__(self, handle, dispatcher=dispatch):

--- a/python/tests/sbp/client/test_logger.py
+++ b/python/tests/sbp/client/test_logger.py
@@ -28,10 +28,11 @@ def test_log():
   Abstract interface won't work
   """
   log_datafile = "./data/serial_link_log_20150310-115522-test.log.dat"
-  with LogIterator(log_datafile) as log:
-    with pytest.raises(NotImplementedError) as exc_info:
-      for msg, metadata in log.next():
-        pass
+  with open(log_datafile, 'r') as infile:
+    with LogIterator(infile) as log:
+      with pytest.raises(NotImplementedError) as exc_info:
+        for msg, metadata in log.next():
+          pass
   assert exc_info.value.message == "next() not implemented!"
 
 def test_json_log():
@@ -41,13 +42,14 @@ def test_json_log():
   log_datafile = "./data/serial_link_log_20150310-115522-test.log.dat"
   count = 0
   with warnings.catch_warnings(record=True) as w:
-    with JSONLogIterator(log_datafile) as log:
-      for msg, metadata in log.next():
-        assert type(metadata['time']) == unicode
-        assert isinstance(msg, SBP) or issubclass(type(msg), SBP)
-        count += 1
-      warnings.simplefilter("always")
-      assert len(w) == 0
+    with open(log_datafile, 'r') as infile:
+      with JSONLogIterator(infile) as log:
+        for msg, metadata in log.next():
+          assert type(metadata['time']) == unicode
+          assert isinstance(msg, SBP) or issubclass(type(msg), SBP)
+          count += 1
+        warnings.simplefilter("always")
+        assert len(w) == 0
   assert count == 2650
 
 def test_multi_json_log():
@@ -80,26 +82,28 @@ def test_non_utf8_json_log():
   log_datafile = "./data/serial_link_non_utf8.log.dat"
   count = 0
   with warnings.catch_warnings(record=True) as w:
-    with JSONLogIterator(log_datafile) as log:
-      for msg, metadata in log.next():
-        pass
-      warnings.simplefilter("always")
-      assert len(w) == 1
+    with open(log_datafile, 'r') as infile:
+      with JSONLogIterator(infile) as log:
+        for msg, metadata in log.next():
+          pass
+        warnings.simplefilter("always")
+        assert len(w) == 1
 
 @pytest.mark.xfail
 def test_msg_print():
   """
   """
   log_datafile = "./data/serial_link_log_20150428-084729.log.dat"
-  with JSONLogIterator(log_datafile) as log:
-    with warnings.catch_warnings(record=True) as w:
-      for msg, metadata in log.next():
-        pass
-      warnings.simplefilter("always")
-      # Check for warnings.
-      assert len(w) == 1
-      assert issubclass(w[0].category, RuntimeWarning)
-      assert str(w[0].message).startswith('Bad message parsing for line')
+  with open(log_datafile, 'r') as infile:
+    with JSONLogIterator(infile) as log:
+      with warnings.catch_warnings(record=True) as w:
+        for msg, metadata in log.next():
+          pass
+        warnings.simplefilter("always")
+        # Check for warnings.
+        assert len(w) == 1
+        assert issubclass(w[0].category, RuntimeWarning)
+        assert str(w[0].message).startswith('Bad message parsing for line')
 
 def udp_handler(data):
   class MockRequestHandler(SocketServer.BaseRequestHandler):
@@ -150,11 +154,12 @@ def test_rolling_json_log():
             msgs.append(msg)
           t = time.time()
       i = 0
-      with JSONLogIterator(tf.name) as log:
-        for msg, metadata in log.next():
-          assert isinstance(msg, MsgPrintDep)
-          assert msg.text == "abc\n"
-          i += 1
+      with open(tf.name, 'r') as infile:
+        with JSONLogIterator(infile) as log:
+          for msg, metadata in log.next():
+            assert isinstance(msg, MsgPrintDep)
+            assert msg.text == "abc\n"
+            i += 1
       assert i > 0
       assert i <= len(msgs)
   except Exception:


### PR DESCRIPTION
Use filehandles instead of filenames.

The passing in a of a filename is a bad pattern - it bakes in the management of the file into the object, doesn't get cleaned up, etc.

And let's not preserve backwards compatibility - let's just fix things to do the right thing.

/cc @benjamin0 