### PR TITLE
Add decimal SBP MSG_ID to doc

### DIFF
--- a/generator/sbpg/targets/resources/sbp_messages_desc.tex
+++ b/generator/sbpg/targets/resources/sbp_messages_desc.tex
@@ -9,7 +9,7 @@
 (((m.pkg_desc | escape_tex | no_us)))
 \end{large}
 ((* endif *))
-\subsubsection{(((m.name|escape_tex))) --- ((('0x%04X'|format(m.sbp_id))))}
+\subsubsection{(((m.name|escape_tex))) --- ((('0x%04X'|format(m.sbp_id)))) --- (((m.sbp_id)))}
 \label{sec:(((m.name)))}
 
 \begin{large}
@@ -94,7 +94,7 @@
 (((m.pkg_desc)))
 \end{large}
 ((* endif *))
-\subsubsection*{(((m.name|escape_tex))) --- ((('0x%04X'|format(m.sbp_id))))}
+\subsubsection*{(((m.name|escape_tex))) --- ((('0x%04X'|format(m.sbp_id)))) --- (((m.sbp_id)))}
 \label{sec:(((m.name)))}
 \begin{minipage}{\textwidth}
 \begin{large}


### PR DESCRIPTION
generated PDF looks like this:

[sbp.pdf](https://github.com/swift-nav/libsbp/files/994674/sbp.pdf)

![image](https://cloud.githubusercontent.com/assets/11276774/25976142/c302a37e-3667-11e7-9274-a54c39578627.png)

