### PR TITLE
Adding `extern "C"` to sbp.h for inclusion into C++ programs

### DIFF
--- a/c/include/libsbp/edc.h
+++ b/c/include/libsbp/edc.h
@@ -13,8 +13,16 @@
 #ifndef LIBSBP_EDC_H
 #define LIBSBP_EDC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 
 u16 crc16_ccitt(const u8 *buf, u32 len, u16 crc);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBSBP_EDC_H */

--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -13,6 +13,10 @@
 #ifndef LIBSBP_SBP_H
 #define LIBSBP_SBP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 
 /** \addtogroup sbp
@@ -83,6 +87,10 @@ s8 sbp_process_payload(sbp_state_t *s, u16 sender_id, u16 msg_type, u8 msg_len,
     u8 payload[]);
 s8 sbp_send_message(sbp_state_t *s, u16 msg_type, u16 sender_id, u8 len, u8 *payload,
                     u32 (*write)(u8 *buff, u32 n, void* context));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBSBP_SBP_H */
 


### PR DESCRIPTION
Otherwise linking will fail with messages like `undefined reference to 'sbp_state_init(sbp_state_t*)'`