### PR TITLE
python: pyserial driver.  Add hdw flow control to API

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -35,12 +35,13 @@ class PySerialDriver(BaseDriver):
     Baud rate of serial port (defaults to 115200)
 
   """
-  def __init__(self, port, baud=115200):
+  def __init__(self, port, baud=115200, rtscts=False):
     import serial
     try:
       handle = serial.serial_for_url(port)
       handle.baudrate = baud
       handle.timeout = 1
+      handle.rtscts = rtscts
       super(PySerialDriver, self).__init__(handle)
     except (OSError, serial.SerialException) as e:
       print


### PR DESCRIPTION
we need hdw flow control options for the serial driver.