### PR TITLE
Fixup termios.error exception handling for Windows

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -11,7 +11,12 @@
 from .base_driver import BaseDriver
 import serial
 import serial.tools.list_ports
-import termios
+try:
+  import termios
+  SerialError = termios.error  
+except ImportError:
+  SerialError = None
+  
 
 class PySerialDriver(BaseDriver):
   """
@@ -106,5 +111,5 @@ class PySerialDriver(BaseDriver):
     try:
       self.flush()
       self.close()
-    except (OSError, termios.error, serial.SerialException) as e:
+    except (OSError, SerialError, serial.SerialException) as e:
       pass


### PR DESCRIPTION
Intended as a fix for #467 

Anyone have something more pythonic to catch the low level exception on osx and linux but do nothingo n windows?