### PR TITLE
Rename member variable to avoid name collision

### DIFF
--- a/c/include/libsbp/ndb.h
+++ b/c/include/libsbp/ndb.h
@@ -34,18 +34,18 @@
  */
 #define SBP_MSG_NDB_EVENT 0x0400
 typedef struct __attribute__((packed)) {
-  u64 recv_time;      /**< HW time in milliseconds. [ms] */
-  u8 event;          /**< Event type. */
-  u8 object_type;    /**< Event object type. */
-  u8 result;         /**< Event result. */
-  u8 data_source;    /**< Data source for STORE event, reserved for other events. */
-  gnss_signal16_t sid;            /**< GNSS signal identifier,
+  u64 recv_time;          /**< HW time in milliseconds. [ms] */
+  u8 event;              /**< Event type. */
+  u8 object_type;        /**< Event object type. */
+  u8 result;             /**< Event result. */
+  u8 data_source;        /**< Data source for STORE event, reserved for other events. */
+  gnss_signal16_t sid;                /**< GNSS signal identifier,
 If object_type is Ephemeris OR Almanac, sid indicates for which
 signal the object belongs to. If object_type is Iono OR L2C
 capabilities AND data_source is NDB_DS_RECEIVER sid indicates
 from which SV data was decoded. Reserved in other cases.
  */
-  u16 sender;         /**< A unique identifier of the sending hardware. For v1.0,
+  u16 original_sender;    /**< A unique identifier of the sending hardware. For v1.0,
 set to the 2 least significant bytes of the device serial
 number, valid only if data_source is NDB_DS_SBP. Reserved in case
 of other data_source.

--- a/haskell/src/SwiftNav/SBP/Ndb.hs
+++ b/haskell/src/SwiftNav/SBP/Ndb.hs
@@ -36,22 +36,22 @@ msgNdbEvent = 0x0400
 -- This message is sent out when an object is stored into NDB. If needed
 -- message could also be sent out when fetching an object from NDB.
 data MsgNdbEvent = MsgNdbEvent
-  { _msgNdbEvent_recv_time :: Word64
+  { _msgNdbEvent_recv_time     :: Word64
     -- ^ HW time in milliseconds.
-  , _msgNdbEvent_event     :: Word8
+  , _msgNdbEvent_event         :: Word8
     -- ^ Event type.
-  , _msgNdbEvent_object_type :: Word8
+  , _msgNdbEvent_object_type   :: Word8
     -- ^ Event object type.
-  , _msgNdbEvent_result    :: Word8
+  , _msgNdbEvent_result        :: Word8
     -- ^ Event result.
-  , _msgNdbEvent_data_source :: Word8
+  , _msgNdbEvent_data_source   :: Word8
     -- ^ Data source for STORE event, reserved for other events.
-  , _msgNdbEvent_sid       :: GnssSignal16
+  , _msgNdbEvent_sid           :: GnssSignal16
     -- ^ GNSS signal identifier, If object_type is Ephemeris OR Almanac, sid
     -- indicates for which signal the object belongs to. If object_type is Iono
     -- OR L2C capabilities AND data_source is NDB_DS_RECEIVER sid indicates
     -- from which SV data was decoded. Reserved in other cases.
-  , _msgNdbEvent_sender    :: Word16
+  , _msgNdbEvent_original_sender :: Word16
     -- ^ A unique identifier of the sending hardware. For v1.0, set to the 2
     -- least significant bytes of the device serial number, valid only if
     -- data_source is NDB_DS_SBP. Reserved in case of other data_source.
@@ -65,7 +65,7 @@ instance Binary MsgNdbEvent where
     _msgNdbEvent_result <- getWord8
     _msgNdbEvent_data_source <- getWord8
     _msgNdbEvent_sid <- get
-    _msgNdbEvent_sender <- getWord16le
+    _msgNdbEvent_original_sender <- getWord16le
     return MsgNdbEvent {..}
 
   put MsgNdbEvent {..} = do
@@ -75,7 +75,7 @@ instance Binary MsgNdbEvent where
     putWord8 _msgNdbEvent_result
     putWord8 _msgNdbEvent_data_source
     put _msgNdbEvent_sid
-    putWord16le _msgNdbEvent_sender
+    putWord16le _msgNdbEvent_original_sender
 
 $(deriveSBP 'msgNdbEvent ''MsgNdbEvent)
 

--- a/java/src/com/swiftnav/sbp/ndb/MsgNdbEvent.java
+++ b/java/src/com/swiftnav/sbp/ndb/MsgNdbEvent.java
@@ -63,7 +63,7 @@ set to the 2 least significant bytes of the device serial
 number, valid only if data_source is NDB_DS_SBP. Reserved in case
 of other data_source.
  */
-    public int sender;
+    public int original_sender;
     
 
     public MsgNdbEvent (int sender) { super(sender, TYPE); }
@@ -82,7 +82,7 @@ of other data_source.
         result = parser.getU8();
         data_source = parser.getU8();
         sid = new GnssSignal16().parse(parser);
-        sender = parser.getU16();
+        original_sender = parser.getU16();
     }
 
     @Override
@@ -93,7 +93,7 @@ of other data_source.
         builder.putU8(result);
         builder.putU8(data_source);
         sid.build(builder);
-        builder.putU16(sender);
+        builder.putU16(original_sender);
     }
 
     @Override
@@ -105,7 +105,7 @@ of other data_source.
         obj.put("result", result);
         obj.put("data_source", data_source);
         obj.put("sid", sid.toJSON());
-        obj.put("sender", sender);
+        obj.put("original_sender", original_sender);
         return obj;
     }
 }

--- a/javascript/sbp/ndb.js
+++ b/javascript/sbp/ndb.js
@@ -44,7 +44,7 @@ var GPSTimeNano = require("./gnss").GPSTimeNano;
  *   for which signal the object belongs to. If object_type is Iono OR L2C
  *   capabilities AND data_source is NDB_DS_RECEIVER sid indicates from which SV data
  *   was decoded. Reserved in other cases.
- * @field sender number (unsigned 16-bit int, 2 bytes) A unique identifier of the sending hardware. For v1.0, set to the 2 least
+ * @field original_sender number (unsigned 16-bit int, 2 bytes) A unique identifier of the sending hardware. For v1.0, set to the 2 least
  *   significant bytes of the device serial number, valid only if data_source is
  *   NDB_DS_SBP. Reserved in case of other data_source.
  *
@@ -69,7 +69,7 @@ MsgNdbEvent.prototype.parser = new Parser()
   .uint8('result')
   .uint8('data_source')
   .nest('sid', { type: GnssSignal16.prototype.parser })
-  .uint16('sender');
+  .uint16('original_sender');
 MsgNdbEvent.prototype.fieldSpec = [];
 MsgNdbEvent.prototype.fieldSpec.push(['recv_time', 'writeUInt64LE', 8]);
 MsgNdbEvent.prototype.fieldSpec.push(['event', 'writeUInt8', 1]);
@@ -77,7 +77,7 @@ MsgNdbEvent.prototype.fieldSpec.push(['object_type', 'writeUInt8', 1]);
 MsgNdbEvent.prototype.fieldSpec.push(['result', 'writeUInt8', 1]);
 MsgNdbEvent.prototype.fieldSpec.push(['data_source', 'writeUInt8', 1]);
 MsgNdbEvent.prototype.fieldSpec.push(['sid', GnssSignal16.prototype.fieldSpec]);
-MsgNdbEvent.prototype.fieldSpec.push(['sender', 'writeUInt16LE', 2]);
+MsgNdbEvent.prototype.fieldSpec.push(['original_sender', 'writeUInt16LE', 2]);
 
 module.exports = {
   0x0400: MsgNdbEvent,

--- a/python/sbp/ndb.py
+++ b/python/sbp/ndb.py
@@ -59,7 +59,7 @@ signal the object belongs to. If object_type is Iono OR L2C
 capabilities AND data_source is NDB_DS_RECEIVER sid indicates
 from which SV data was decoded. Reserved in other cases.
 
-  sender : int
+  original_sender : int
     A unique identifier of the sending hardware. For v1.0,
 set to the 2 least significant bytes of the device serial
 number, valid only if data_source is NDB_DS_SBP. Reserved in case
@@ -76,7 +76,7 @@ of other data_source.
                    ULInt8('result'),
                    ULInt8('data_source'),
                    Struct('sid', GnssSignal16._parser),
-                   ULInt16('sender'),)
+                   ULInt16('original_sender'),)
   __slots__ = [
                'recv_time',
                'event',
@@ -84,7 +84,7 @@ of other data_source.
                'result',
                'data_source',
                'sid',
-               'sender',
+               'original_sender',
               ]
 
   def __init__(self, sbp=None, **kwargs):
@@ -103,7 +103,7 @@ of other data_source.
       self.result = kwargs.pop('result')
       self.data_source = kwargs.pop('data_source')
       self.sid = kwargs.pop('sid')
-      self.sender = kwargs.pop('sender')
+      self.original_sender = kwargs.pop('original_sender')
 
   def __repr__(self):
     return fmt_repr(self)

--- a/spec/yaml/swiftnav/sbp/ndb.yaml
+++ b/spec/yaml/swiftnav/sbp/ndb.yaml
@@ -98,7 +98,7 @@ definitions:
              signal the object belongs to. If object_type is Iono OR L2C
              capabilities AND data_source is NDB_DS_RECEIVER sid indicates
              from which SV data was decoded. Reserved in other cases.
-      - sender:
+      - original_sender:
            type: u16
            desc: |
              A unique identifier of the sending hardware. For v1.0,


### PR DESCRIPTION
'sender' variable name is already taken by default in SBP message, rename.