### PR TITLE
Pyserial_driver: except termios_error in context management

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -11,7 +11,7 @@
 from .base_driver import BaseDriver
 import serial
 import serial.tools.list_ports
-
+import termios
 
 class PySerialDriver(BaseDriver):
   """
@@ -97,3 +97,14 @@ class PySerialDriver(BaseDriver):
         print "Piksi disconnected"
         print
         raise IOError
+
+  def __enter__(self):
+    self.flush()
+    return self
+
+  def __exit__(self, *args):
+    try:
+      self.flush()
+      self.close()
+    except (OSError, termios.error, serial.SerialException) as e:
+      pass


### PR DESCRIPTION
Somehow the driver context manager was preventing the gui console from closing.

without this fix.  Open console, unplug serial, then close console. 
Result: console hangs on OSX

With this fix repeat:
Result: console closes cleanly

Somewhat related to: 
https://github.com/swift-nav/piksi_tools/issues/432