### PR TITLE
Jdiamond/network status

### DIFF
--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -34,7 +34,7 @@
  * This is a legacy message for sending and loading a satellite
  * alamanac onto the Piksi's flash memory from the host.
  */
-#define SBP_MSG_ALMANAC         0x0069
+#define SBP_MSG_ALMANAC            0x0069
 
 
 /** Send GPS time from host (host => Piksi)
@@ -42,7 +42,7 @@
  * This message sets up timing functionality using a coarse GPS
  * time estimate sent by the host.
  */
-#define SBP_MSG_SET_TIME        0x0068
+#define SBP_MSG_SET_TIME           0x0068
 
 
 /** Reset the device (host => Piksi)
@@ -50,7 +50,7 @@
  * This message from the host resets the Piksi back into the
  * bootloader.
  */
-#define SBP_MSG_RESET           0x00B6
+#define SBP_MSG_RESET              0x00B6
 typedef struct __attribute__((packed)) {
   u32 flags;    /**< Reset flags */
 } msg_reset_t;
@@ -61,7 +61,7 @@ typedef struct __attribute__((packed)) {
  * This message from the host resets the Piksi back into the
  * bootloader.
  */
-#define SBP_MSG_RESET_DEP       0x00B2
+#define SBP_MSG_RESET_DEP          0x00B2
 
 
 /** Legacy message for CW interference channel (Piksi => host)
@@ -70,7 +70,7 @@ typedef struct __attribute__((packed)) {
  * CW interference channel on the SwiftNAP. This message will be
  * removed in a future release.
  */
-#define SBP_MSG_CW_RESULTS      0x00C0
+#define SBP_MSG_CW_RESULTS         0x00C0
 
 
 /** Legacy message for CW interference channel (host => Piksi)
@@ -79,7 +79,7 @@ typedef struct __attribute__((packed)) {
  * the CW interference channel on the SwiftNAP. This message will
  * be removed in a future release.
  */
-#define SBP_MSG_CW_START        0x00C1
+#define SBP_MSG_CW_START           0x00C1
 
 
 /** Reset IAR filters (host => Piksi)
@@ -87,7 +87,7 @@ typedef struct __attribute__((packed)) {
  * This message resets either the DGNSS Kalman filters or Integer
  * Ambiguity Resolution (IAR) process.
  */
-#define SBP_MSG_RESET_FILTERS   0x0022
+#define SBP_MSG_RESET_FILTERS      0x0022
 typedef struct __attribute__((packed)) {
   u8 filter;    /**< Filter flags */
 } msg_reset_filters_t;
@@ -101,7 +101,7 @@ typedef struct __attribute__((packed)) {
  * there aren't a shared minimum number (4) of satellite
  * observations between the two.
  */
-#define SBP_MSG_INIT_BASE       0x0023
+#define SBP_MSG_INIT_BASE          0x0023
 
 
 /** State of an RTOS thread
@@ -110,7 +110,7 @@ typedef struct __attribute__((packed)) {
  * operating system (RTOS) thread usage statistics for the named
  * thread. The reported percentage values must be normalized.
  */
-#define SBP_MSG_THREAD_STATE    0x0017
+#define SBP_MSG_THREAD_STATE       0x0017
 typedef struct __attribute__((packed)) {
   char name[20];      /**< Thread name (NULL terminated) */
   u16 cpu;           /**< Percentage cpu use for this thread. Values range from 0
@@ -185,7 +185,7 @@ typedef struct __attribute__((packed)) {
  * the timeliness of received base observations while the
  * period indicates their likelihood of transmission.
  */
-#define SBP_MSG_UART_STATE      0x001D
+#define SBP_MSG_UART_STATE         0x001D
 typedef struct __attribute__((packed)) {
   uart_channel_t uart_a;        /**< State of UART A */
   uart_channel_t uart_b;        /**< State of UART B */
@@ -199,7 +199,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated
  */
-#define SBP_MSG_UART_STATE_DEPA 0x0018
+#define SBP_MSG_UART_STATE_DEPA    0x0018
 typedef struct __attribute__((packed)) {
   uart_channel_t uart_a;       /**< State of UART A */
   uart_channel_t uart_b;       /**< State of UART B */
@@ -215,7 +215,7 @@ typedef struct __attribute__((packed)) {
  * ambiguities from double-differenced carrier-phase measurements
  * from satellite observations.
  */
-#define SBP_MSG_IAR_STATE       0x0019
+#define SBP_MSG_IAR_STATE          0x0019
 typedef struct __attribute__((packed)) {
   u32 num_hyps;    /**< Number of integer ambiguity hypotheses remaining */
 } msg_iar_state_t;
@@ -226,7 +226,7 @@ typedef struct __attribute__((packed)) {
  * This message allows setting a mask to prevent a particular satellite
  * from being used in various Piksi subsystems.
  */
-#define SBP_MSG_MASK_SATELLITE  0x001B
+#define SBP_MSG_MASK_SATELLITE     0x001B
 typedef struct __attribute__((packed)) {
   u8 mask;    /**< Mask of systems that should ignore this satellite. */
   sbp_gnss_signal_t sid;     /**< GNSS signal for which the mask is applied */
@@ -239,7 +239,7 @@ typedef struct __attribute__((packed)) {
  * processor's monitoring system and the RF frontend die temperature if
  * available.
  */
-#define SBP_MSG_DEVICE_MONITOR  0x00B5
+#define SBP_MSG_DEVICE_MONITOR     0x00B5
 typedef struct __attribute__((packed)) {
   s16 dev_vin;            /**< Device V_in [V * 1000] */
   s16 cpu_vint;           /**< Processor V_int [V * 1000] */
@@ -255,7 +255,7 @@ typedef struct __attribute__((packed)) {
  * Output will be sent in MSG_LOG messages, and the exit
  * code will be returned with MSG_COMMAND_RESP.
  */
-#define SBP_MSG_COMMAND_REQ     0x00B8
+#define SBP_MSG_COMMAND_REQ        0x00B8
 typedef struct __attribute__((packed)) {
   u32 sequence;    /**< Sequence number */
   char command[0];  /**< Command line to execute */
@@ -267,11 +267,31 @@ typedef struct __attribute__((packed)) {
  * The response to MSG_COMMAND_REQ with the return code of
  * the command.  A return code of zero indicates success.
  */
-#define SBP_MSG_COMMAND_RESP    0x00B9
+#define SBP_MSG_COMMAND_RESP       0x00B9
 typedef struct __attribute__((packed)) {
   u32 sequence;    /**< Sequence number */
   s32 code;        /**< Exit code */
 } msg_command_resp_t;
+
+
+/** Request state of Piksi network interfaces
+ *
+ * Request state of Piksi network interfaces.
+ * Output will be sent in MSG_NETWORK_STATE_RESP messages
+ */
+#define SBP_MSG_NETWORK_STATE_REQ  0x00BA
+
+
+/** State of network interface
+ *
+ * The state of a network interface on the Piksi
+ */
+#define SBP_MSG_NETWORK_STATE_RESP 0x00BB
+typedef struct __attribute__((packed)) {
+  u32 ip_address;        /**< IPv4 Address */
+  char interface_name[16]; /**< Interface Name */
+  u8 status;            /**< Status of interface */
+} msg_network_state_resp_t;
 
 
 /** \} */

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -290,11 +290,10 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
   u32 ip_address;        /**< IPv4 address */
   u32 ip_mask;           /**< IPv4 netmask */
-  u32 ip_gateway;        /**< IPv4 gateway */
-  u32 rx_packets;        /**< Number of Rx packets */
-  u32 tx_packets;        /**< Number of Tx packets */
+  u32 rx_bytes;          /**< Number of Rx bytes */
+  u32 tx_bytes;          /**< Number of Tx bytes */
   char interface_name[16]; /**< Interface Name */
-  u8 status;            /**< Status of interface */
+  u32 flags;             /**< Interface flags from SIOCGIFFLAGS */
 } msg_network_state_resp_t;
 
 

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -288,8 +288,10 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_NETWORK_STATE_RESP 0x00BB
 typedef struct __attribute__((packed)) {
-  u32 ip_address;        /**< IPv4 address */
-  u32 ip_mask;           /**< IPv4 netmask */
+  u8 ipv4_address[4];   /**< IPv4 address (all zero when unavailable) */
+  u8 ipv4_mask_size;    /**< IPv4 netmask CIDR notation */
+  u8 ipv6_address[16];  /**< IPv6 address (all zero when unavailable) */
+  u8 ipv6_mask_size;    /**< IPv6 netmask CIDR notation */
   u32 rx_bytes;          /**< Number of Rx bytes */
   u32 tx_bytes;          /**< Number of Tx bytes */
   char interface_name[16]; /**< Interface Name */

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -284,7 +284,9 @@ typedef struct __attribute__((packed)) {
 
 /** State of network interface
  *
- * The state of a network interface on the Piksi
+ * The state of a network interface on the Piksi.
+ * Data is made to reflect output of ifaddrs struct returned by getifaddrs
+ * in c.
  */
 #define SBP_MSG_NETWORK_STATE_RESP 0x00BB
 typedef struct __attribute__((packed)) {

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -288,7 +288,11 @@ typedef struct __attribute__((packed)) {
  */
 #define SBP_MSG_NETWORK_STATE_RESP 0x00BB
 typedef struct __attribute__((packed)) {
-  u32 ip_address;        /**< IPv4 Address */
+  u32 ip_address;        /**< IPv4 address */
+  u32 ip_mask;           /**< IPv4 netmask */
+  u32 ip_gateway;        /**< IPv4 gateway */
+  u32 rx_packets;        /**< Number of Rx packets */
+  u32 tx_packets;        /**< Number of Tx packets */
   char interface_name[16]; /**< Interface Name */
   u8 status;            /**< Status of interface */
 } msg_network_state_resp_t;

--- a/haskell/src/SwiftNav/SBP.hs
+++ b/haskell/src/SwiftNav/SBP.hs
@@ -122,6 +122,8 @@ data SBPMsg =
    | SBPMsgNapDeviceDnaReq MsgNapDeviceDnaReq Msg
    | SBPMsgNapDeviceDnaResp MsgNapDeviceDnaResp Msg
    | SBPMsgNdbEvent MsgNdbEvent Msg
+   | SBPMsgNetworkStateReq MsgNetworkStateReq Msg
+   | SBPMsgNetworkStateResp MsgNetworkStateResp Msg
    | SBPMsgObs MsgObs Msg
    | SBPMsgObsDepA MsgObsDepA Msg
    | SBPMsgObsDepB MsgObsDepB Msg
@@ -240,6 +242,8 @@ instance Binary SBPMsg where
           | _msgSBPType == msgNapDeviceDnaReq = SBPMsgNapDeviceDnaReq (decode (fromStrict _msgSBPPayload)) m
           | _msgSBPType == msgNapDeviceDnaResp = SBPMsgNapDeviceDnaResp (decode (fromStrict _msgSBPPayload)) m
           | _msgSBPType == msgNdbEvent = SBPMsgNdbEvent (decode (fromStrict _msgSBPPayload)) m
+          | _msgSBPType == msgNetworkStateReq = SBPMsgNetworkStateReq (decode (fromStrict _msgSBPPayload)) m
+          | _msgSBPType == msgNetworkStateResp = SBPMsgNetworkStateResp (decode (fromStrict _msgSBPPayload)) m
           | _msgSBPType == msgObs = SBPMsgObs (decode (fromStrict _msgSBPPayload)) m
           | _msgSBPType == msgObsDepA = SBPMsgObsDepA (decode (fromStrict _msgSBPPayload)) m
           | _msgSBPType == msgObsDepB = SBPMsgObsDepB (decode (fromStrict _msgSBPPayload)) m
@@ -350,6 +354,8 @@ instance Binary SBPMsg where
       encode' (SBPMsgNapDeviceDnaReq _ m) = put m
       encode' (SBPMsgNapDeviceDnaResp _ m) = put m
       encode' (SBPMsgNdbEvent _ m) = put m
+      encode' (SBPMsgNetworkStateReq _ m) = put m
+      encode' (SBPMsgNetworkStateResp _ m) = put m
       encode' (SBPMsgObs _ m) = put m
       encode' (SBPMsgObsDepA _ m) = put m
       encode' (SBPMsgObsDepB _ m) = put m
@@ -463,6 +469,8 @@ instance FromJSON SBPMsg where
         | msgType == msgNapDeviceDnaReq = SBPMsgNapDeviceDnaReq <$> parseJSON obj <*> parseJSON obj
         | msgType == msgNapDeviceDnaResp = SBPMsgNapDeviceDnaResp <$> parseJSON obj <*> parseJSON obj
         | msgType == msgNdbEvent = SBPMsgNdbEvent <$> parseJSON obj <*> parseJSON obj
+        | msgType == msgNetworkStateReq = SBPMsgNetworkStateReq <$> parseJSON obj <*> parseJSON obj
+        | msgType == msgNetworkStateResp = SBPMsgNetworkStateResp <$> parseJSON obj <*> parseJSON obj
         | msgType == msgObs = SBPMsgObs <$> parseJSON obj <*> parseJSON obj
         | msgType == msgObsDepA = SBPMsgObsDepA <$> parseJSON obj <*> parseJSON obj
         | msgType == msgObsDepB = SBPMsgObsDepB <$> parseJSON obj <*> parseJSON obj
@@ -578,6 +586,8 @@ instance ToJSON SBPMsg where
   toJSON (SBPMsgNapDeviceDnaReq n m) = toJSON n `mergeValues` toJSON m
   toJSON (SBPMsgNapDeviceDnaResp n m) = toJSON n `mergeValues` toJSON m
   toJSON (SBPMsgNdbEvent n m) = toJSON n `mergeValues` toJSON m
+  toJSON (SBPMsgNetworkStateReq n m) = toJSON n `mergeValues` toJSON m
+  toJSON (SBPMsgNetworkStateResp n m) = toJSON n `mergeValues` toJSON m
   toJSON (SBPMsgObs n m) = toJSON n `mergeValues` toJSON m
   toJSON (SBPMsgObsDepA n m) = toJSON n `mergeValues` toJSON m
   toJSON (SBPMsgObsDepB n m) = toJSON n `mergeValues` toJSON m
@@ -687,6 +697,8 @@ instance HasMsg SBPMsg where
   msg f (SBPMsgNapDeviceDnaReq n m) = SBPMsgNapDeviceDnaReq n <$> f m
   msg f (SBPMsgNapDeviceDnaResp n m) = SBPMsgNapDeviceDnaResp n <$> f m
   msg f (SBPMsgNdbEvent n m) = SBPMsgNdbEvent n <$> f m
+  msg f (SBPMsgNetworkStateReq n m) = SBPMsgNetworkStateReq n <$> f m
+  msg f (SBPMsgNetworkStateResp n m) = SBPMsgNetworkStateResp n <$> f m
   msg f (SBPMsgObs n m) = SBPMsgObs n <$> f m
   msg f (SBPMsgObsDepA n m) = SBPMsgObsDepA n <$> f m
   msg f (SBPMsgObsDepB n m) = SBPMsgObsDepB n <$> f m

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -643,7 +643,15 @@ msgNetworkStateResp = 0x00BB
 -- The state of a network interface on the Piksi
 data MsgNetworkStateResp = MsgNetworkStateResp
   { _msgNetworkStateResp_ip_address   :: Word32
-    -- ^ IPv4 Address
+    -- ^ IPv4 address
+  , _msgNetworkStateResp_ip_mask      :: Word32
+    -- ^ IPv4 netmask
+  , _msgNetworkStateResp_ip_gateway   :: Word32
+    -- ^ IPv4 gateway
+  , _msgNetworkStateResp_rx_packets   :: Word32
+    -- ^ Number of Rx packets
+  , _msgNetworkStateResp_tx_packets   :: Word32
+    -- ^ Number of Tx packets
   , _msgNetworkStateResp_interface_name :: Text
     -- ^ Interface Name
   , _msgNetworkStateResp_status       :: Word8
@@ -653,12 +661,20 @@ data MsgNetworkStateResp = MsgNetworkStateResp
 instance Binary MsgNetworkStateResp where
   get = do
     _msgNetworkStateResp_ip_address <- getWord32le
+    _msgNetworkStateResp_ip_mask <- getWord32le
+    _msgNetworkStateResp_ip_gateway <- getWord32le
+    _msgNetworkStateResp_rx_packets <- getWord32le
+    _msgNetworkStateResp_tx_packets <- getWord32le
     _msgNetworkStateResp_interface_name <- decodeUtf8 <$> getByteString 16
     _msgNetworkStateResp_status <- getWord8
     return MsgNetworkStateResp {..}
 
   put MsgNetworkStateResp {..} = do
     putWord32le _msgNetworkStateResp_ip_address
+    putWord32le _msgNetworkStateResp_ip_mask
+    putWord32le _msgNetworkStateResp_ip_gateway
+    putWord32le _msgNetworkStateResp_rx_packets
+    putWord32le _msgNetworkStateResp_tx_packets
     putByteString $ encodeUtf8 _msgNetworkStateResp_interface_name
     putWord8 _msgNetworkStateResp_status
 

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -640,7 +640,8 @@ msgNetworkStateResp = 0x00BB
 
 -- | SBP class for message MSG_NETWORK_STATE_RESP (0x00BB).
 --
--- The state of a network interface on the Piksi
+-- The state of a network interface on the Piksi. Data is made to reflect
+-- output of ifaddrs struct returned by getifaddrs in c.
 data MsgNetworkStateResp = MsgNetworkStateResp
   { _msgNetworkStateResp_ipv4_address :: [Word8]
     -- ^ IPv4 address (all zero when unavailable)

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -646,37 +646,33 @@ data MsgNetworkStateResp = MsgNetworkStateResp
     -- ^ IPv4 address
   , _msgNetworkStateResp_ip_mask      :: Word32
     -- ^ IPv4 netmask
-  , _msgNetworkStateResp_ip_gateway   :: Word32
-    -- ^ IPv4 gateway
-  , _msgNetworkStateResp_rx_packets   :: Word32
-    -- ^ Number of Rx packets
-  , _msgNetworkStateResp_tx_packets   :: Word32
-    -- ^ Number of Tx packets
+  , _msgNetworkStateResp_rx_bytes     :: Word32
+    -- ^ Number of Rx bytes
+  , _msgNetworkStateResp_tx_bytes     :: Word32
+    -- ^ Number of Tx bytes
   , _msgNetworkStateResp_interface_name :: Text
     -- ^ Interface Name
-  , _msgNetworkStateResp_status       :: Word8
-    -- ^ Status of interface
+  , _msgNetworkStateResp_flags        :: Word32
+    -- ^ Interface flags from SIOCGIFFLAGS
   } deriving ( Show, Read, Eq )
 
 instance Binary MsgNetworkStateResp where
   get = do
     _msgNetworkStateResp_ip_address <- getWord32le
     _msgNetworkStateResp_ip_mask <- getWord32le
-    _msgNetworkStateResp_ip_gateway <- getWord32le
-    _msgNetworkStateResp_rx_packets <- getWord32le
-    _msgNetworkStateResp_tx_packets <- getWord32le
+    _msgNetworkStateResp_rx_bytes <- getWord32le
+    _msgNetworkStateResp_tx_bytes <- getWord32le
     _msgNetworkStateResp_interface_name <- decodeUtf8 <$> getByteString 16
-    _msgNetworkStateResp_status <- getWord8
+    _msgNetworkStateResp_flags <- getWord32le
     return MsgNetworkStateResp {..}
 
   put MsgNetworkStateResp {..} = do
     putWord32le _msgNetworkStateResp_ip_address
     putWord32le _msgNetworkStateResp_ip_mask
-    putWord32le _msgNetworkStateResp_ip_gateway
-    putWord32le _msgNetworkStateResp_rx_packets
-    putWord32le _msgNetworkStateResp_tx_packets
+    putWord32le _msgNetworkStateResp_rx_bytes
+    putWord32le _msgNetworkStateResp_tx_bytes
     putByteString $ encodeUtf8 _msgNetworkStateResp_interface_name
-    putWord8 _msgNetworkStateResp_status
+    putWord32le _msgNetworkStateResp_flags
 
 $(deriveSBP 'msgNetworkStateResp ''MsgNetworkStateResp)
 

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -642,10 +642,14 @@ msgNetworkStateResp = 0x00BB
 --
 -- The state of a network interface on the Piksi
 data MsgNetworkStateResp = MsgNetworkStateResp
-  { _msgNetworkStateResp_ip_address   :: Word32
-    -- ^ IPv4 address
-  , _msgNetworkStateResp_ip_mask      :: Word32
-    -- ^ IPv4 netmask
+  { _msgNetworkStateResp_ipv4_address :: [Word8]
+    -- ^ IPv4 address (all zero when unavailable)
+  , _msgNetworkStateResp_ipv4_mask_size :: Word8
+    -- ^ IPv4 netmask CIDR notation
+  , _msgNetworkStateResp_ipv6_address :: [Word8]
+    -- ^ IPv6 address (all zero when unavailable)
+  , _msgNetworkStateResp_ipv6_mask_size :: Word8
+    -- ^ IPv6 netmask CIDR notation
   , _msgNetworkStateResp_rx_bytes     :: Word32
     -- ^ Number of Rx bytes
   , _msgNetworkStateResp_tx_bytes     :: Word32
@@ -658,8 +662,10 @@ data MsgNetworkStateResp = MsgNetworkStateResp
 
 instance Binary MsgNetworkStateResp where
   get = do
-    _msgNetworkStateResp_ip_address <- getWord32le
-    _msgNetworkStateResp_ip_mask <- getWord32le
+    _msgNetworkStateResp_ipv4_address <- replicateM 4 getWord8
+    _msgNetworkStateResp_ipv4_mask_size <- getWord8
+    _msgNetworkStateResp_ipv6_address <- replicateM 16 getWord8
+    _msgNetworkStateResp_ipv6_mask_size <- getWord8
     _msgNetworkStateResp_rx_bytes <- getWord32le
     _msgNetworkStateResp_tx_bytes <- getWord32le
     _msgNetworkStateResp_interface_name <- decodeUtf8 <$> getByteString 16
@@ -667,8 +673,10 @@ instance Binary MsgNetworkStateResp where
     return MsgNetworkStateResp {..}
 
   put MsgNetworkStateResp {..} = do
-    putWord32le _msgNetworkStateResp_ip_address
-    putWord32le _msgNetworkStateResp_ip_mask
+    mapM_ putWord8 _msgNetworkStateResp_ipv4_address
+    putWord8 _msgNetworkStateResp_ipv4_mask_size
+    mapM_ putWord8 _msgNetworkStateResp_ipv6_address
+    putWord8 _msgNetworkStateResp_ipv6_mask_size
     putWord32le _msgNetworkStateResp_rx_bytes
     putWord32le _msgNetworkStateResp_tx_bytes
     putByteString $ encodeUtf8 _msgNetworkStateResp_interface_name

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -611,3 +611,59 @@ $(deriveSBP 'msgCommandResp ''MsgCommandResp)
 $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msgCommandResp_" . P.stripPrefix "_msgCommandResp_"}
              ''MsgCommandResp)
 $(makeLenses ''MsgCommandResp)
+
+msgNetworkStateReq :: Word16
+msgNetworkStateReq = 0x00BA
+
+-- | SBP class for message MSG_NETWORK_STATE_REQ (0x00BA).
+--
+-- Request state of Piksi network interfaces. Output will be sent in
+-- MSG_NETWORK_STATE_RESP messages
+data MsgNetworkStateReq = MsgNetworkStateReq
+  deriving ( Show, Read, Eq )
+
+instance Binary MsgNetworkStateReq where
+  get =
+    return MsgNetworkStateReq
+
+  put MsgNetworkStateReq =
+    return ()
+
+$(deriveSBP 'msgNetworkStateReq ''MsgNetworkStateReq)
+
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msgNetworkStateReq_" . P.stripPrefix "_msgNetworkStateReq_"}
+             ''MsgNetworkStateReq)
+$(makeLenses ''MsgNetworkStateReq)
+
+msgNetworkStateResp :: Word16
+msgNetworkStateResp = 0x00BB
+
+-- | SBP class for message MSG_NETWORK_STATE_RESP (0x00BB).
+--
+-- The state of a network interface on the Piksi
+data MsgNetworkStateResp = MsgNetworkStateResp
+  { _msgNetworkStateResp_ip_address   :: Word32
+    -- ^ IPv4 Address
+  , _msgNetworkStateResp_interface_name :: Text
+    -- ^ Interface Name
+  , _msgNetworkStateResp_status       :: Word8
+    -- ^ Status of interface
+  } deriving ( Show, Read, Eq )
+
+instance Binary MsgNetworkStateResp where
+  get = do
+    _msgNetworkStateResp_ip_address <- getWord32le
+    _msgNetworkStateResp_interface_name <- decodeUtf8 <$> getByteString 16
+    _msgNetworkStateResp_status <- getWord8
+    return MsgNetworkStateResp {..}
+
+  put MsgNetworkStateResp {..} = do
+    putWord32le _msgNetworkStateResp_ip_address
+    putByteString $ encodeUtf8 _msgNetworkStateResp_interface_name
+    putWord8 _msgNetworkStateResp_status
+
+$(deriveSBP 'msgNetworkStateResp ''MsgNetworkStateResp)
+
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msgNetworkStateResp_" . P.stripPrefix "_msgNetworkStateResp_"}
+             ''MsgNetworkStateResp)
+$(makeLenses ''MsgNetworkStateResp)

--- a/java/src/com/swiftnav/sbp/client/MessageTable.java
+++ b/java/src/com/swiftnav/sbp/client/MessageTable.java
@@ -15,26 +15,14 @@ import com.swiftnav.sbp.SBPBinaryException;
 import com.swiftnav.sbp.SBPMessage;
 import com.swiftnav.sbp.SBPMessage.Builder;
 import com.swiftnav.sbp.SBPMessage.Parser;
-import com.swiftnav.sbp.ndb.MsgNdbEvent;
-import com.swiftnav.sbp.user.MsgUserData;
-import com.swiftnav.sbp.imu.MsgImuRaw;
-import com.swiftnav.sbp.imu.MsgImuAux;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDetailed;
-import com.swiftnav.sbp.tracking.MsgTrackingState;
-import com.swiftnav.sbp.tracking.MsgTrackingIq;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
 import com.swiftnav.sbp.acquisition.MsgAcqResult;
 import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
 import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
 import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
-import com.swiftnav.sbp.file_io.MsgFileioReadReq;
-import com.swiftnav.sbp.file_io.MsgFileioReadResp;
-import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
-import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
-import com.swiftnav.sbp.file_io.MsgFileioRemove;
-import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
-import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
-import com.swiftnav.sbp.ext_events.MsgExtEvent;
+import com.swiftnav.sbp.logging.MsgLog;
+import com.swiftnav.sbp.logging.MsgFwd;
+import com.swiftnav.sbp.logging.MsgTweet;
+import com.swiftnav.sbp.logging.MsgPrintDep;
 import com.swiftnav.sbp.navigation.MsgGPSTime;
 import com.swiftnav.sbp.navigation.MsgUtcTime;
 import com.swiftnav.sbp.navigation.MsgDops;
@@ -55,6 +43,16 @@ import com.swiftnav.sbp.navigation.MsgBaselineNEDDepA;
 import com.swiftnav.sbp.navigation.MsgVelECEFDepA;
 import com.swiftnav.sbp.navigation.MsgVelNEDDepA;
 import com.swiftnav.sbp.navigation.MsgBaselineHeadingDepA;
+import com.swiftnav.sbp.system.MsgStartup;
+import com.swiftnav.sbp.system.MsgDgnssStatus;
+import com.swiftnav.sbp.system.MsgHeartbeat;
+import com.swiftnav.sbp.imu.MsgImuRaw;
+import com.swiftnav.sbp.imu.MsgImuAux;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDetailed;
+import com.swiftnav.sbp.tracking.MsgTrackingState;
+import com.swiftnav.sbp.tracking.MsgTrackingIq;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
+import com.swiftnav.sbp.ext_events.MsgExtEvent;
 import com.swiftnav.sbp.observation.MsgObs;
 import com.swiftnav.sbp.observation.MsgBasePosLLH;
 import com.swiftnav.sbp.observation.MsgBasePosECEF;
@@ -73,6 +71,39 @@ import com.swiftnav.sbp.observation.MsgSvConfigurationGPS;
 import com.swiftnav.sbp.observation.MsgGroupDelay;
 import com.swiftnav.sbp.observation.MsgAlmanacGPS;
 import com.swiftnav.sbp.observation.MsgAlmanacGlo;
+import com.swiftnav.sbp.flash.MsgFlashProgram;
+import com.swiftnav.sbp.flash.MsgFlashDone;
+import com.swiftnav.sbp.flash.MsgFlashReadReq;
+import com.swiftnav.sbp.flash.MsgFlashReadResp;
+import com.swiftnav.sbp.flash.MsgFlashErase;
+import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
+import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
+import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
+import com.swiftnav.sbp.ndb.MsgNdbEvent;
+import com.swiftnav.sbp.settings.MsgSettingsSave;
+import com.swiftnav.sbp.settings.MsgSettingsWrite;
+import com.swiftnav.sbp.settings.MsgSettingsReadReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
+import com.swiftnav.sbp.settings.MsgSettingsRegister;
+import com.swiftnav.sbp.file_io.MsgFileioReadReq;
+import com.swiftnav.sbp.file_io.MsgFileioReadResp;
+import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
+import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
+import com.swiftnav.sbp.file_io.MsgFileioRemove;
+import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
+import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
+import com.swiftnav.sbp.user.MsgUserData;
 import com.swiftnav.sbp.piksi.MsgAlmanac;
 import com.swiftnav.sbp.piksi.MsgSetTime;
 import com.swiftnav.sbp.piksi.MsgReset;
@@ -89,57 +120,12 @@ import com.swiftnav.sbp.piksi.MsgMaskSatellite;
 import com.swiftnav.sbp.piksi.MsgDeviceMonitor;
 import com.swiftnav.sbp.piksi.MsgCommandReq;
 import com.swiftnav.sbp.piksi.MsgCommandResp;
-import com.swiftnav.sbp.settings.MsgSettingsSave;
-import com.swiftnav.sbp.settings.MsgSettingsWrite;
-import com.swiftnav.sbp.settings.MsgSettingsReadReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
-import com.swiftnav.sbp.settings.MsgSettingsRegister;
-import com.swiftnav.sbp.logging.MsgLog;
-import com.swiftnav.sbp.logging.MsgFwd;
-import com.swiftnav.sbp.logging.MsgTweet;
-import com.swiftnav.sbp.logging.MsgPrintDep;
-import com.swiftnav.sbp.system.MsgStartup;
-import com.swiftnav.sbp.system.MsgDgnssStatus;
-import com.swiftnav.sbp.system.MsgHeartbeat;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
-import com.swiftnav.sbp.flash.MsgFlashProgram;
-import com.swiftnav.sbp.flash.MsgFlashDone;
-import com.swiftnav.sbp.flash.MsgFlashReadReq;
-import com.swiftnav.sbp.flash.MsgFlashReadResp;
-import com.swiftnav.sbp.flash.MsgFlashErase;
-import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
-import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
-import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
+import com.swiftnav.sbp.piksi.MsgNetworkStateReq;
+import com.swiftnav.sbp.piksi.MsgNetworkStateResp;
 
 final class MessageTable {
     static SBPMessage dispatch(SBPMessage msg) throws SBPBinaryException {
         switch (msg.type) {
-            case MsgNdbEvent.TYPE:
-                return new MsgNdbEvent(msg);
-            case MsgUserData.TYPE:
-                return new MsgUserData(msg);
-            case MsgImuRaw.TYPE:
-                return new MsgImuRaw(msg);
-            case MsgImuAux.TYPE:
-                return new MsgImuAux(msg);
-            case MsgTrackingStateDetailed.TYPE:
-                return new MsgTrackingStateDetailed(msg);
-            case MsgTrackingState.TYPE:
-                return new MsgTrackingState(msg);
-            case MsgTrackingIq.TYPE:
-                return new MsgTrackingIq(msg);
-            case MsgTrackingStateDepA.TYPE:
-                return new MsgTrackingStateDepA(msg);
             case MsgAcqResult.TYPE:
                 return new MsgAcqResult(msg);
             case MsgAcqResultDepB.TYPE:
@@ -148,22 +134,14 @@ final class MessageTable {
                 return new MsgAcqResultDepA(msg);
             case MsgAcqSvProfile.TYPE:
                 return new MsgAcqSvProfile(msg);
-            case MsgFileioReadReq.TYPE:
-                return new MsgFileioReadReq(msg);
-            case MsgFileioReadResp.TYPE:
-                return new MsgFileioReadResp(msg);
-            case MsgFileioReadDirReq.TYPE:
-                return new MsgFileioReadDirReq(msg);
-            case MsgFileioReadDirResp.TYPE:
-                return new MsgFileioReadDirResp(msg);
-            case MsgFileioRemove.TYPE:
-                return new MsgFileioRemove(msg);
-            case MsgFileioWriteReq.TYPE:
-                return new MsgFileioWriteReq(msg);
-            case MsgFileioWriteResp.TYPE:
-                return new MsgFileioWriteResp(msg);
-            case MsgExtEvent.TYPE:
-                return new MsgExtEvent(msg);
+            case MsgLog.TYPE:
+                return new MsgLog(msg);
+            case MsgFwd.TYPE:
+                return new MsgFwd(msg);
+            case MsgTweet.TYPE:
+                return new MsgTweet(msg);
+            case MsgPrintDep.TYPE:
+                return new MsgPrintDep(msg);
             case MsgGPSTime.TYPE:
                 return new MsgGPSTime(msg);
             case MsgUtcTime.TYPE:
@@ -204,6 +182,26 @@ final class MessageTable {
                 return new MsgVelNEDDepA(msg);
             case MsgBaselineHeadingDepA.TYPE:
                 return new MsgBaselineHeadingDepA(msg);
+            case MsgStartup.TYPE:
+                return new MsgStartup(msg);
+            case MsgDgnssStatus.TYPE:
+                return new MsgDgnssStatus(msg);
+            case MsgHeartbeat.TYPE:
+                return new MsgHeartbeat(msg);
+            case MsgImuRaw.TYPE:
+                return new MsgImuRaw(msg);
+            case MsgImuAux.TYPE:
+                return new MsgImuAux(msg);
+            case MsgTrackingStateDetailed.TYPE:
+                return new MsgTrackingStateDetailed(msg);
+            case MsgTrackingState.TYPE:
+                return new MsgTrackingState(msg);
+            case MsgTrackingIq.TYPE:
+                return new MsgTrackingIq(msg);
+            case MsgTrackingStateDepA.TYPE:
+                return new MsgTrackingStateDepA(msg);
+            case MsgExtEvent.TYPE:
+                return new MsgExtEvent(msg);
             case MsgObs.TYPE:
                 return new MsgObs(msg);
             case MsgBasePosLLH.TYPE:
@@ -240,6 +238,72 @@ final class MessageTable {
                 return new MsgAlmanacGPS(msg);
             case MsgAlmanacGlo.TYPE:
                 return new MsgAlmanacGlo(msg);
+            case MsgFlashProgram.TYPE:
+                return new MsgFlashProgram(msg);
+            case MsgFlashDone.TYPE:
+                return new MsgFlashDone(msg);
+            case MsgFlashReadReq.TYPE:
+                return new MsgFlashReadReq(msg);
+            case MsgFlashReadResp.TYPE:
+                return new MsgFlashReadResp(msg);
+            case MsgFlashErase.TYPE:
+                return new MsgFlashErase(msg);
+            case MsgStmFlashLockSector.TYPE:
+                return new MsgStmFlashLockSector(msg);
+            case MsgStmFlashUnlockSector.TYPE:
+                return new MsgStmFlashUnlockSector(msg);
+            case MsgStmUniqueIdReq.TYPE:
+                return new MsgStmUniqueIdReq(msg);
+            case MsgStmUniqueIdResp.TYPE:
+                return new MsgStmUniqueIdResp(msg);
+            case MsgM25FlashWriteStatus.TYPE:
+                return new MsgM25FlashWriteStatus(msg);
+            case MsgBootloaderHandshakeReq.TYPE:
+                return new MsgBootloaderHandshakeReq(msg);
+            case MsgBootloaderHandshakeResp.TYPE:
+                return new MsgBootloaderHandshakeResp(msg);
+            case MsgBootloaderJumpToApp.TYPE:
+                return new MsgBootloaderJumpToApp(msg);
+            case MsgNapDeviceDnaReq.TYPE:
+                return new MsgNapDeviceDnaReq(msg);
+            case MsgNapDeviceDnaResp.TYPE:
+                return new MsgNapDeviceDnaResp(msg);
+            case MsgBootloaderHandshakeDepA.TYPE:
+                return new MsgBootloaderHandshakeDepA(msg);
+            case MsgNdbEvent.TYPE:
+                return new MsgNdbEvent(msg);
+            case MsgSettingsSave.TYPE:
+                return new MsgSettingsSave(msg);
+            case MsgSettingsWrite.TYPE:
+                return new MsgSettingsWrite(msg);
+            case MsgSettingsReadReq.TYPE:
+                return new MsgSettingsReadReq(msg);
+            case MsgSettingsReadResp.TYPE:
+                return new MsgSettingsReadResp(msg);
+            case MsgSettingsReadByIndexReq.TYPE:
+                return new MsgSettingsReadByIndexReq(msg);
+            case MsgSettingsReadByIndexResp.TYPE:
+                return new MsgSettingsReadByIndexResp(msg);
+            case MsgSettingsReadByIndexDone.TYPE:
+                return new MsgSettingsReadByIndexDone(msg);
+            case MsgSettingsRegister.TYPE:
+                return new MsgSettingsRegister(msg);
+            case MsgFileioReadReq.TYPE:
+                return new MsgFileioReadReq(msg);
+            case MsgFileioReadResp.TYPE:
+                return new MsgFileioReadResp(msg);
+            case MsgFileioReadDirReq.TYPE:
+                return new MsgFileioReadDirReq(msg);
+            case MsgFileioReadDirResp.TYPE:
+                return new MsgFileioReadDirResp(msg);
+            case MsgFileioRemove.TYPE:
+                return new MsgFileioRemove(msg);
+            case MsgFileioWriteReq.TYPE:
+                return new MsgFileioWriteReq(msg);
+            case MsgFileioWriteResp.TYPE:
+                return new MsgFileioWriteResp(msg);
+            case MsgUserData.TYPE:
+                return new MsgUserData(msg);
             case MsgAlmanac.TYPE:
                 return new MsgAlmanac(msg);
             case MsgSetTime.TYPE:
@@ -272,68 +336,10 @@ final class MessageTable {
                 return new MsgCommandReq(msg);
             case MsgCommandResp.TYPE:
                 return new MsgCommandResp(msg);
-            case MsgSettingsSave.TYPE:
-                return new MsgSettingsSave(msg);
-            case MsgSettingsWrite.TYPE:
-                return new MsgSettingsWrite(msg);
-            case MsgSettingsReadReq.TYPE:
-                return new MsgSettingsReadReq(msg);
-            case MsgSettingsReadResp.TYPE:
-                return new MsgSettingsReadResp(msg);
-            case MsgSettingsReadByIndexReq.TYPE:
-                return new MsgSettingsReadByIndexReq(msg);
-            case MsgSettingsReadByIndexResp.TYPE:
-                return new MsgSettingsReadByIndexResp(msg);
-            case MsgSettingsReadByIndexDone.TYPE:
-                return new MsgSettingsReadByIndexDone(msg);
-            case MsgSettingsRegister.TYPE:
-                return new MsgSettingsRegister(msg);
-            case MsgLog.TYPE:
-                return new MsgLog(msg);
-            case MsgFwd.TYPE:
-                return new MsgFwd(msg);
-            case MsgTweet.TYPE:
-                return new MsgTweet(msg);
-            case MsgPrintDep.TYPE:
-                return new MsgPrintDep(msg);
-            case MsgStartup.TYPE:
-                return new MsgStartup(msg);
-            case MsgDgnssStatus.TYPE:
-                return new MsgDgnssStatus(msg);
-            case MsgHeartbeat.TYPE:
-                return new MsgHeartbeat(msg);
-            case MsgBootloaderHandshakeReq.TYPE:
-                return new MsgBootloaderHandshakeReq(msg);
-            case MsgBootloaderHandshakeResp.TYPE:
-                return new MsgBootloaderHandshakeResp(msg);
-            case MsgBootloaderJumpToApp.TYPE:
-                return new MsgBootloaderJumpToApp(msg);
-            case MsgNapDeviceDnaReq.TYPE:
-                return new MsgNapDeviceDnaReq(msg);
-            case MsgNapDeviceDnaResp.TYPE:
-                return new MsgNapDeviceDnaResp(msg);
-            case MsgBootloaderHandshakeDepA.TYPE:
-                return new MsgBootloaderHandshakeDepA(msg);
-            case MsgFlashProgram.TYPE:
-                return new MsgFlashProgram(msg);
-            case MsgFlashDone.TYPE:
-                return new MsgFlashDone(msg);
-            case MsgFlashReadReq.TYPE:
-                return new MsgFlashReadReq(msg);
-            case MsgFlashReadResp.TYPE:
-                return new MsgFlashReadResp(msg);
-            case MsgFlashErase.TYPE:
-                return new MsgFlashErase(msg);
-            case MsgStmFlashLockSector.TYPE:
-                return new MsgStmFlashLockSector(msg);
-            case MsgStmFlashUnlockSector.TYPE:
-                return new MsgStmFlashUnlockSector(msg);
-            case MsgStmUniqueIdReq.TYPE:
-                return new MsgStmUniqueIdReq(msg);
-            case MsgStmUniqueIdResp.TYPE:
-                return new MsgStmUniqueIdResp(msg);
-            case MsgM25FlashWriteStatus.TYPE:
-                return new MsgM25FlashWriteStatus(msg);
+            case MsgNetworkStateReq.TYPE:
+                return new MsgNetworkStateReq(msg);
+            case MsgNetworkStateResp.TYPE:
+                return new MsgNetworkStateResp(msg);
         }
         return msg;
     }

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateReq.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateReq.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Gareth McMullin <gareth@swiftnav.com>
+ * Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+
+/** SBP class for message MSG_NETWORK_STATE_REQ (0x00BA).
+ *
+ * You can have MSG_NETWORK_STATE_REQ inherent its fields directly from
+ * an inherited SBP object, or construct it inline using a dict of its
+ * fields.
+ *
+ * Request state of Piksi network interfaces.
+ * Output will be sent in MSG_NETWORK_STATE_RESP messages */
+
+public class MsgNetworkStateReq extends SBPMessage {
+    public static final int TYPE = 0x00BA;
+
+    
+
+    public MsgNetworkStateReq (int sender) { super(sender, TYPE); }
+    public MsgNetworkStateReq () { super(TYPE); }
+    public MsgNetworkStateReq (SBPMessage msg) throws SBPBinaryException {
+        super(msg);
+        assert msg.type != TYPE;
+    }
+
+    @Override
+    protected void parse(Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+    }
+
+    @Override
+    protected void build(Builder builder) {
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = super.toJSON();
+        return obj;
+    }
+}

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
@@ -34,8 +34,20 @@ public class MsgNetworkStateResp extends SBPMessage {
     public static final int TYPE = 0x00BB;
 
     
-    /** IPv4 Address */
+    /** IPv4 address */
     public long ip_address;
+    
+    /** IPv4 netmask */
+    public long ip_mask;
+    
+    /** IPv4 gateway */
+    public long ip_gateway;
+    
+    /** Number of Rx packets */
+    public long rx_packets;
+    
+    /** Number of Tx packets */
+    public long tx_packets;
     
     /** Interface Name */
     public String interface_name;
@@ -55,6 +67,10 @@ public class MsgNetworkStateResp extends SBPMessage {
     protected void parse(Parser parser) throws SBPBinaryException {
         /* Parse fields from binary */
         ip_address = parser.getU32();
+        ip_mask = parser.getU32();
+        ip_gateway = parser.getU32();
+        rx_packets = parser.getU32();
+        tx_packets = parser.getU32();
         interface_name = parser.getString(16);
         status = parser.getU8();
     }
@@ -62,6 +78,10 @@ public class MsgNetworkStateResp extends SBPMessage {
     @Override
     protected void build(Builder builder) {
         builder.putU32(ip_address);
+        builder.putU32(ip_mask);
+        builder.putU32(ip_gateway);
+        builder.putU32(rx_packets);
+        builder.putU32(tx_packets);
         builder.putString(interface_name, 16);
         builder.putU8(status);
     }
@@ -70,6 +90,10 @@ public class MsgNetworkStateResp extends SBPMessage {
     public JSONObject toJSON() {
         JSONObject obj = super.toJSON();
         obj.put("ip_address", ip_address);
+        obj.put("ip_mask", ip_mask);
+        obj.put("ip_gateway", ip_gateway);
+        obj.put("rx_packets", rx_packets);
+        obj.put("tx_packets", tx_packets);
         obj.put("interface_name", interface_name);
         obj.put("status", status);
         return obj;

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
@@ -40,20 +40,17 @@ public class MsgNetworkStateResp extends SBPMessage {
     /** IPv4 netmask */
     public long ip_mask;
     
-    /** IPv4 gateway */
-    public long ip_gateway;
+    /** Number of Rx bytes */
+    public long rx_bytes;
     
-    /** Number of Rx packets */
-    public long rx_packets;
-    
-    /** Number of Tx packets */
-    public long tx_packets;
+    /** Number of Tx bytes */
+    public long tx_bytes;
     
     /** Interface Name */
     public String interface_name;
     
-    /** Status of interface */
-    public int status;
+    /** Interface flags from SIOCGIFFLAGS */
+    public long flags;
     
 
     public MsgNetworkStateResp (int sender) { super(sender, TYPE); }
@@ -68,22 +65,20 @@ public class MsgNetworkStateResp extends SBPMessage {
         /* Parse fields from binary */
         ip_address = parser.getU32();
         ip_mask = parser.getU32();
-        ip_gateway = parser.getU32();
-        rx_packets = parser.getU32();
-        tx_packets = parser.getU32();
+        rx_bytes = parser.getU32();
+        tx_bytes = parser.getU32();
         interface_name = parser.getString(16);
-        status = parser.getU8();
+        flags = parser.getU32();
     }
 
     @Override
     protected void build(Builder builder) {
         builder.putU32(ip_address);
         builder.putU32(ip_mask);
-        builder.putU32(ip_gateway);
-        builder.putU32(rx_packets);
-        builder.putU32(tx_packets);
+        builder.putU32(rx_bytes);
+        builder.putU32(tx_bytes);
         builder.putString(interface_name, 16);
-        builder.putU8(status);
+        builder.putU32(flags);
     }
 
     @Override
@@ -91,11 +86,10 @@ public class MsgNetworkStateResp extends SBPMessage {
         JSONObject obj = super.toJSON();
         obj.put("ip_address", ip_address);
         obj.put("ip_mask", ip_mask);
-        obj.put("ip_gateway", ip_gateway);
-        obj.put("rx_packets", rx_packets);
-        obj.put("tx_packets", tx_packets);
+        obj.put("rx_bytes", rx_bytes);
+        obj.put("tx_bytes", tx_bytes);
         obj.put("interface_name", interface_name);
-        obj.put("status", status);
+        obj.put("flags", flags);
         return obj;
     }
 }

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
@@ -34,11 +34,17 @@ public class MsgNetworkStateResp extends SBPMessage {
     public static final int TYPE = 0x00BB;
 
     
-    /** IPv4 address */
-    public long ip_address;
+    /** IPv4 address (all zero when unavailable) */
+    public int[] ipv4_address;
     
-    /** IPv4 netmask */
-    public long ip_mask;
+    /** IPv4 netmask CIDR notation */
+    public int ipv4_mask_size;
+    
+    /** IPv6 address (all zero when unavailable) */
+    public int[] ipv6_address;
+    
+    /** IPv6 netmask CIDR notation */
+    public int ipv6_mask_size;
     
     /** Number of Rx bytes */
     public long rx_bytes;
@@ -63,8 +69,10 @@ public class MsgNetworkStateResp extends SBPMessage {
     @Override
     protected void parse(Parser parser) throws SBPBinaryException {
         /* Parse fields from binary */
-        ip_address = parser.getU32();
-        ip_mask = parser.getU32();
+        ipv4_address = parser.getArrayofU8(4);
+        ipv4_mask_size = parser.getU8();
+        ipv6_address = parser.getArrayofU8(16);
+        ipv6_mask_size = parser.getU8();
         rx_bytes = parser.getU32();
         tx_bytes = parser.getU32();
         interface_name = parser.getString(16);
@@ -73,8 +81,10 @@ public class MsgNetworkStateResp extends SBPMessage {
 
     @Override
     protected void build(Builder builder) {
-        builder.putU32(ip_address);
-        builder.putU32(ip_mask);
+        builder.putArrayofU8(ipv4_address, 4);
+        builder.putU8(ipv4_mask_size);
+        builder.putArrayofU8(ipv6_address, 16);
+        builder.putU8(ipv6_mask_size);
         builder.putU32(rx_bytes);
         builder.putU32(tx_bytes);
         builder.putString(interface_name, 16);
@@ -84,8 +94,10 @@ public class MsgNetworkStateResp extends SBPMessage {
     @Override
     public JSONObject toJSON() {
         JSONObject obj = super.toJSON();
-        obj.put("ip_address", ip_address);
-        obj.put("ip_mask", ip_mask);
+        obj.put("ipv4_address", new JSONArray(ipv4_address));
+        obj.put("ipv4_mask_size", ipv4_mask_size);
+        obj.put("ipv6_address", new JSONArray(ipv6_address));
+        obj.put("ipv6_mask_size", ipv6_mask_size);
         obj.put("rx_bytes", rx_bytes);
         obj.put("tx_bytes", tx_bytes);
         obj.put("interface_name", interface_name);

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Gareth McMullin <gareth@swiftnav.com>
+ * Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+
+/** SBP class for message MSG_NETWORK_STATE_RESP (0x00BB).
+ *
+ * You can have MSG_NETWORK_STATE_RESP inherent its fields directly from
+ * an inherited SBP object, or construct it inline using a dict of its
+ * fields.
+ *
+ * The state of a network interface on the Piksi */
+
+public class MsgNetworkStateResp extends SBPMessage {
+    public static final int TYPE = 0x00BB;
+
+    
+    /** IPv4 Address */
+    public long ip_address;
+    
+    /** Interface Name */
+    public String interface_name;
+    
+    /** Status of interface */
+    public int status;
+    
+
+    public MsgNetworkStateResp (int sender) { super(sender, TYPE); }
+    public MsgNetworkStateResp () { super(TYPE); }
+    public MsgNetworkStateResp (SBPMessage msg) throws SBPBinaryException {
+        super(msg);
+        assert msg.type != TYPE;
+    }
+
+    @Override
+    protected void parse(Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+        ip_address = parser.getU32();
+        interface_name = parser.getString(16);
+        status = parser.getU8();
+    }
+
+    @Override
+    protected void build(Builder builder) {
+        builder.putU32(ip_address);
+        builder.putString(interface_name, 16);
+        builder.putU8(status);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = super.toJSON();
+        obj.put("ip_address", ip_address);
+        obj.put("interface_name", interface_name);
+        obj.put("status", status);
+        return obj;
+    }
+}

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
@@ -28,7 +28,9 @@ import org.json.JSONArray;
  * an inherited SBP object, or construct it inline using a dict of its
  * fields.
  *
- * The state of a network interface on the Piksi */
+ * The state of a network interface on the Piksi.
+ * Data is made to reflect output of ifaddrs struct returned by getifaddrs
+ * in c. */
 
 public class MsgNetworkStateResp extends SBPMessage {
     public static final int TYPE = 0x00BB;

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStatusReq.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStatusReq.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Gareth McMullin <gareth@swiftnav.com>
+ * Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+
+/** SBP class for message MSG_NETWORK_STATUS_REQ (0x00BA).
+ *
+ * You can have MSG_NETWORK_STATUS_REQ inherent its fields directly from
+ * an inherited SBP object, or construct it inline using a dict of its
+ * fields.
+ *
+ * Request status of Piksi network interfaces.
+ * Output will be sent in MSG_NETWORK_STATUS_RESP messages */
+
+public class MsgNetworkStatusReq extends SBPMessage {
+    public static final int TYPE = 0x00BA;
+
+    
+
+    public MsgNetworkStatusReq (int sender) { super(sender, TYPE); }
+    public MsgNetworkStatusReq () { super(TYPE); }
+    public MsgNetworkStatusReq (SBPMessage msg) throws SBPBinaryException {
+        super(msg);
+        assert msg.type != TYPE;
+    }
+
+    @Override
+    protected void parse(Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+    }
+
+    @Override
+    protected void build(Builder builder) {
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = super.toJSON();
+        return obj;
+    }
+}

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStatusResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStatusResp.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Gareth McMullin <gareth@swiftnav.com>
+ * Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+
+/** SBP class for message MSG_NETWORK_STATUS_RESP (0x00BB).
+ *
+ * You can have MSG_NETWORK_STATUS_RESP inherent its fields directly from
+ * an inherited SBP object, or construct it inline using a dict of its
+ * fields.
+ *
+ * The state of each network interface on the Piksi */
+
+public class MsgNetworkStatusResp extends SBPMessage {
+    public static final int TYPE = 0x00BB;
+
+    
+    /** IPv4 Address */
+    public long ip_address;
+    
+    /** Interface Name */
+    public String interface_name;
+    
+
+    public MsgNetworkStatusResp (int sender) { super(sender, TYPE); }
+    public MsgNetworkStatusResp () { super(TYPE); }
+    public MsgNetworkStatusResp (SBPMessage msg) throws SBPBinaryException {
+        super(msg);
+        assert msg.type != TYPE;
+    }
+
+    @Override
+    protected void parse(Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+        ip_address = parser.getU32();
+        interface_name = parser.getString(16);
+    }
+
+    @Override
+    protected void build(Builder builder) {
+        builder.putU32(ip_address);
+        builder.putString(interface_name, 16);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = super.toJSON();
+        obj.put("ip_address", ip_address);
+        obj.put("interface_name", interface_name);
+        return obj;
+    }
+}

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -650,7 +650,11 @@ MsgNetworkStateReq.prototype.fieldSpec = [];
  * The state of a network interface on the Piksi
  *
  * Fields in the SBP payload (`sbp.payload`):
- * @field ip_address number (unsigned 32-bit int, 4 bytes) IPv4 Address
+ * @field ip_address number (unsigned 32-bit int, 4 bytes) IPv4 address
+ * @field ip_mask number (unsigned 32-bit int, 4 bytes) IPv4 netmask
+ * @field ip_gateway number (unsigned 32-bit int, 4 bytes) IPv4 gateway
+ * @field rx_packets number (unsigned 32-bit int, 4 bytes) Number of Rx packets
+ * @field tx_packets number (unsigned 32-bit int, 4 bytes) Number of Tx packets
  * @field interface_name string Interface Name
  * @field status number (unsigned 8-bit int, 1 byte) Status of interface
  *
@@ -670,10 +674,18 @@ MsgNetworkStateResp.prototype.constructor = MsgNetworkStateResp;
 MsgNetworkStateResp.prototype.parser = new Parser()
   .endianess('little')
   .uint32('ip_address')
+  .uint32('ip_mask')
+  .uint32('ip_gateway')
+  .uint32('rx_packets')
+  .uint32('tx_packets')
   .string('interface_name', { length: 16 })
   .uint8('status');
 MsgNetworkStateResp.prototype.fieldSpec = [];
 MsgNetworkStateResp.prototype.fieldSpec.push(['ip_address', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['ip_mask', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['ip_gateway', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['rx_packets', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['tx_packets', 'writeUInt32LE', 4]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['interface_name', 'string', 16]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['status', 'writeUInt8', 1]);
 

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -652,11 +652,10 @@ MsgNetworkStateReq.prototype.fieldSpec = [];
  * Fields in the SBP payload (`sbp.payload`):
  * @field ip_address number (unsigned 32-bit int, 4 bytes) IPv4 address
  * @field ip_mask number (unsigned 32-bit int, 4 bytes) IPv4 netmask
- * @field ip_gateway number (unsigned 32-bit int, 4 bytes) IPv4 gateway
- * @field rx_packets number (unsigned 32-bit int, 4 bytes) Number of Rx packets
- * @field tx_packets number (unsigned 32-bit int, 4 bytes) Number of Tx packets
+ * @field rx_bytes number (unsigned 32-bit int, 4 bytes) Number of Rx bytes
+ * @field tx_bytes number (unsigned 32-bit int, 4 bytes) Number of Tx bytes
  * @field interface_name string Interface Name
- * @field status number (unsigned 8-bit int, 1 byte) Status of interface
+ * @field flags number (unsigned 32-bit int, 4 bytes) Interface flags from SIOCGIFFLAGS
  *
  * @param sbp An SBP object with a payload to be decoded.
  */
@@ -675,19 +674,17 @@ MsgNetworkStateResp.prototype.parser = new Parser()
   .endianess('little')
   .uint32('ip_address')
   .uint32('ip_mask')
-  .uint32('ip_gateway')
-  .uint32('rx_packets')
-  .uint32('tx_packets')
+  .uint32('rx_bytes')
+  .uint32('tx_bytes')
   .string('interface_name', { length: 16 })
-  .uint8('status');
+  .uint32('flags');
 MsgNetworkStateResp.prototype.fieldSpec = [];
 MsgNetworkStateResp.prototype.fieldSpec.push(['ip_address', 'writeUInt32LE', 4]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['ip_mask', 'writeUInt32LE', 4]);
-MsgNetworkStateResp.prototype.fieldSpec.push(['ip_gateway', 'writeUInt32LE', 4]);
-MsgNetworkStateResp.prototype.fieldSpec.push(['rx_packets', 'writeUInt32LE', 4]);
-MsgNetworkStateResp.prototype.fieldSpec.push(['tx_packets', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['rx_bytes', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['tx_bytes', 'writeUInt32LE', 4]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['interface_name', 'string', 16]);
-MsgNetworkStateResp.prototype.fieldSpec.push(['status', 'writeUInt8', 1]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['flags', 'writeUInt32LE', 4]);
 
 module.exports = {
   0x0069: MsgAlmanac,

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -621,6 +621,62 @@ MsgCommandResp.prototype.fieldSpec = [];
 MsgCommandResp.prototype.fieldSpec.push(['sequence', 'writeUInt32LE', 4]);
 MsgCommandResp.prototype.fieldSpec.push(['code', 'writeInt32LE', 4]);
 
+/**
+ * SBP class for message MSG_NETWORK_STATE_REQ (0x00BA).
+ *
+ * Request state of Piksi network interfaces. Output will be sent in
+ * MSG_NETWORK_STATE_RESP messages
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var MsgNetworkStateReq = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "MSG_NETWORK_STATE_REQ";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+MsgNetworkStateReq.prototype = Object.create(SBP.prototype);
+MsgNetworkStateReq.prototype.messageType = "MSG_NETWORK_STATE_REQ";
+MsgNetworkStateReq.prototype.msg_type = 0x00BA;
+MsgNetworkStateReq.prototype.constructor = MsgNetworkStateReq;
+MsgNetworkStateReq.prototype.parser = new Parser()
+  .endianess('little');
+MsgNetworkStateReq.prototype.fieldSpec = [];
+
+/**
+ * SBP class for message MSG_NETWORK_STATE_RESP (0x00BB).
+ *
+ * The state of a network interface on the Piksi
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field ip_address number (unsigned 32-bit int, 4 bytes) IPv4 Address
+ * @field interface_name string Interface Name
+ * @field status number (unsigned 8-bit int, 1 byte) Status of interface
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var MsgNetworkStateResp = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "MSG_NETWORK_STATE_RESP";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+MsgNetworkStateResp.prototype = Object.create(SBP.prototype);
+MsgNetworkStateResp.prototype.messageType = "MSG_NETWORK_STATE_RESP";
+MsgNetworkStateResp.prototype.msg_type = 0x00BB;
+MsgNetworkStateResp.prototype.constructor = MsgNetworkStateResp;
+MsgNetworkStateResp.prototype.parser = new Parser()
+  .endianess('little')
+  .uint32('ip_address')
+  .string('interface_name', { length: 16 })
+  .uint8('status');
+MsgNetworkStateResp.prototype.fieldSpec = [];
+MsgNetworkStateResp.prototype.fieldSpec.push(['ip_address', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['interface_name', 'string', 16]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['status', 'writeUInt8', 1]);
+
 module.exports = {
   0x0069: MsgAlmanac,
   MsgAlmanac: MsgAlmanac,
@@ -657,4 +713,8 @@ module.exports = {
   MsgCommandReq: MsgCommandReq,
   0x00B9: MsgCommandResp,
   MsgCommandResp: MsgCommandResp,
+  0x00BA: MsgNetworkStateReq,
+  MsgNetworkStateReq: MsgNetworkStateReq,
+  0x00BB: MsgNetworkStateResp,
+  MsgNetworkStateResp: MsgNetworkStateResp,
 }

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -650,8 +650,10 @@ MsgNetworkStateReq.prototype.fieldSpec = [];
  * The state of a network interface on the Piksi
  *
  * Fields in the SBP payload (`sbp.payload`):
- * @field ip_address number (unsigned 32-bit int, 4 bytes) IPv4 address
- * @field ip_mask number (unsigned 32-bit int, 4 bytes) IPv4 netmask
+ * @field ipv4_address array IPv4 address (all zero when unavailable)
+ * @field ipv4_mask_size number (unsigned 8-bit int, 1 byte) IPv4 netmask CIDR notation
+ * @field ipv6_address array IPv6 address (all zero when unavailable)
+ * @field ipv6_mask_size number (unsigned 8-bit int, 1 byte) IPv6 netmask CIDR notation
  * @field rx_bytes number (unsigned 32-bit int, 4 bytes) Number of Rx bytes
  * @field tx_bytes number (unsigned 32-bit int, 4 bytes) Number of Tx bytes
  * @field interface_name string Interface Name
@@ -672,15 +674,19 @@ MsgNetworkStateResp.prototype.msg_type = 0x00BB;
 MsgNetworkStateResp.prototype.constructor = MsgNetworkStateResp;
 MsgNetworkStateResp.prototype.parser = new Parser()
   .endianess('little')
-  .uint32('ip_address')
-  .uint32('ip_mask')
+  .array('ipv4_address', { length: 4, type: 'uint8' })
+  .uint8('ipv4_mask_size')
+  .array('ipv6_address', { length: 16, type: 'uint8' })
+  .uint8('ipv6_mask_size')
   .uint32('rx_bytes')
   .uint32('tx_bytes')
   .string('interface_name', { length: 16 })
   .uint32('flags');
 MsgNetworkStateResp.prototype.fieldSpec = [];
-MsgNetworkStateResp.prototype.fieldSpec.push(['ip_address', 'writeUInt32LE', 4]);
-MsgNetworkStateResp.prototype.fieldSpec.push(['ip_mask', 'writeUInt32LE', 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['ipv4_address', 'array', 'writeUInt8', function () { return 1; }, 4]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['ipv4_mask_size', 'writeUInt8', 1]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['ipv6_address', 'array', 'writeUInt8', function () { return 1; }, 16]);
+MsgNetworkStateResp.prototype.fieldSpec.push(['ipv6_mask_size', 'writeUInt8', 1]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['rx_bytes', 'writeUInt32LE', 4]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['tx_bytes', 'writeUInt32LE', 4]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['interface_name', 'string', 16]);

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -647,7 +647,8 @@ MsgNetworkStateReq.prototype.fieldSpec = [];
 /**
  * SBP class for message MSG_NETWORK_STATE_RESP (0x00BB).
  *
- * The state of a network interface on the Piksi
+ * The state of a network interface on the Piksi. Data is made to reflect output of
+ * ifaddrs struct returned by getifaddrs in c.
  *
  * Fields in the SBP payload (`sbp.payload`):
  * @field ipv4_address array IPv4 address (all zero when unavailable)

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1461,7 +1461,15 @@ class MsgNetworkStateResp(SBP):
   sbp : SBP
     SBP parent object to inherit from.
   ip_address : int
-    IPv4 Address
+    IPv4 address
+  ip_mask : int
+    IPv4 netmask
+  ip_gateway : int
+    IPv4 gateway
+  rx_packets : int
+    Number of Rx packets
+  tx_packets : int
+    Number of Tx packets
   interface_name : string
     Interface Name
   status : int
@@ -1472,10 +1480,18 @@ class MsgNetworkStateResp(SBP):
   """
   _parser = Struct("MsgNetworkStateResp",
                    ULInt32('ip_address'),
+                   ULInt32('ip_mask'),
+                   ULInt32('ip_gateway'),
+                   ULInt32('rx_packets'),
+                   ULInt32('tx_packets'),
                    String('interface_name', 16),
                    ULInt8('status'),)
   __slots__ = [
                'ip_address',
+               'ip_mask',
+               'ip_gateway',
+               'rx_packets',
+               'tx_packets',
                'interface_name',
                'status',
               ]
@@ -1491,6 +1507,10 @@ class MsgNetworkStateResp(SBP):
       self.msg_type = SBP_MSG_NETWORK_STATE_RESP
       self.sender = kwargs.pop('sender', SENDER_ID)
       self.ip_address = kwargs.pop('ip_address')
+      self.ip_mask = kwargs.pop('ip_mask')
+      self.ip_gateway = kwargs.pop('ip_gateway')
+      self.rx_packets = kwargs.pop('rx_packets')
+      self.tx_packets = kwargs.pop('tx_packets')
       self.interface_name = kwargs.pop('interface_name')
       self.status = kwargs.pop('status')
 

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1453,7 +1453,9 @@ class MsgNetworkStateResp(SBP):
   of its fields.
 
   
-  The state of a network interface on the Piksi
+  The state of a network interface on the Piksi.
+Data is made to reflect output of ifaddrs struct returned by getifaddrs
+in c.
 
 
   Parameters

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1464,16 +1464,14 @@ class MsgNetworkStateResp(SBP):
     IPv4 address
   ip_mask : int
     IPv4 netmask
-  ip_gateway : int
-    IPv4 gateway
-  rx_packets : int
-    Number of Rx packets
-  tx_packets : int
-    Number of Tx packets
+  rx_bytes : int
+    Number of Rx bytes
+  tx_bytes : int
+    Number of Tx bytes
   interface_name : string
     Interface Name
-  status : int
-    Status of interface
+  flags : int
+    Interface flags from SIOCGIFFLAGS
   sender : int
     Optional sender ID, defaults to SENDER_ID (see sbp/msg.py).
 
@@ -1481,19 +1479,17 @@ class MsgNetworkStateResp(SBP):
   _parser = Struct("MsgNetworkStateResp",
                    ULInt32('ip_address'),
                    ULInt32('ip_mask'),
-                   ULInt32('ip_gateway'),
-                   ULInt32('rx_packets'),
-                   ULInt32('tx_packets'),
+                   ULInt32('rx_bytes'),
+                   ULInt32('tx_bytes'),
                    String('interface_name', 16),
-                   ULInt8('status'),)
+                   ULInt32('flags'),)
   __slots__ = [
                'ip_address',
                'ip_mask',
-               'ip_gateway',
-               'rx_packets',
-               'tx_packets',
+               'rx_bytes',
+               'tx_bytes',
                'interface_name',
-               'status',
+               'flags',
               ]
 
   def __init__(self, sbp=None, **kwargs):
@@ -1508,11 +1504,10 @@ class MsgNetworkStateResp(SBP):
       self.sender = kwargs.pop('sender', SENDER_ID)
       self.ip_address = kwargs.pop('ip_address')
       self.ip_mask = kwargs.pop('ip_mask')
-      self.ip_gateway = kwargs.pop('ip_gateway')
-      self.rx_packets = kwargs.pop('rx_packets')
-      self.tx_packets = kwargs.pop('tx_packets')
+      self.rx_bytes = kwargs.pop('rx_bytes')
+      self.tx_bytes = kwargs.pop('tx_bytes')
       self.interface_name = kwargs.pop('interface_name')
-      self.status = kwargs.pop('status')
+      self.flags = kwargs.pop('flags')
 
   def __repr__(self):
     return fmt_repr(self)

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1460,10 +1460,14 @@ class MsgNetworkStateResp(SBP):
   ----------
   sbp : SBP
     SBP parent object to inherit from.
-  ip_address : int
-    IPv4 address
-  ip_mask : int
-    IPv4 netmask
+  ipv4_address : array
+    IPv4 address (all zero when unavailable)
+  ipv4_mask_size : int
+    IPv4 netmask CIDR notation
+  ipv6_address : array
+    IPv6 address (all zero when unavailable)
+  ipv6_mask_size : int
+    IPv6 netmask CIDR notation
   rx_bytes : int
     Number of Rx bytes
   tx_bytes : int
@@ -1477,15 +1481,19 @@ class MsgNetworkStateResp(SBP):
 
   """
   _parser = Struct("MsgNetworkStateResp",
-                   ULInt32('ip_address'),
-                   ULInt32('ip_mask'),
+                   Struct('ipv4_address', Array(4, ULInt8('ipv4_address'))),
+                   ULInt8('ipv4_mask_size'),
+                   Struct('ipv6_address', Array(16, ULInt8('ipv6_address'))),
+                   ULInt8('ipv6_mask_size'),
                    ULInt32('rx_bytes'),
                    ULInt32('tx_bytes'),
                    String('interface_name', 16),
                    ULInt32('flags'),)
   __slots__ = [
-               'ip_address',
-               'ip_mask',
+               'ipv4_address',
+               'ipv4_mask_size',
+               'ipv6_address',
+               'ipv6_mask_size',
                'rx_bytes',
                'tx_bytes',
                'interface_name',
@@ -1502,8 +1510,10 @@ class MsgNetworkStateResp(SBP):
       super( MsgNetworkStateResp, self).__init__()
       self.msg_type = SBP_MSG_NETWORK_STATE_RESP
       self.sender = kwargs.pop('sender', SENDER_ID)
-      self.ip_address = kwargs.pop('ip_address')
-      self.ip_mask = kwargs.pop('ip_mask')
+      self.ipv4_address = kwargs.pop('ipv4_address')
+      self.ipv4_mask_size = kwargs.pop('ipv4_mask_size')
+      self.ipv6_address = kwargs.pop('ipv6_address')
+      self.ipv6_mask_size = kwargs.pop('ipv6_mask_size')
       self.rx_bytes = kwargs.pop('rx_bytes')
       self.tx_bytes = kwargs.pop('tx_bytes')
       self.interface_name = kwargs.pop('interface_name')

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1398,6 +1398,143 @@ the command.  A return code of zero indicates success.
     d.update(j)
     return d
     
+SBP_MSG_NETWORK_STATE_REQ = 0x00BA
+class MsgNetworkStateReq(SBP):
+  """SBP class for message MSG_NETWORK_STATE_REQ (0x00BA).
+
+  You can have MSG_NETWORK_STATE_REQ inherit its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
+  
+  Request state of Piksi network interfaces.
+Output will be sent in MSG_NETWORK_STATE_RESP messages
+
+
+  """
+  __slots__ = []
+
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      super( MsgNetworkStateReq,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
+      self.payload = sbp.payload
+    else:
+      super( MsgNetworkStateReq, self).__init__()
+      self.msg_type = SBP_MSG_NETWORK_STATE_REQ
+      self.sender = kwargs.pop('sender', SENDER_ID)
+      self.payload = ""
+
+  def __repr__(self):
+    return fmt_repr(self)
+
+  @staticmethod
+  def from_json(s):
+    """Given a JSON-encoded string s, build a message object.
+
+    """
+    d = json.loads(s)
+    return MsgNetworkStateReq.from_json_dict(d)
+
+  @staticmethod
+  def from_json_dict(d):
+    sbp = SBP.from_json_dict(d)
+    return MsgNetworkStateReq(sbp, **d)
+
+ 
+    
+SBP_MSG_NETWORK_STATE_RESP = 0x00BB
+class MsgNetworkStateResp(SBP):
+  """SBP class for message MSG_NETWORK_STATE_RESP (0x00BB).
+
+  You can have MSG_NETWORK_STATE_RESP inherit its fields directly
+  from an inherited SBP object, or construct it inline using a dict
+  of its fields.
+
+  
+  The state of a network interface on the Piksi
+
+
+  Parameters
+  ----------
+  sbp : SBP
+    SBP parent object to inherit from.
+  ip_address : int
+    IPv4 Address
+  interface_name : string
+    Interface Name
+  status : int
+    Status of interface
+  sender : int
+    Optional sender ID, defaults to SENDER_ID (see sbp/msg.py).
+
+  """
+  _parser = Struct("MsgNetworkStateResp",
+                   ULInt32('ip_address'),
+                   String('interface_name', 16),
+                   ULInt8('status'),)
+  __slots__ = [
+               'ip_address',
+               'interface_name',
+               'status',
+              ]
+
+  def __init__(self, sbp=None, **kwargs):
+    if sbp:
+      super( MsgNetworkStateResp,
+             self).__init__(sbp.msg_type, sbp.sender, sbp.length,
+                            sbp.payload, sbp.crc)
+      self.from_binary(sbp.payload)
+    else:
+      super( MsgNetworkStateResp, self).__init__()
+      self.msg_type = SBP_MSG_NETWORK_STATE_RESP
+      self.sender = kwargs.pop('sender', SENDER_ID)
+      self.ip_address = kwargs.pop('ip_address')
+      self.interface_name = kwargs.pop('interface_name')
+      self.status = kwargs.pop('status')
+
+  def __repr__(self):
+    return fmt_repr(self)
+
+  @staticmethod
+  def from_json(s):
+    """Given a JSON-encoded string s, build a message object.
+
+    """
+    d = json.loads(s)
+    return MsgNetworkStateResp.from_json_dict(d)
+
+  @staticmethod
+  def from_json_dict(d):
+    sbp = SBP.from_json_dict(d)
+    return MsgNetworkStateResp(sbp, **d)
+
+ 
+  def from_binary(self, d):
+    """Given a binary payload d, update the appropriate payload fields of
+    the message.
+
+    """
+    p = MsgNetworkStateResp._parser.parse(d)
+    for n in self.__class__.__slots__:
+      setattr(self, n, getattr(p, n))
+
+  def to_binary(self):
+    """Produce a framed/packed SBP message.
+
+    """
+    c = containerize(exclude_fields(self))
+    self.payload = MsgNetworkStateResp._parser.build(c)
+    return self.pack()
+
+  def to_json_dict(self):
+    self.to_binary()
+    d = super( MsgNetworkStateResp, self).to_json_dict()
+    j = walk_json_dict(exclude_fields(self))
+    d.update(j)
+    return d
+    
 
 msg_classes = {
   0x0069: MsgAlmanac,
@@ -1416,4 +1553,6 @@ msg_classes = {
   0x00B5: MsgDeviceMonitor,
   0x00B8: MsgCommandReq,
   0x00B9: MsgCommandResp,
+  0x00BA: MsgNetworkStateReq,
+  0x00BB: MsgNetworkStateResp,
 }

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -37,7 +37,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 105
+  number_of_messages = 107
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -370,7 +370,9 @@ definitions:
     id: 0x00BB
     short_desc: State of network interface
     desc: |
-      The state of a network interface on the Piksi
+      The state of a network interface on the Piksi.
+      Data is made to reflect output of ifaddrs struct returned by getifaddrs
+      in c.
     fields:
       - ipv4_address:
           type: array

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -374,7 +374,19 @@ definitions:
     fields:
       - ip_address:
           type: u32
-          desc: IPv4 Address
+          desc: IPv4 address
+      - ip_mask:
+          type: u32
+          desc: IPv4 netmask
+      - ip_gateway:
+          type: u32
+          desc: IPv4 gateway
+      - rx_packets:
+          type: u32
+          desc: Number of Rx packets
+      - tx_packets:
+          type: u32
+          desc: Number of Tx packets
       - interface_name:
           type: string
           size: 16

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -358,3 +358,33 @@ definitions:
       - code:
           type: s32
           desc: Exit code
+
+ - MSG_NETWORK_STATE_REQ:
+    id: 0x00BA
+    short_desc: Request state of Piksi network interfaces
+    desc: |
+      Request state of Piksi network interfaces.
+      Output will be sent in MSG_NETWORK_STATE_RESP messages
+
+ - MSG_NETWORK_STATE_RESP:
+    id: 0x00BB
+    short_desc: State of network interface
+    desc: |
+      The state of a network interface on the Piksi
+    fields:
+      - ip_address:
+          type: u32
+          desc: IPv4 Address
+      - interface_name:
+          type: string
+          size: 16
+          desc: Interface Name
+      - status:
+          type: u8
+          desc: Status of interface 
+          fields:
+            - 0-7:
+                desc: IP configuration mode
+                values:
+                  - 0: Down
+                  - 1: Up

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -378,25 +378,16 @@ definitions:
       - ip_mask:
           type: u32
           desc: IPv4 netmask
-      - ip_gateway:
+      - rx_bytes:
           type: u32
-          desc: IPv4 gateway
-      - rx_packets:
+          desc: Number of Rx bytes
+      - tx_bytes:
           type: u32
-          desc: Number of Rx packets
-      - tx_packets:
-          type: u32
-          desc: Number of Tx packets
+          desc: Number of Tx bytes
       - interface_name:
           type: string
           size: 16
           desc: Interface Name
-      - status:
-          type: u8
-          desc: Status of interface 
-          fields:
-            - 0-7:
-                desc: IP configuration mode
-                values:
-                  - 0: Down
-                  - 1: Up
+      - flags:
+          type: u32
+          desc: Interface flags from SIOCGIFFLAGS

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -372,12 +372,22 @@ definitions:
     desc: |
       The state of a network interface on the Piksi
     fields:
-      - ip_address:
-          type: u32
-          desc: IPv4 address
-      - ip_mask:
-          type: u32
-          desc: IPv4 netmask
+      - ipv4_address:
+          type: array
+          size: 4
+          fill: u8
+          desc: IPv4 address (all zero when unavailable)
+      - ipv4_mask_size:
+          type: u8
+          desc: IPv4 netmask CIDR notation
+      - ipv6_address:
+          type: array
+          size: 16
+          fill: u8
+          desc: IPv6 address (all zero when unavailable)
+      - ipv6_mask_size:
+          type: u8
+          desc: IPv6 netmask CIDR notation
       - rx_bytes:
           type: u32
           desc: Number of Rx bytes
@@ -391,3 +401,38 @@ definitions:
       - flags:
           type: u32
           desc: Interface flags from SIOCGIFFLAGS
+          fields:
+            - 16-31:
+                desc: Reserved
+            - 15:
+                desc: IFF_MULTICAST - supports multicast
+            - 14:
+                desc: IFF_LINK2 - per link layer defined bit
+            - 13:
+                desc: IFF_LINK1 - per link layer defined bit
+            - 12:
+                desc: IFF_LINK0 - per link layer defined bit
+            - 11:
+                desc: IFF_SIMPLEX - can't hear own transmissions
+            - 10:
+                desc: IFF_OACTIVE - transmission in progress
+            - 9:
+                desc: IFF_ALLMULTI - receive all multicast packets
+            - 8:
+                desc: IFF_PROMISC - receive all packets
+            - 7:
+                desc: IFF_NOARP - no address resolution protocol
+            - 6:
+                desc: IFF_RUNNING - resources allocated
+            - 5:
+                desc: IFF_NOTRAILERS - avoid use of trailers
+            - 4:
+                desc: IFF_POINTOPOINT - interface is point-to-point link
+            - 3:
+                desc: IFF_LOOPBACK - is a loopback net
+            - 2:
+                desc: IFF_DEBUG - broadcast address valid
+            - 1:
+                desc: IFF_BROADCAST - broadcast address valid
+            - 0:
+                desc: IFF_UP - interface is up


### PR DESCRIPTION
Added message to query and return state of network adapters. Data is made to reflect output of ifaddrs struct returned by getifaddrs() in c.

The purpose of this message is to be able to determine network state through the piksi console, mainly to allow connecting over TCP after a DHCP configuration.

This is dependency for https://github.com/swift-nav/piksi_buildroot/pull/151, and once both these are in the console will be updated to display this information

@denniszollo 