### PR TITLE
Pdf publish version fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - npm install -g mocha
   - npm install
   - stack update
-  - stack setup
+  - (cd haskell && stack setup)
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ dist:
 	stack sdist
 	stack upload .
 	popd
+	make pdf_dist
 	$(call announce-end,"Finished deploying packages")
 
 pdf:
@@ -224,9 +225,12 @@ pdf:
 	cd $(SWIFTNAV_ROOT)/generator; \
 	$(SBP_GEN_BIN) -i $(SBP_SPEC_DIR) \
 		       -o $(SWIFTNAV_ROOT)/latex/ \
-                       -r $(SBP_MAJOR_VERSION).$(SBP_MINOR_VERSION) \
+                       -r $(SBP_MAJOR_VERSION).$(SBP_MINOR_VERSION).$(SBP_PATCH_VERSION) \
 	               --latex
 	$(call announce-end,"Finished! Please check $(SWIFTNAV_ROOT)/latex and $(SWIFTNAV_ROOT)/docs")
+
+pdf_dist:
+	s3cmd put  $(SWIFTNAV_ROOT)/docs/sbp.pdf s3://downloads.swiftnav.com/sbp/docs/sbp_$(SBP_VERSION).pdf
 
 html:
 	$(call announce-begin,"Generating bindings documentation")

--- a/generator/sbpg/generator.py
+++ b/generator/sbpg/generator.py
@@ -103,7 +103,7 @@ def main():
       print "Writing to %s" % output_dir
     if args.latex:
       parsed = [yaml.parse_spec(spec) for spec in file_index.values()]
-      tex.render_source(output_dir, parsed)
+      tex.render_source(output_dir, parsed, args.release[0])
     else:
       spec_no = 0
       all_specs = []

--- a/generator/sbpg/targets/latex.py
+++ b/generator/sbpg/targets/latex.py
@@ -252,7 +252,7 @@ def handle_fields(definitions, fields, prefix, offset, multiplier):
       offset += size
   return (items, offset, multiplier)
 
-def render_source(output_dir, package_specs):
+def render_source(output_dir, package_specs, version):
   """
   Render and output
   """
@@ -301,7 +301,8 @@ def render_source(output_dir, package_specs):
   with open(destination_filename, 'w') as f:
     f.write(py_template.render(msgs=stable_msgs,
                                umsgs=unstable_msgs,
-                               prims=prims))
+                               prims=prims,
+                               version=version))
   import subprocess
   import os
   os.chdir(output_dir)

--- a/generator/sbpg/targets/resources/sbp_base.tex
+++ b/generator/sbpg/targets/resources/sbp_base.tex
@@ -64,7 +64,7 @@
 \title{Swift Navigation Binary Protocol}
 \version{\input{\jobname.info}}
 \author{Swift Navigation}
-\mysubtitle{Protocol Specification \theversion}
+\mysubtitle{Protocol Specification (((version)))}
 \date{\today}
 
 \begin{document}

--- a/generator/sbpg/targets/resources/sbp_base.tex
+++ b/generator/sbpg/targets/resources/sbp_base.tex
@@ -32,6 +32,7 @@
 \numberwithin{table}{subsection}
 \numberwithin{field}{subsection}
 
+\renewcommand{\version}{(((version)))}
 \renewcommand{\thesubsubsection}{\hspace{-0.45cm}}
 
 \newcommand{\specialcell}[2][c]{%
@@ -62,7 +63,6 @@
 \immediate\write18{git describe --abbrev=0 --tags | cut -c 2-5 > \jobname.info }
 
 \title{Swift Navigation Binary Protocol}
-\version{\input{\jobname.info}}
 \author{Swift Navigation}
 \mysubtitle{Protocol Specification (((version)))}
 \date{\today}
@@ -108,7 +108,7 @@ SBP consists of two pieces:
   \item an over-the-wire message framing format
   \item structured payload definitions
 \end{itemize}
-As of Version~\theversion, the frame consists of a 6-byte binary
+As of Version (((version))), the frame consists of a 6-byte binary
 header section, a variable-sized payload field, and a 16-bit CRC
 value. All multibyte values are ordered in \textbf{little-endian}
 format. SBP uses the CCITT CRC16 (XMODEM implementation) for error

--- a/generator/sbpg/targets/resources/sbp_base.tex
+++ b/generator/sbpg/targets/resources/sbp_base.tex
@@ -64,7 +64,7 @@
 
 \title{Swift Navigation Binary Protocol}
 \author{Swift Navigation}
-\mysubtitle{Protocol Specification (((version)))}
+\mysubtitle{Protocol Specification \version}
 \date{\today}
 
 \begin{document}
@@ -108,7 +108,7 @@ SBP consists of two pieces:
   \item an over-the-wire message framing format
   \item structured payload definitions
 \end{itemize}
-As of Version (((version))), the frame consists of a 6-byte binary
+As of Version~\version, the frame consists of a 6-byte binary
 header section, a variable-sized payload field, and a 16-bit CRC
 value. All multibyte values are ordered in \textbf{little-endian}
 format. SBP uses the CCITT CRC16 (XMODEM implementation) for error

--- a/latex/swiftnav.sty
+++ b/latex/swiftnav.sty
@@ -63,7 +63,7 @@
 \lhead{\@author}
 \chead{}
 \rhead{\@title}
-\lfoot{\footnotesize{Version \theversion, \@date}}
+\lfoot{\footnotesize{Version \version, \@date}}
 \cfoot{}
 \rfoot{\thepage}
 \renewcommand{\headrulewidth}{0.5pt}


### PR DESCRIPTION
This uses the makefile's idea of the version for the pdf document

It also adds a distribution target to downloads.swiftnav.com for which you will need s3cmd and aws credentials

/cc @mfine @JoshuaGross 