### PR TITLE
Performance enhancements

### DIFF
--- a/generator/requirements.txt
+++ b/generator/requirements.txt
@@ -13,3 +13,4 @@ voluptuous
 construct
 pytest-cov
 pytest-xdist
+numpy

--- a/generator/sbpg/targets/python.py
+++ b/generator/sbpg/targets/python.py
@@ -36,6 +36,21 @@ CONSTRUCT_CODE = {
   'double': 'LFloat64',
 }
 
+
+CONSTRUCT_CODE_NP = {
+  'u8': 'np.uint8',
+  'u16': 'np.uint16',
+  'u32': 'np.uint32',
+  'u64': 'np.uint64',
+  's8': 'np.int8',
+  's16': 'np.int16',
+  's32': 'np.int32',
+  's64': 'np.int64',
+  'float': 'np.float32',
+  'double': 'np.float64',
+}
+
+
 PYDOC_CODE = {
   'u8': 'int',
   'u16': 'int',
@@ -81,6 +96,33 @@ def construct_format(f, type_map=CONSTRUCT_CODE):
   return formatted
 
 
+def construct_format_np(f, type_map=CONSTRUCT_CODE_NP):
+  """
+  Formats for Construct.
+  """
+  formatted = ""
+  if type_map.get(f.type_id, None):
+    return "'%s'" % (f.type_id)
+  elif f.type_id == 'string' and f.options.get('size', None):
+    return "'str:%d'" % (f.options['size'].value)
+  elif f.type_id == 'string':
+    return "'str'"
+  elif f.type_id == 'array' and f.options.get('size', None):
+    fill = f.options['fill'].value
+    f_ = copy.copy(f)
+    f_.type_id = fill
+    s = f.options.get('size', None).value
+    return "'array:%s:%d'" % (construct_format_np(f_).replace('\'', ''), s)
+  elif f.type_id == 'array':
+    fill = f.options['fill'].value
+    f_ = copy.copy(f)
+    f_.type_id = fill
+    return "'array:%s'" % construct_format_np(f_).replace('\'', '')
+  else:
+    return "'%s'" % (f.type_id)
+  return formatted
+
+
 def pydoc_format(type_id, pydoc=PYDOC_CODE):
   """
   Formats type for pydoc.
@@ -95,6 +137,7 @@ def classnameify(s):
   return ''.join(w if w in ACRONYMS else w.title() for w in s.split('_'))
 
 JENV.filters['construct_py'] = construct_format
+JENV.filters['construct_py_np'] = construct_format_np
 JENV.filters['classnameify'] = classnameify
 JENV.filters['pydoc'] = pydoc_format
 

--- a/generator/sbpg/targets/python.py
+++ b/generator/sbpg/targets/python.py
@@ -85,7 +85,7 @@ def construct_format(f, type_map=CONSTRUCT_CODE):
     f_ = copy.copy(f)
     f_.type_id = fill
     s = f.options.get('size', None).value
-    return "Struct('%s', Array(%d, %s))" % (f.identifier, s, construct_format(f_))
+    return "Array(%d, %s)" % (s, construct_format(f_))
   elif f.type_id == 'array':
     fill = f.options['fill'].value
     f_ = copy.copy(f)

--- a/generator/sbpg/targets/python.py
+++ b/generator/sbpg/targets/python.py
@@ -85,7 +85,7 @@ def construct_format(f, type_map=CONSTRUCT_CODE):
     f_ = copy.copy(f)
     f_.type_id = fill
     s = f.options.get('size', None).value
-    return "Array(%d, %s)" % (s, construct_format(f_))
+    return "Struct('%s', Array(%d, %s))" % (f.identifier, s, construct_format(f_))
   elif f.type_id == 'array':
     fill = f.options['fill'].value
     f_ = copy.copy(f)

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -16,8 +16,11 @@
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 ((*- for i in include *))
 from (((module_path))).(((i))) import *
@@ -55,33 +58,42 @@ class ((( m.identifier )))(object):
                '((( f.identifier )))',
                ((*- endfor *))
               ]
+  __zips__ = [((* for f in m.fields *))
+              ('((( f.type_id )))', '((( f.identifier )))'),
+              ((*- endfor *))
+             ]
   ((*- endif *))
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      ((*- if m.fields *))
-      self.from_binary(payload)
-      ((*- else *))
-      self.payload = payload
-      ((*- endif *))
-      ((*- if m.fields *))
-    else:
-        ((*- for f in m.fields *))
-      self.(((f.identifier))) = kwargs.pop('(((f.identifier)))')
-        ((*- endfor *))
-      ((*- endif *))
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   ((* if m.fields *))
-  def from_binary(self, d):
-    p = ((( m.identifier )))._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in ((( m.identifier ))).__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return ((( m.identifier ))).build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return ((( m.identifier ))).build(d)
+    except:
+      print traceback.print_exc()
   ((*- endif *))
     ((* endif *))
   ((*- endif *))
@@ -128,8 +140,13 @@ class ((( m.identifier | classnameify )))(SBP):
                '((( f.identifier )))',
                ((*- endfor *))
               ]
+  __zips__ = [((* for f in m.fields *))
+              ( ((( f | construct_py_np ))), '((( f.identifier )))'),
+              ((*- endfor *))
+             ]
   ((*- else *))
   __slots__ = []
+  __zips__ = []
   ((*- endif *))
 
   def __init__(self, sbp=None, **kwargs):
@@ -176,9 +193,16 @@ class ((( m.identifier | classnameify )))(SBP):
     the message.
 
     """
-    p = ((( m.identifier | classnameify )))._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -58,10 +58,10 @@ class ((( m.identifier )))(object):
                '((( f.identifier )))',
                ((*- endfor *))
               ]
-  __zips__ = [((* for f in m.fields *))
-              ('((( f.type_id )))', '((( f.identifier )))'),
-              ((*- endfor *))
-             ]
+  _fields = [((* for f in m.fields *))
+             ( '((( f.type_id )))', '((( f.identifier )))' ),
+             ((*- endfor *))
+            ]
   ((*- endif *))
 
   def __repr__(self):
@@ -74,7 +74,7 @@ class ((( m.identifier )))(object):
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in ((( m.identifier ))).__zips__:
+      for t, s in ((( m.identifier )))._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -140,13 +140,13 @@ class ((( m.identifier | classnameify )))(SBP):
                '((( f.identifier )))',
                ((*- endfor *))
               ]
-  __zips__ = [((* for f in m.fields *))
-              ( ((( f | construct_py_np ))), '((( f.identifier )))'),
-              ((*- endfor *))
-             ]
+  _fields = [((* for f in m.fields *))
+             ( ((( f | construct_py_np ))), '((( f.identifier )))' ),
+             ((*- endfor *))
+            ]
   ((*- else *))
   __slots__ = []
-  __zips__ = []
+  _fields = []
   ((*- endif *))
 
   def __init__(self, sbp=None, **kwargs):

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -71,17 +71,17 @@ class ((( m.identifier )))(object):
     return getattr(self, item)
 
   ((* if m.fields *))
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in ((( m.identifier )))._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in ((( m.identifier )))._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -72,28 +72,21 @@ class ((( m.identifier )))(object):
 
   ((* if m.fields *))
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in ((( m.identifier )))._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in ((( m.identifier )))._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return ((( m.identifier ))).build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return ((( m.identifier ))).build(d)
   ((*- endif *))
     ((* endif *))
   ((*- endif *))
@@ -193,10 +186,7 @@ class ((( m.identifier | classnameify )))(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -20,7 +20,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 ((*- for i in include *))
 from (((module_path))).(((i))) import *

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,4 @@ pylibftdi==0.14.2
 pyserial==2.7
 pyyaml==3.11
 tox==1.8.1
+numpy

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -113,28 +113,21 @@ The message is used to debug and measure the performance.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in AcqSvProfile._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in AcqSvProfile._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return AcqSvProfile.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return AcqSvProfile.build(d)
     
 SBP_MSG_ACQ_RESULT = 0x001F
 class MsgAcqResult(SBP):
@@ -223,10 +216,7 @@ ratio.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -333,10 +323,7 @@ be in units of dB Hz in a later revision of this message.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -445,10 +432,7 @@ acquisition was attempted
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -537,10 +521,7 @@ The message is used to debug and measure the performance.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -112,17 +112,17 @@ The message is used to debug and measure the performance.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in AcqSvProfile._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in AcqSvProfile._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -20,7 +20,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/acquisition.yaml with generate.py.

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -90,20 +90,20 @@ The message is used to debug and measure the performance.
                'cf',
                'cp',
               ]
-  __zips__ = [
-              ('u8', 'job_type'),
-              ('u8', 'status'),
-              ('u16', 'cn0'),
-              ('u8', 'int_time'),
-              ('GnssSignal', 'sid'),
-              ('u16', 'bin_width'),
-              ('u32', 'timestamp'),
-              ('u32', 'time_spent'),
-              ('s32', 'cf_min'),
-              ('s32', 'cf_max'),
-              ('s32', 'cf'),
-              ('u32', 'cp'),
-             ]
+  _fields = [
+             ( 'u8', 'job_type' ),
+             ( 'u8', 'status' ),
+             ( 'u16', 'cn0' ),
+             ( 'u8', 'int_time' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 'u16', 'bin_width' ),
+             ( 'u32', 'timestamp' ),
+             ( 'u32', 'time_spent' ),
+             ( 's32', 'cf_min' ),
+             ( 's32', 'cf_max' ),
+             ( 's32', 'cf' ),
+             ( 'u32', 'cp' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -115,7 +115,7 @@ The message is used to debug and measure the performance.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in AcqSvProfile.__zips__:
+      for t, s in AcqSvProfile._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -179,12 +179,12 @@ ratio.
                'cf',
                'sid',
               ]
-  __zips__ = [
-              ( 'float', 'cn0'),
-              ( 'float', 'cp'),
-              ( 'float', 'cf'),
-              ( 'GnssSignal', 'sid'),
-             ]
+  _fields = [
+             ( 'float', 'cn0' ),
+             ( 'float', 'cp' ),
+             ( 'float', 'cf' ),
+             ( 'GnssSignal', 'sid' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -289,12 +289,12 @@ be in units of dB Hz in a later revision of this message.
                'cf',
                'sid',
               ]
-  __zips__ = [
-              ( 'float', 'snr'),
-              ( 'float', 'cp'),
-              ( 'float', 'cf'),
-              ( 'GnssSignal', 'sid'),
-             ]
+  _fields = [
+             ( 'float', 'snr' ),
+             ( 'float', 'cp' ),
+             ( 'float', 'cf' ),
+             ( 'GnssSignal', 'sid' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -401,12 +401,12 @@ acquisition was attempted
                'cf',
                'prn',
               ]
-  __zips__ = [
-              ( 'float', 'snr'),
-              ( 'float', 'cp'),
-              ( 'float', 'cf'),
-              ( 'u8', 'prn'),
-             ]
+  _fields = [
+             ( 'float', 'snr' ),
+             ( 'float', 'cp' ),
+             ( 'float', 'cf' ),
+             ( 'u8', 'prn' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -499,9 +499,9 @@ The message is used to debug and measure the performance.
   __slots__ = [
                'acq_sv_profile',
               ]
-  __zips__ = [
-              ( 'array:AcqSvProfile', 'acq_sv_profile'),
-             ]
+  _fields = [
+             ( 'array:AcqSvProfile', 'acq_sv_profile' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -21,8 +21,11 @@ host request and the device response.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/bootload.yaml with generate.py.
 # Please do not hand edit!
@@ -44,6 +47,7 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_RESP.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -110,6 +114,10 @@ protocol version number.
                'flags',
                'version',
               ]
+  __zips__ = [
+              ( 'u32', 'flags'),
+              ( 'str', 'version'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -146,9 +154,16 @@ protocol version number.
     the message.
 
     """
-    p = MsgBootloaderHandshakeResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -192,6 +207,9 @@ class MsgBootloaderJumpToApp(SBP):
   __slots__ = [
                'jump',
               ]
+  __zips__ = [
+              ( 'u8', 'jump'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -227,9 +245,16 @@ class MsgBootloaderJumpToApp(SBP):
     the message.
 
     """
-    p = MsgBootloaderJumpToApp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -265,6 +290,7 @@ and not related to the Piksi's serial number.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -330,6 +356,9 @@ on the right.
   __slots__ = [
                'dna',
               ]
+  __zips__ = [
+              ( 'array:u8:8', 'dna'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -365,9 +394,16 @@ on the right.
     the message.
 
     """
-    p = MsgNapDeviceDnaResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -410,6 +446,9 @@ class MsgBootloaderHandshakeDepA(SBP):
   __slots__ = [
                'handshake',
               ]
+  __zips__ = [
+              ( 'array:u8', 'handshake'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -445,9 +484,16 @@ class MsgBootloaderHandshakeDepA(SBP):
     the message.
 
     """
-    p = MsgBootloaderHandshakeDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -352,7 +352,7 @@ on the right.
 
   """
   _parser = Struct("MsgNapDeviceDnaResp",
-                   Array(8, ULInt8('dna')),)
+                   Struct('dna', Array(8, ULInt8('dna'))),)
   __slots__ = [
                'dna',
               ]

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -47,7 +47,7 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_RESP.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -114,10 +114,10 @@ protocol version number.
                'flags',
                'version',
               ]
-  __zips__ = [
-              ( 'u32', 'flags'),
-              ( 'str', 'version'),
-             ]
+  _fields = [
+             ( 'u32', 'flags' ),
+             ( 'str', 'version' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -207,9 +207,9 @@ class MsgBootloaderJumpToApp(SBP):
   __slots__ = [
                'jump',
               ]
-  __zips__ = [
-              ( 'u8', 'jump'),
-             ]
+  _fields = [
+             ( 'u8', 'jump' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -290,7 +290,7 @@ and not related to the Piksi's serial number.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -356,9 +356,9 @@ on the right.
   __slots__ = [
                'dna',
               ]
-  __zips__ = [
-              ( 'array:u8:8', 'dna'),
-             ]
+  _fields = [
+             ( 'array:u8:8', 'dna' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -446,9 +446,9 @@ class MsgBootloaderHandshakeDepA(SBP):
   __slots__ = [
                'handshake',
               ]
-  __zips__ = [
-              ( 'array:u8', 'handshake'),
-             ]
+  _fields = [
+             ( 'array:u8', 'handshake' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -25,7 +25,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/bootload.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -154,10 +154,7 @@ protocol version number.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -245,10 +242,7 @@ class MsgBootloaderJumpToApp(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -394,10 +388,7 @@ on the right.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -484,10 +475,7 @@ class MsgBootloaderHandshakeDepA(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -352,7 +352,7 @@ on the right.
 
   """
   _parser = Struct("MsgNapDeviceDnaResp",
-                   Struct('dna', Array(8, ULInt8('dna'))),)
+                   Array(8, ULInt8('dna')),)
   __slots__ = [
                'dna',
               ]

--- a/python/sbp/client/framer.py
+++ b/python/sbp/client/framer.py
@@ -111,7 +111,8 @@ class Framer(object):
 
     # hdr
     hdr = self._readall(5)
-    msg_type, sender, msg_len = np.ndarray(1, 'u2, u2, u1', hdr)[0]
+    msg_type, sender, msg_len =\
+     np.asscalar(np.ndarray(1, 'u2, u2, u1', hdr)[0])
 
     # data
     data = self._readall(msg_len)
@@ -119,7 +120,7 @@ class Framer(object):
 
     # crc
     crc = self._readall(2)
-    crc = np.ndarray(1, 'u2', crc)[0]
+    crc = np.ndarray(1, 'u2', crc)[0].item()
     if crc != msg_crc:
       print "crc mismatch: 0x%04X 0x%04X" % (msg_crc, crc)
       return None

--- a/python/sbp/client/framer.py
+++ b/python/sbp/client/framer.py
@@ -16,6 +16,8 @@ import datetime
 import time
 import uuid
 
+import numpy as np
+
 class Framer(object):
   """
   Framer
@@ -106,24 +108,27 @@ class Framer(object):
       if self._verbose:
         print "Host Side Unhandled byte: 0x%02x" % ord(preamble)
       return None
+
     # hdr
     hdr = self._readall(5)
-    msg_crc = crc16(hdr)
-    msg_type, sender, msg_len = struct.unpack("<HHB", hdr)
+    msg_type, sender, msg_len = np.ndarray(1, 'u2, u2, u1', hdr)[0]
+
     # data
     data = self._readall(msg_len)
-    msg_crc = crc16(data, msg_crc)
+    msg_crc = crc16(hdr + data)
+
     # crc
     crc = self._readall(2)
-    crc, = struct.unpack("<H", crc)
+    crc = np.ndarray(1, 'u2', crc)[0]
     if crc != msg_crc:
       print "crc mismatch: 0x%04X 0x%04X" % (msg_crc, crc)
       return None
+
     msg = SBP(msg_type, sender, msg_len, data, crc)
     try:
       msg = self._dispatch(msg)
     except:
-      pass
+      print 'Error dispatching sbp msg of type:', msg_type
     return msg
 
   def __call__(self, msg, **metadata):

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -74,13 +74,13 @@ from -500000 to 500000)
                'flags',
                'pin',
               ]
-  __zips__ = [
-              ( 'u16', 'wn'),
-              ( 'u32', 'tow'),
-              ( 's32', 'ns_residual'),
-              ( 'u8', 'flags'),
-              ( 'u8', 'pin'),
-             ]
+  _fields = [
+             ( 'u16', 'wn' ),
+             ( 'u32', 'tow' ),
+             ( 's32', 'ns_residual' ),
+             ( 'u8', 'flags' ),
+             ( 'u8', 'pin' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -18,8 +18,11 @@ e.g. camera shutter time.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml with generate.py.
 # Please do not hand edit!
@@ -71,6 +74,13 @@ from -500000 to 500000)
                'flags',
                'pin',
               ]
+  __zips__ = [
+              ( 'u16', 'wn'),
+              ( 'u32', 'tow'),
+              ( 's32', 'ns_residual'),
+              ( 'u8', 'flags'),
+              ( 'u8', 'pin'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -110,9 +120,16 @@ from -500000 to 500000)
     the message.
 
     """
-    p = MsgExtEvent._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -22,7 +22,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ext_events.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -120,10 +120,7 @@ from -500000 to 500000)
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -24,8 +24,11 @@ host request and the device response.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/file_io.yaml with generate.py.
 # Please do not hand edit!
@@ -77,6 +80,12 @@ to this message when it is received from sender ID 0x42.
                'chunk_size',
                'filename',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 'u32', 'offset'),
+              ( 'u8', 'chunk_size'),
+              ( 'str', 'filename'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -115,9 +124,16 @@ to this message when it is received from sender ID 0x42.
     the message.
 
     """
-    p = MsgFileioReadReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -169,6 +185,10 @@ preserved from the request.
                'sequence',
                'contents',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 'array:u8', 'contents'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -205,9 +225,16 @@ preserved from the request.
     the message.
 
     """
-    p = MsgFileioReadResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -269,6 +296,11 @@ from sender ID 0x42.
                'offset',
                'dirname',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 'u32', 'offset'),
+              ( 'str', 'dirname'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -306,9 +338,16 @@ from sender ID 0x42.
     the message.
 
     """
-    p = MsgFileioReadDirReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -361,6 +400,10 @@ the response is preserved from the request.
                'sequence',
                'contents',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 'array:u8', 'contents'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -397,9 +440,16 @@ the response is preserved from the request.
     the message.
 
     """
-    p = MsgFileioReadDirResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -446,6 +496,9 @@ process this message when it is received from sender ID 0x42.
   __slots__ = [
                'filename',
               ]
+  __zips__ = [
+              ( 'str', 'filename'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -481,9 +534,16 @@ process this message when it is received from sender ID 0x42.
     the message.
 
     """
-    p = MsgFileioRemove._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -546,6 +606,12 @@ only  process this message when it is received from sender ID
                'filename',
                'data',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 'u32', 'offset'),
+              ( 'str', 'filename'),
+              ( 'array:u8', 'data'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -584,9 +650,16 @@ only  process this message when it is received from sender ID
     the message.
 
     """
-    p = MsgFileioWriteReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -634,6 +707,9 @@ request.
   __slots__ = [
                'sequence',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -669,9 +745,16 @@ request.
     the message.
 
     """
-    p = MsgFileioWriteResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -28,7 +28,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/file_io.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -80,12 +80,12 @@ to this message when it is received from sender ID 0x42.
                'chunk_size',
                'filename',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 'u32', 'offset'),
-              ( 'u8', 'chunk_size'),
-              ( 'str', 'filename'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 'u32', 'offset' ),
+             ( 'u8', 'chunk_size' ),
+             ( 'str', 'filename' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -185,10 +185,10 @@ preserved from the request.
                'sequence',
                'contents',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 'array:u8', 'contents'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 'array:u8', 'contents' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -296,11 +296,11 @@ from sender ID 0x42.
                'offset',
                'dirname',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 'u32', 'offset'),
-              ( 'str', 'dirname'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 'u32', 'offset' ),
+             ( 'str', 'dirname' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -400,10 +400,10 @@ the response is preserved from the request.
                'sequence',
                'contents',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 'array:u8', 'contents'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 'array:u8', 'contents' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -496,9 +496,9 @@ process this message when it is received from sender ID 0x42.
   __slots__ = [
                'filename',
               ]
-  __zips__ = [
-              ( 'str', 'filename'),
-             ]
+  _fields = [
+             ( 'str', 'filename' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -606,12 +606,12 @@ only  process this message when it is received from sender ID
                'filename',
                'data',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 'u32', 'offset'),
-              ( 'str', 'filename'),
-              ( 'array:u8', 'data'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 'u32', 'offset' ),
+             ( 'str', 'filename' ),
+             ( 'array:u8', 'data' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -707,9 +707,9 @@ request.
   __slots__ = [
                'sequence',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -124,10 +124,7 @@ to this message when it is received from sender ID 0x42.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -225,10 +222,7 @@ preserved from the request.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -338,10 +332,7 @@ from sender ID 0x42.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -440,10 +431,7 @@ the response is preserved from the request.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -534,10 +522,7 @@ process this message when it is received from sender ID 0x42.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -650,10 +635,7 @@ only  process this message when it is received from sender ID
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -745,10 +727,7 @@ request.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -68,7 +68,7 @@ starting address
   """
   _parser = Struct("MsgFlashProgram",
                    ULInt8('target'),
-                   Array(3, ULInt8('addr_start')),
+                   Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),
                    OptionalGreedyRange(ULInt8('data')),)
   __slots__ = [
@@ -277,7 +277,7 @@ starting address
   """
   _parser = Struct("MsgFlashReadReq",
                    ULInt8('target'),
-                   Array(3, ULInt8('addr_start')),
+                   Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),)
   __slots__ = [
                'target',
@@ -388,7 +388,7 @@ starting address
   """
   _parser = Struct("MsgFlashReadResp",
                    ULInt8('target'),
-                   Array(3, ULInt8('addr_start')),
+                   Struct('addr_start', Array(3, ULInt8('addr_start'))),
                    ULInt8('addr_len'),)
   __slots__ = [
                'target',
@@ -825,7 +825,7 @@ ID in the payload..
 
   """
   _parser = Struct("MsgStmUniqueIdResp",
-                   Array(12, ULInt8('stm_id')),)
+                   Struct('stm_id', Array(12, ULInt8('stm_id'))),)
   __slots__ = [
                'stm_id',
               ]
@@ -917,7 +917,7 @@ register. The device replies with a MSG_FLASH_DONE message.
 
   """
   _parser = Struct("MsgM25FlashWriteStatus",
-                   Array(1, ULInt8('status')),)
+                   Struct('status', Array(1, ULInt8('status'))),)
   __slots__ = [
                'status',
               ]

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -25,7 +25,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/flash.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -77,12 +77,12 @@ starting address
                'addr_len',
                'data',
               ]
-  __zips__ = [
-              ( 'u8', 'target'),
-              ( 'array:u8:3', 'addr_start'),
-              ( 'u8', 'addr_len'),
-              ( 'array:u8', 'data'),
-             ]
+  _fields = [
+             ( 'u8', 'target' ),
+             ( 'array:u8:3', 'addr_start' ),
+             ( 'u8', 'addr_len' ),
+             ( 'array:u8', 'data' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -177,9 +177,9 @@ MSG_FLASH_PROGRAM, may return this message on failure.
   __slots__ = [
                'response',
               ]
-  __zips__ = [
-              ( 'u8', 'response'),
-             ]
+  _fields = [
+             ( 'u8', 'response' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -284,11 +284,11 @@ starting address
                'addr_start',
                'addr_len',
               ]
-  __zips__ = [
-              ( 'u8', 'target'),
-              ( 'array:u8:3', 'addr_start'),
-              ( 'u8', 'addr_len'),
-             ]
+  _fields = [
+             ( 'u8', 'target' ),
+             ( 'array:u8:3', 'addr_start' ),
+             ( 'u8', 'addr_len' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -395,11 +395,11 @@ starting address
                'addr_start',
                'addr_len',
               ]
-  __zips__ = [
-              ( 'u8', 'target'),
-              ( 'array:u8:3', 'addr_start'),
-              ( 'u8', 'addr_len'),
-             ]
+  _fields = [
+             ( 'u8', 'target' ),
+             ( 'array:u8:3', 'addr_start' ),
+             ( 'u8', 'addr_len' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -500,10 +500,10 @@ the M25)
                'target',
                'sector_num',
               ]
-  __zips__ = [
-              ( 'u8', 'target'),
-              ( 'u32', 'sector_num'),
-             ]
+  _fields = [
+             ( 'u8', 'target' ),
+             ( 'u32', 'sector_num' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -594,9 +594,9 @@ memory. The device replies with a MSG_FLASH_DONE message.
   __slots__ = [
                'sector',
               ]
-  __zips__ = [
-              ( 'u32', 'sector'),
-             ]
+  _fields = [
+             ( 'u32', 'sector' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -686,9 +686,9 @@ memory. The device replies with a MSG_FLASH_DONE message.
   __slots__ = [
                'sector',
               ]
-  __zips__ = [
-              ( 'u32', 'sector'),
-             ]
+  _fields = [
+             ( 'u32', 'sector' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -767,7 +767,7 @@ ID in the payload.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -829,9 +829,9 @@ ID in the payload..
   __slots__ = [
                'stm_id',
               ]
-  __zips__ = [
-              ( 'array:u8:12', 'stm_id'),
-             ]
+  _fields = [
+             ( 'array:u8:12', 'stm_id' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -921,9 +921,9 @@ register. The device replies with a MSG_FLASH_DONE message.
   __slots__ = [
                'status',
               ]
-  __zips__ = [
-              ( 'array:u8:1', 'status'),
-             ]
+  _fields = [
+             ( 'array:u8:1', 'status' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -121,10 +121,7 @@ starting address
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -215,10 +212,7 @@ MSG_FLASH_PROGRAM, may return this message on failure.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -326,10 +320,7 @@ starting address
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -437,10 +428,7 @@ starting address
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -540,10 +528,7 @@ the M25)
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -632,10 +617,7 @@ memory. The device replies with a MSG_FLASH_DONE message.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -724,10 +706,7 @@ memory. The device replies with a MSG_FLASH_DONE message.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -867,10 +846,7 @@ ID in the payload..
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -959,10 +935,7 @@ register. The device replies with a MSG_FLASH_DONE message.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -68,7 +68,7 @@ starting address
   """
   _parser = Struct("MsgFlashProgram",
                    ULInt8('target'),
-                   Struct('addr_start', Array(3, ULInt8('addr_start'))),
+                   Array(3, ULInt8('addr_start')),
                    ULInt8('addr_len'),
                    OptionalGreedyRange(ULInt8('data')),)
   __slots__ = [
@@ -277,7 +277,7 @@ starting address
   """
   _parser = Struct("MsgFlashReadReq",
                    ULInt8('target'),
-                   Struct('addr_start', Array(3, ULInt8('addr_start'))),
+                   Array(3, ULInt8('addr_start')),
                    ULInt8('addr_len'),)
   __slots__ = [
                'target',
@@ -388,7 +388,7 @@ starting address
   """
   _parser = Struct("MsgFlashReadResp",
                    ULInt8('target'),
-                   Struct('addr_start', Array(3, ULInt8('addr_start'))),
+                   Array(3, ULInt8('addr_start')),
                    ULInt8('addr_len'),)
   __slots__ = [
                'target',
@@ -825,7 +825,7 @@ ID in the payload..
 
   """
   _parser = Struct("MsgStmUniqueIdResp",
-                   Struct('stm_id', Array(12, ULInt8('stm_id'))),)
+                   Array(12, ULInt8('stm_id')),)
   __slots__ = [
                'stm_id',
               ]
@@ -917,7 +917,7 @@ register. The device replies with a MSG_FLASH_DONE message.
 
   """
   _parser = Struct("MsgM25FlashWriteStatus",
-                   Struct('status', Array(1, ULInt8('status'))),)
+                   Array(1, ULInt8('status')),)
   __slots__ = [
                'status',
               ]

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -21,8 +21,11 @@ to Piksi Multi.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/flash.yaml with generate.py.
 # Please do not hand edit!
@@ -74,6 +77,12 @@ starting address
                'addr_len',
                'data',
               ]
+  __zips__ = [
+              ( 'u8', 'target'),
+              ( 'array:u8:3', 'addr_start'),
+              ( 'u8', 'addr_len'),
+              ( 'array:u8', 'data'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -112,9 +121,16 @@ starting address
     the message.
 
     """
-    p = MsgFlashProgram._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -161,6 +177,9 @@ MSG_FLASH_PROGRAM, may return this message on failure.
   __slots__ = [
                'response',
               ]
+  __zips__ = [
+              ( 'u8', 'response'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -196,9 +215,16 @@ MSG_FLASH_PROGRAM, may return this message on failure.
     the message.
 
     """
-    p = MsgFlashDone._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -258,6 +284,11 @@ starting address
                'addr_start',
                'addr_len',
               ]
+  __zips__ = [
+              ( 'u8', 'target'),
+              ( 'array:u8:3', 'addr_start'),
+              ( 'u8', 'addr_len'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -295,9 +326,16 @@ starting address
     the message.
 
     """
-    p = MsgFlashReadReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -357,6 +395,11 @@ starting address
                'addr_start',
                'addr_len',
               ]
+  __zips__ = [
+              ( 'u8', 'target'),
+              ( 'array:u8:3', 'addr_start'),
+              ( 'u8', 'addr_len'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -394,9 +437,16 @@ starting address
     the message.
 
     """
-    p = MsgFlashReadResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -450,6 +500,10 @@ the M25)
                'target',
                'sector_num',
               ]
+  __zips__ = [
+              ( 'u8', 'target'),
+              ( 'u32', 'sector_num'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -486,9 +540,16 @@ the M25)
     the message.
 
     """
-    p = MsgFlashErase._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -533,6 +594,9 @@ memory. The device replies with a MSG_FLASH_DONE message.
   __slots__ = [
                'sector',
               ]
+  __zips__ = [
+              ( 'u32', 'sector'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -568,9 +632,16 @@ memory. The device replies with a MSG_FLASH_DONE message.
     the message.
 
     """
-    p = MsgStmFlashLockSector._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -615,6 +686,9 @@ memory. The device replies with a MSG_FLASH_DONE message.
   __slots__ = [
                'sector',
               ]
+  __zips__ = [
+              ( 'u32', 'sector'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -650,9 +724,16 @@ memory. The device replies with a MSG_FLASH_DONE message.
     the message.
 
     """
-    p = MsgStmFlashUnlockSector._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -686,6 +767,7 @@ ID in the payload.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -747,6 +829,9 @@ ID in the payload..
   __slots__ = [
                'stm_id',
               ]
+  __zips__ = [
+              ( 'array:u8:12', 'stm_id'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -782,9 +867,16 @@ ID in the payload..
     the message.
 
     """
-    p = MsgStmUniqueIdResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -829,6 +921,9 @@ register. The device replies with a MSG_FLASH_DONE message.
   __slots__ = [
                'status',
               ]
+  __zips__ = [
+              ( 'array:u8:1', 'status'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -864,9 +959,16 @@ register. The device replies with a MSG_FLASH_DONE message.
     the message.
 
     """
-    p = MsgM25FlashWriteStatus._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/gnss.py
+++ b/python/sbp/gnss.py
@@ -60,28 +60,21 @@ class GnssSignal16(object):
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in GnssSignal16._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in GnssSignal16._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return GnssSignal16.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return GnssSignal16.build(d)
     
 class GnssSignal(object):
   """GnssSignal.
@@ -126,28 +119,21 @@ Note: unlike GnssSignal16, GPS satellites are encoded as
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in GnssSignal._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in GnssSignal._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return GnssSignal.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return GnssSignal.build(d)
     
 class GPSTime(object):
   """GPSTime.
@@ -185,28 +171,21 @@ transition.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in GPSTime._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in GPSTime._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return GPSTime.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return GPSTime.build(d)
     
 class GPSTimeSec(object):
   """GPSTimeSec.
@@ -244,28 +223,21 @@ transition.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in GPSTimeSec._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in GPSTimeSec._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return GPSTimeSec.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return GPSTimeSec.build(d)
     
 class GPSTimeNano(object):
   """GPSTimeNano.
@@ -311,28 +283,21 @@ from -500000 to 500000)
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in GPSTimeNano._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in GPSTimeNano._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return GPSTimeNano.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return GPSTimeNano.build(d)
     
 class CarrierPhase(object):
   """CarrierPhase.
@@ -371,28 +336,21 @@ same sign as the pseudorange.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in CarrierPhase._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in CarrierPhase._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return CarrierPhase.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return CarrierPhase.build(d)
     
 
 msg_classes = {

--- a/python/sbp/gnss.py
+++ b/python/sbp/gnss.py
@@ -59,17 +59,17 @@ class GnssSignal16(object):
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in GnssSignal16._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in GnssSignal16._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -118,17 +118,17 @@ Note: unlike GnssSignal16, GPS satellites are encoded as
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in GnssSignal._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in GnssSignal._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -170,17 +170,17 @@ transition.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in GPSTime._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in GPSTime._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -222,17 +222,17 @@ transition.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in GPSTimeSec._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in GPSTimeSec._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -282,17 +282,17 @@ from -500000 to 500000)
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in GPSTimeNano._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in GPSTimeNano._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -335,17 +335,17 @@ same sign as the pseudorange.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in CarrierPhase._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in CarrierPhase._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):

--- a/python/sbp/gnss.py
+++ b/python/sbp/gnss.py
@@ -20,7 +20,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/gnss.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/gnss.py
+++ b/python/sbp/gnss.py
@@ -47,10 +47,10 @@ class GnssSignal16(object):
                'sat',
                'code',
               ]
-  __zips__ = [
-              ('u8', 'sat'),
-              ('u8', 'code'),
-             ]
+  _fields = [
+             ( 'u8', 'sat' ),
+             ( 'u8', 'code' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -62,7 +62,7 @@ class GnssSignal16(object):
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in GnssSignal16.__zips__:
+      for t, s in GnssSignal16._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -112,11 +112,11 @@ Note: unlike GnssSignal16, GPS satellites are encoded as
                'code',
                'reserved',
               ]
-  __zips__ = [
-              ('u16', 'sat'),
-              ('u8', 'code'),
-              ('u8', 'reserved'),
-             ]
+  _fields = [
+             ( 'u16', 'sat' ),
+             ( 'u8', 'code' ),
+             ( 'u8', 'reserved' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -128,7 +128,7 @@ Note: unlike GnssSignal16, GPS satellites are encoded as
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in GnssSignal.__zips__:
+      for t, s in GnssSignal._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -172,10 +172,10 @@ transition.
                'tow',
                'wn',
               ]
-  __zips__ = [
-              ('u32', 'tow'),
-              ('u16', 'wn'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u16', 'wn' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -187,7 +187,7 @@ transition.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in GPSTime.__zips__:
+      for t, s in GPSTime._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -231,10 +231,10 @@ transition.
                'tow',
                'wn',
               ]
-  __zips__ = [
-              ('u32', 'tow'),
-              ('u16', 'wn'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u16', 'wn' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -246,7 +246,7 @@ transition.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in GPSTimeSec.__zips__:
+      for t, s in GPSTimeSec._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -297,11 +297,11 @@ from -500000 to 500000)
                'ns_residual',
                'wn',
               ]
-  __zips__ = [
-              ('u32', 'tow'),
-              ('s32', 'ns_residual'),
-              ('u16', 'wn'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'ns_residual' ),
+             ( 'u16', 'wn' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -313,7 +313,7 @@ from -500000 to 500000)
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in GPSTimeNano.__zips__:
+      for t, s in GPSTimeNano._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -358,10 +358,10 @@ same sign as the pseudorange.
                'i',
                'f',
               ]
-  __zips__ = [
-              ('s32', 'i'),
-              ('u8', 'f'),
-             ]
+  _fields = [
+             ( 's32', 'i' ),
+             ( 'u8', 'f' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -373,7 +373,7 @@ same sign as the pseudorange.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in CarrierPhase.__zips__:
+      for t, s in CarrierPhase._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize

--- a/python/sbp/gnss.py
+++ b/python/sbp/gnss.py
@@ -16,8 +16,11 @@ Various structs shared between modules
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/gnss.yaml with generate.py.
 # Please do not hand edit!
@@ -44,25 +47,41 @@ class GnssSignal16(object):
                'sat',
                'code',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.sat = kwargs.pop('sat')
-      self.code = kwargs.pop('code')
+  __zips__ = [
+              ('u8', 'sat'),
+              ('u8', 'code'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = GnssSignal16._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in GnssSignal16.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return GnssSignal16.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return GnssSignal16.build(d)
+    except:
+      print traceback.print_exc()
     
 class GnssSignal(object):
   """GnssSignal.
@@ -93,26 +112,42 @@ Note: unlike GnssSignal16, GPS satellites are encoded as
                'code',
                'reserved',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.sat = kwargs.pop('sat')
-      self.code = kwargs.pop('code')
-      self.reserved = kwargs.pop('reserved')
+  __zips__ = [
+              ('u16', 'sat'),
+              ('u8', 'code'),
+              ('u8', 'reserved'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = GnssSignal._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in GnssSignal.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return GnssSignal.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return GnssSignal.build(d)
+    except:
+      print traceback.print_exc()
     
 class GPSTime(object):
   """GPSTime.
@@ -137,25 +172,41 @@ transition.
                'tow',
                'wn',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.tow = kwargs.pop('tow')
-      self.wn = kwargs.pop('wn')
+  __zips__ = [
+              ('u32', 'tow'),
+              ('u16', 'wn'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = GPSTime._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in GPSTime.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return GPSTime.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return GPSTime.build(d)
+    except:
+      print traceback.print_exc()
     
 class GPSTimeSec(object):
   """GPSTimeSec.
@@ -180,25 +231,41 @@ transition.
                'tow',
                'wn',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.tow = kwargs.pop('tow')
-      self.wn = kwargs.pop('wn')
+  __zips__ = [
+              ('u32', 'tow'),
+              ('u16', 'wn'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = GPSTimeSec._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in GPSTimeSec.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return GPSTimeSec.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return GPSTimeSec.build(d)
+    except:
+      print traceback.print_exc()
     
 class GPSTimeNano(object):
   """GPSTimeNano.
@@ -230,26 +297,42 @@ from -500000 to 500000)
                'ns_residual',
                'wn',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.tow = kwargs.pop('tow')
-      self.ns_residual = kwargs.pop('ns_residual')
-      self.wn = kwargs.pop('wn')
+  __zips__ = [
+              ('u32', 'tow'),
+              ('s32', 'ns_residual'),
+              ('u16', 'wn'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = GPSTimeNano._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in GPSTimeNano.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return GPSTimeNano.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return GPSTimeNano.build(d)
+    except:
+      print traceback.print_exc()
     
 class CarrierPhase(object):
   """CarrierPhase.
@@ -275,25 +358,41 @@ same sign as the pseudorange.
                'i',
                'f',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.i = kwargs.pop('i')
-      self.f = kwargs.pop('f')
+  __zips__ = [
+              ('s32', 'i'),
+              ('u8', 'f'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = CarrierPhase._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in CarrierPhase.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return CarrierPhase.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return CarrierPhase.build(d)
+    except:
+      print traceback.print_exc()
     
 
 msg_classes = {

--- a/python/sbp/imu.py
+++ b/python/sbp/imu.py
@@ -16,8 +16,11 @@ Inertial Measurement Unit (IMU) messages.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/imu.yaml with generate.py.
 # Please do not hand edit!
@@ -82,6 +85,16 @@ time is unknown or invalid.
                'gyr_y',
                'gyr_z',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'u8', 'tow_f'),
+              ( 's16', 'acc_x'),
+              ( 's16', 'acc_y'),
+              ( 's16', 'acc_z'),
+              ( 's16', 'gyr_x'),
+              ( 's16', 'gyr_y'),
+              ( 's16', 'gyr_z'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -124,9 +137,16 @@ time is unknown or invalid.
     the message.
 
     """
-    p = MsgImuRaw._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -180,6 +200,11 @@ depends on the value of `imu_type`.
                'temp',
                'imu_conf',
               ]
+  __zips__ = [
+              ( 'u8', 'imu_type'),
+              ( 's16', 'temp'),
+              ( 'u8', 'imu_conf'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -217,9 +242,16 @@ depends on the value of `imu_type`.
     the message.
 
     """
-    p = MsgImuAux._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/imu.py
+++ b/python/sbp/imu.py
@@ -20,7 +20,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/imu.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/imu.py
+++ b/python/sbp/imu.py
@@ -85,16 +85,16 @@ time is unknown or invalid.
                'gyr_y',
                'gyr_z',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'u8', 'tow_f'),
-              ( 's16', 'acc_x'),
-              ( 's16', 'acc_y'),
-              ( 's16', 'acc_z'),
-              ( 's16', 'gyr_x'),
-              ( 's16', 'gyr_y'),
-              ( 's16', 'gyr_z'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u8', 'tow_f' ),
+             ( 's16', 'acc_x' ),
+             ( 's16', 'acc_y' ),
+             ( 's16', 'acc_z' ),
+             ( 's16', 'gyr_x' ),
+             ( 's16', 'gyr_y' ),
+             ( 's16', 'gyr_z' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -200,11 +200,11 @@ depends on the value of `imu_type`.
                'temp',
                'imu_conf',
               ]
-  __zips__ = [
-              ( 'u8', 'imu_type'),
-              ( 's16', 'temp'),
-              ( 'u8', 'imu_conf'),
-             ]
+  _fields = [
+             ( 'u8', 'imu_type' ),
+             ( 's16', 'temp' ),
+             ( 'u8', 'imu_conf' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/imu.py
+++ b/python/sbp/imu.py
@@ -137,10 +137,7 @@ time is unknown or invalid.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -242,10 +239,7 @@ depends on the value of `imu_type`.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -60,10 +60,10 @@ ERROR, WARNING, DEBUG, INFO logging levels.
                'level',
                'text',
               ]
-  __zips__ = [
-              ( 'u8', 'level'),
-              ( 'str', 'text'),
-             ]
+  _fields = [
+             ( 'u8', 'level' ),
+             ( 'str', 'text' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -167,11 +167,11 @@ Protocol 0 represents SBP and the remaining values are implementation defined.
                'protocol',
                'fwd_payload',
               ]
-  __zips__ = [
-              ( 'u8', 'source'),
-              ( 'u8', 'protocol'),
-              ( 'str', 'fwd_payload'),
-             ]
+  _fields = [
+             ( 'u8', 'source' ),
+             ( 'u8', 'protocol' ),
+             ( 'str', 'fwd_payload' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -261,9 +261,9 @@ class MsgTweet(SBP):
   __slots__ = [
                'tweet',
               ]
-  __zips__ = [
-              ( 'str:140', 'tweet'),
-             ]
+  _fields = [
+             ( 'str:140', 'tweet' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -351,9 +351,9 @@ class MsgPrintDep(SBP):
   __slots__ = [
                'text',
               ]
-  __zips__ = [
-              ( 'str', 'text'),
-             ]
+  _fields = [
+             ( 'str', 'text' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -100,10 +100,7 @@ ERROR, WARNING, DEBUG, INFO logging levels.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -209,10 +206,7 @@ Protocol 0 represents SBP and the remaining values are implementation defined.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -299,10 +293,7 @@ class MsgTweet(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -389,10 +380,7 @@ class MsgPrintDep(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -21,7 +21,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/logging.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -17,8 +17,11 @@ Logging and debugging messages from the device.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/logging.yaml with generate.py.
 # Please do not hand edit!
@@ -57,6 +60,10 @@ ERROR, WARNING, DEBUG, INFO logging levels.
                'level',
                'text',
               ]
+  __zips__ = [
+              ( 'u8', 'level'),
+              ( 'str', 'text'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -93,9 +100,16 @@ ERROR, WARNING, DEBUG, INFO logging levels.
     the message.
 
     """
-    p = MsgLog._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -153,6 +167,11 @@ Protocol 0 represents SBP and the remaining values are implementation defined.
                'protocol',
                'fwd_payload',
               ]
+  __zips__ = [
+              ( 'u8', 'source'),
+              ( 'u8', 'protocol'),
+              ( 'str', 'fwd_payload'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -190,9 +209,16 @@ Protocol 0 represents SBP and the remaining values are implementation defined.
     the message.
 
     """
-    p = MsgFwd._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -235,6 +261,9 @@ class MsgTweet(SBP):
   __slots__ = [
                'tweet',
               ]
+  __zips__ = [
+              ( 'str:140', 'tweet'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -270,9 +299,16 @@ class MsgTweet(SBP):
     the message.
 
     """
-    p = MsgTweet._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -315,6 +351,9 @@ class MsgPrintDep(SBP):
   __slots__ = [
                'text',
               ]
+  __zips__ = [
+              ( 'str', 'text'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -350,9 +389,16 @@ class MsgPrintDep(SBP):
     the message.
 
     """
-    p = MsgPrintDep._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/msg.py
+++ b/python/sbp/msg.py
@@ -15,13 +15,17 @@ import copy
 import json
 import struct
 
+import numpy as np
+
+from sbp.utils import walk_json_dict
+
 SBP_PREAMBLE = 0x55
 
 # Default sender ID. Intended for messages sent from the host to the
 # device.
 SENDER_ID = 0x42
 
-crc16_tab = [0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,
+crc16_tab = (0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,
              0x8108,0x9129,0xa14a,0xb16b,0xc18c,0xd1ad,0xe1ce,0xf1ef,
              0x1231,0x0210,0x3273,0x2252,0x52b5,0x4294,0x72f7,0x62d6,
              0x9339,0x8318,0xb37b,0xa35a,0xd3bd,0xc39c,0xf3ff,0xe3de,
@@ -52,7 +56,7 @@ crc16_tab = [0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,
              0xfd2e,0xed0f,0xdd6c,0xcd4d,0xbdaa,0xad8b,0x9de8,0x8dc9,
              0x7c26,0x6c07,0x5c64,0x4c45,0x3ca2,0x2c83,0x1ce0,0x0cc1,
              0xef1f,0xff3e,0xcf5d,0xdf7c,0xaf9b,0xbfba,0x8fd9,0x9ff8,
-             0x6e17,0x7e36,0x4e55,0x5e74,0x2e93,0x3eb2,0x0ed1,0x1ef0]
+             0x6e17,0x7e36,0x4e55,0x5e74,0x2e93,0x3eb2,0x0ed1,0x1ef0)
 
 def crc16(s, crc=0):
   """CRC16 implementation acording to CCITT standards.
@@ -62,6 +66,24 @@ def crc16(s, crc=0):
     crc = ((crc<<8)&0xFFFF) ^ crc16_tab[ ((crc>>8)&0xFF) ^ (ord(ch)&0xFF) ]
     crc &= 0xFFFF
   return crc
+
+
+TYPES_NP = {
+  'u8': 'u1',
+  'u16': 'u2',
+  'u32': 'u4',
+  'u64': 'u8',
+  's8': 'i1',
+  's16': 'i2',
+  's32': 'i4',
+  's64': 'i8',
+  'float': 'f4',
+  'double': 'f8',
+}
+
+
+TYPES_KEYS_NP = TYPES_NP.keys()
+
 
 class SBP(object):
   """Swift Binary Protocol container.
@@ -100,8 +122,10 @@ class SBP(object):
       elif self.__slots__ != other.__slots__:
         return False
       else:
-        return all(getattr(self, s) == getattr(other, s) for s in self.__slots__)
-    except AttributeError:
+        self_flat = walk_json_dict(self)
+        other_flat = walk_json_dict(other)
+        return self_flat == other_flat
+    except AttributeError as e:
       return False
 
   def __update(self):
@@ -133,9 +157,13 @@ class SBP(object):
     """Unpack and return a framed binary message.
 
     """
-    p = SBP._parser.parse(d)
-    assert p.preamble == SBP_PREAMBLE, "Invalid preamble 0x%x." % p.preamble
-    return SBP(p.msg_type, p.sender, p.length, p.payload, p.crc)
+    preamble, msg_type, sender, length =\
+      np.asscalar(np.ndarray(1, 'u1, u2, u2, u1', d))
+    payload_len = len(d) - 8
+    payload = np.ndarray((payload_len,), 'u1', d, 6).tobytes()
+    crc = np.asscalar(np.ndarray(1,'u2', d, 6 + payload_len)[0])
+    assert preamble == SBP_PREAMBLE, "Invalid preamble 0x%x." % preamble
+    return SBP(msg_type, sender, length, payload, crc)
 
   def copy(self):
     return copy.deepcopy(self)
@@ -145,6 +173,53 @@ class SBP(object):
          repr(self.payload), self.crc)
     fmt = "<SBP (preamble=0x%X, msg_type=0x%X, sender=%s, length=%d, payload=%s, crc=0x%X)>"
     return fmt % p
+
+  def _from_binary(self, d):
+    offset = 0
+    for t, s in self.__zips__:
+
+      # numpy dtype
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, offset)
+        offset += a.itemsize
+        res = a.item()
+
+      # array
+      elif t.startswith('array'):
+        # get array item and length
+        splits = t.split(':')
+        item = splits[1]
+        a_size = int(splits[2]) if len(splits) > 2 else None
+        res = []
+        is_np_type = item in TYPES_KEYS_NP
+        item = TYPES_NP[item] if is_np_type else self._get_embedded_type(item)
+
+        # iterate array items
+        while (a_size is None or a_size > 0) and offset < len(d):
+          if is_np_type:
+            a = np.ndarray(1, item, d, offset)
+            offset += a.itemsize
+            res.append(a.item())
+          else:
+            o = item()
+            offset += o.from_binary(d, offset)
+            res.append(o)
+          if a_size is not None:
+            a_size -= 1
+ 
+      # string
+      elif t.startswith('str'):
+        count = int(t.split(':')[1]) if ':' in t else -1
+        res = ''.join(chr(c) for c in np.frombuffer(d, 'u1', count, offset))
+        offset += len(res)
+        res = res.ljust(count, '\x00')  
+  
+      # custom embedded type       
+      else:
+        res = self._get_embedded_type(t)()
+        offset += res.from_binary(d, offset)
+
+      setattr(self, s, res)
 
   def to_binary(self):
     ret = struct.pack("<BHHB", SBP_PREAMBLE,

--- a/python/sbp/msg.py
+++ b/python/sbp/msg.py
@@ -176,7 +176,7 @@ class SBP(object):
 
   def _from_binary(self, d):
     offset = 0
-    for t, s in self.__zips__:
+    for t, s in self._fields:
 
       # numpy dtype
       if t in TYPES_KEYS_NP:

--- a/python/sbp/msg.py
+++ b/python/sbp/msg.py
@@ -206,6 +206,11 @@ class SBP(object):
             res.append(o)
           if a_size is not None:
             a_size -= 1
+
+        # for backwards compatibility with Struct('x', Array(3, LFloat64('x')))
+        # style dual packaging
+        if a_size is not None:
+          res = Container(**{s: res})
  
       # string
       elif t.startswith('str'):

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -31,7 +31,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/navigation.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -27,8 +27,11 @@ and the RTK solution in tandem.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/navigation.yaml with generate.py.
 # Please do not hand edit!
@@ -87,6 +90,12 @@ from -500000 to 500000)
                'ns_residual',
                'flags',
               ]
+  __zips__ = [
+              ( 'u16', 'wn'),
+              ( 'u32', 'tow'),
+              ( 's32', 'ns_residual'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -125,9 +134,16 @@ from -500000 to 500000)
     the message.
 
     """
-    p = MsgGPSTime._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -204,6 +220,17 @@ which indicate the source of the UTC offset value and source of the time fix.
                'seconds',
                'ns',
               ]
+  __zips__ = [
+              ( 'u8', 'flags'),
+              ( 'u32', 'tow'),
+              ( 'u16', 'year'),
+              ( 'u8', 'month'),
+              ( 'u8', 'day'),
+              ( 'u8', 'hours'),
+              ( 'u8', 'minutes'),
+              ( 'u8', 'seconds'),
+              ( 'u32', 'ns'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -247,9 +274,16 @@ which indicate the source of the UTC offset value and source of the time fix.
     the message.
 
     """
-    p = MsgUtcTime._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -320,6 +354,15 @@ corresponds to differential or SPP solution.
                'vdop',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'u16', 'gdop'),
+              ( 'u16', 'pdop'),
+              ( 'u16', 'tdop'),
+              ( 'u16', 'hdop'),
+              ( 'u16', 'vdop'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -361,9 +404,16 @@ corresponds to differential or SPP solution.
     the message.
 
     """
-    p = MsgDops._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -438,6 +488,15 @@ MSG_GPS_TIME with the matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'double', 'x'),
+              ( 'double', 'y'),
+              ( 'double', 'z'),
+              ( 'u16', 'accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -479,9 +538,16 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     the message.
 
     """
-    p = MsgPosECEF._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -560,6 +626,16 @@ matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'double', 'lat'),
+              ( 'double', 'lon'),
+              ( 'double', 'height'),
+              ( 'u16', 'h_accuracy'),
+              ( 'u16', 'v_accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -602,9 +678,16 @@ matching time-of-week (tow).
     the message.
 
     """
-    p = MsgPosLLH._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -676,6 +759,15 @@ matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'x'),
+              ( 's32', 'y'),
+              ( 's32', 'z'),
+              ( 'u16', 'accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -717,9 +809,16 @@ matching time-of-week (tow).
     the message.
 
     """
-    p = MsgBaselineECEF._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -796,6 +895,16 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'n'),
+              ( 's32', 'e'),
+              ( 's32', 'd'),
+              ( 'u16', 'h_accuracy'),
+              ( 'u16', 'v_accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -838,9 +947,16 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     the message.
 
     """
-    p = MsgBaselineNED._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -912,6 +1028,15 @@ to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'x'),
+              ( 's32', 'y'),
+              ( 's32', 'z'),
+              ( 'u16', 'accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -953,9 +1078,16 @@ to 0.
     the message.
 
     """
-    p = MsgVelECEF._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1034,6 +1166,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'n'),
+              ( 's32', 'e'),
+              ( 's32', 'd'),
+              ( 'u16', 'h_accuracy'),
+              ( 'u16', 'v_accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1076,9 +1218,16 @@ implemented). Defaults to 0.
     the message.
 
     """
-    p = MsgVelNED._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1137,6 +1286,12 @@ that time-matched RTK mode is used when the base station is moving.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'u32', 'heading'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1175,9 +1330,16 @@ that time-matched RTK mode is used when the base station is moving.
     the message.
 
     """
-    p = MsgBaselineHeading._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1226,6 +1388,10 @@ Differential solution
                'tow',
                'age',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'u16', 'age'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1262,9 +1428,16 @@ Differential solution
     the message.
 
     """
-    p = MsgAgeCorrections._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1334,6 +1507,12 @@ from -500000 to 500000)
                'ns_residual',
                'flags',
               ]
+  __zips__ = [
+              ( 'u16', 'wn'),
+              ( 'u32', 'tow'),
+              ( 's32', 'ns_residual'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1372,9 +1551,16 @@ from -500000 to 500000)
     the message.
 
     """
-    p = MsgGPSTimeDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1440,6 +1626,14 @@ precision.
                'hdop',
                'vdop',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'u16', 'gdop'),
+              ( 'u16', 'pdop'),
+              ( 'u16', 'tdop'),
+              ( 'u16', 'hdop'),
+              ( 'u16', 'vdop'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1480,9 +1674,16 @@ precision.
     the message.
 
     """
-    p = MsgDopsDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1559,6 +1760,15 @@ to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'double', 'x'),
+              ( 'double', 'y'),
+              ( 'double', 'z'),
+              ( 'u16', 'accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1600,9 +1810,16 @@ to 0.
     the message.
 
     """
-    p = MsgPosECEFDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1685,6 +1902,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'double', 'lat'),
+              ( 'double', 'lon'),
+              ( 'double', 'height'),
+              ( 'u16', 'h_accuracy'),
+              ( 'u16', 'v_accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1727,9 +1954,16 @@ implemented). Defaults to 0.
     the message.
 
     """
-    p = MsgPosLLHDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1803,6 +2037,15 @@ to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'x'),
+              ( 's32', 'y'),
+              ( 's32', 'z'),
+              ( 'u16', 'accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1844,9 +2087,16 @@ to 0.
     the message.
 
     """
-    p = MsgBaselineECEFDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1927,6 +2177,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'n'),
+              ( 's32', 'e'),
+              ( 's32', 'd'),
+              ( 'u16', 'h_accuracy'),
+              ( 'u16', 'v_accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1969,9 +2229,16 @@ implemented). Defaults to 0.
     the message.
 
     """
-    p = MsgBaselineNEDDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2043,6 +2310,15 @@ to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'x'),
+              ( 's32', 'y'),
+              ( 's32', 'z'),
+              ( 'u16', 'accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2084,9 +2360,16 @@ to 0.
     the message.
 
     """
-    p = MsgVelECEFDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2165,6 +2448,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 's32', 'n'),
+              ( 's32', 'e'),
+              ( 's32', 'd'),
+              ( 'u16', 'h_accuracy'),
+              ( 'u16', 'v_accuracy'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2207,9 +2500,16 @@ implemented). Defaults to 0.
     the message.
 
     """
-    p = MsgVelNEDDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2267,6 +2567,12 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'tow'),
+              ( 'u32', 'heading'),
+              ( 'u8', 'n_sats'),
+              ( 'u8', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2305,9 +2611,16 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     the message.
 
     """
-    p = MsgBaselineHeadingDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -90,12 +90,12 @@ from -500000 to 500000)
                'ns_residual',
                'flags',
               ]
-  __zips__ = [
-              ( 'u16', 'wn'),
-              ( 'u32', 'tow'),
-              ( 's32', 'ns_residual'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u16', 'wn' ),
+             ( 'u32', 'tow' ),
+             ( 's32', 'ns_residual' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -220,17 +220,17 @@ which indicate the source of the UTC offset value and source of the time fix.
                'seconds',
                'ns',
               ]
-  __zips__ = [
-              ( 'u8', 'flags'),
-              ( 'u32', 'tow'),
-              ( 'u16', 'year'),
-              ( 'u8', 'month'),
-              ( 'u8', 'day'),
-              ( 'u8', 'hours'),
-              ( 'u8', 'minutes'),
-              ( 'u8', 'seconds'),
-              ( 'u32', 'ns'),
-             ]
+  _fields = [
+             ( 'u8', 'flags' ),
+             ( 'u32', 'tow' ),
+             ( 'u16', 'year' ),
+             ( 'u8', 'month' ),
+             ( 'u8', 'day' ),
+             ( 'u8', 'hours' ),
+             ( 'u8', 'minutes' ),
+             ( 'u8', 'seconds' ),
+             ( 'u32', 'ns' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -354,15 +354,15 @@ corresponds to differential or SPP solution.
                'vdop',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'u16', 'gdop'),
-              ( 'u16', 'pdop'),
-              ( 'u16', 'tdop'),
-              ( 'u16', 'hdop'),
-              ( 'u16', 'vdop'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u16', 'gdop' ),
+             ( 'u16', 'pdop' ),
+             ( 'u16', 'tdop' ),
+             ( 'u16', 'hdop' ),
+             ( 'u16', 'vdop' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -488,15 +488,15 @@ MSG_GPS_TIME with the matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'double', 'x'),
-              ( 'double', 'y'),
-              ( 'double', 'z'),
-              ( 'u16', 'accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'double', 'x' ),
+             ( 'double', 'y' ),
+             ( 'double', 'z' ),
+             ( 'u16', 'accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -626,16 +626,16 @@ matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'double', 'lat'),
-              ( 'double', 'lon'),
-              ( 'double', 'height'),
-              ( 'u16', 'h_accuracy'),
-              ( 'u16', 'v_accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'double', 'lat' ),
+             ( 'double', 'lon' ),
+             ( 'double', 'height' ),
+             ( 'u16', 'h_accuracy' ),
+             ( 'u16', 'v_accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -759,15 +759,15 @@ matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'x'),
-              ( 's32', 'y'),
-              ( 's32', 'z'),
-              ( 'u16', 'accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'x' ),
+             ( 's32', 'y' ),
+             ( 's32', 'z' ),
+             ( 'u16', 'accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -895,16 +895,16 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'n'),
-              ( 's32', 'e'),
-              ( 's32', 'd'),
-              ( 'u16', 'h_accuracy'),
-              ( 'u16', 'v_accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'n' ),
+             ( 's32', 'e' ),
+             ( 's32', 'd' ),
+             ( 'u16', 'h_accuracy' ),
+             ( 'u16', 'v_accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1028,15 +1028,15 @@ to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'x'),
-              ( 's32', 'y'),
-              ( 's32', 'z'),
-              ( 'u16', 'accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'x' ),
+             ( 's32', 'y' ),
+             ( 's32', 'z' ),
+             ( 'u16', 'accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1166,16 +1166,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'n'),
-              ( 's32', 'e'),
-              ( 's32', 'd'),
-              ( 'u16', 'h_accuracy'),
-              ( 'u16', 'v_accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'n' ),
+             ( 's32', 'e' ),
+             ( 's32', 'd' ),
+             ( 'u16', 'h_accuracy' ),
+             ( 'u16', 'v_accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1286,12 +1286,12 @@ that time-matched RTK mode is used when the base station is moving.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'u32', 'heading'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u32', 'heading' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1388,10 +1388,10 @@ Differential solution
                'tow',
                'age',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'u16', 'age'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u16', 'age' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1507,12 +1507,12 @@ from -500000 to 500000)
                'ns_residual',
                'flags',
               ]
-  __zips__ = [
-              ( 'u16', 'wn'),
-              ( 'u32', 'tow'),
-              ( 's32', 'ns_residual'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u16', 'wn' ),
+             ( 'u32', 'tow' ),
+             ( 's32', 'ns_residual' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1626,14 +1626,14 @@ precision.
                'hdop',
                'vdop',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'u16', 'gdop'),
-              ( 'u16', 'pdop'),
-              ( 'u16', 'tdop'),
-              ( 'u16', 'hdop'),
-              ( 'u16', 'vdop'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u16', 'gdop' ),
+             ( 'u16', 'pdop' ),
+             ( 'u16', 'tdop' ),
+             ( 'u16', 'hdop' ),
+             ( 'u16', 'vdop' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1760,15 +1760,15 @@ to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'double', 'x'),
-              ( 'double', 'y'),
-              ( 'double', 'z'),
-              ( 'u16', 'accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'double', 'x' ),
+             ( 'double', 'y' ),
+             ( 'double', 'z' ),
+             ( 'u16', 'accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1902,16 +1902,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'double', 'lat'),
-              ( 'double', 'lon'),
-              ( 'double', 'height'),
-              ( 'u16', 'h_accuracy'),
-              ( 'u16', 'v_accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'double', 'lat' ),
+             ( 'double', 'lon' ),
+             ( 'double', 'height' ),
+             ( 'u16', 'h_accuracy' ),
+             ( 'u16', 'v_accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2037,15 +2037,15 @@ to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'x'),
-              ( 's32', 'y'),
-              ( 's32', 'z'),
-              ( 'u16', 'accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'x' ),
+             ( 's32', 'y' ),
+             ( 's32', 'z' ),
+             ( 'u16', 'accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2177,16 +2177,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'n'),
-              ( 's32', 'e'),
-              ( 's32', 'd'),
-              ( 'u16', 'h_accuracy'),
-              ( 'u16', 'v_accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'n' ),
+             ( 's32', 'e' ),
+             ( 's32', 'd' ),
+             ( 'u16', 'h_accuracy' ),
+             ( 'u16', 'v_accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2310,15 +2310,15 @@ to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'x'),
-              ( 's32', 'y'),
-              ( 's32', 'z'),
-              ( 'u16', 'accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'x' ),
+             ( 's32', 'y' ),
+             ( 's32', 'z' ),
+             ( 'u16', 'accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2448,16 +2448,16 @@ implemented). Defaults to 0.
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 's32', 'n'),
-              ( 's32', 'e'),
-              ( 's32', 'd'),
-              ( 'u16', 'h_accuracy'),
-              ( 'u16', 'v_accuracy'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 's32', 'n' ),
+             ( 's32', 'e' ),
+             ( 's32', 'd' ),
+             ( 'u16', 'h_accuracy' ),
+             ( 'u16', 'v_accuracy' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2567,12 +2567,12 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
                'n_sats',
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'tow'),
-              ( 'u32', 'heading'),
-              ( 'u8', 'n_sats'),
-              ( 'u8', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'tow' ),
+             ( 'u32', 'heading' ),
+             ( 'u8', 'n_sats' ),
+             ( 'u8', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -134,10 +134,7 @@ from -500000 to 500000)
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -274,10 +271,7 @@ which indicate the source of the UTC offset value and source of the time fix.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -404,10 +398,7 @@ corresponds to differential or SPP solution.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -538,10 +529,7 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -678,10 +666,7 @@ matching time-of-week (tow).
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -809,10 +794,7 @@ matching time-of-week (tow).
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -947,10 +929,7 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1078,10 +1057,7 @@ to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1218,10 +1194,7 @@ implemented). Defaults to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1330,10 +1303,7 @@ that time-matched RTK mode is used when the base station is moving.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1428,10 +1398,7 @@ Differential solution
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1551,10 +1518,7 @@ from -500000 to 500000)
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1674,10 +1638,7 @@ precision.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1810,10 +1771,7 @@ to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1954,10 +1912,7 @@ implemented). Defaults to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2087,10 +2042,7 @@ to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2229,10 +2181,7 @@ implemented). Defaults to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2360,10 +2309,7 @@ to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2500,10 +2446,7 @@ implemented). Defaults to 0.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2611,10 +2554,7 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/ndb.py
+++ b/python/sbp/ndb.py
@@ -21,7 +21,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ndb.yaml with generate.py.

--- a/python/sbp/ndb.py
+++ b/python/sbp/ndb.py
@@ -95,16 +95,16 @@ of other data_source.
                'src_sid',
                'original_sender',
               ]
-  __zips__ = [
-              ( 'u64', 'recv_time'),
-              ( 'u8', 'event'),
-              ( 'u8', 'object_type'),
-              ( 'u8', 'result'),
-              ( 'u8', 'data_source'),
-              ( 'GnssSignal16', 'object_sid'),
-              ( 'GnssSignal16', 'src_sid'),
-              ( 'u16', 'original_sender'),
-             ]
+  _fields = [
+             ( 'u64', 'recv_time' ),
+             ( 'u8', 'event' ),
+             ( 'u8', 'object_type' ),
+             ( 'u8', 'result' ),
+             ( 'u8', 'data_source' ),
+             ( 'GnssSignal16', 'object_sid' ),
+             ( 'GnssSignal16', 'src_sid' ),
+             ( 'u16', 'original_sender' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/ndb.py
+++ b/python/sbp/ndb.py
@@ -17,8 +17,11 @@ Messages for logging NDB events.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/ndb.yaml with generate.py.
@@ -92,6 +95,16 @@ of other data_source.
                'src_sid',
                'original_sender',
               ]
+  __zips__ = [
+              ( 'u64', 'recv_time'),
+              ( 'u8', 'event'),
+              ( 'u8', 'object_type'),
+              ( 'u8', 'result'),
+              ( 'u8', 'data_source'),
+              ( 'GnssSignal16', 'object_sid'),
+              ( 'GnssSignal16', 'src_sid'),
+              ( 'u16', 'original_sender'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -134,9 +147,16 @@ of other data_source.
     the message.
 
     """
-    p = MsgNdbEvent._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/ndb.py
+++ b/python/sbp/ndb.py
@@ -147,10 +147,7 @@ of other data_source.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -50,10 +50,10 @@ counter (ith packet of n)
                't',
                'n_obs',
               ]
-  __zips__ = [
-              ('GPSTimeNano', 't'),
-              ('u8', 'n_obs'),
-             ]
+  _fields = [
+             ( 'GPSTimeNano', 't' ),
+             ( 'u8', 'n_obs' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -65,7 +65,7 @@ counter (ith packet of n)
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in ObservationHeader.__zips__:
+      for t, s in ObservationHeader._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -110,10 +110,10 @@ as positive for approaching satellites.
                'i',
                'f',
               ]
-  __zips__ = [
-              ('s16', 'i'),
-              ('u8', 'f'),
-             ]
+  _fields = [
+             ( 's16', 'i' ),
+             ( 'u8', 'f' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -125,7 +125,7 @@ as positive for approaching satellites.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in Doppler.__zips__:
+      for t, s in Doppler._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -198,15 +198,15 @@ estimate for the signal is valid.
                'flags',
                'sid',
               ]
-  __zips__ = [
-              ('u32', 'P'),
-              ('CarrierPhase', 'L'),
-              ('Doppler', 'D'),
-              ('u8', 'cn0'),
-              ('u8', 'lock'),
-              ('u8', 'flags'),
-              ('GnssSignal16', 'sid'),
-             ]
+  _fields = [
+             ( 'u32', 'P' ),
+             ( 'CarrierPhase', 'L' ),
+             ( 'Doppler', 'D' ),
+             ( 'u8', 'cn0' ),
+             ( 'u8', 'lock' ),
+             ( 'u8', 'flags' ),
+             ( 'GnssSignal16', 'sid' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -218,7 +218,7 @@ estimate for the signal is valid.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in PackedObsContent.__zips__:
+      for t, s in PackedObsContent._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -278,14 +278,14 @@ GLO: 0 = valid, non-zero = invalid
                'valid',
                'health_bits',
               ]
-  __zips__ = [
-              ('GnssSignal16', 'sid'),
-              ('GPSTimeSec', 'toe'),
-              ('double', 'ura'),
-              ('u32', 'fit_interval'),
-              ('u8', 'valid'),
-              ('u8', 'health_bits'),
-             ]
+  _fields = [
+             ( 'GnssSignal16', 'sid' ),
+             ( 'GPSTimeSec', 'toe' ),
+             ( 'double', 'ura' ),
+             ( 'u32', 'fit_interval' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'health_bits' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -297,7 +297,7 @@ GLO: 0 = valid, non-zero = invalid
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in EphemerisCommonContent.__zips__:
+      for t, s in EphemerisCommonContent._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -357,14 +357,14 @@ GLO: 0 = valid, non-zero = invalid
                'valid',
                'health_bits',
               ]
-  __zips__ = [
-              ('GnssSignal', 'sid'),
-              ('GPSTime', 'toe'),
-              ('double', 'ura'),
-              ('u32', 'fit_interval'),
-              ('u8', 'valid'),
-              ('u8', 'health_bits'),
-             ]
+  _fields = [
+             ( 'GnssSignal', 'sid' ),
+             ( 'GPSTime', 'toe' ),
+             ( 'double', 'ura' ),
+             ( 'u32', 'fit_interval' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'health_bits' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -376,7 +376,7 @@ GLO: 0 = valid, non-zero = invalid
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in EphemerisCommonContentDepA.__zips__:
+      for t, s in EphemerisCommonContentDepA._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -420,10 +420,10 @@ counter (ith packet of n)
                't',
                'n_obs',
               ]
-  __zips__ = [
-              ('GPSTime', 't'),
-              ('u8', 'n_obs'),
-             ]
+  _fields = [
+             ( 'GPSTime', 't' ),
+             ( 'u8', 'n_obs' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -435,7 +435,7 @@ counter (ith packet of n)
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in ObservationHeaderDep.__zips__:
+      for t, s in ObservationHeaderDep._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -481,10 +481,10 @@ the opposite sign as the pseudorange.
                'i',
                'f',
               ]
-  __zips__ = [
-              ('s32', 'i'),
-              ('u8', 'f'),
-             ]
+  _fields = [
+             ( 's32', 'i' ),
+             ( 'u8', 'f' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -496,7 +496,7 @@ the opposite sign as the pseudorange.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in CarrierPhaseDepA.__zips__:
+      for t, s in CarrierPhaseDepA._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -552,13 +552,13 @@ carrier phase ambiguity may have changed.
                'lock',
                'prn',
               ]
-  __zips__ = [
-              ('u32', 'P'),
-              ('CarrierPhaseDepA', 'L'),
-              ('u8', 'cn0'),
-              ('u16', 'lock'),
-              ('u8', 'prn'),
-             ]
+  _fields = [
+             ( 'u32', 'P' ),
+             ( 'CarrierPhaseDepA', 'L' ),
+             ( 'u8', 'cn0' ),
+             ( 'u16', 'lock' ),
+             ( 'u8', 'prn' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -570,7 +570,7 @@ carrier phase ambiguity may have changed.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in PackedObsContentDepA.__zips__:
+      for t, s in PackedObsContentDepA._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -628,13 +628,13 @@ carrier phase ambiguity may have changed.
                'lock',
                'sid',
               ]
-  __zips__ = [
-              ('u32', 'P'),
-              ('CarrierPhaseDepA', 'L'),
-              ('u8', 'cn0'),
-              ('u16', 'lock'),
-              ('GnssSignal', 'sid'),
-             ]
+  _fields = [
+             ( 'u32', 'P' ),
+             ( 'CarrierPhaseDepA', 'L' ),
+             ( 'u8', 'cn0' ),
+             ( 'u16', 'lock' ),
+             ( 'GnssSignal', 'sid' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -646,7 +646,7 @@ carrier phase ambiguity may have changed.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in PackedObsContentDepB.__zips__:
+      for t, s in PackedObsContentDepB._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -705,13 +705,13 @@ carrier phase ambiguity may have changed.
                'lock',
                'sid',
               ]
-  __zips__ = [
-              ('u32', 'P'),
-              ('CarrierPhase', 'L'),
-              ('u8', 'cn0'),
-              ('u16', 'lock'),
-              ('GnssSignal', 'sid'),
-             ]
+  _fields = [
+             ( 'u32', 'P' ),
+             ( 'CarrierPhase', 'L' ),
+             ( 'u8', 'cn0' ),
+             ( 'u16', 'lock' ),
+             ( 'GnssSignal', 'sid' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -723,7 +723,7 @@ carrier phase ambiguity may have changed.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in PackedObsContentDepC.__zips__:
+      for t, s in PackedObsContentDepC._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -794,14 +794,14 @@ Satellite health status for GLO:
                'valid',
                'health_bits',
               ]
-  __zips__ = [
-              ('GnssSignal', 'sid'),
-              ('GPSTimeSec', 'toa'),
-              ('double', 'ura'),
-              ('u32', 'fit_interval'),
-              ('u8', 'valid'),
-              ('u8', 'health_bits'),
-             ]
+  _fields = [
+             ( 'GnssSignal', 'sid' ),
+             ( 'GPSTimeSec', 'toa' ),
+             ( 'double', 'ura' ),
+             ( 'u32', 'fit_interval' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'health_bits' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -813,7 +813,7 @@ Satellite health status for GLO:
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in AlmanacCommonContent.__zips__:
+      for t, s in AlmanacCommonContent._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -873,10 +873,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
-  __zips__ = [
-              ( 'ObservationHeader', 'header'),
-              ( 'array:PackedObsContent', 'obs'),
-             ]
+  _fields = [
+             ( 'ObservationHeader', 'header' ),
+             ( 'array:PackedObsContent', 'obs' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -978,11 +978,11 @@ error in the pseudo-absolute position output.
                'lon',
                'height',
               ]
-  __zips__ = [
-              ( 'double', 'lat'),
-              ( 'double', 'lon'),
-              ( 'double', 'height'),
-             ]
+  _fields = [
+             ( 'double', 'lat' ),
+             ( 'double', 'lon' ),
+             ( 'double', 'height' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1086,11 +1086,11 @@ pseudo-absolute position output.
                'y',
                'z',
               ]
-  __zips__ = [
-              ( 'double', 'x'),
-              ( 'double', 'y'),
-              ( 'double', 'z'),
-             ]
+  _fields = [
+             ( 'double', 'x' ),
+             ( 'double', 'y' ),
+             ( 'double', 'z' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1273,31 +1273,31 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iode',
                'iodc',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContentDepA', 'common'),
-              ( 'double', 'tgd'),
-              ( 'double', 'c_rs'),
-              ( 'double', 'c_rc'),
-              ( 'double', 'c_uc'),
-              ( 'double', 'c_us'),
-              ( 'double', 'c_ic'),
-              ( 'double', 'c_is'),
-              ( 'double', 'dn'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'inc_dot'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-              ( 'double', 'af2'),
-              ( 'GPSTime', 'toc'),
-              ( 'u8', 'iode'),
-              ( 'u16', 'iodc'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContentDepA', 'common' ),
+             ( 'double', 'tgd' ),
+             ( 'double', 'c_rs' ),
+             ( 'double', 'c_rc' ),
+             ( 'double', 'c_uc' ),
+             ( 'double', 'c_us' ),
+             ( 'double', 'c_ic' ),
+             ( 'double', 'c_is' ),
+             ( 'double', 'dn' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'inc_dot' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+             ( 'double', 'af2' ),
+             ( 'GPSTime', 'toc' ),
+             ( 'u8', 'iode' ),
+             ( 'u16', 'iodc' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1500,31 +1500,31 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iode',
                'iodc',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContent', 'common'),
-              ( 'double', 'tgd'),
-              ( 'double', 'c_rs'),
-              ( 'double', 'c_rc'),
-              ( 'double', 'c_uc'),
-              ( 'double', 'c_us'),
-              ( 'double', 'c_ic'),
-              ( 'double', 'c_is'),
-              ( 'double', 'dn'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'inc_dot'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-              ( 'double', 'af2'),
-              ( 'GPSTimeSec', 'toc'),
-              ( 'u8', 'iode'),
-              ( 'u16', 'iodc'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContent', 'common' ),
+             ( 'double', 'tgd' ),
+             ( 'double', 'c_rs' ),
+             ( 'double', 'c_rc' ),
+             ( 'double', 'c_uc' ),
+             ( 'double', 'c_us' ),
+             ( 'double', 'c_ic' ),
+             ( 'double', 'c_is' ),
+             ( 'double', 'dn' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'inc_dot' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+             ( 'double', 'af2' ),
+             ( 'GPSTimeSec', 'toc' ),
+             ( 'u8', 'iode' ),
+             ( 'u16', 'iodc' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1653,14 +1653,14 @@ class MsgEphemerisSbasDepA(SBP):
                'a_gf0',
                'a_gf1',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContentDepA', 'common'),
-              ( 'array:double:3', 'pos'),
-              ( 'array:double:3', 'vel'),
-              ( 'array:double:3', 'acc'),
-              ( 'double', 'a_gf0'),
-              ( 'double', 'a_gf1'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContentDepA', 'common' ),
+             ( 'array:double:3', 'pos' ),
+             ( 'array:double:3', 'vel' ),
+             ( 'array:double:3', 'acc' ),
+             ( 'double', 'a_gf0' ),
+             ( 'double', 'a_gf1' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1778,14 +1778,14 @@ for more details.
                'vel',
                'acc',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContentDepA', 'common'),
-              ( 'double', 'gamma'),
-              ( 'double', 'tau'),
-              ( 'array:double:3', 'pos'),
-              ( 'array:double:3', 'vel'),
-              ( 'array:double:3', 'acc'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContentDepA', 'common' ),
+             ( 'double', 'gamma' ),
+             ( 'double', 'tau' ),
+             ( 'array:double:3', 'pos' ),
+             ( 'array:double:3', 'vel' ),
+             ( 'array:double:3', 'acc' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1897,14 +1897,14 @@ class MsgEphemerisSbas(SBP):
                'a_gf0',
                'a_gf1',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContent', 'common'),
-              ( 'array:double:3', 'pos'),
-              ( 'array:double:3', 'vel'),
-              ( 'array:double:3', 'acc'),
-              ( 'double', 'a_gf0'),
-              ( 'double', 'a_gf1'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContent', 'common' ),
+             ( 'array:double:3', 'pos' ),
+             ( 'array:double:3', 'vel' ),
+             ( 'array:double:3', 'acc' ),
+             ( 'double', 'a_gf0' ),
+             ( 'double', 'a_gf1' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2022,14 +2022,14 @@ for more details.
                'vel',
                'acc',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContent', 'common'),
-              ( 'double', 'gamma'),
-              ( 'double', 'tau'),
-              ( 'array:double:3', 'pos'),
-              ( 'array:double:3', 'vel'),
-              ( 'array:double:3', 'acc'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContent', 'common' ),
+             ( 'double', 'gamma' ),
+             ( 'double', 'tau' ),
+             ( 'array:double:3', 'pos' ),
+             ( 'array:double:3', 'vel' ),
+             ( 'array:double:3', 'acc' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2155,16 +2155,16 @@ for more details.
                'acc',
                'fcn',
               ]
-  __zips__ = [
-              ( 'EphemerisCommonContent', 'common'),
-              ( 'double', 'gamma'),
-              ( 'double', 'tau'),
-              ( 'double', 'd_tau'),
-              ( 'array:double:3', 'pos'),
-              ( 'array:double:3', 'vel'),
-              ( 'array:double:3', 'acc'),
-              ( 'u8', 'fcn'),
-             ]
+  _fields = [
+             ( 'EphemerisCommonContent', 'common' ),
+             ( 'double', 'gamma' ),
+             ( 'double', 'tau' ),
+             ( 'double', 'd_tau' ),
+             ( 'array:double:3', 'pos' ),
+             ( 'array:double:3', 'vel' ),
+             ( 'array:double:3', 'acc' ),
+             ( 'u8', 'fcn' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2376,37 +2376,37 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iodc',
                'reserved',
               ]
-  __zips__ = [
-              ( 'double', 'tgd'),
-              ( 'double', 'c_rs'),
-              ( 'double', 'c_rc'),
-              ( 'double', 'c_uc'),
-              ( 'double', 'c_us'),
-              ( 'double', 'c_ic'),
-              ( 'double', 'c_is'),
-              ( 'double', 'dn'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'inc_dot'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-              ( 'double', 'af2'),
-              ( 'double', 'toe_tow'),
-              ( 'u16', 'toe_wn'),
-              ( 'double', 'toc_tow'),
-              ( 'u16', 'toc_wn'),
-              ( 'u8', 'valid'),
-              ( 'u8', 'healthy'),
-              ( 'GnssSignal', 'sid'),
-              ( 'u8', 'iode'),
-              ( 'u16', 'iodc'),
-              ( 'u32', 'reserved'),
-             ]
+  _fields = [
+             ( 'double', 'tgd' ),
+             ( 'double', 'c_rs' ),
+             ( 'double', 'c_rc' ),
+             ( 'double', 'c_uc' ),
+             ( 'double', 'c_us' ),
+             ( 'double', 'c_ic' ),
+             ( 'double', 'c_is' ),
+             ( 'double', 'dn' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'inc_dot' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+             ( 'double', 'af2' ),
+             ( 'double', 'toe_tow' ),
+             ( 'u16', 'toe_wn' ),
+             ( 'double', 'toc_tow' ),
+             ( 'u16', 'toc_wn' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'healthy' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 'u8', 'iode' ),
+             ( 'u16', 'iodc' ),
+             ( 'u32', 'reserved' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2622,34 +2622,34 @@ class MsgEphemerisDepA(SBP):
                'healthy',
                'prn',
               ]
-  __zips__ = [
-              ( 'double', 'tgd'),
-              ( 'double', 'c_rs'),
-              ( 'double', 'c_rc'),
-              ( 'double', 'c_uc'),
-              ( 'double', 'c_us'),
-              ( 'double', 'c_ic'),
-              ( 'double', 'c_is'),
-              ( 'double', 'dn'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'inc_dot'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-              ( 'double', 'af2'),
-              ( 'double', 'toe_tow'),
-              ( 'u16', 'toe_wn'),
-              ( 'double', 'toc_tow'),
-              ( 'u16', 'toc_wn'),
-              ( 'u8', 'valid'),
-              ( 'u8', 'healthy'),
-              ( 'u8', 'prn'),
-             ]
+  _fields = [
+             ( 'double', 'tgd' ),
+             ( 'double', 'c_rs' ),
+             ( 'double', 'c_rc' ),
+             ( 'double', 'c_uc' ),
+             ( 'double', 'c_us' ),
+             ( 'double', 'c_ic' ),
+             ( 'double', 'c_is' ),
+             ( 'double', 'dn' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'inc_dot' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+             ( 'double', 'af2' ),
+             ( 'double', 'toe_tow' ),
+             ( 'u16', 'toe_wn' ),
+             ( 'double', 'toc_tow' ),
+             ( 'u16', 'toc_wn' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'healthy' ),
+             ( 'u8', 'prn' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2866,35 +2866,35 @@ class MsgEphemerisDepB(SBP):
                'prn',
                'iode',
               ]
-  __zips__ = [
-              ( 'double', 'tgd'),
-              ( 'double', 'c_rs'),
-              ( 'double', 'c_rc'),
-              ( 'double', 'c_uc'),
-              ( 'double', 'c_us'),
-              ( 'double', 'c_ic'),
-              ( 'double', 'c_is'),
-              ( 'double', 'dn'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'inc_dot'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-              ( 'double', 'af2'),
-              ( 'double', 'toe_tow'),
-              ( 'u16', 'toe_wn'),
-              ( 'double', 'toc_tow'),
-              ( 'u16', 'toc_wn'),
-              ( 'u8', 'valid'),
-              ( 'u8', 'healthy'),
-              ( 'u8', 'prn'),
-              ( 'u8', 'iode'),
-             ]
+  _fields = [
+             ( 'double', 'tgd' ),
+             ( 'double', 'c_rs' ),
+             ( 'double', 'c_rc' ),
+             ( 'double', 'c_uc' ),
+             ( 'double', 'c_us' ),
+             ( 'double', 'c_ic' ),
+             ( 'double', 'c_is' ),
+             ( 'double', 'dn' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'inc_dot' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+             ( 'double', 'af2' ),
+             ( 'double', 'toe_tow' ),
+             ( 'u16', 'toe_wn' ),
+             ( 'double', 'toc_tow' ),
+             ( 'u16', 'toc_wn' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'healthy' ),
+             ( 'u8', 'prn' ),
+             ( 'u8', 'iode' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3125,37 +3125,37 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iodc',
                'reserved',
               ]
-  __zips__ = [
-              ( 'double', 'tgd'),
-              ( 'double', 'c_rs'),
-              ( 'double', 'c_rc'),
-              ( 'double', 'c_uc'),
-              ( 'double', 'c_us'),
-              ( 'double', 'c_ic'),
-              ( 'double', 'c_is'),
-              ( 'double', 'dn'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'inc_dot'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-              ( 'double', 'af2'),
-              ( 'double', 'toe_tow'),
-              ( 'u16', 'toe_wn'),
-              ( 'double', 'toc_tow'),
-              ( 'u16', 'toc_wn'),
-              ( 'u8', 'valid'),
-              ( 'u8', 'healthy'),
-              ( 'GnssSignal', 'sid'),
-              ( 'u8', 'iode'),
-              ( 'u16', 'iodc'),
-              ( 'u32', 'reserved'),
-             ]
+  _fields = [
+             ( 'double', 'tgd' ),
+             ( 'double', 'c_rs' ),
+             ( 'double', 'c_rc' ),
+             ( 'double', 'c_uc' ),
+             ( 'double', 'c_us' ),
+             ( 'double', 'c_ic' ),
+             ( 'double', 'c_is' ),
+             ( 'double', 'dn' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'inc_dot' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+             ( 'double', 'af2' ),
+             ( 'double', 'toe_tow' ),
+             ( 'u16', 'toe_wn' ),
+             ( 'double', 'toc_tow' ),
+             ( 'u16', 'toc_wn' ),
+             ( 'u8', 'valid' ),
+             ( 'u8', 'healthy' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 'u8', 'iode' ),
+             ( 'u16', 'iodc' ),
+             ( 'u32', 'reserved' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3277,10 +3277,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
-  __zips__ = [
-              ( 'ObservationHeaderDep', 'header'),
-              ( 'array:PackedObsContentDepA', 'obs'),
-             ]
+  _fields = [
+             ( 'ObservationHeaderDep', 'header' ),
+             ( 'array:PackedObsContentDepA', 'obs' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3381,10 +3381,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
-  __zips__ = [
-              ( 'ObservationHeaderDep', 'header'),
-              ( 'array:PackedObsContentDepB', 'obs'),
-             ]
+  _fields = [
+             ( 'ObservationHeaderDep', 'header' ),
+             ( 'array:PackedObsContentDepB', 'obs' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3486,10 +3486,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
-  __zips__ = [
-              ( 'ObservationHeaderDep', 'header'),
-              ( 'array:PackedObsContentDepC', 'obs'),
-             ]
+  _fields = [
+             ( 'ObservationHeaderDep', 'header' ),
+             ( 'array:PackedObsContentDepC', 'obs' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3605,17 +3605,17 @@ Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
                'b2',
                'b3',
               ]
-  __zips__ = [
-              ( 'GPSTimeSec', 't_nmct'),
-              ( 'double', 'a0'),
-              ( 'double', 'a1'),
-              ( 'double', 'a2'),
-              ( 'double', 'a3'),
-              ( 'double', 'b0'),
-              ( 'double', 'b1'),
-              ( 'double', 'b2'),
-              ( 'double', 'b3'),
-             ]
+  _fields = [
+             ( 'GPSTimeSec', 't_nmct' ),
+             ( 'double', 'a0' ),
+             ( 'double', 'a1' ),
+             ( 'double', 'a2' ),
+             ( 'double', 'a3' ),
+             ( 'double', 'b0' ),
+             ( 'double', 'b1' ),
+             ( 'double', 'b2' ),
+             ( 'double', 'b3' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3716,10 +3716,10 @@ class MsgSvConfigurationGPS(SBP):
                't_nmct',
                'l2c_mask',
               ]
-  __zips__ = [
-              ( 'GPSTimeSec', 't_nmct'),
-              ( 'u32', 'l2c_mask'),
-             ]
+  _fields = [
+             ( 'GPSTimeSec', 't_nmct' ),
+             ( 'u32', 'l2c_mask' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3828,14 +3828,14 @@ LSB indicating tgd validity etc.
                'isc_l1ca',
                'isc_l2c',
               ]
-  __zips__ = [
-              ( 'GPSTime', 't_op'),
-              ( 'u8', 'prn'),
-              ( 'u8', 'valid'),
-              ( 's16', 'tgd'),
-              ( 's16', 'isc_l1ca'),
-              ( 's16', 'isc_l2c'),
-             ]
+  _fields = [
+             ( 'GPSTime', 't_op' ),
+             ( 'u8', 'prn' ),
+             ( 'u8', 'valid' ),
+             ( 's16', 'tgd' ),
+             ( 's16', 'isc_l1ca' ),
+             ( 's16', 'isc_l2c' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3948,14 +3948,14 @@ LSB indicating tgd validity etc.
                'isc_l1ca',
                'isc_l2c',
               ]
-  __zips__ = [
-              ( 'GPSTimeSec', 't_op'),
-              ( 'GnssSignal', 'sid'),
-              ( 'u8', 'valid'),
-              ( 's16', 'tgd'),
-              ( 's16', 'isc_l1ca'),
-              ( 's16', 'isc_l2c'),
-             ]
+  _fields = [
+             ( 'GPSTimeSec', 't_op' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 'u8', 'valid' ),
+             ( 's16', 'tgd' ),
+             ( 's16', 'isc_l1ca' ),
+             ( 's16', 'isc_l2c' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -4088,18 +4088,18 @@ Please see the Navstar GPS Space Segment/Navigation user interfaces
                'af0',
                'af1',
               ]
-  __zips__ = [
-              ( 'AlmanacCommonContent', 'common'),
-              ( 'double', 'm0'),
-              ( 'double', 'ecc'),
-              ( 'double', 'sqrta'),
-              ( 'double', 'omega0'),
-              ( 'double', 'omegadot'),
-              ( 'double', 'w'),
-              ( 'double', 'inc'),
-              ( 'double', 'af0'),
-              ( 'double', 'af1'),
-             ]
+  _fields = [
+             ( 'AlmanacCommonContent', 'common' ),
+             ( 'double', 'm0' ),
+             ( 'double', 'ecc' ),
+             ( 'double', 'sqrta' ),
+             ( 'double', 'omega0' ),
+             ( 'double', 'omegadot' ),
+             ( 'double', 'w' ),
+             ( 'double', 'inc' ),
+             ( 'double', 'af0' ),
+             ( 'double', 'af1' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -4230,16 +4230,16 @@ coordinate system
                'epsilon',
                'omega',
               ]
-  __zips__ = [
-              ( 'AlmanacCommonContent', 'common'),
-              ( 'double', 'lambda_na'),
-              ( 'double', 't_lambda_na'),
-              ( 'double', 'i'),
-              ( 'double', 't'),
-              ( 'double', 't_dot'),
-              ( 'double', 'epsilon'),
-              ( 'double', 'omega'),
-             ]
+  _fields = [
+             ( 'AlmanacCommonContent', 'common' ),
+             ( 'double', 'lambda_na' ),
+             ( 'double', 't_lambda_na' ),
+             ( 'double', 'i' ),
+             ( 'double', 't' ),
+             ( 'double', 't_dot' ),
+             ( 'double', 'epsilon' ),
+             ( 'double', 'omega' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -4353,11 +4353,11 @@ index (SV orbital slot)  fcns[index]
                'tow_ms',
                'fcns',
               ]
-  __zips__ = [
-              ( 'u16', 'wn'),
-              ( 'u32', 'tow_ms'),
-              ( 'array:u8:32', 'fcns'),
-             ]
+  _fields = [
+             ( 'u16', 'wn' ),
+             ( 'u32', 'tow_ms' ),
+             ( 'array:u8:32', 'fcns' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -20,7 +20,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/observation.yaml with generate.py.

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -1640,9 +1640,9 @@ class MsgEphemerisSbasDepA(SBP):
   """
   _parser = Struct("MsgEphemerisSbasDepA",
                    Struct('common', EphemerisCommonContentDepA._parser),
-                   Array(3, LFloat64('pos')),
-                   Array(3, LFloat64('vel')),
-                   Array(3, LFloat64('acc')),
+                   Struct('pos', Array(3, LFloat64('pos'))),
+                   Struct('vel', Array(3, LFloat64('vel'))),
+                   Struct('acc', Array(3, LFloat64('acc'))),
                    LFloat64('a_gf0'),
                    LFloat64('a_gf1'),)
   __slots__ = [
@@ -1767,9 +1767,9 @@ for more details.
                    Struct('common', EphemerisCommonContentDepA._parser),
                    LFloat64('gamma'),
                    LFloat64('tau'),
-                   Array(3, LFloat64('pos')),
-                   Array(3, LFloat64('vel')),
-                   Array(3, LFloat64('acc')),)
+                   Struct('pos', Array(3, LFloat64('pos'))),
+                   Struct('vel', Array(3, LFloat64('vel'))),
+                   Struct('acc', Array(3, LFloat64('acc'))),)
   __slots__ = [
                'common',
                'gamma',
@@ -1884,9 +1884,9 @@ class MsgEphemerisSbas(SBP):
   """
   _parser = Struct("MsgEphemerisSbas",
                    Struct('common', EphemerisCommonContent._parser),
-                   Array(3, LFloat64('pos')),
-                   Array(3, LFloat64('vel')),
-                   Array(3, LFloat64('acc')),
+                   Struct('pos', Array(3, LFloat64('pos'))),
+                   Struct('vel', Array(3, LFloat64('vel'))),
+                   Struct('acc', Array(3, LFloat64('acc'))),
                    LFloat64('a_gf0'),
                    LFloat64('a_gf1'),)
   __slots__ = [
@@ -2011,9 +2011,9 @@ for more details.
                    Struct('common', EphemerisCommonContent._parser),
                    LFloat64('gamma'),
                    LFloat64('tau'),
-                   Array(3, LFloat64('pos')),
-                   Array(3, LFloat64('vel')),
-                   Array(3, LFloat64('acc')),)
+                   Struct('pos', Array(3, LFloat64('pos'))),
+                   Struct('vel', Array(3, LFloat64('vel'))),
+                   Struct('acc', Array(3, LFloat64('acc'))),)
   __slots__ = [
                'common',
                'gamma',
@@ -2141,9 +2141,9 @@ for more details.
                    LFloat64('gamma'),
                    LFloat64('tau'),
                    LFloat64('d_tau'),
-                   Array(3, LFloat64('pos')),
-                   Array(3, LFloat64('vel')),
-                   Array(3, LFloat64('acc')),
+                   Struct('pos', Array(3, LFloat64('pos'))),
+                   Struct('vel', Array(3, LFloat64('vel'))),
+                   Struct('acc', Array(3, LFloat64('acc'))),
                    ULInt8('fcn'),)
   __slots__ = [
                'common',
@@ -4347,7 +4347,7 @@ index (SV orbital slot)  fcns[index]
   _parser = Struct("MsgFcnsGlo",
                    ULInt16('wn'),
                    ULInt32('tow_ms'),
-                   Array(32, ULInt8('fcns')),)
+                   Struct('fcns', Array(32, ULInt8('fcns'))),)
   __slots__ = [
                'wn',
                'tow_ms',

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -16,8 +16,11 @@ Satellite observation messages from the device.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/observation.yaml with generate.py.
@@ -47,25 +50,41 @@ counter (ith packet of n)
                't',
                'n_obs',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.t = kwargs.pop('t')
-      self.n_obs = kwargs.pop('n_obs')
+  __zips__ = [
+              ('GPSTimeNano', 't'),
+              ('u8', 'n_obs'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = ObservationHeader._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in ObservationHeader.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return ObservationHeader.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return ObservationHeader.build(d)
+    except:
+      print traceback.print_exc()
     
 class Doppler(object):
   """Doppler.
@@ -91,25 +110,41 @@ as positive for approaching satellites.
                'i',
                'f',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.i = kwargs.pop('i')
-      self.f = kwargs.pop('f')
+  __zips__ = [
+              ('s16', 'i'),
+              ('u8', 'f'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = Doppler._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in Doppler.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return Doppler.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return Doppler.build(d)
+    except:
+      print traceback.print_exc()
     
 class PackedObsContent(object):
   """PackedObsContent.
@@ -163,30 +198,46 @@ estimate for the signal is valid.
                'flags',
                'sid',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.P = kwargs.pop('P')
-      self.L = kwargs.pop('L')
-      self.D = kwargs.pop('D')
-      self.cn0 = kwargs.pop('cn0')
-      self.lock = kwargs.pop('lock')
-      self.flags = kwargs.pop('flags')
-      self.sid = kwargs.pop('sid')
+  __zips__ = [
+              ('u32', 'P'),
+              ('CarrierPhase', 'L'),
+              ('Doppler', 'D'),
+              ('u8', 'cn0'),
+              ('u8', 'lock'),
+              ('u8', 'flags'),
+              ('GnssSignal16', 'sid'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = PackedObsContent._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in PackedObsContent.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return PackedObsContent.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return PackedObsContent.build(d)
+    except:
+      print traceback.print_exc()
     
 class EphemerisCommonContent(object):
   """EphemerisCommonContent.
@@ -227,29 +278,45 @@ GLO: 0 = valid, non-zero = invalid
                'valid',
                'health_bits',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.sid = kwargs.pop('sid')
-      self.toe = kwargs.pop('toe')
-      self.ura = kwargs.pop('ura')
-      self.fit_interval = kwargs.pop('fit_interval')
-      self.valid = kwargs.pop('valid')
-      self.health_bits = kwargs.pop('health_bits')
+  __zips__ = [
+              ('GnssSignal16', 'sid'),
+              ('GPSTimeSec', 'toe'),
+              ('double', 'ura'),
+              ('u32', 'fit_interval'),
+              ('u8', 'valid'),
+              ('u8', 'health_bits'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = EphemerisCommonContent._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in EphemerisCommonContent.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return EphemerisCommonContent.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return EphemerisCommonContent.build(d)
+    except:
+      print traceback.print_exc()
     
 class EphemerisCommonContentDepA(object):
   """EphemerisCommonContentDepA.
@@ -290,29 +357,45 @@ GLO: 0 = valid, non-zero = invalid
                'valid',
                'health_bits',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.sid = kwargs.pop('sid')
-      self.toe = kwargs.pop('toe')
-      self.ura = kwargs.pop('ura')
-      self.fit_interval = kwargs.pop('fit_interval')
-      self.valid = kwargs.pop('valid')
-      self.health_bits = kwargs.pop('health_bits')
+  __zips__ = [
+              ('GnssSignal', 'sid'),
+              ('GPSTime', 'toe'),
+              ('double', 'ura'),
+              ('u32', 'fit_interval'),
+              ('u8', 'valid'),
+              ('u8', 'health_bits'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = EphemerisCommonContentDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in EphemerisCommonContentDepA.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return EphemerisCommonContentDepA.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return EphemerisCommonContentDepA.build(d)
+    except:
+      print traceback.print_exc()
     
 class ObservationHeaderDep(object):
   """ObservationHeaderDep.
@@ -337,25 +420,41 @@ counter (ith packet of n)
                't',
                'n_obs',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.t = kwargs.pop('t')
-      self.n_obs = kwargs.pop('n_obs')
+  __zips__ = [
+              ('GPSTime', 't'),
+              ('u8', 'n_obs'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = ObservationHeaderDep._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in ObservationHeaderDep.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return ObservationHeaderDep.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return ObservationHeaderDep.build(d)
+    except:
+      print traceback.print_exc()
     
 class CarrierPhaseDepA(object):
   """CarrierPhaseDepA.
@@ -382,25 +481,41 @@ the opposite sign as the pseudorange.
                'i',
                'f',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.i = kwargs.pop('i')
-      self.f = kwargs.pop('f')
+  __zips__ = [
+              ('s32', 'i'),
+              ('u8', 'f'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = CarrierPhaseDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in CarrierPhaseDepA.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return CarrierPhaseDepA.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return CarrierPhaseDepA.build(d)
+    except:
+      print traceback.print_exc()
     
 class PackedObsContentDepA(object):
   """PackedObsContentDepA.
@@ -437,28 +552,44 @@ carrier phase ambiguity may have changed.
                'lock',
                'prn',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.P = kwargs.pop('P')
-      self.L = kwargs.pop('L')
-      self.cn0 = kwargs.pop('cn0')
-      self.lock = kwargs.pop('lock')
-      self.prn = kwargs.pop('prn')
+  __zips__ = [
+              ('u32', 'P'),
+              ('CarrierPhaseDepA', 'L'),
+              ('u8', 'cn0'),
+              ('u16', 'lock'),
+              ('u8', 'prn'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = PackedObsContentDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in PackedObsContentDepA.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return PackedObsContentDepA.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return PackedObsContentDepA.build(d)
+    except:
+      print traceback.print_exc()
     
 class PackedObsContentDepB(object):
   """PackedObsContentDepB.
@@ -497,28 +628,44 @@ carrier phase ambiguity may have changed.
                'lock',
                'sid',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.P = kwargs.pop('P')
-      self.L = kwargs.pop('L')
-      self.cn0 = kwargs.pop('cn0')
-      self.lock = kwargs.pop('lock')
-      self.sid = kwargs.pop('sid')
+  __zips__ = [
+              ('u32', 'P'),
+              ('CarrierPhaseDepA', 'L'),
+              ('u8', 'cn0'),
+              ('u16', 'lock'),
+              ('GnssSignal', 'sid'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = PackedObsContentDepB._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in PackedObsContentDepB.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return PackedObsContentDepB.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return PackedObsContentDepB.build(d)
+    except:
+      print traceback.print_exc()
     
 class PackedObsContentDepC(object):
   """PackedObsContentDepC.
@@ -558,28 +705,44 @@ carrier phase ambiguity may have changed.
                'lock',
                'sid',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.P = kwargs.pop('P')
-      self.L = kwargs.pop('L')
-      self.cn0 = kwargs.pop('cn0')
-      self.lock = kwargs.pop('lock')
-      self.sid = kwargs.pop('sid')
+  __zips__ = [
+              ('u32', 'P'),
+              ('CarrierPhase', 'L'),
+              ('u8', 'cn0'),
+              ('u16', 'lock'),
+              ('GnssSignal', 'sid'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = PackedObsContentDepC._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in PackedObsContentDepC.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return PackedObsContentDepC.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return PackedObsContentDepC.build(d)
+    except:
+      print traceback.print_exc()
     
 class AlmanacCommonContent(object):
   """AlmanacCommonContent.
@@ -631,29 +794,45 @@ Satellite health status for GLO:
                'valid',
                'health_bits',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.sid = kwargs.pop('sid')
-      self.toa = kwargs.pop('toa')
-      self.ura = kwargs.pop('ura')
-      self.fit_interval = kwargs.pop('fit_interval')
-      self.valid = kwargs.pop('valid')
-      self.health_bits = kwargs.pop('health_bits')
+  __zips__ = [
+              ('GnssSignal', 'sid'),
+              ('GPSTimeSec', 'toa'),
+              ('double', 'ura'),
+              ('u32', 'fit_interval'),
+              ('u8', 'valid'),
+              ('u8', 'health_bits'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = AlmanacCommonContent._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in AlmanacCommonContent.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return AlmanacCommonContent.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return AlmanacCommonContent.build(d)
+    except:
+      print traceback.print_exc()
     
 SBP_MSG_OBS = 0x004A
 class MsgObs(SBP):
@@ -694,6 +873,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
+  __zips__ = [
+              ( 'ObservationHeader', 'header'),
+              ( 'array:PackedObsContent', 'obs'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -730,9 +913,16 @@ satellite being tracked.
     the message.
 
     """
-    p = MsgObs._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -788,6 +978,11 @@ error in the pseudo-absolute position output.
                'lon',
                'height',
               ]
+  __zips__ = [
+              ( 'double', 'lat'),
+              ( 'double', 'lon'),
+              ( 'double', 'height'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -825,9 +1020,16 @@ error in the pseudo-absolute position output.
     the message.
 
     """
-    p = MsgBasePosLLH._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -884,6 +1086,11 @@ pseudo-absolute position output.
                'y',
                'z',
               ]
+  __zips__ = [
+              ( 'double', 'x'),
+              ( 'double', 'y'),
+              ( 'double', 'z'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -921,9 +1128,16 @@ pseudo-absolute position output.
     the message.
 
     """
-    p = MsgBasePosECEF._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1059,6 +1273,31 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iode',
                'iodc',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContentDepA', 'common'),
+              ( 'double', 'tgd'),
+              ( 'double', 'c_rs'),
+              ( 'double', 'c_rc'),
+              ( 'double', 'c_uc'),
+              ( 'double', 'c_us'),
+              ( 'double', 'c_ic'),
+              ( 'double', 'c_is'),
+              ( 'double', 'dn'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'inc_dot'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+              ( 'double', 'af2'),
+              ( 'GPSTime', 'toc'),
+              ( 'u8', 'iode'),
+              ( 'u16', 'iodc'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1116,9 +1355,16 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    p = MsgEphemerisGPSDepE._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1254,6 +1500,31 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iode',
                'iodc',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContent', 'common'),
+              ( 'double', 'tgd'),
+              ( 'double', 'c_rs'),
+              ( 'double', 'c_rc'),
+              ( 'double', 'c_uc'),
+              ( 'double', 'c_us'),
+              ( 'double', 'c_ic'),
+              ( 'double', 'c_is'),
+              ( 'double', 'dn'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'inc_dot'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+              ( 'double', 'af2'),
+              ( 'GPSTimeSec', 'toc'),
+              ( 'u8', 'iode'),
+              ( 'u16', 'iodc'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1311,9 +1582,16 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    p = MsgEphemerisGPS._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1375,6 +1653,14 @@ class MsgEphemerisSbasDepA(SBP):
                'a_gf0',
                'a_gf1',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContentDepA', 'common'),
+              ( 'array:double:3', 'pos'),
+              ( 'array:double:3', 'vel'),
+              ( 'array:double:3', 'acc'),
+              ( 'double', 'a_gf0'),
+              ( 'double', 'a_gf1'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1415,9 +1701,16 @@ class MsgEphemerisSbasDepA(SBP):
     the message.
 
     """
-    p = MsgEphemerisSbasDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1485,6 +1778,14 @@ for more details.
                'vel',
                'acc',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContentDepA', 'common'),
+              ( 'double', 'gamma'),
+              ( 'double', 'tau'),
+              ( 'array:double:3', 'pos'),
+              ( 'array:double:3', 'vel'),
+              ( 'array:double:3', 'acc'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1525,9 +1826,16 @@ for more details.
     the message.
 
     """
-    p = MsgEphemerisGloDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1589,6 +1897,14 @@ class MsgEphemerisSbas(SBP):
                'a_gf0',
                'a_gf1',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContent', 'common'),
+              ( 'array:double:3', 'pos'),
+              ( 'array:double:3', 'vel'),
+              ( 'array:double:3', 'acc'),
+              ( 'double', 'a_gf0'),
+              ( 'double', 'a_gf1'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1629,9 +1945,16 @@ class MsgEphemerisSbas(SBP):
     the message.
 
     """
-    p = MsgEphemerisSbas._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1699,6 +2022,14 @@ for more details.
                'vel',
                'acc',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContent', 'common'),
+              ( 'double', 'gamma'),
+              ( 'double', 'tau'),
+              ( 'array:double:3', 'pos'),
+              ( 'array:double:3', 'vel'),
+              ( 'array:double:3', 'acc'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1739,9 +2070,16 @@ for more details.
     the message.
 
     """
-    p = MsgEphemerisGloDepB._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1817,6 +2155,16 @@ for more details.
                'acc',
                'fcn',
               ]
+  __zips__ = [
+              ( 'EphemerisCommonContent', 'common'),
+              ( 'double', 'gamma'),
+              ( 'double', 'tau'),
+              ( 'double', 'd_tau'),
+              ( 'array:double:3', 'pos'),
+              ( 'array:double:3', 'vel'),
+              ( 'array:double:3', 'acc'),
+              ( 'u8', 'fcn'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1859,9 +2207,16 @@ for more details.
     the message.
 
     """
-    p = MsgEphemerisGlo._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2021,6 +2376,37 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iodc',
                'reserved',
               ]
+  __zips__ = [
+              ( 'double', 'tgd'),
+              ( 'double', 'c_rs'),
+              ( 'double', 'c_rc'),
+              ( 'double', 'c_uc'),
+              ( 'double', 'c_us'),
+              ( 'double', 'c_ic'),
+              ( 'double', 'c_is'),
+              ( 'double', 'dn'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'inc_dot'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+              ( 'double', 'af2'),
+              ( 'double', 'toe_tow'),
+              ( 'u16', 'toe_wn'),
+              ( 'double', 'toc_tow'),
+              ( 'u16', 'toc_wn'),
+              ( 'u8', 'valid'),
+              ( 'u8', 'healthy'),
+              ( 'GnssSignal', 'sid'),
+              ( 'u8', 'iode'),
+              ( 'u16', 'iodc'),
+              ( 'u32', 'reserved'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2084,9 +2470,16 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    p = MsgEphemerisDepD._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2229,6 +2622,34 @@ class MsgEphemerisDepA(SBP):
                'healthy',
                'prn',
               ]
+  __zips__ = [
+              ( 'double', 'tgd'),
+              ( 'double', 'c_rs'),
+              ( 'double', 'c_rc'),
+              ( 'double', 'c_uc'),
+              ( 'double', 'c_us'),
+              ( 'double', 'c_ic'),
+              ( 'double', 'c_is'),
+              ( 'double', 'dn'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'inc_dot'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+              ( 'double', 'af2'),
+              ( 'double', 'toe_tow'),
+              ( 'u16', 'toe_wn'),
+              ( 'double', 'toc_tow'),
+              ( 'u16', 'toc_wn'),
+              ( 'u8', 'valid'),
+              ( 'u8', 'healthy'),
+              ( 'u8', 'prn'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2289,9 +2710,16 @@ class MsgEphemerisDepA(SBP):
     the message.
 
     """
-    p = MsgEphemerisDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2438,6 +2866,35 @@ class MsgEphemerisDepB(SBP):
                'prn',
                'iode',
               ]
+  __zips__ = [
+              ( 'double', 'tgd'),
+              ( 'double', 'c_rs'),
+              ( 'double', 'c_rc'),
+              ( 'double', 'c_uc'),
+              ( 'double', 'c_us'),
+              ( 'double', 'c_ic'),
+              ( 'double', 'c_is'),
+              ( 'double', 'dn'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'inc_dot'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+              ( 'double', 'af2'),
+              ( 'double', 'toe_tow'),
+              ( 'u16', 'toe_wn'),
+              ( 'double', 'toc_tow'),
+              ( 'u16', 'toc_wn'),
+              ( 'u8', 'valid'),
+              ( 'u8', 'healthy'),
+              ( 'u8', 'prn'),
+              ( 'u8', 'iode'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2499,9 +2956,16 @@ class MsgEphemerisDepB(SBP):
     the message.
 
     """
-    p = MsgEphemerisDepB._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2661,6 +3125,37 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
                'iodc',
                'reserved',
               ]
+  __zips__ = [
+              ( 'double', 'tgd'),
+              ( 'double', 'c_rs'),
+              ( 'double', 'c_rc'),
+              ( 'double', 'c_uc'),
+              ( 'double', 'c_us'),
+              ( 'double', 'c_ic'),
+              ( 'double', 'c_is'),
+              ( 'double', 'dn'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'inc_dot'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+              ( 'double', 'af2'),
+              ( 'double', 'toe_tow'),
+              ( 'u16', 'toe_wn'),
+              ( 'double', 'toc_tow'),
+              ( 'u16', 'toc_wn'),
+              ( 'u8', 'valid'),
+              ( 'u8', 'healthy'),
+              ( 'GnssSignal', 'sid'),
+              ( 'u8', 'iode'),
+              ( 'u16', 'iodc'),
+              ( 'u32', 'reserved'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2724,9 +3219,16 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    p = MsgEphemerisDepC._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2775,6 +3277,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
+  __zips__ = [
+              ( 'ObservationHeaderDep', 'header'),
+              ( 'array:PackedObsContentDepA', 'obs'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2811,9 +3317,16 @@ satellite being tracked.
     the message.
 
     """
-    p = MsgObsDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2868,6 +3381,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
+  __zips__ = [
+              ( 'ObservationHeaderDep', 'header'),
+              ( 'array:PackedObsContentDepB', 'obs'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2904,9 +3421,16 @@ satellite being tracked.
     the message.
 
     """
-    p = MsgObsDepB._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -2962,6 +3486,10 @@ satellite being tracked.
                'header',
                'obs',
               ]
+  __zips__ = [
+              ( 'ObservationHeaderDep', 'header'),
+              ( 'array:PackedObsContentDepC', 'obs'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -2998,9 +3526,16 @@ satellite being tracked.
     the message.
 
     """
-    p = MsgObsDepC._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3070,6 +3605,17 @@ Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
                'b2',
                'b3',
               ]
+  __zips__ = [
+              ( 'GPSTimeSec', 't_nmct'),
+              ( 'double', 'a0'),
+              ( 'double', 'a1'),
+              ( 'double', 'a2'),
+              ( 'double', 'a3'),
+              ( 'double', 'b0'),
+              ( 'double', 'b1'),
+              ( 'double', 'b2'),
+              ( 'double', 'b3'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3113,9 +3659,16 @@ Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
     the message.
 
     """
-    p = MsgIono._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3163,6 +3716,10 @@ class MsgSvConfigurationGPS(SBP):
                't_nmct',
                'l2c_mask',
               ]
+  __zips__ = [
+              ( 'GPSTimeSec', 't_nmct'),
+              ( 'u32', 'l2c_mask'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3199,9 +3756,16 @@ class MsgSvConfigurationGPS(SBP):
     the message.
 
     """
-    p = MsgSvConfigurationGPS._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3264,6 +3828,14 @@ LSB indicating tgd validity etc.
                'isc_l1ca',
                'isc_l2c',
               ]
+  __zips__ = [
+              ( 'GPSTime', 't_op'),
+              ( 'u8', 'prn'),
+              ( 'u8', 'valid'),
+              ( 's16', 'tgd'),
+              ( 's16', 'isc_l1ca'),
+              ( 's16', 'isc_l2c'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3304,9 +3876,16 @@ LSB indicating tgd validity etc.
     the message.
 
     """
-    p = MsgGroupDelayDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3369,6 +3948,14 @@ LSB indicating tgd validity etc.
                'isc_l1ca',
                'isc_l2c',
               ]
+  __zips__ = [
+              ( 'GPSTimeSec', 't_op'),
+              ( 'GnssSignal', 'sid'),
+              ( 'u8', 'valid'),
+              ( 's16', 'tgd'),
+              ( 's16', 'isc_l1ca'),
+              ( 's16', 'isc_l2c'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3409,9 +3996,16 @@ LSB indicating tgd validity etc.
     the message.
 
     """
-    p = MsgGroupDelay._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3494,6 +4088,18 @@ Please see the Navstar GPS Space Segment/Navigation user interfaces
                'af0',
                'af1',
               ]
+  __zips__ = [
+              ( 'AlmanacCommonContent', 'common'),
+              ( 'double', 'm0'),
+              ( 'double', 'ecc'),
+              ( 'double', 'sqrta'),
+              ( 'double', 'omega0'),
+              ( 'double', 'omegadot'),
+              ( 'double', 'w'),
+              ( 'double', 'inc'),
+              ( 'double', 'af0'),
+              ( 'double', 'af1'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3538,9 +4144,16 @@ Please see the Navstar GPS Space Segment/Navigation user interfaces
     the message.
 
     """
-    p = MsgAlmanacGPS._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3617,6 +4230,16 @@ coordinate system
                'epsilon',
                'omega',
               ]
+  __zips__ = [
+              ( 'AlmanacCommonContent', 'common'),
+              ( 'double', 'lambda_na'),
+              ( 'double', 't_lambda_na'),
+              ( 'double', 'i'),
+              ( 'double', 't'),
+              ( 'double', 't_dot'),
+              ( 'double', 'epsilon'),
+              ( 'double', 'omega'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3659,9 +4282,16 @@ coordinate system
     the message.
 
     """
-    p = MsgAlmanacGlo._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -3723,6 +4353,11 @@ index (SV orbital slot)  fcns[index]
                'tow_ms',
                'fcns',
               ]
+  __zips__ = [
+              ( 'u16', 'wn'),
+              ( 'u32', 'tow_ms'),
+              ( 'array:u8:32', 'fcns'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -3760,9 +4395,16 @@ index (SV orbital slot)  fcns[index]
     the message.
 
     """
-    p = MsgFcnsGlo._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -63,28 +63,21 @@ counter (ith packet of n)
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in ObservationHeader._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in ObservationHeader._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return ObservationHeader.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return ObservationHeader.build(d)
     
 class Doppler(object):
   """Doppler.
@@ -123,28 +116,21 @@ as positive for approaching satellites.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in Doppler._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in Doppler._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return Doppler.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return Doppler.build(d)
     
 class PackedObsContent(object):
   """PackedObsContent.
@@ -216,28 +202,21 @@ estimate for the signal is valid.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in PackedObsContent._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in PackedObsContent._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return PackedObsContent.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return PackedObsContent.build(d)
     
 class EphemerisCommonContent(object):
   """EphemerisCommonContent.
@@ -295,28 +274,21 @@ GLO: 0 = valid, non-zero = invalid
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in EphemerisCommonContent._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in EphemerisCommonContent._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return EphemerisCommonContent.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return EphemerisCommonContent.build(d)
     
 class EphemerisCommonContentDepA(object):
   """EphemerisCommonContentDepA.
@@ -374,28 +346,21 @@ GLO: 0 = valid, non-zero = invalid
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in EphemerisCommonContentDepA._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in EphemerisCommonContentDepA._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return EphemerisCommonContentDepA.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return EphemerisCommonContentDepA.build(d)
     
 class ObservationHeaderDep(object):
   """ObservationHeaderDep.
@@ -433,28 +398,21 @@ counter (ith packet of n)
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in ObservationHeaderDep._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in ObservationHeaderDep._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return ObservationHeaderDep.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return ObservationHeaderDep.build(d)
     
 class CarrierPhaseDepA(object):
   """CarrierPhaseDepA.
@@ -494,28 +452,21 @@ the opposite sign as the pseudorange.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in CarrierPhaseDepA._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in CarrierPhaseDepA._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return CarrierPhaseDepA.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return CarrierPhaseDepA.build(d)
     
 class PackedObsContentDepA(object):
   """PackedObsContentDepA.
@@ -568,28 +519,21 @@ carrier phase ambiguity may have changed.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in PackedObsContentDepA._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in PackedObsContentDepA._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return PackedObsContentDepA.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return PackedObsContentDepA.build(d)
     
 class PackedObsContentDepB(object):
   """PackedObsContentDepB.
@@ -644,28 +588,21 @@ carrier phase ambiguity may have changed.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in PackedObsContentDepB._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in PackedObsContentDepB._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return PackedObsContentDepB.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return PackedObsContentDepB.build(d)
     
 class PackedObsContentDepC(object):
   """PackedObsContentDepC.
@@ -721,28 +658,21 @@ carrier phase ambiguity may have changed.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in PackedObsContentDepC._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in PackedObsContentDepC._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return PackedObsContentDepC.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return PackedObsContentDepC.build(d)
     
 class AlmanacCommonContent(object):
   """AlmanacCommonContent.
@@ -811,28 +741,21 @@ Satellite health status for GLO:
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in AlmanacCommonContent._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in AlmanacCommonContent._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return AlmanacCommonContent.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return AlmanacCommonContent.build(d)
     
 SBP_MSG_OBS = 0x004A
 class MsgObs(SBP):
@@ -913,10 +836,7 @@ satellite being tracked.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1020,10 +940,7 @@ error in the pseudo-absolute position output.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1128,10 +1045,7 @@ pseudo-absolute position output.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1355,10 +1269,7 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1582,10 +1493,7 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1701,10 +1609,7 @@ class MsgEphemerisSbasDepA(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1826,10 +1731,7 @@ for more details.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1945,10 +1847,7 @@ class MsgEphemerisSbas(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2070,10 +1969,7 @@ for more details.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2207,10 +2103,7 @@ for more details.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2470,10 +2363,7 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2710,10 +2600,7 @@ class MsgEphemerisDepA(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -2956,10 +2843,7 @@ class MsgEphemerisDepB(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3219,10 +3103,7 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3317,10 +3198,7 @@ satellite being tracked.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3421,10 +3299,7 @@ satellite being tracked.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3526,10 +3401,7 @@ satellite being tracked.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3659,10 +3531,7 @@ Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3756,10 +3625,7 @@ class MsgSvConfigurationGPS(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3876,10 +3742,7 @@ LSB indicating tgd validity etc.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -3996,10 +3859,7 @@ LSB indicating tgd validity etc.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -4144,10 +4004,7 @@ Please see the Navstar GPS Space Segment/Navigation user interfaces
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -4282,10 +4139,7 @@ coordinate system
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -4395,10 +4249,7 @@ index (SV orbital slot)  fcns[index]
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -62,17 +62,17 @@ counter (ith packet of n)
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in ObservationHeader._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in ObservationHeader._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -115,17 +115,17 @@ as positive for approaching satellites.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in Doppler._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in Doppler._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -201,17 +201,17 @@ estimate for the signal is valid.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in PackedObsContent._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in PackedObsContent._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -273,17 +273,17 @@ GLO: 0 = valid, non-zero = invalid
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in EphemerisCommonContent._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in EphemerisCommonContent._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -345,17 +345,17 @@ GLO: 0 = valid, non-zero = invalid
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in EphemerisCommonContentDepA._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in EphemerisCommonContentDepA._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -397,17 +397,17 @@ counter (ith packet of n)
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in ObservationHeaderDep._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in ObservationHeaderDep._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -451,17 +451,17 @@ the opposite sign as the pseudorange.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in CarrierPhaseDepA._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in CarrierPhaseDepA._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -518,17 +518,17 @@ carrier phase ambiguity may have changed.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in PackedObsContentDepA._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in PackedObsContentDepA._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -587,17 +587,17 @@ carrier phase ambiguity may have changed.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in PackedObsContentDepB._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in PackedObsContentDepB._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -657,17 +657,17 @@ carrier phase ambiguity may have changed.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in PackedObsContentDepC._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in PackedObsContentDepC._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -740,17 +740,17 @@ Satellite health status for GLO:
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in AlmanacCommonContent._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in AlmanacCommonContent._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -1640,9 +1640,9 @@ class MsgEphemerisSbasDepA(SBP):
   """
   _parser = Struct("MsgEphemerisSbasDepA",
                    Struct('common', EphemerisCommonContentDepA._parser),
-                   Struct('pos', Array(3, LFloat64('pos'))),
-                   Struct('vel', Array(3, LFloat64('vel'))),
-                   Struct('acc', Array(3, LFloat64('acc'))),
+                   Array(3, LFloat64('pos')),
+                   Array(3, LFloat64('vel')),
+                   Array(3, LFloat64('acc')),
                    LFloat64('a_gf0'),
                    LFloat64('a_gf1'),)
   __slots__ = [
@@ -1767,9 +1767,9 @@ for more details.
                    Struct('common', EphemerisCommonContentDepA._parser),
                    LFloat64('gamma'),
                    LFloat64('tau'),
-                   Struct('pos', Array(3, LFloat64('pos'))),
-                   Struct('vel', Array(3, LFloat64('vel'))),
-                   Struct('acc', Array(3, LFloat64('acc'))),)
+                   Array(3, LFloat64('pos')),
+                   Array(3, LFloat64('vel')),
+                   Array(3, LFloat64('acc')),)
   __slots__ = [
                'common',
                'gamma',
@@ -1884,9 +1884,9 @@ class MsgEphemerisSbas(SBP):
   """
   _parser = Struct("MsgEphemerisSbas",
                    Struct('common', EphemerisCommonContent._parser),
-                   Struct('pos', Array(3, LFloat64('pos'))),
-                   Struct('vel', Array(3, LFloat64('vel'))),
-                   Struct('acc', Array(3, LFloat64('acc'))),
+                   Array(3, LFloat64('pos')),
+                   Array(3, LFloat64('vel')),
+                   Array(3, LFloat64('acc')),
                    LFloat64('a_gf0'),
                    LFloat64('a_gf1'),)
   __slots__ = [
@@ -2011,9 +2011,9 @@ for more details.
                    Struct('common', EphemerisCommonContent._parser),
                    LFloat64('gamma'),
                    LFloat64('tau'),
-                   Struct('pos', Array(3, LFloat64('pos'))),
-                   Struct('vel', Array(3, LFloat64('vel'))),
-                   Struct('acc', Array(3, LFloat64('acc'))),)
+                   Array(3, LFloat64('pos')),
+                   Array(3, LFloat64('vel')),
+                   Array(3, LFloat64('acc')),)
   __slots__ = [
                'common',
                'gamma',
@@ -2141,9 +2141,9 @@ for more details.
                    LFloat64('gamma'),
                    LFloat64('tau'),
                    LFloat64('d_tau'),
-                   Struct('pos', Array(3, LFloat64('pos'))),
-                   Struct('vel', Array(3, LFloat64('vel'))),
-                   Struct('acc', Array(3, LFloat64('acc'))),
+                   Array(3, LFloat64('pos')),
+                   Array(3, LFloat64('vel')),
+                   Array(3, LFloat64('acc')),
                    ULInt8('fcn'),)
   __slots__ = [
                'common',
@@ -4347,7 +4347,7 @@ index (SV orbital slot)  fcns[index]
   _parser = Struct("MsgFcnsGlo",
                    ULInt16('wn'),
                    ULInt32('tow_ms'),
-                   Struct('fcns', Array(32, ULInt8('fcns'))),)
+                   Array(32, ULInt8('fcns')),)
   __slots__ = [
                'wn',
                'tow_ms',

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -23,7 +23,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/piksi.yaml with generate.py.

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -89,17 +89,17 @@ be normalized.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in UARTChannel._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in UARTChannel._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -154,17 +154,17 @@ can cause momentary RTK solution outages.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in Period._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in Period._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -218,17 +218,17 @@ communication latency in the system.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in Latency._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in Latency._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -90,28 +90,21 @@ be normalized.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in UARTChannel._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in UARTChannel._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return UARTChannel.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return UARTChannel.build(d)
     
 class Period(object):
   """Period.
@@ -162,28 +155,21 @@ can cause momentary RTK solution outages.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in Period._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in Period._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return Period.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return Period.build(d)
     
 class Latency(object):
   """Latency.
@@ -233,28 +219,21 @@ communication latency in the system.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in Latency._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in Latency._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return Latency.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return Latency.build(d)
     
 SBP_MSG_ALMANAC = 0x0069
 class MsgAlmanac(SBP):
@@ -416,10 +395,7 @@ bootloader.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -651,10 +627,7 @@ Ambiguity Resolution (IAR) process.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -808,10 +781,7 @@ thread. The reported percentage values must be normalized.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -931,10 +901,7 @@ period indicates their likelihood of transmission.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1039,10 +1006,7 @@ class MsgUartStateDepa(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1133,10 +1097,7 @@ from satellite observations.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1231,10 +1192,7 @@ from being used in various Piksi subsystems.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1348,10 +1306,7 @@ available.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1447,10 +1402,7 @@ code will be returned with MSG_COMMAND_RESP.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1545,10 +1497,7 @@ the command.  A return code of zero indicates success.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1727,10 +1676,7 @@ in c.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -1853,10 +1799,7 @@ class MsgSpecan(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -19,8 +19,11 @@ may no longer be used.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/piksi.yaml with generate.py.
@@ -70,29 +73,45 @@ be normalized.
                'tx_buffer_level',
                'rx_buffer_level',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.tx_throughput = kwargs.pop('tx_throughput')
-      self.rx_throughput = kwargs.pop('rx_throughput')
-      self.crc_error_count = kwargs.pop('crc_error_count')
-      self.io_error_count = kwargs.pop('io_error_count')
-      self.tx_buffer_level = kwargs.pop('tx_buffer_level')
-      self.rx_buffer_level = kwargs.pop('rx_buffer_level')
+  __zips__ = [
+              ('float', 'tx_throughput'),
+              ('float', 'rx_throughput'),
+              ('u16', 'crc_error_count'),
+              ('u16', 'io_error_count'),
+              ('u8', 'tx_buffer_level'),
+              ('u8', 'rx_buffer_level'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = UARTChannel._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in UARTChannel.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return UARTChannel.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return UARTChannel.build(d)
+    except:
+      print traceback.print_exc()
     
 class Period(object):
   """Period.
@@ -128,27 +147,43 @@ can cause momentary RTK solution outages.
                'pmax',
                'current',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.avg = kwargs.pop('avg')
-      self.pmin = kwargs.pop('pmin')
-      self.pmax = kwargs.pop('pmax')
-      self.current = kwargs.pop('current')
+  __zips__ = [
+              ('s32', 'avg'),
+              ('s32', 'pmin'),
+              ('s32', 'pmax'),
+              ('s32', 'current'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = Period._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in Period.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return Period.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return Period.build(d)
+    except:
+      print traceback.print_exc()
     
 class Latency(object):
   """Latency.
@@ -183,27 +218,43 @@ communication latency in the system.
                'lmax',
                'current',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.avg = kwargs.pop('avg')
-      self.lmin = kwargs.pop('lmin')
-      self.lmax = kwargs.pop('lmax')
-      self.current = kwargs.pop('current')
+  __zips__ = [
+              ('s32', 'avg'),
+              ('s32', 'lmin'),
+              ('s32', 'lmax'),
+              ('s32', 'current'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = Latency._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in Latency.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return Latency.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return Latency.build(d)
+    except:
+      print traceback.print_exc()
     
 SBP_MSG_ALMANAC = 0x0069
 class MsgAlmanac(SBP):
@@ -220,6 +271,7 @@ alamanac onto the Piksi's flash memory from the host.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -266,6 +318,7 @@ time estimate sent by the host.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -325,6 +378,9 @@ bootloader.
   __slots__ = [
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -360,9 +416,16 @@ bootloader.
     the message.
 
     """
-    p = MsgReset._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -394,6 +457,7 @@ bootloader.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -441,6 +505,7 @@ removed in a future release.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -488,6 +553,7 @@ be removed in a future release.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -547,6 +613,9 @@ Ambiguity Resolution (IAR) process.
   __slots__ = [
                'filter',
               ]
+  __zips__ = [
+              ( 'u8', 'filter'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -582,9 +651,16 @@ Ambiguity Resolution (IAR) process.
     the message.
 
     """
-    p = MsgResetFilters._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -619,6 +695,7 @@ observations between the two.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -689,6 +766,11 @@ thread. The reported percentage values must be normalized.
                'cpu',
                'stack_free',
               ]
+  __zips__ = [
+              ( 'str:20', 'name'),
+              ( 'u16', 'cpu'),
+              ( 'u32', 'stack_free'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -726,9 +808,16 @@ thread. The reported percentage values must be normalized.
     the message.
 
     """
-    p = MsgThreadState._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -796,6 +885,13 @@ period indicates their likelihood of transmission.
                'latency',
                'obs_period',
               ]
+  __zips__ = [
+              ( 'UARTChannel', 'uart_a'),
+              ( 'UARTChannel', 'uart_b'),
+              ( 'UARTChannel', 'uart_ftdi'),
+              ( 'Latency', 'latency'),
+              ( 'Period', 'obs_period'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -835,9 +931,16 @@ period indicates their likelihood of transmission.
     the message.
 
     """
-    p = MsgUartState._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -892,6 +995,12 @@ class MsgUartStateDepa(SBP):
                'uart_ftdi',
                'latency',
               ]
+  __zips__ = [
+              ( 'UARTChannel', 'uart_a'),
+              ( 'UARTChannel', 'uart_b'),
+              ( 'UARTChannel', 'uart_ftdi'),
+              ( 'Latency', 'latency'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -930,9 +1039,16 @@ class MsgUartStateDepa(SBP):
     the message.
 
     """
-    p = MsgUartStateDepa._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -979,6 +1095,9 @@ from satellite observations.
   __slots__ = [
                'num_hyps',
               ]
+  __zips__ = [
+              ( 'u32', 'num_hyps'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1014,9 +1133,16 @@ from satellite observations.
     the message.
 
     """
-    p = MsgIarState._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1065,6 +1191,10 @@ from being used in various Piksi subsystems.
                'mask',
                'sid',
               ]
+  __zips__ = [
+              ( 'u8', 'mask'),
+              ( 'GnssSignal', 'sid'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1101,9 +1231,16 @@ from being used in various Piksi subsystems.
     the message.
 
     """
-    p = MsgMaskSatellite._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1165,6 +1302,13 @@ available.
                'cpu_temperature',
                'fe_temperature',
               ]
+  __zips__ = [
+              ( 's16', 'dev_vin'),
+              ( 's16', 'cpu_vint'),
+              ( 's16', 'cpu_vaux'),
+              ( 's16', 'cpu_temperature'),
+              ( 's16', 'fe_temperature'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1204,9 +1348,16 @@ available.
     the message.
 
     """
-    p = MsgDeviceMonitor._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1256,6 +1407,10 @@ code will be returned with MSG_COMMAND_RESP.
                'sequence',
                'command',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 'str', 'command'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1292,9 +1447,16 @@ code will be returned with MSG_COMMAND_RESP.
     the message.
 
     """
-    p = MsgCommandReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1343,6 +1505,10 @@ the command.  A return code of zero indicates success.
                'sequence',
                'code',
               ]
+  __zips__ = [
+              ( 'u32', 'sequence'),
+              ( 's32', 'code'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1379,9 +1545,16 @@ the command.  A return code of zero indicates success.
     the message.
 
     """
-    p = MsgCommandResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1413,6 +1586,7 @@ Output will be sent in MSG_NETWORK_STATE_RESP messages
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1501,6 +1675,16 @@ in c.
                'interface_name',
                'flags',
               ]
+  __zips__ = [
+              ( 'array:u8:4', 'ipv4_address'),
+              ( 'u8', 'ipv4_mask_size'),
+              ( 'array:u8:16', 'ipv6_address'),
+              ( 'u8', 'ipv6_mask_size'),
+              ( 'u32', 'rx_bytes'),
+              ( 'u32', 'tx_bytes'),
+              ( 'str:16', 'interface_name'),
+              ( 'u32', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1543,9 +1727,16 @@ in c.
     the message.
 
     """
-    p = MsgNetworkStateResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -1614,6 +1805,14 @@ class MsgSpecan(SBP):
                'amplitude_unit',
                'amplitude_value',
               ]
+  __zips__ = [
+              ( 'GPSTime', 't'),
+              ( 'float', 'freq_ref'),
+              ( 'float', 'freq_step'),
+              ( 'float', 'amplitude_ref'),
+              ( 'float', 'amplitude_unit'),
+              ( 'array:u8', 'amplitude_value'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1654,9 +1853,16 @@ class MsgSpecan(SBP):
     the message.
 
     """
-    p = MsgSpecan._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1657,9 +1657,9 @@ in c.
 
   """
   _parser = Struct("MsgNetworkStateResp",
-                   Struct('ipv4_address', Array(4, ULInt8('ipv4_address'))),
+                   Array(4, ULInt8('ipv4_address')),
                    ULInt8('ipv4_mask_size'),
-                   Struct('ipv6_address', Array(16, ULInt8('ipv6_address'))),
+                   Array(16, ULInt8('ipv6_address')),
                    ULInt8('ipv6_mask_size'),
                    ULInt32('rx_bytes'),
                    ULInt32('tx_bytes'),

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -73,14 +73,14 @@ be normalized.
                'tx_buffer_level',
                'rx_buffer_level',
               ]
-  __zips__ = [
-              ('float', 'tx_throughput'),
-              ('float', 'rx_throughput'),
-              ('u16', 'crc_error_count'),
-              ('u16', 'io_error_count'),
-              ('u8', 'tx_buffer_level'),
-              ('u8', 'rx_buffer_level'),
-             ]
+  _fields = [
+             ( 'float', 'tx_throughput' ),
+             ( 'float', 'rx_throughput' ),
+             ( 'u16', 'crc_error_count' ),
+             ( 'u16', 'io_error_count' ),
+             ( 'u8', 'tx_buffer_level' ),
+             ( 'u8', 'rx_buffer_level' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -92,7 +92,7 @@ be normalized.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in UARTChannel.__zips__:
+      for t, s in UARTChannel._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -147,12 +147,12 @@ can cause momentary RTK solution outages.
                'pmax',
                'current',
               ]
-  __zips__ = [
-              ('s32', 'avg'),
-              ('s32', 'pmin'),
-              ('s32', 'pmax'),
-              ('s32', 'current'),
-             ]
+  _fields = [
+             ( 's32', 'avg' ),
+             ( 's32', 'pmin' ),
+             ( 's32', 'pmax' ),
+             ( 's32', 'current' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -164,7 +164,7 @@ can cause momentary RTK solution outages.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in Period.__zips__:
+      for t, s in Period._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -218,12 +218,12 @@ communication latency in the system.
                'lmax',
                'current',
               ]
-  __zips__ = [
-              ('s32', 'avg'),
-              ('s32', 'lmin'),
-              ('s32', 'lmax'),
-              ('s32', 'current'),
-             ]
+  _fields = [
+             ( 's32', 'avg' ),
+             ( 's32', 'lmin' ),
+             ( 's32', 'lmax' ),
+             ( 's32', 'current' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -235,7 +235,7 @@ communication latency in the system.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in Latency.__zips__:
+      for t, s in Latency._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -271,7 +271,7 @@ alamanac onto the Piksi's flash memory from the host.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -318,7 +318,7 @@ time estimate sent by the host.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -378,9 +378,9 @@ bootloader.
   __slots__ = [
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -457,7 +457,7 @@ bootloader.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -505,7 +505,7 @@ removed in a future release.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -553,7 +553,7 @@ be removed in a future release.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -613,9 +613,9 @@ Ambiguity Resolution (IAR) process.
   __slots__ = [
                'filter',
               ]
-  __zips__ = [
-              ( 'u8', 'filter'),
-             ]
+  _fields = [
+             ( 'u8', 'filter' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -695,7 +695,7 @@ observations between the two.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -766,11 +766,11 @@ thread. The reported percentage values must be normalized.
                'cpu',
                'stack_free',
               ]
-  __zips__ = [
-              ( 'str:20', 'name'),
-              ( 'u16', 'cpu'),
-              ( 'u32', 'stack_free'),
-             ]
+  _fields = [
+             ( 'str:20', 'name' ),
+             ( 'u16', 'cpu' ),
+             ( 'u32', 'stack_free' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -885,13 +885,13 @@ period indicates their likelihood of transmission.
                'latency',
                'obs_period',
               ]
-  __zips__ = [
-              ( 'UARTChannel', 'uart_a'),
-              ( 'UARTChannel', 'uart_b'),
-              ( 'UARTChannel', 'uart_ftdi'),
-              ( 'Latency', 'latency'),
-              ( 'Period', 'obs_period'),
-             ]
+  _fields = [
+             ( 'UARTChannel', 'uart_a' ),
+             ( 'UARTChannel', 'uart_b' ),
+             ( 'UARTChannel', 'uart_ftdi' ),
+             ( 'Latency', 'latency' ),
+             ( 'Period', 'obs_period' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -995,12 +995,12 @@ class MsgUartStateDepa(SBP):
                'uart_ftdi',
                'latency',
               ]
-  __zips__ = [
-              ( 'UARTChannel', 'uart_a'),
-              ( 'UARTChannel', 'uart_b'),
-              ( 'UARTChannel', 'uart_ftdi'),
-              ( 'Latency', 'latency'),
-             ]
+  _fields = [
+             ( 'UARTChannel', 'uart_a' ),
+             ( 'UARTChannel', 'uart_b' ),
+             ( 'UARTChannel', 'uart_ftdi' ),
+             ( 'Latency', 'latency' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1095,9 +1095,9 @@ from satellite observations.
   __slots__ = [
                'num_hyps',
               ]
-  __zips__ = [
-              ( 'u32', 'num_hyps'),
-             ]
+  _fields = [
+             ( 'u32', 'num_hyps' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1191,10 +1191,10 @@ from being used in various Piksi subsystems.
                'mask',
                'sid',
               ]
-  __zips__ = [
-              ( 'u8', 'mask'),
-              ( 'GnssSignal', 'sid'),
-             ]
+  _fields = [
+             ( 'u8', 'mask' ),
+             ( 'GnssSignal', 'sid' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1302,13 +1302,13 @@ available.
                'cpu_temperature',
                'fe_temperature',
               ]
-  __zips__ = [
-              ( 's16', 'dev_vin'),
-              ( 's16', 'cpu_vint'),
-              ( 's16', 'cpu_vaux'),
-              ( 's16', 'cpu_temperature'),
-              ( 's16', 'fe_temperature'),
-             ]
+  _fields = [
+             ( 's16', 'dev_vin' ),
+             ( 's16', 'cpu_vint' ),
+             ( 's16', 'cpu_vaux' ),
+             ( 's16', 'cpu_temperature' ),
+             ( 's16', 'fe_temperature' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1407,10 +1407,10 @@ code will be returned with MSG_COMMAND_RESP.
                'sequence',
                'command',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 'str', 'command'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 'str', 'command' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1505,10 +1505,10 @@ the command.  A return code of zero indicates success.
                'sequence',
                'code',
               ]
-  __zips__ = [
-              ( 'u32', 'sequence'),
-              ( 's32', 'code'),
-             ]
+  _fields = [
+             ( 'u32', 'sequence' ),
+             ( 's32', 'code' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1586,7 +1586,7 @@ Output will be sent in MSG_NETWORK_STATE_RESP messages
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1675,16 +1675,16 @@ in c.
                'interface_name',
                'flags',
               ]
-  __zips__ = [
-              ( 'array:u8:4', 'ipv4_address'),
-              ( 'u8', 'ipv4_mask_size'),
-              ( 'array:u8:16', 'ipv6_address'),
-              ( 'u8', 'ipv6_mask_size'),
-              ( 'u32', 'rx_bytes'),
-              ( 'u32', 'tx_bytes'),
-              ( 'str:16', 'interface_name'),
-              ( 'u32', 'flags'),
-             ]
+  _fields = [
+             ( 'array:u8:4', 'ipv4_address' ),
+             ( 'u8', 'ipv4_mask_size' ),
+             ( 'array:u8:16', 'ipv6_address' ),
+             ( 'u8', 'ipv6_mask_size' ),
+             ( 'u32', 'rx_bytes' ),
+             ( 'u32', 'tx_bytes' ),
+             ( 'str:16', 'interface_name' ),
+             ( 'u32', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -1805,14 +1805,14 @@ class MsgSpecan(SBP):
                'amplitude_unit',
                'amplitude_value',
               ]
-  __zips__ = [
-              ( 'GPSTime', 't'),
-              ( 'float', 'freq_ref'),
-              ( 'float', 'freq_step'),
-              ( 'float', 'amplitude_ref'),
-              ( 'float', 'amplitude_unit'),
-              ( 'array:u8', 'amplitude_value'),
-             ]
+  _fields = [
+             ( 'GPSTime', 't' ),
+             ( 'float', 'freq_ref' ),
+             ( 'float', 'freq_step' ),
+             ( 'float', 'amplitude_ref' ),
+             ( 'float', 'amplitude_unit' ),
+             ( 'array:u8', 'amplitude_value' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -1657,9 +1657,9 @@ in c.
 
   """
   _parser = Struct("MsgNetworkStateResp",
-                   Array(4, ULInt8('ipv4_address')),
+                   Struct('ipv4_address', Array(4, ULInt8('ipv4_address'))),
                    ULInt8('ipv4_mask_size'),
-                   Array(16, ULInt8('ipv6_address')),
+                   Struct('ipv6_address', Array(16, ULInt8('ipv6_address'))),
                    ULInt8('ipv6_mask_size'),
                    ULInt32('rx_bytes'),
                    ULInt32('tx_bytes'),

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -48,7 +48,7 @@ configuration to its onboard flash memory file system.
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -110,9 +110,9 @@ process to this message when it is received from sender ID
   __slots__ = [
                'setting',
               ]
-  __zips__ = [
-              ( 'str', 'setting'),
-             ]
+  _fields = [
+             ( 'str', 'setting' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -203,9 +203,9 @@ this message when it is received from sender ID 0x42.
   __slots__ = [
                'setting',
               ]
-  __zips__ = [
-              ( 'str', 'setting'),
-             ]
+  _fields = [
+             ( 'str', 'setting' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -295,9 +295,9 @@ class MsgSettingsReadResp(SBP):
   __slots__ = [
                'setting',
               ]
-  __zips__ = [
-              ( 'str', 'setting'),
-             ]
+  _fields = [
+             ( 'str', 'setting' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -392,9 +392,9 @@ this message when it is received from sender ID 0x42.
   __slots__ = [
                'index',
               ]
-  __zips__ = [
-              ( 'u16', 'index'),
-             ]
+  _fields = [
+             ( 'u16', 'index' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -494,10 +494,10 @@ NULL-terminated and delimited string with contents
                'index',
                'setting',
               ]
-  __zips__ = [
-              ( 'u16', 'index'),
-              ( 'str', 'setting'),
-             ]
+  _fields = [
+             ( 'u16', 'index' ),
+             ( 'str', 'setting' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -574,7 +574,7 @@ class MsgSettingsReadByIndexDone(SBP):
 
   """
   __slots__ = []
-  __zips__ = []
+  _fields = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -637,9 +637,9 @@ for this setting to set the initial value.
   __slots__ = [
                'setting',
               ]
-  __zips__ = [
-              ( 'str', 'setting'),
-             ]
+  _fields = [
+             ( 'str', 'setting' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -148,10 +148,7 @@ process to this message when it is received from sender ID
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -241,10 +238,7 @@ this message when it is received from sender ID 0x42.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -333,10 +327,7 @@ class MsgSettingsReadResp(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -430,10 +421,7 @@ this message when it is received from sender ID 0x42.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -534,10 +522,7 @@ NULL-terminated and delimited string with contents
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -675,10 +660,7 @@ for this setting to set the initial value.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -27,7 +27,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/settings.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -23,8 +23,11 @@ https://github.com/swift-nav/piksi\_firmware/blob/master/docs/settings.pdf
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/settings.yaml with generate.py.
 # Please do not hand edit!
@@ -45,6 +48,7 @@ configuration to its onboard flash memory file system.
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -106,6 +110,9 @@ process to this message when it is received from sender ID
   __slots__ = [
                'setting',
               ]
+  __zips__ = [
+              ( 'str', 'setting'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -141,9 +148,16 @@ process to this message when it is received from sender ID
     the message.
 
     """
-    p = MsgSettingsWrite._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -189,6 +203,9 @@ this message when it is received from sender ID 0x42.
   __slots__ = [
                'setting',
               ]
+  __zips__ = [
+              ( 'str', 'setting'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -224,9 +241,16 @@ this message when it is received from sender ID 0x42.
     the message.
 
     """
-    p = MsgSettingsReadReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -271,6 +295,9 @@ class MsgSettingsReadResp(SBP):
   __slots__ = [
                'setting',
               ]
+  __zips__ = [
+              ( 'str', 'setting'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -306,9 +333,16 @@ class MsgSettingsReadResp(SBP):
     the message.
 
     """
-    p = MsgSettingsReadResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -358,6 +392,9 @@ this message when it is received from sender ID 0x42.
   __slots__ = [
                'index',
               ]
+  __zips__ = [
+              ( 'u16', 'index'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -393,9 +430,16 @@ this message when it is received from sender ID 0x42.
     the message.
 
     """
-    p = MsgSettingsReadByIndexReq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -450,6 +494,10 @@ NULL-terminated and delimited string with contents
                'index',
                'setting',
               ]
+  __zips__ = [
+              ( 'u16', 'index'),
+              ( 'str', 'setting'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -486,9 +534,16 @@ NULL-terminated and delimited string with contents
     the message.
 
     """
-    p = MsgSettingsReadByIndexResp._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -519,6 +574,7 @@ class MsgSettingsReadByIndexDone(SBP):
 
   """
   __slots__ = []
+  __zips__ = []
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -581,6 +637,9 @@ for this setting to set the initial value.
   __slots__ = [
                'setting',
               ]
+  __zips__ = [
+              ( 'str', 'setting'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -616,9 +675,16 @@ for this setting to set the initial value.
     the message.
 
     """
-    p = MsgSettingsRegister._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -64,11 +64,11 @@ or configuration requests.
                'startup_type',
                'reserved',
               ]
-  __zips__ = [
-              ( 'u8', 'cause'),
-              ( 'u8', 'startup_type'),
-              ( 'u16', 'reserved'),
-             ]
+  _fields = [
+             ( 'u8', 'cause' ),
+             ( 'u8', 'startup_type' ),
+             ( 'u16', 'reserved' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -173,12 +173,12 @@ corrections packet.
                'num_signals',
                'source',
               ]
-  __zips__ = [
-              ( 'u8', 'flags'),
-              ( 'u16', 'latency'),
-              ( 'u8', 'num_signals'),
-              ( 'str', 'source'),
-             ]
+  _fields = [
+             ( 'u8', 'flags' ),
+             ( 'u16', 'latency' ),
+             ( 'u8', 'num_signals' ),
+             ( 'str', 'source' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -279,9 +279,9 @@ the remaining error flags should be inspected.
   __slots__ = [
                'flags',
               ]
-  __zips__ = [
-              ( 'u32', 'flags'),
-             ]
+  _fields = [
+             ( 'u32', 'flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -20,7 +20,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/system.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -16,8 +16,11 @@ Standardized system messages from Swift Navigation devices.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/system.yaml with generate.py.
 # Please do not hand edit!
@@ -61,6 +64,11 @@ or configuration requests.
                'startup_type',
                'reserved',
               ]
+  __zips__ = [
+              ( 'u8', 'cause'),
+              ( 'u8', 'startup_type'),
+              ( 'u16', 'reserved'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -98,9 +106,16 @@ or configuration requests.
     the message.
 
     """
-    p = MsgStartup._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -158,6 +173,12 @@ corrections packet.
                'num_signals',
                'source',
               ]
+  __zips__ = [
+              ( 'u8', 'flags'),
+              ( 'u16', 'latency'),
+              ( 'u8', 'num_signals'),
+              ( 'str', 'source'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -196,9 +217,16 @@ corrections packet.
     the message.
 
     """
-    p = MsgDgnssStatus._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -251,6 +279,9 @@ the remaining error flags should be inspected.
   __slots__ = [
                'flags',
               ]
+  __zips__ = [
+              ( 'u32', 'flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -286,9 +317,16 @@ the remaining error flags should be inspected.
     the message.
 
     """
-    p = MsgHeartbeat._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -106,10 +106,7 @@ or configuration requests.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -217,10 +214,7 @@ corrections packet.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -317,10 +311,7 @@ the remaining error flags should be inspected.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -21,7 +21,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/tracking.yaml with generate.py.

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -620,7 +620,7 @@ update interval.
   _parser = Struct("MsgTrackingIq",
                    ULInt8('channel'),
                    Struct('sid', GnssSignal._parser),
-                   Struct('corrs', Array(3, Struct('corrs', TrackingChannelCorrelation._parser))),)
+                   Array(3, Struct('corrs', TrackingChannelCorrelation._parser)),)
   __slots__ = [
                'channel',
                'sid',

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -67,17 +67,17 @@ measured signal power.
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in TrackingChannelState._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in TrackingChannelState._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -117,17 +117,17 @@ class TrackingChannelCorrelation(object):
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in TrackingChannelCorrelation._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in TrackingChannelCorrelation._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -171,17 +171,17 @@ class TrackingChannelStateDepA(object):
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in TrackingChannelStateDepA._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in TrackingChannelStateDepA._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):
@@ -225,17 +225,17 @@ class TrackingChannelStateDepB(object):
     return getattr(self, item)
 
   
-  def from_binary(self, d, offset=0):
+  def from_binary(self, data, offset=0):
     size = 0
-    for t, s in TrackingChannelStateDepB._fields:
-      if t in TYPES_KEYS_NP:
-        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-        size += a.itemsize
-        setattr(self, s, a.item())
+    for field_type, field_name in TrackingChannelStateDepB._fields:
+      if field_type in TYPES_KEYS_NP:
+        parsed = np.ndarray(1, TYPES_NP[field_type], data, size + offset)
+        size += parsed.itemsize
+        setattr(self, field_name, parsed.item())
       else:
-        o = globals()[t]()
-        size += o.from_binary(d, size + offset)
-        setattr(self, s, o)
+        obj = globals()[field_type]()
+        size += obj.from_binary(data, size + offset)
+        setattr(self, field_name, obj)
     return size
 
   def to_binary(self):

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -620,7 +620,7 @@ update interval.
   _parser = Struct("MsgTrackingIq",
                    ULInt8('channel'),
                    Struct('sid', GnssSignal._parser),
-                   Array(3, Struct('corrs', TrackingChannelCorrelation._parser)),)
+                   Struct('corrs', Array(3, Struct('corrs', TrackingChannelCorrelation._parser))),)
   __slots__ = [
                'channel',
                'sid',

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -17,8 +17,11 @@ Satellite code and carrier-phase tracking messages from the device.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 from sbp.gnss import *
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/tracking.yaml with generate.py.
@@ -51,26 +54,42 @@ measured signal power.
                'fcn',
                'cn0',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.sid = kwargs.pop('sid')
-      self.fcn = kwargs.pop('fcn')
-      self.cn0 = kwargs.pop('cn0')
+  __zips__ = [
+              ('GnssSignal16', 'sid'),
+              ('u8', 'fcn'),
+              ('u8', 'cn0'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = TrackingChannelState._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in TrackingChannelState.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return TrackingChannelState.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return TrackingChannelState.build(d)
+    except:
+      print traceback.print_exc()
     
 class TrackingChannelCorrelation(object):
   """TrackingChannelCorrelation.
@@ -93,25 +112,41 @@ class TrackingChannelCorrelation(object):
                'I',
                'Q',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.I = kwargs.pop('I')
-      self.Q = kwargs.pop('Q')
+  __zips__ = [
+              ('s32', 'I'),
+              ('s32', 'Q'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = TrackingChannelCorrelation._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in TrackingChannelCorrelation.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return TrackingChannelCorrelation.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return TrackingChannelCorrelation.build(d)
+    except:
+      print traceback.print_exc()
     
 class TrackingChannelStateDepA(object):
   """TrackingChannelStateDepA.
@@ -137,26 +172,42 @@ class TrackingChannelStateDepA(object):
                'prn',
                'cn0',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.state = kwargs.pop('state')
-      self.prn = kwargs.pop('prn')
-      self.cn0 = kwargs.pop('cn0')
+  __zips__ = [
+              ('u8', 'state'),
+              ('u8', 'prn'),
+              ('float', 'cn0'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = TrackingChannelStateDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in TrackingChannelStateDepA.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return TrackingChannelStateDepA.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return TrackingChannelStateDepA.build(d)
+    except:
+      print traceback.print_exc()
     
 class TrackingChannelStateDepB(object):
   """TrackingChannelStateDepB.
@@ -182,26 +233,42 @@ class TrackingChannelStateDepB(object):
                'sid',
                'cn0',
               ]
-
-  def __init__(self, payload=None, **kwargs):
-    if payload:
-      self.from_binary(payload)
-    else:
-      self.state = kwargs.pop('state')
-      self.sid = kwargs.pop('sid')
-      self.cn0 = kwargs.pop('cn0')
+  __zips__ = [
+              ('u8', 'state'),
+              ('GnssSignal', 'sid'),
+              ('float', 'cn0'),
+             ]
 
   def __repr__(self):
     return fmt_repr(self)
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
   
-  def from_binary(self, d):
-    p = TrackingChannelStateDepB._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+  def from_binary(self, d, offset=0):
+    try:
+      size = 0
+      for t, s in TrackingChannelStateDepB.__zips__:
+        if t in TYPES_KEYS_NP:
+          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+          size += a.itemsize
+          setattr(self, s, a.item())
+        else:
+          o = globals()[t]()
+          size += o.from_binary(d, size + offset)
+          setattr(self, s, o)
+      return size
+    except:
+      print traceback.print_exc()
+      return 0
 
   def to_binary(self):
-    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-    return TrackingChannelStateDepB.build(d)
+    try:
+      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+      return TrackingChannelStateDepB.build(d)
+    except:
+      print traceback.print_exc()
     
 SBP_MSG_TRACKING_STATE_DETAILED = 0x0011
 class MsgTrackingStateDetailed(SBP):
@@ -326,6 +393,29 @@ signal is in continuous track.
                'pset_flags',
                'misc_flags',
               ]
+  __zips__ = [
+              ( 'u64', 'recv_time'),
+              ( 'GPSTime', 'tot'),
+              ( 'u32', 'P'),
+              ( 'u16', 'P_std'),
+              ( 'CarrierPhase', 'L'),
+              ( 'u8', 'cn0'),
+              ( 'u16', 'lock'),
+              ( 'GnssSignal', 'sid'),
+              ( 's32', 'doppler'),
+              ( 'u16', 'doppler_std'),
+              ( 'u32', 'uptime'),
+              ( 's16', 'clock_offset'),
+              ( 's16', 'clock_drift'),
+              ( 'u16', 'corr_spacing'),
+              ( 's8', 'acceleration'),
+              ( 'u8', 'sync_flags'),
+              ( 'u8', 'tow_flags'),
+              ( 'u8', 'track_flags'),
+              ( 'u8', 'nav_flags'),
+              ( 'u8', 'pset_flags'),
+              ( 'u8', 'misc_flags'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -381,9 +471,16 @@ signal is in continuous track.
     the message.
 
     """
-    p = MsgTrackingStateDetailed._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -429,6 +526,9 @@ measurements for all tracked satellites.
   __slots__ = [
                'states',
               ]
+  __zips__ = [
+              ( 'array:TrackingChannelState', 'states'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -464,9 +564,16 @@ measurements for all tracked satellites.
     the message.
 
     """
-    p = MsgTrackingState._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -519,6 +626,11 @@ update interval.
                'sid',
                'corrs',
               ]
+  __zips__ = [
+              ( 'u8', 'channel'),
+              ( 'GnssSignal', 'sid'),
+              ( 'array:TrackingChannelCorrelation:3', 'corrs'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -556,9 +668,16 @@ update interval.
     the message.
 
     """
-    p = MsgTrackingIq._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -601,6 +720,9 @@ class MsgTrackingStateDepA(SBP):
   __slots__ = [
                'states',
               ]
+  __zips__ = [
+              ( 'array:TrackingChannelStateDepA', 'states'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -636,9 +758,16 @@ class MsgTrackingStateDepA(SBP):
     the message.
 
     """
-    p = MsgTrackingStateDepA._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.
@@ -681,6 +810,9 @@ class MsgTrackingStateDepB(SBP):
   __slots__ = [
                'states',
               ]
+  __zips__ = [
+              ( 'array:TrackingChannelStateDepB', 'states'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -716,9 +848,16 @@ class MsgTrackingStateDepB(SBP):
     the message.
 
     """
-    p = MsgTrackingStateDepB._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -54,11 +54,11 @@ measured signal power.
                'fcn',
                'cn0',
               ]
-  __zips__ = [
-              ('GnssSignal16', 'sid'),
-              ('u8', 'fcn'),
-              ('u8', 'cn0'),
-             ]
+  _fields = [
+             ( 'GnssSignal16', 'sid' ),
+             ( 'u8', 'fcn' ),
+             ( 'u8', 'cn0' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -70,7 +70,7 @@ measured signal power.
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in TrackingChannelState.__zips__:
+      for t, s in TrackingChannelState._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -112,10 +112,10 @@ class TrackingChannelCorrelation(object):
                'I',
                'Q',
               ]
-  __zips__ = [
-              ('s32', 'I'),
-              ('s32', 'Q'),
-             ]
+  _fields = [
+             ( 's32', 'I' ),
+             ( 's32', 'Q' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -127,7 +127,7 @@ class TrackingChannelCorrelation(object):
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in TrackingChannelCorrelation.__zips__:
+      for t, s in TrackingChannelCorrelation._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -172,11 +172,11 @@ class TrackingChannelStateDepA(object):
                'prn',
                'cn0',
               ]
-  __zips__ = [
-              ('u8', 'state'),
-              ('u8', 'prn'),
-              ('float', 'cn0'),
-             ]
+  _fields = [
+             ( 'u8', 'state' ),
+             ( 'u8', 'prn' ),
+             ( 'float', 'cn0' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -188,7 +188,7 @@ class TrackingChannelStateDepA(object):
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in TrackingChannelStateDepA.__zips__:
+      for t, s in TrackingChannelStateDepA._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -233,11 +233,11 @@ class TrackingChannelStateDepB(object):
                'sid',
                'cn0',
               ]
-  __zips__ = [
-              ('u8', 'state'),
-              ('GnssSignal', 'sid'),
-              ('float', 'cn0'),
-             ]
+  _fields = [
+             ( 'u8', 'state' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 'float', 'cn0' ),
+            ]
 
   def __repr__(self):
     return fmt_repr(self)
@@ -249,7 +249,7 @@ class TrackingChannelStateDepB(object):
   def from_binary(self, d, offset=0):
     try:
       size = 0
-      for t, s in TrackingChannelStateDepB.__zips__:
+      for t, s in TrackingChannelStateDepB._fields:
         if t in TYPES_KEYS_NP:
           a = np.ndarray(1, TYPES_NP[t], d, size + offset)
           size += a.itemsize
@@ -393,29 +393,29 @@ signal is in continuous track.
                'pset_flags',
                'misc_flags',
               ]
-  __zips__ = [
-              ( 'u64', 'recv_time'),
-              ( 'GPSTime', 'tot'),
-              ( 'u32', 'P'),
-              ( 'u16', 'P_std'),
-              ( 'CarrierPhase', 'L'),
-              ( 'u8', 'cn0'),
-              ( 'u16', 'lock'),
-              ( 'GnssSignal', 'sid'),
-              ( 's32', 'doppler'),
-              ( 'u16', 'doppler_std'),
-              ( 'u32', 'uptime'),
-              ( 's16', 'clock_offset'),
-              ( 's16', 'clock_drift'),
-              ( 'u16', 'corr_spacing'),
-              ( 's8', 'acceleration'),
-              ( 'u8', 'sync_flags'),
-              ( 'u8', 'tow_flags'),
-              ( 'u8', 'track_flags'),
-              ( 'u8', 'nav_flags'),
-              ( 'u8', 'pset_flags'),
-              ( 'u8', 'misc_flags'),
-             ]
+  _fields = [
+             ( 'u64', 'recv_time' ),
+             ( 'GPSTime', 'tot' ),
+             ( 'u32', 'P' ),
+             ( 'u16', 'P_std' ),
+             ( 'CarrierPhase', 'L' ),
+             ( 'u8', 'cn0' ),
+             ( 'u16', 'lock' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 's32', 'doppler' ),
+             ( 'u16', 'doppler_std' ),
+             ( 'u32', 'uptime' ),
+             ( 's16', 'clock_offset' ),
+             ( 's16', 'clock_drift' ),
+             ( 'u16', 'corr_spacing' ),
+             ( 's8', 'acceleration' ),
+             ( 'u8', 'sync_flags' ),
+             ( 'u8', 'tow_flags' ),
+             ( 'u8', 'track_flags' ),
+             ( 'u8', 'nav_flags' ),
+             ( 'u8', 'pset_flags' ),
+             ( 'u8', 'misc_flags' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -526,9 +526,9 @@ measurements for all tracked satellites.
   __slots__ = [
                'states',
               ]
-  __zips__ = [
-              ( 'array:TrackingChannelState', 'states'),
-             ]
+  _fields = [
+             ( 'array:TrackingChannelState', 'states' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -626,11 +626,11 @@ update interval.
                'sid',
                'corrs',
               ]
-  __zips__ = [
-              ( 'u8', 'channel'),
-              ( 'GnssSignal', 'sid'),
-              ( 'array:TrackingChannelCorrelation:3', 'corrs'),
-             ]
+  _fields = [
+             ( 'u8', 'channel' ),
+             ( 'GnssSignal', 'sid' ),
+             ( 'array:TrackingChannelCorrelation:3', 'corrs' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -720,9 +720,9 @@ class MsgTrackingStateDepA(SBP):
   __slots__ = [
                'states',
               ]
-  __zips__ = [
-              ( 'array:TrackingChannelStateDepA', 'states'),
-             ]
+  _fields = [
+             ( 'array:TrackingChannelStateDepA', 'states' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -810,9 +810,9 @@ class MsgTrackingStateDepB(SBP):
   __slots__ = [
                'states',
               ]
-  __zips__ = [
-              ( 'array:TrackingChannelStateDepB', 'states'),
-             ]
+  _fields = [
+             ( 'array:TrackingChannelStateDepB', 'states' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -68,28 +68,21 @@ measured signal power.
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in TrackingChannelState._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in TrackingChannelState._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return TrackingChannelState.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return TrackingChannelState.build(d)
     
 class TrackingChannelCorrelation(object):
   """TrackingChannelCorrelation.
@@ -125,28 +118,21 @@ class TrackingChannelCorrelation(object):
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in TrackingChannelCorrelation._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in TrackingChannelCorrelation._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return TrackingChannelCorrelation.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return TrackingChannelCorrelation.build(d)
     
 class TrackingChannelStateDepA(object):
   """TrackingChannelStateDepA.
@@ -186,28 +172,21 @@ class TrackingChannelStateDepA(object):
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in TrackingChannelStateDepA._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in TrackingChannelStateDepA._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return TrackingChannelStateDepA.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return TrackingChannelStateDepA.build(d)
     
 class TrackingChannelStateDepB(object):
   """TrackingChannelStateDepB.
@@ -247,28 +226,21 @@ class TrackingChannelStateDepB(object):
 
   
   def from_binary(self, d, offset=0):
-    try:
-      size = 0
-      for t, s in TrackingChannelStateDepB._fields:
-        if t in TYPES_KEYS_NP:
-          a = np.ndarray(1, TYPES_NP[t], d, size + offset)
-          size += a.itemsize
-          setattr(self, s, a.item())
-        else:
-          o = globals()[t]()
-          size += o.from_binary(d, size + offset)
-          setattr(self, s, o)
-      return size
-    except:
-      print traceback.print_exc()
-      return 0
+    size = 0
+    for t, s in TrackingChannelStateDepB._fields:
+      if t in TYPES_KEYS_NP:
+        a = np.ndarray(1, TYPES_NP[t], d, size + offset)
+        size += a.itemsize
+        setattr(self, s, a.item())
+      else:
+        o = globals()[t]()
+        size += o.from_binary(d, size + offset)
+        setattr(self, s, o)
+    return size
 
   def to_binary(self):
-    try:
-      d = dict([(k, getattr(obj, k)) for k in self.__slots__])
-      return TrackingChannelStateDepB.build(d)
-    except:
-      print traceback.print_exc()
+    d = dict([(k, getattr(obj, k)) for k in self.__slots__])
+    return TrackingChannelStateDepB.build(d)
     
 SBP_MSG_TRACKING_STATE_DETAILED = 0x0011
 class MsgTrackingStateDetailed(SBP):
@@ -471,10 +443,7 @@ signal is in continuous track.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -564,10 +533,7 @@ measurements for all tracked satellites.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -668,10 +634,7 @@ update interval.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -758,10 +721,7 @@ class MsgTrackingStateDepA(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)
@@ -848,10 +808,7 @@ class MsgTrackingStateDepB(SBP):
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/user.py
+++ b/python/sbp/user.py
@@ -55,9 +55,9 @@ maximum length of 255 bytes per message.
   __slots__ = [
                'contents',
               ]
-  __zips__ = [
-              ( 'array:u8', 'contents'),
-             ]
+  _fields = [
+             ( 'array:u8', 'contents' ),
+            ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:

--- a/python/sbp/user.py
+++ b/python/sbp/user.py
@@ -21,7 +21,6 @@ from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
 from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
                       greedy_string
 import numpy as np
-import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/user.yaml with generate.py.
 # Please do not hand edit!

--- a/python/sbp/user.py
+++ b/python/sbp/user.py
@@ -93,10 +93,7 @@ maximum length of 255 bytes per message.
     the message.
 
     """
-    try:
-      self._from_binary(d)
-    except:
-      print traceback.print_exc()
+    self._from_binary(d)
 
   def __getitem__(self, item):
     return getattr(self, item)

--- a/python/sbp/user.py
+++ b/python/sbp/user.py
@@ -17,8 +17,11 @@ Messages reserved for use by the user.
 
 from construct import *
 import json
-from sbp.msg import SBP, SENDER_ID
-from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize, greedy_string
+from sbp.msg import SBP, SENDER_ID, TYPES_NP, TYPES_KEYS_NP
+from sbp.utils import fmt_repr, exclude_fields, walk_json_dict, containerize,\
+                      greedy_string
+import numpy as np
+import traceback
 
 # Automatically generated from piksi/yaml/swiftnav/sbp/user.yaml with generate.py.
 # Please do not hand edit!
@@ -52,6 +55,9 @@ maximum length of 255 bytes per message.
   __slots__ = [
                'contents',
               ]
+  __zips__ = [
+              ( 'array:u8', 'contents'),
+             ]
 
   def __init__(self, sbp=None, **kwargs):
     if sbp:
@@ -87,9 +93,16 @@ maximum length of 255 bytes per message.
     the message.
 
     """
-    p = MsgUserData._parser.parse(d)
-    for n in self.__class__.__slots__:
-      setattr(self, n, getattr(p, n))
+    try:
+      self._from_binary(d)
+    except:
+      print traceback.print_exc()
+
+  def __getitem__(self, item):
+    return getattr(self, item)
+
+  def _get_embedded_type(self, t):
+    return globals()[t]
 
   def to_binary(self):
     """Produce a framed/packed SBP message.

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -46,7 +46,7 @@ def walk_json_dict(coll):
     return coll
 
 
-def containerize(coll):
+def containerize(coll, key=None):
   """Walk attribute fields passed from an SBP message and convert to
   Containers where appropriate. Needed for Construct proper
   serialization.
@@ -57,15 +57,10 @@ def containerize(coll):
 
   """
   if isinstance(coll, Container):
-    [setattr(coll, k, containerize(v)) for (k, v) in coll.iteritems()]
+    [setattr(coll, k, containerize(v, k)) for (k, v) in coll.iteritems()]
     return coll
   elif isinstance(coll, dict):
     return containerize(Container(**coll))
-  elif isinstance(coll, list):
-    for j, i in enumerate(coll):
-      if isinstance(i, dict):
-        coll[j] = containerize(Container(**i))
-    return coll
   else:
     return coll
 

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -16,6 +16,7 @@
 EXCLUDE = ['sender', 'msg_type', 'crc', 'length', 'preamble', 'payload']
 
 from construct import Container, Field, OptionalGreedyRange, Rename, StringAdapter
+import traceback
 
 
 def exclude_fields(obj, exclude=EXCLUDE):
@@ -39,6 +40,8 @@ def walk_json_dict(coll):
     return dict((k, walk_json_dict(v)) for (k, v) in coll.iteritems())
   elif hasattr(coll, '__iter__'):
     return [walk_json_dict(seq) for seq in coll]
+  elif hasattr(coll, '__slots__'):
+    return dict([(k, walk_json_dict(getattr(coll, k))) for k in coll.__slots__])
   else:
     return coll
 

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -2,3 +2,4 @@ pytest==2.6.4
 pytest-cov==1.8.1
 cov-core==1.15.0
 coverage==3.7.1
+numpy

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -79,8 +79,11 @@ def _assert_msg(msg, test_case):
   if test_case['fields']:
     for field_name, field_value in test_case['fields'].iteritems():
       assert field_eq(getattr(msg, field_name), field_value), \
-        "Unequal field values: got %s, but expected %s!" \
-        % (getattr(msg, field_name), field_value)
+        "Unequal field values for %s.%s: got %s, but expected %s!" \
+        % (msg.__class__.__name__,
+           field_name,
+           getattr(msg, field_name),
+           field_value)
 
 def _assert_msg_roundtrip(msg, raw_packet):
   """


### PR DESCRIPTION
  * Msg decoding from construct to numpy
  * _SBPQueueIterator internals from Queue to deque
  * PySerialDriver read

PR CPU profile (30 seconds wall time)

```
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..hon2.7/threading.py:752 Thread.run  1      0.000134  4.929672  4.929672
..handler.py:46 Handler._recv_thread  1      0.064880  4.929537  4.929537
..bp/client/framer.py:64 Framer.next  4700   0.053170  4.649743  0.000989
..lient/framer.py:99 Framer._receive  4723   0.600478  4.468708  0.000946
..py2.7.egg/sbp/table.py:56 dispatch  4699   0.100224  1.745657  0.000371
..bservation.py:1005 MsgObs.__init__  882    0.015912  0.978820  0.001110
..rvation.py:1035 MsgObs.from_binary  882    0.070853  0.960264  0.001089
..n.py:228 PackedObsContent.__init__  4116   0.016826  0.770654  0.000187
..y:250 PackedObsContent.from_binary  4116   0.307912  0.753828  0.000183
..627b-py2.7.egg/sbp/msg.py:61 crc16  4699   0.492355  0.682192  0.000145
..lient/framer.py:75 Framer._readall  14099  0.362817  0.624950  0.000044
..core/_internal.py:151 _commastring  4700   0.320664  0.572828  0.000122
..l_driver.py:69 PySerialDriver.read  18822  0.151017  0.426449  0.000023
..ial/serialposix.py:453 Serial.read  859    0.068900  0.252343  0.000294
..lient/handler.py:163 Handler._call  4699   0.072073  0.214897  0.000046
..1019 MsgTrackingStateDepB.__init__  59     0.001038  0.141885  0.002405
..8 MsgTrackingStateDepB.from_binary  59     0.012502  0.140493  0.002381
..p/client/framer.py:54 Framer._time  4699   0.043678  0.127866  0.000027
.. TrackingChannelStateDepB.__init__  1416   0.004914  0.123774  0.000087
../gnss.py:412 CarrierPhase.__init__  4116   0.016526  0.123169  0.000030
..p/gnss.py:54 GnssSignal16.__init__  4226   0.015869  0.121829  0.000029
..bservation.py:126 Doppler.__init__  4116   0.017472  0.121517  0.000030
..ackingChannelStateDepB.from_binary  1416   0.049233  0.118860  0.000084
../sbp/client/handler.py:84 feediter  9398   0.060285  0.110733  0.000012
..ss.py:429 CarrierPhase.from_binary  4116   0.083712  0.106643  0.000026
..nss.py:71 GnssSignal16.from_binary  4226   0.082619  0.105961  0.000025
..rvation.py:143 Doppler.from_binary  4116   0.080705  0.104044  0.000025
..n.py:57 ObservationHeader.__init__  882    0.005541  0.095457  0.000108
..y:74 ObservationHeader.from_binary  882    0.028407  0.089917  0.000102
..dler.py:270 _SBPQueueIterator.next  930..  0.040519  0.070078  0.000008
..ksi.py:891 MsgThreadState.__init__  285    0.004105  0.066876  0.000235
..bp/gnss.py:129 GnssSignal.__init__  1561   0.006120  0.066417  0.000043
...py:922 MsgThreadState.from_binary  285    0.017536  0.061632  0.000216
..gnss.py:147 GnssSignal.from_binary  1561   0.046846  0.060297  0.000039
..p/gnss.py:342 GPSTimeNano.__init__  882    0.004867  0.056588  0.000064
..nss.py:360 GPSTimeNano.from_binary  882    0.040458  0.051721  0.000059
...py:263 _SBPQueueIterator.__call__  9398   0.038272  0.050448  0.000005
..tem.py:223 MsgDgnssStatus.__init__  295    0.006887  0.047792  0.000162
...7.egg/sbp/msg.py:107 SBP.__init__  9398   0.044625  0.044625  0.000005
..igation.py:275 MsgUtcTime.__init__  294    0.004830  0.041403  0.000141
..navigation.py:448 MsgDops.__init__  294    0.005827  0.040619  0.000138
...py:255 MsgDgnssStatus.from_binary  295    0.023253  0.039932  0.000135
..on.py:1154 MsgBaselineNED.__init__  294    0.005147  0.039542  0.000134
..vigation.py:803 MsgPosLLH.__init__  294    0.004596  0.037556  0.000128
..igation.py:1507 MsgVelNED.__init__  294    0.004859  0.036852  0.000125
..on.py:976 MsgBaselineECEF.__init__  294    0.004678  0.035692  0.000121
..tion.py:312 MsgUtcTime.from_binary  294    0.025454  0.035602  0.000121
..igation.py:623 MsgPosECEF.__init__  294    0.004741  0.034793  0.000118
..gation.py:1327 MsgVelECEF.__init__  294    0.004814  0.034633  0.000118
..igation.py:483 MsgDops.from_binary  294    0.024764  0.033658  0.000114
..py:1190 MsgBaselineNED.from_binary  294    0.024685  0.033097  0.000113
..dler.py:152 Handler._get_callbacks  4699   0.032090  0.032090  0.000007
..ation.py:839 MsgPosLLH.from_binary  294    0.022883  0.031750  0.000108
..tion.py:1543 MsgVelNED.from_binary  294    0.023180  0.030949  0.000105
..y:1011 MsgBaselineECEF.from_binary  294    0.021971  0.029594  0.000101
..tion.py:658 MsgPosECEF.from_binary  294    0.021321  0.028807  0.000098
..ion.py:1362 MsgVelECEF.from_binary  294    0.020944  0.028674  0.000098
..2.7.egg/sbp/piksi.py:961 <genexpr>  5985   0.019623  0.026772  0.000004
..vigation.py:99 MsgGPSTime.__init__  294    0.005332  0.025256  0.000086
piksi_tools/serial_link.py:295 main   1      0.000180  0.021922  0.021922
..tion.py:131 MsgGPSTime.from_binary  294    0.014160  0.018927  0.000064
..py:1805 MsgAgeCorrections.__init__  295    0.005050  0.018806  0.000064
..on.py:647 MsgAcqSvProfile.__init__  29     0.000581  0.017219  0.000594
..py:676 MsgAcqSvProfile.from_binary  29     0.001505  0.016467  0.000568
..ition.py:107 AcqSvProfile.__init__  67     0.000337  0.014511  0.000217
..on.py:134 AcqSvProfile.from_binary  67     0.008224  0.014174  0.000212
..iksi.py:1053 MsgUartState.__init__  30     0.000564  0.013790  0.000460
..i.py:1086 MsgUartState.from_binary  30     0.002429  0.013094  0.000436
..1835 MsgAgeCorrections.from_binary  295    0.009562  0.012276  0.000042
..l_logger.py:17 NullLogger.__call__  9303   0.012137  0.012137  0.000001
..bp/ndb.py:108 MsgNdbEvent.__init__  55     0.000941  0.011917  0.000217
..ition.py:207 MsgAcqResult.__init__  67     0.001062  0.011098  0.000166
..ndb.py:144 MsgNdbEvent.from_binary  55     0.005311  0.010823  0.000197
..ools/serial_link.py:120 get_driver  1      0.000051  0.010396  0.010396
..s/list_ports_linux.py:135 comports  1      0.000068  0.009640  0.009640
..on.py:239 MsgAcqResult.from_binary  67     0.004300  0.009556  0.000143
piksi_tools/serial_link.py:259 run    1      0.001106  0.008663  0.008663
..p/piksi.py:84 UARTChannel.__init__  90     0.000393  0.006643  0.000074
..:1549 MsgEphemerisGPSDepE.__init__  11     0.000236  0.006479  0.000589
..ksi.py:105 UARTChannel.from_binary  90     0.004770  0.006250  0.000069
..00 MsgEphemerisGPSDepE.from_binary  11     0.002229  0.006137  0.000558
..ls/list_ports_linux.py:97 describe  33     0.000150  0.005643  0.000171
..i_tools/serial_link.py:98 get_args  1      0.000536  0.004492  0.004492
..ports_linux.py:79 usb_lsusb_string  1      0.000038  0.004263  0.004263
..r/lib/python2.7/re.py:226 _compile  51     0.000162  0.003843  0.000075
..thon2.7/sre_compile.py:493 compile  11     0.000127  0.003609  0.000328
...7.egg/sbp/system.py:294 <genexpr>  295    0.003354  0.003354  0.000011
..phemerisCommonContentDepA.__init__  11     0.000099  0.002632  0.000239
..merisCommonContentDepA.from_binary  11     0.000799  0.002533  0.000230
../serial_link.py:51 base_cl_options  1      0.000036  0.002503  0.002503
..ls/list_ports_linux.py:52 re_group  5      0.000029  0.002404  0.000481
/usr/lib/python2.7/re.py:139 search   5      0.000016  0.002373  0.000475
/usr/lib/python2.7/glob.py:18 glob    3      0.000032  0.002077  0.000692
/usr/lib/python2.7/glob.py:29 iglob   36     0.000059  0.002045  0.000057
..b/python2.7/sre_parse.py:675 parse  11     0.000085  0.002016  0.000183
..ols/list_ports_linux.py:115 hwinfo  33     0.000235  0.001852  0.000056
..ystem.py:367 MsgHeartbeat.__init__  29     0.000571  0.001838  0.000063
..hon2.7/sre_parse.py:301 _parse_sub  17/11  0.000096  0.001827  0.000107
../sbp/piksi.py:251 Latency.__init__  30     0.000148  0.001817  0.000061
/usr/lib/python2.7/glob.py:66 glob1   3      0.000022  0.001802  0.000601
..g/sbp/piksi.py:169 Period.__init__  30     0.000138  0.001734  0.000058
../python2.7/sre_parse.py:379 _parse  18/12  0.000656  0.001718  0.000095
..tools/list_ports_linux.py:26 popen  1      0.000029  0.001704  0.001704
..p/piksi.py:270 Latency.from_binary  30     0.001301  0.001670  0.000056
..2.7/subprocess.py:544 check_output  1      0.000050  0.001663  0.001663
..bp/piksi.py:188 Period.from_binary  30     0.001180  0.001596  0.000053
..python2.7/genericpath.py:15 exists  186    0.000325  0.001577  0.000008
..py:4565 MsgGroupDelayDepA.__init__  6      0.000111  0.001563  0.000260
..se.py:1545 ArgumentParser.__init__  1      0.000032  0.001545  0.001545
..7/threading.py:308 _Condition.wait  4      0.000466  0.001504  0.000376
..y:1252 ArgumentParser.add_argument  19     0.000175  0.001488  0.000078
..4599 MsgGroupDelayDepA.from_binary  6      0.000542  0.001429  0.000238
..python2.7/sre_compile.py:478 _code  11     0.000045  0.001416  0.000129
/usr/lib/python2.7/re.py:188 compile  44     0.000042  0.001394  0.000032
..7/subprocess.py:650 Popen.__init__  1      0.000053  0.001332  0.001332
..ent/handler.py:64 Handler.__exit__  1      0.000017  0.001288  0.001288
..client/handler.py:188 Handler.stop  1      0.000041  0.001271  0.001271
..lib/python2.7/fnmatch.py:45 filter  3      0.000264  0.001241  0.000414
..on2.7/threading.py:911 Thread.join  1      0.000139  0.001224  0.001224
..g/sbp/gnss.py:198 GPSTime.__init__  28     0.000149  0.001177  0.000042
..em.py:396 MsgHeartbeat.from_binary  29     0.000949  0.001133  0.000039
..ocess.py:1187 Popen._execute_child  1      0.000228  0.001121  0.001121
..ython2.7/posixpath.py:379 realpath  4      0.000013  0.001068  0.000267
..bp/gnss.py:215 GPSTime.from_binary  28     0.000828  0.001027  0.000037
...py:1634 MsgDeviceMonitor.__init__  10     0.000173  0.001005  0.000100
..2.7/posixpath.py:387 _joinrealpath  12/4   0.000226  0.000970  0.000081
..nt/handler.py:198 Handler.is_alive  30     0.000264  0.000895  0.000030
..:1667 MsgDeviceMonitor.from_binary  10     0.000596  0.000792  0.000079
..thon2.7/sre_compile.py:32 _compile  41/11  0.000378  0.000766  0.000019
../python2.7/argparse.py:62 <module>  1      0.000628  0.000746  0.000746
..n2.7/threading.py:726 Thread.start  3      0.000040  0.000707  0.000236
..iver.py:43 PySerialDriver.__init__  1      0.000063  0.000704  0.000704
...7/threading.py:995 Thread.isAlive  30     0.000544  0.000630  0.000021
..se.py:1171 ArgumentParser.__init__  3      0.000056  0.000613  0.000204
..7/sre_compile.py:359 _compile_info  11     0.000302  0.000603  0.000055
..2315 ArgumentParser._get_formatter  19     0.000037  0.000599  0.000032
..b/python2.7/gettext.py:580 gettext  3      0.000006  0.000582  0.000194
../python2.7/gettext.py:542 dgettext  3      0.000011  0.000576  0.000192
..thon2.7/gettext.py:476 translation  3      0.000011  0.000563  0.000188
..arse.py:154 HelpFormatter.__init__  19     0.000155  0.000562  0.000030
../lib/python2.7/gettext.py:421 find  3      0.000087  0.000552  0.000184
..on2.7/threading.py:602 _Event.wait  3      0.000030  0.000516  0.000172
..2.7/sre_parse.py:201 Tokenizer.get  167    0.000156  0.000511  0.000003
..nt/handler.py:60 Handler.__enter__  1      0.000005  0.000493  0.000493
..lient/handler.py:182 Handler.start  1      0.000003  0.000487  0.000487
..rial/__init__.py:32 serial_for_url  1      0.000029  0.000484  0.000484
..lib/python2.7/posixpath.py:68 join  139    0.000289  0.000459  0.000003
...py:1689 ArgumentParser.parse_args  1      0.000003  0.000420  0.000420
..96 ArgumentParser.parse_known_args  1      0.000032  0.000417  0.000417
../sre_parse.py:182 Tokenizer.__next  188    0.000290  0.000406  0.000002
..ial/serialposix.py:279 Serial.open  1      0.000068  0.000396  0.000396
../python2.7/posixpath.py:139 islink  80     0.000112  0.000365  0.000005
..1 ArgumentParser._parse_known_args  1      0.000051  0.000354  0.000354
..s/list_ports_linux.py:42 read_line  6      0.000033  0.000284  0.000047
..arse.py:130 SubPattern.__getitem__  159    0.000201  0.000280  0.000002
..ubprocess.py:768 Popen.communicate  1      0.000048  0.000275  0.000275
..ts_linux.py:65 usb_sysfs_hw_string  1      0.000012  0.000274  0.000274
..six.py:311 Serial._reconfigurePort  4      0.000119  0.000272  0.000068
../argparse.py:1799 consume_optional  2      0.000012  0.000253  0.000126
..forwarder.py:32 Forwarder.__init__  2      0.000135  0.000245  0.000122
..ubprocess.py:473 _eintr_retry_call  3      0.000024  0.000242  0.000081
..7/threading.py:656 Thread.__init__  3      0.000065  0.000226  0.000075
..e_parse.py:140 SubPattern.getwidth  63/33  0.000179  0.000218  0.000003
..lient/framer.py:35 Framer.__init__  1      0.000028  0.000218  0.000218
..hon2.7/gettext.py:130 _expand_lang  6      0.000064  0.000196  0.000033
..erial_link.py:344 signal_handler_c  1      0.000192  0.000192  0.000192
..009 ArgumentParser._match_argument  2      0.000013  0.000188  0.000094
/usr/lib/python2.7/uuid.py:546 uuid4  1      0.000072  0.000186  0.000186
..py:1669 ArgumentParser._add_action  19     0.000020  0.000182  0.000010
../lib/python2.7/glob.py:77 <lambda>  606    0.000176  0.000176  0.000000
..rgumentParser._get_optional_kwargs  19     0.000114  0.000169  0.000009
/usr/lib/python2.7/re.py:134 match    2      0.000004  0.000167  0.000084
..ent/handler.py:37 Handler.__init__  1      0.000040  0.000165  0.000165
..py:1497 _ArgumentGroup._add_action  19     0.000034  0.000163  0.000009
...py:573 HelpFormatter._format_args  19     0.000086  0.000143  0.000008
..sre_parse.py:138 SubPattern.append  114    0.000095  0.000134  0.000001
..process.py:1161 Popen.pipe_cloexec  2      0.000011  0.000134  0.000067
..ib/python2.7/posixpath.py:89 split  39     0.000091  0.000134  0.000003
..process.py:1099 Popen._get_handles  1      0.000009  0.000130  0.000130
..py:1309 _ArgumentGroup._add_action  19     0.000067  0.000123  0.000006
..ss.py:1148 Popen._set_cloexec_flag  4      0.000012  0.000105  0.000026
..ython2.7/posixpath.py:119 basename  69     0.000067  0.000100  0.000001
..rialutil.py:333 Serial.setBaudrate  2      0.000016  0.000098  0.000049
..ent/handler.py:93 Handler.__iter__  2      0.000010  0.000095  0.000048
..re_compile.py:178 _compile_charset  13     0.000050  0.000094  0.000007
..2.7/threading.py:866 Thread.__stop  1      0.000027  0.000092  0.000092
..re_parse.py:126 SubPattern.__len__  96     0.000067  0.000092  0.000001
..n2.7/threading.py:569 _Event.isSet  37     0.000092  0.000092  0.000002
..r/lib/python2.7/stat.py:55 S_ISLNK  80     0.000061  0.000091  0.000001
../python2.7/locale.py:363 normalize  6      0.000031  0.000091  0.000015
..b/python2.7/threading.py:541 Event  3      0.000011  0.000090  0.000030
..thon2.7/sre_compile.py:354 _simple  22     0.000047  0.000087  0.000004
.. ArgumentParser.add_argument_group  2      0.000008  0.000086  0.000043
..lient/handler.py:72 Handler.filter  2      0.000057  0.000085  0.000042
..python2.7/posixpath.py:365 abspath  4      0.000010  0.000085  0.000021
..thon2.7/threading.py:241 Condition  6      0.000022  0.000082  0.000014
..7/threading.py:560 _Event.__init__  3      0.000015  0.000079  0.000026
..se.py:1475 _ArgumentGroup.__init__  2      0.000014  0.000078  0.000039
.._init__.py:52 create_string_buffer  1      0.000073  0.000076  0.000076
..ython2.7/posixpath.py:336 normpath  4      0.000044  0.000070  0.000018
..re_parse.py:178 Tokenizer.__init__  11     0.000023  0.000062  0.000006
..reading.py:259 _Condition.__init__  6      0.000056  0.000060  0.000010
..eading.py:399 _Condition.notifyAll  1      0.000017  0.000060  0.000060
..python2.7/argparse.py:95 _callable  44     0.000035  0.000058  0.000001
..4 ArgumentParser._pop_action_class  19     0.000029  0.000058  0.000003
../python2.7/fnmatch.py:81 translate  3      0.000020  0.000057  0.000019
...7/threading.py:1152 currentThread  4      0.000049  0.000056  0.000014
../serialutil.py:234 Serial.__init__  1      0.000041  0.000055  0.000055
..7/sre_parse.py:195 Tokenizer.match  73     0.000040  0.000053  0.000001
..on2.7/argparse.py:1778 take_action  2      0.000014  0.000052  0.000026
..se.py:1223 ArgumentParser.register  34     0.000039  0.000051  0.000001
..:1227 ArgumentParser._registry_get  44     0.000036  0.000051  0.000001
..n2.7/subprocess.py:1371 Popen.wait  1      0.000022  0.000050  0.000050
..serDict.py:18 _Environ.__getitem__  22     0.000028  0.000049  0.000002
..b/python2.7/gettext.py:11 <module>  1      0.000030  0.000044  0.000044
...7/locale.py:347 _replace_encoding  3      0.000019  0.000043  0.000014
..andler.py:100 Handler.add_callback  4      0.000033  0.000043  0.000011
..hreading.py:709 Thread._set_daemon  3      0.000021  0.000042  0.000014
..threading.py:372 _Condition.notify  1      0.000026  0.000041  0.000041
..python2.7/sre_parse.py:257 _escape  20     0.000027  0.000041  0.000002
..hon2.7/sre_compile.py:472 isstring  22     0.000032  0.000040  0.000002
..erialutil.py:393 Serial.setTimeout  2      0.000007  0.000038  0.000019
..ython2.7/uuid.py:101 UUID.__init__  1      0.000026  0.000037  0.000037
..e.py:865 _StoreTrueAction.__init__  8      0.000013  0.000037  0.000005
/usr/lib/python2.7/re.py:204 escape   16     0.000032  0.000037  0.000002
..eading.py:299 _Condition._is_owned  5      0.000026  0.000035  0.000007
..b/python2.7/argparse.py:566 format  19     0.000022  0.000035  0.000002
..e_compile.py:207 _optimize_charset  13     0.000034  0.000034  0.000003
..gparse.py:765 _HelpAction.__init__  19     0.000033  0.000033  0.000002
..py:2189 ArgumentParser._get_values  2      0.000016  0.000032  0.000016
...py:2241 ArgumentParser._get_value  6      0.000014  0.000031  0.000005
/usr/lib/python2.7/stat.py:24 S_IFMT  80     0.000031  0.000031  0.000000
..hon2.7/UserDict.py:58 _Environ.get  12     0.000021  0.000029  0.000002
..parse.py:807 _StoreAction.__init__  10     0.000017  0.000029  0.000003
..re_parse.py:90 SubPattern.__init__  41     0.000028  0.000028  0.000001
..py:296 _Condition._acquire_restore  4      0.000017  0.000024  0.000006
..e.py:842 _StoreTrueAction.__init__  8      0.000011  0.000024  0.000003
..on2.7/threading.py:63 Thread._note  11     0.000023  0.000023  0.000002
..7/sre_parse.py:67 Pattern.__init__  11     0.000023  0.000023  0.000002
..n2.7/argparse.py:147 HelpFormatter  1      0.000022  0.000022  0.000022
..ib/python2.7/posixpath.py:59 isabs  16     0.000015  0.000022  0.000001
..lib/python2.7/glob.py:94 has_magic  9      0.000010  0.000021  0.000002
..serialutil.py:441 Serial.setRtsCts  2      0.000003  0.000020  0.000010
../__init__.py:49 normalize_encoding  3      0.000011  0.000020  0.000007
..ubprocess.py:1208 _close_in_parent  1      0.000013  0.000019  0.000019
..ng.py:293 _Condition._release_save  4      0.000014  0.000017  0.000004
..py:266 _SBPQueueIterator.breakiter  2      0.000013  0.000016  0.000008
..437 _ArgumentGroup._check_conflict  19     0.000015  0.000015  0.000001
..7 HelpFormatter._metavar_formatter  19     0.000015  0.000015  0.000001
../sre_parse.py:72 Pattern.opengroup  6      0.000011  0.000014  0.000002
..ools/serial_link.py:42 logfilename  1      0.000003  0.000014  0.000014
..gparse.py:983 _HelpAction.__init__  1      0.000004  0.000014  0.000014
..python2.7/posixpath.py:127 dirname  4      0.000008  0.000013  0.000003
../argparse.py:199 _Section.__init__  19     0.000011  0.000011  0.000001
...7/threading.py:58 Thread.__init__  12     0.000011  0.000011  0.000001
..arse.py:134 SubPattern.__setitem__  22     0.000011  0.000011  0.000000
..rialposix.py:526 Serial.flushInput  1      0.000006  0.000011  0.000011
..sre_parse.py:83 Pattern.closegroup  6      0.000008  0.000011  0.000002
..argparse.py:1025 _SubParsersAction  1      0.000010  0.000011  0.000011
..gparse.py:1876 consume_positionals  1      0.000006  0.000010  0.000010
..y:1428 ArgumentParser._get_handler  3      0.000007  0.000010  0.000003
..s.py:1330 Popen._handle_exitstatus  1      0.000005  0.000009  0.000009
...7/threading.py:1024 Thread.daemon  3      0.000007  0.000009  0.000003
.._.py:23 VendorImporter.find_module  2      0.000006  0.000007  0.000003
...7/subprocess.py:754 Popen.__del__  1      0.000006  0.000007  0.000007
.. ArgumentParser._get_nargs_pattern  2      0.000004  0.000007  0.000003
..erDict.py:70 _Environ.__contains__  12     0.000007  0.000007  0.000001
..l/serialutil.py:307 Serial.setPort  2      0.000006  0.000006  0.000003
..ools/serial_link.py:151 get_logger  1      0.000006  0.000006  0.000006
..l_logger.py:35 NullLogger.__exit__  2      0.000006  0.000006  0.000003
...py:256 _SBPQueueIterator.__init__  2      0.000006  0.000006  0.000003
...7/argparse.py:1527 ArgumentParser  1      0.000006  0.000006  0.000006
..on2.7/subprocess.py:802 Popen.poll  1      0.000005  0.000006  0.000006
..ient/framer.py:47 Framer.breakiter  1      0.000006  0.000006  0.000006
...7/argparse.py:1473 _ArgumentGroup  1      0.000006  0.000006  0.000006
..reading.py:1008 _MainThread.daemon  3      0.000005  0.000005  0.000002
..argparse.py:1169 _ActionsContainer  1      0.000004  0.000004  0.000004
..python2.7/uuid.py:197 UUID.__str__  1      0.000004  0.000004  0.000004
..4 _SixMetaPathImporter.find_module  2      0.000004  0.000004  0.000002
..entParser._match_arguments_partial  1      0.000002  0.000003  0.000003
..iver.py:23 PySerialDriver.__init__  1      0.000003  0.000003  0.000003
..parse.py:836 _StoreAction.__call__  2      0.000002  0.000003  0.000002
..thon2.7/subprocess.py:458 _cleanup  1      0.000003  0.000003  0.000003
..044 ArgumentParser._parse_optional  4      0.000003  0.000003  0.000001
..arse.py:128 SubPattern.__delitem__  4      0.000003  0.000003  0.000001
...7/gettext.py:173 NullTranslations  1      0.000003  0.000003  0.000003
..rialutil.py:354 Serial.setByteSize  1      0.000002  0.000002  0.000002
..ocess.py:1344 Popen._internal_poll  2      0.000002  0.000002  0.000001
..4 _SixMetaPathImporter.find_module  2      0.000002  0.000002  0.000001
..serialutil.py:367 Serial.setParity  1      0.000002  0.000002  0.000002
...7/argparse.py:1000 _VersionAction  1      0.000002  0.000002  0.000002
..ython2.7/argparse.py:1591 identity  6      0.000002  0.000002  0.000000
..mentParser._get_positional_actions  1      0.000002  0.000002  0.000002
..rialutil.py:380 Serial.setStopbits  1      0.000002  0.000002  0.000002
../argparse.py:705 ArgumentTypeError  1      0.000002  0.000002  0.000002
.._logger.py:20 NullLogger.__enter__  2      0.000001  0.000001  0.000001
..4 _SixMetaPathImporter.find_module  2      0.000001  0.000001  0.000001
..lient/framer.py:43 Framer.__iter__  1      0.000001  0.000001  0.000001
..2.7/gettext.py:257 GNUTranslations  1      0.000001  0.000001  0.000001
..4 _SixMetaPathImporter.find_module  2      0.000001  0.000001  0.000001
..b/python2.7/argparse.py:714 Action  1      0.000001  0.000001  0.000001
..thon2.7/argparse.py:1146 Namespace  1      0.000001  0.000001  0.000001
..python2.7/posixpath.py:51 normcase  3      0.000001  0.000001  0.000000
..rgparse.py:1153 Namespace.__init__  1      0.000001  0.000001  0.000001
...py:468 Serial.setInterCharTimeout  1      0.000001  0.000001  0.000001
..ython2.7/argparse.py:1102 FileType  1      0.000001  0.000001  0.000001
..7/argparse.py:112 _AttributeHolder  1      0.000001  0.000001  0.000001
..python2.7/argparse.py:197 _Section  1      0.000001  0.000001  0.000001
..y:2266 ArgumentParser._check_value  2      0.000001  0.000001  0.000000
..se.py:1507 _MutuallyExclusiveGroup  1      0.000001  0.000001  0.000001
..hon2.7/argparse.py:981 _HelpAction  1      0.000001  0.000001  0.000001
..argparse.py:934 _AppendConstAction  1      0.000001  0.000001  0.000001
../argparse.py:840 _StoreConstAction  1      0.000001  0.000001  0.000001
..on2.7/argparse.py:805 _StoreAction  1      0.000001  0.000001  0.000001
..n2.7/argparse.py:897 _AppendAction  1      0.000001  0.000001  0.000001
..7/argparse.py:863 _StoreTrueAction  1      0.000001  0.000001  0.000001
..on2.7/argparse.py:960 _CountAction  1      0.000001  0.000001  0.000001
..rial_link.py:171 get_append_logger  1      0.000001  0.000001  0.000001
..n2.7/argparse.py:685 ArgumentError  1      0.000001  0.000001  0.000001
..py:629 RawDescriptionHelpFormatter  1      0.000001  0.000001  0.000001
..gparse.py:640 RawTextHelpFormatter  1      0.000001  0.000001  0.000001
../argparse.py:880 _StoreFalseAction  1      0.000001  0.000001  0.000001
..erialutil.py:430 Serial.setXonXoff  1      0.000001  0.000001  0.000001
..parse.py:1027 _ChoicesPseudoAction  1      0.000001  0.000001  0.000001
..serialutil.py:452 Serial.setDsrDtr  1      0.000001  0.000001  0.000001
..:651 ArgumentDefaultsHelpFormatter  1      0.000001  0.000001  0.000001
..util.py:411 Serial.setWriteTimeout  1      0.000000  0.000000  0.000000
..ient/forwarder.py:39 Forwarder.run  2      0.000000  0.000000  0.000000

name           id     tid              ttot      scnt        
Forwarder      3      139824986769152  0.489911  63        
Forwarder      2      139824978376448  0.489881  61        
Thread         1      139824969983744  0.489824  133       
_MainThread    0      139825076565824  0.104408  36
```

Master b3eab7879bc9ad88cc41120ce2897e0ac77da10c CPU profile (30 seconds wall time)
```
Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
..hon2.7/threading.py:752 Thread.run  1      0.000041  7.467627  7.467627
..handler.py:43 Handler._recv_thread  1      0.056838  7.467586  7.467586
..bp/client/framer.py:62 Framer.next  4777   0.052543  6.541999  0.001369
..lient/framer.py:96 Framer._receive  4880   0.189594  6.378164  0.001307
..py2.7.egg/sbp/table.py:56 dispatch  4776   0.047098  4.111740  0.000861
..construct/core.py:180 Struct.parse  4776   0.027236  3.695312  0.000774
..ct/core.py:190 Struct.parse_stream  4776   0.051040  3.645202  0.000763
..onstruct/core.py:657 Struct._parse  507..  1.104910  3.546414  0.000070
..observation.py:698 MsgObs.__init__  899    0.014159  2.435000  0.002709
..construct/core.py:515 Range._parse  1287   0.063602  2.434687  0.001892
..ervation.py:728 MsgObs.from_binary  899    0.015267  2.417802  0.002689
..struct/core.py:270 Reconfig._parse  232..  0.063825  2.393546  0.000103
..ient/forwarder.py:39 Forwarder.run  2      0.132859  2.033064  1.016532
..dler.py:267 _SBPQueueIterator.next  9554   0.051575  1.884516  0.000197
..b/python2.7/Queue.py:150 Queue.get  9553   0.231279  1.832928  0.000192
..l_driver.py:68 PySerialDriver.read  19212  0.099288  1.233932  0.000064
..ial/serialposix.py:453 Serial.read  19212  0.424618  1.134644  0.000059
..7/threading.py:308 _Condition.wait  9215   0.225904  1.085722  0.000118
..tainer.py:36 Container.__setitem__  241..  0.791155  0.988724  0.000004
..lient/framer.py:73 Framer._readall  14332  0.130173  0.896638  0.000063
..uct/core.py:361 FormatField._parse  78513  0.340438  0.874119  0.000011
..lient/handler.py:160 Handler._call  4776   0.071612  0.868614  0.000182
../sbp/client/handler.py:81 feediter  9552   0.068792  0.772333  0.000081
...py:260 _SBPQueueIterator.__call__  9552   0.052185  0.703541  0.000074
..threading.py:372 _Condition.notify  19110  0.191746  0.659106  0.000034
..b/python2.7/Queue.py:107 Queue.put  9554   0.131708  0.651461  0.000068
..ab78-py2.7.egg/sbp/msg.py:57 crc16  9554   0.487286  0.629580  0.000066
..container.py:27 Container.__init__  60258  0.305059  0.494303  0.000008
..construct/core.py:300 _read_stream  79097  0.303458  0.455700  0.000006
..eading.py:299 _Condition._is_owned  28325  0.118670  0.363445  0.000013
..:685 MsgTrackingStateDepB.__init__  60     0.000702  0.321024  0.005350
..4 MsgTrackingStateDepB.from_binary  60     0.000816  0.320032  0.005334
..py:296 _Condition._acquire_restore  9215   0.041935  0.170513  0.000019
..igation.py:208 MsgUtcTime.__init__  300    0.004315  0.118995  0.000397
..tion.py:245 MsgUtcTime.from_binary  300    0.008761  0.113628  0.000379
..igation.py:1038 MsgVelNED.__init__  300    0.004251  0.112266  0.000374
..ion.py:800 MsgBaselineNED.__init__  299    0.004245  0.111972  0.000374
..p/client/framer.py:52 Framer._time  4776   0.038072  0.111291  0.000023
..vigation.py:564 MsgPosLLH.__init__  300    0.004043  0.111078  0.000370
..navigation.py:324 MsgDops.__init__  301    0.004541  0.110031  0.000366
..tion.py:1074 MsgVelNED.from_binary  300    0.008982  0.107217  0.000357
...py:836 MsgBaselineNED.from_binary  299    0.008586  0.106411  0.000356
..igation.py:442 MsgPosECEF.__init__  300    0.004164  0.106102  0.000354
..ation.py:600 MsgPosLLH.from_binary  300    0.008313  0.105755  0.000353
..igation.py:916 MsgVelECEF.__init__  301    0.004370  0.105360  0.000350
..igation.py:359 MsgDops.from_binary  301    0.008381  0.104163  0.000346
..on.py:680 MsgBaselineECEF.__init__  300    0.004859  0.103639  0.000345
..tainer.py:40 Container.__delitem__  22965  0.073200  0.101733  0.000004
..tion.py:477 MsgPosECEF.from_binary  300    0.007896  0.100712  0.000336
..tion.py:951 MsgVelECEF.from_binary  301    0.008078  0.099866  0.000332
..py:715 MsgBaselineECEF.from_binary  300    0.007874  0.097740  0.000326
..tem.py:162 MsgDgnssStatus.__init__  299    0.003752  0.092601  0.000310
...py:194 MsgDgnssStatus.from_binary  299    0.005671  0.087839  0.000294
..vigation.py:91 MsgGPSTime.__init__  300    0.004555  0.075237  0.000251
..ython2.7/Queue.py:200 Queue._qsize  18765  0.050332  0.070243  0.000004
..tion.py:123 MsgGPSTime.from_binary  300    0.006166  0.069452  0.000232
..ksi.py:693 MsgThreadState.__init__  285    0.003768  0.063921  0.000224
...py:724 MsgThreadState.from_binary  285    0.004621  0.058961  0.000207
..py:1230 MsgAgeCorrections.__init__  299    0.004088  0.050733  0.000170
..1260 MsgAgeCorrections.from_binary  299    0.004452  0.045680  0.000153
..2.7.egg/sbp/msg.py:85 SBP.__init__  9552   0.042978  0.042978  0.000004
..ng.py:293 _Condition._release_save  9215   0.026716  0.042364  0.000005
../python2.7/Queue.py:208 Queue._get  9553   0.032438  0.041979  0.000004
..7/threading.py:63 _Condition._note  28324  0.041059  0.041059  0.000001
../python2.7/Queue.py:204 Queue._put  9554   0.030271  0.038815  0.000004
..tainer.py:31 Container.__getattr__  25265  0.038439  0.038439  0.000002
..on.py:445 MsgAcqSvProfile.__init__  29     0.000358  0.035311  0.001218
..py:474 MsgAcqSvProfile.from_binary  29     0.000360  0.034857  0.001202
..t/core.py:287 StringAdapter._parse  584    0.005411  0.031414  0.000054
..piksi.py:800 MsgUartState.__init__  30     0.000405  0.028743  0.000958
..si.py:833 MsgUartState.from_binary  30     0.000582  0.028236  0.000941
..sbp/ndb.py:96 MsgNdbEvent.__init__  44     0.001057  0.027590  0.000627
..ndb.py:132 MsgNdbEvent.from_binary  44     0.001510  0.026287  0.000597
..ition.py:164 MsgAcqResult.__init__  67     0.000960  0.025595  0.000382
..dler.py:149 Handler._get_callbacks  4776   0.024668  0.024668  0.000005
..on.py:196 MsgAcqResult.from_binary  67     0.001314  0.024143  0.000360
piksi_tools/serial_link.py:295 main   1      0.000315  0.020534  0.020534
..:1063 MsgEphemerisGPSDepE.__init__  11     0.000165  0.015021  0.001366
..l_logger.py:17 NullLogger.__call__  9552   0.014868  0.014868  0.000002
..14 MsgEphemerisGPSDepE.from_binary  11     0.000817  0.014819  0.001347
..ools/serial_link.py:120 get_driver  1      0.000105  0.011771  0.011771
..uct/core.py:327 StaticField._parse  584    0.002130  0.010302  0.000018
..s/list_ports_linux.py:135 comports  1      0.000072  0.010045  0.010045
..ion.py:3378 MsgAlmanacGPS.__init__  12     0.000135  0.008315  0.000693
...py:3416 MsgAlmanacGPS.from_binary  12     0.000366  0.008138  0.000678
..pters.py:153 StringAdapter._decode  584    0.004414  0.007936  0.000014
..ls/list_ports_linux.py:97 describe  33     0.000170  0.005717  0.000173
..ports_linux.py:79 usb_lsusb_string  1      0.000041  0.004236  0.004236
..i_tools/serial_link.py:98 get_args  1      0.000416  0.004149  0.004149
..r/lib/python2.7/re.py:226 _compile  51     0.000249  0.003882  0.000076
piksi_tools/serial_link.py:259 run    1      0.000830  0.003762  0.003762
..ystem.py:255 MsgHeartbeat.__init__  30     0.000306  0.003588  0.000120
..thon2.7/sre_compile.py:493 compile  11     0.000098  0.003570  0.000325
..em.py:284 MsgHeartbeat.from_binary  30     0.000306  0.003144  0.000105
...py:1169 MsgDeviceMonitor.__init__  10     0.000119  0.002520  0.000252
..ls/list_ports_linux.py:52 re_group  5      0.000034  0.002503  0.000501
/usr/lib/python2.7/re.py:139 search   5      0.000020  0.002468  0.000494
..:1202 MsgDeviceMonitor.from_binary  10     0.000225  0.002372  0.000237
..n2.7/threading.py:726 Thread.start  3      0.000142  0.002327  0.000776
../serial_link.py:51 base_cl_options  1      0.000028  0.002319  0.002319
/usr/lib/python2.7/glob.py:18 glob    3      0.000026  0.002265  0.000755
/usr/lib/python2.7/glob.py:29 iglob   36     0.000055  0.002239  0.000062
/usr/lib/python2.7/glob.py:66 glob1   3      0.000028  0.002074  0.000691
..ols/list_ports_linux.py:115 hwinfo  33     0.000220  0.001991  0.000060
..b/python2.7/sre_parse.py:675 parse  11     0.000079  0.001913  0.000174
..python2.7/genericpath.py:15 exists  186    0.000376  0.001766  0.000009
..hon2.7/sre_parse.py:301 _parse_sub  17/11  0.000092  0.001710  0.000101
..iver.py:43 PySerialDriver.__init__  1      0.000114  0.001619  0.001619
../python2.7/sre_parse.py:379 _parse  18/12  0.000599  0.001607  0.000089
..tools/list_ports_linux.py:26 popen  1      0.000022  0.001548  0.001548
..2.7/subprocess.py:544 check_output  1      0.000043  0.001516  0.001516
..python2.7/sre_compile.py:478 _code  11     0.000046  0.001506  0.000137
..se.py:1545 ArgumentParser.__init__  1      0.000027  0.001464  0.001464
..lib/python2.7/fnmatch.py:45 filter  3      0.000272  0.001450  0.000483
..y:1252 ArgumentParser.add_argument  19     0.000183  0.001368  0.000072
/usr/lib/python2.7/re.py:188 compile  44     0.000042  0.001366  0.000031
..ython2.7/posixpath.py:379 realpath  4      0.000014  0.001217  0.000304
..7/subprocess.py:650 Popen.__init__  1      0.000041  0.001175  0.001175
..2.7/posixpath.py:387 _joinrealpath  12/4   0.000254  0.001119  0.000093
..ocess.py:1187 Popen._execute_child  1      0.000241  0.001052  0.001052
..rial/__init__.py:32 serial_for_url  1      0.000030  0.001003  0.001003
..ial/serialposix.py:279 Serial.open  1      0.000136  0.000917  0.000917
..7/threading.py:656 Thread.__init__  3      0.000183  0.000906  0.000302
..on2.7/threading.py:602 _Event.wait  3      0.000083  0.000895  0.000298
..forwarder.py:32 Forwarder.__init__  2      0.000330  0.000870  0.000435
..thon2.7/threading.py:241 Condition  12     0.000166  0.000850  0.000071
..six.py:311 Serial._reconfigurePort  4      0.000388  0.000845  0.000211
..thon2.7/sre_compile.py:32 _compile  41/11  0.000428  0.000843  0.000021
..ent/handler.py:90 Handler.__iter__  2      0.000044  0.000822  0.000411
..lient/handler.py:69 Handler.filter  2      0.000141  0.000778  0.000389
../python2.7/argparse.py:62 <module>  1      0.000520  0.000704  0.000704
..nt/handler.py:57 Handler.__enter__  1      0.000022  0.000700  0.000700
..reading.py:259 _Condition.__init__  12     0.000587  0.000684  0.000057
..lient/handler.py:179 Handler.start  1      0.000012  0.000678  0.000678
..7/sre_compile.py:359 _compile_info  11     0.000284  0.000614  0.000056
..nt/handler.py:195 Handler.is_alive  30     0.000206  0.000589  0.000020
..b/python2.7/gettext.py:580 gettext  3      0.000005  0.000587  0.000196
../python2.7/gettext.py:542 dgettext  3      0.000011  0.000582  0.000194
..thon2.7/gettext.py:476 translation  3      0.000009  0.000569  0.000190
...py:253 _SBPQueueIterator.__init__  2      0.000041  0.000561  0.000281
../lib/python2.7/gettext.py:421 find  3      0.000083  0.000561  0.000187
..se.py:1171 ArgumentParser.__init__  3      0.000039  0.000557  0.000186
..thon2.7/Queue.py:26 Queue.__init__  2      0.000076  0.000520  0.000260
..lient/framer.py:33 Framer.__init__  1      0.000067  0.000518  0.000518
..ent/handler.py:34 Handler.__init__  1      0.000106  0.000510  0.000510
..2.7/sre_parse.py:201 Tokenizer.get  167    0.000178  0.000499  0.000003
..2315 ArgumentParser._get_formatter  19     0.000038  0.000487  0.000026
..arse.py:154 HelpFormatter.__init__  19     0.000131  0.000450  0.000024
/usr/lib/python2.7/uuid.py:546 uuid4  1      0.000156  0.000436  0.000436
...py:1689 ArgumentParser.parse_args  1      0.000003  0.000424  0.000424
..96 ArgumentParser.parse_known_args  1      0.000034  0.000421  0.000421
../python2.7/posixpath.py:139 islink  80     0.000114  0.000418  0.000005
..lib/python2.7/posixpath.py:68 join  139    0.000269  0.000398  0.000003
...7/threading.py:995 Thread.isAlive  30     0.000297  0.000383  0.000013
../sre_parse.py:182 Tokenizer.__next  188    0.000276  0.000368  0.000002
..1 ArgumentParser._parse_known_args  1      0.000070  0.000358  0.000358
..ent/handler.py:61 Handler.__exit__  1      0.000008  0.000336  0.000336
..client/handler.py:185 Handler.stop  1      0.000032  0.000328  0.000328
..thon2.7/dist-packages/six.py:642 b  299    0.000324  0.000324  0.000001
..b/python2.7/threading.py:541 Event  3      0.000024  0.000313  0.000104
..rialutil.py:333 Serial.setBaudrate  2      0.000027  0.000308  0.000154
..on2.7/threading.py:911 Thread.join  1      0.000055  0.000293  0.000293
..7/threading.py:560 _Event.__init__  3      0.000056  0.000289  0.000096
..ubprocess.py:768 Popen.communicate  1      0.000046  0.000289  0.000289
..arse.py:130 SubPattern.__getitem__  159    0.000199  0.000284  0.000002
..al/serialposix.py:433 Serial.close  1      0.000022  0.000261  0.000261
..ubprocess.py:473 _eintr_retry_call  3      0.000022  0.000258  0.000086
..s/list_ports_linux.py:42 read_line  6      0.000036  0.000250  0.000042
..e_parse.py:140 SubPattern.getwidth  63/33  0.000202  0.000243  0.000004
../argparse.py:1799 consume_optional  2      0.000014  0.000236  0.000118
..ts_linux.py:65 usb_sysfs_hw_string  1      0.000010  0.000227  0.000227
..py:1669 ArgumentParser._add_action  19     0.000020  0.000201  0.000011
../lib/python2.7/glob.py:77 <lambda>  606    0.000185  0.000185  0.000000
.._init__.py:52 create_string_buffer  1      0.000174  0.000182  0.000182
..py:1497 _ArgumentGroup._add_action  19     0.000034  0.000181  0.000010
..009 ArgumentParser._match_argument  2      0.000011  0.000172  0.000086
..hon2.7/gettext.py:130 _expand_lang  6      0.000064  0.000166  0.000028
..hreading.py:709 Thread._set_daemon  3      0.000058  0.000164  0.000055
..rgumentParser._get_optional_kwargs  19     0.000113  0.000163  0.000009
/usr/lib/python2.7/re.py:134 match    2      0.000004  0.000151  0.000075
..ib/python2.7/posixpath.py:89 split  39     0.000098  0.000143  0.000004
..py:1309 _ArgumentGroup._add_action  19     0.000066  0.000142  0.000007
..erialutil.py:393 Serial.setTimeout  2      0.000021  0.000135  0.000067
..py:263 _SBPQueueIterator.breakiter  2      0.000025  0.000130  0.000065
..sre_parse.py:138 SubPattern.append  114    0.000090  0.000127  0.000001
..handler.py:97 Handler.add_callback  4      0.000088  0.000120  0.000030
...py:573 HelpFormatter._format_args  19     0.000060  0.000116  0.000006
..re_compile.py:178 _compile_charset  13     0.000058  0.000106  0.000008
..ython2.7/posixpath.py:119 basename  69     0.000066  0.000099  0.000001
..re_parse.py:126 SubPattern.__len__  96     0.000073  0.000099  0.000001
..ython2.7/uuid.py:101 UUID.__init__  1      0.000075  0.000099  0.000099
..n2.7/threading.py:569 _Event.isSet  37     0.000098  0.000098  0.000003
..thon2.7/sre_compile.py:354 _simple  22     0.000053  0.000096  0.000004
..n2.7/argparse.py:147 HelpFormatter  1      0.000088  0.000089  0.000089
..r/lib/python2.7/stat.py:55 S_ISLNK  80     0.000059  0.000087  0.000001
../python2.7/locale.py:363 normalize  6      0.000031  0.000086  0.000014
..python2.7/posixpath.py:365 abspath  4      0.000010  0.000085  0.000021
..hreading.py:58 _Condition.__init__  6      0.000083  0.000083  0.000014
.. ArgumentParser.add_argument_group  2      0.000008  0.000080  0.000040
../threading.py:866 Forwarder.__stop  2      0.000033  0.000072  0.000036
..se.py:1475 _ArgumentGroup.__init__  2      0.000012  0.000072  0.000036
..ython2.7/posixpath.py:336 normpath  4      0.000041  0.000070  0.000018
..reading.py:1008 _MainThread.daemon  3      0.000065  0.000065  0.000022
../python2.7/fnmatch.py:81 translate  3      0.000023  0.000064  0.000021
..4 ArgumentParser._pop_action_class  19     0.000029  0.000060  0.000003
..serialutil.py:441 Serial.setRtsCts  2      0.000006  0.000057  0.000029
..n2.7/subprocess.py:1371 Popen.wait  1      0.000028  0.000056  0.000056
..python2.7/argparse.py:95 _callable  44     0.000035  0.000055  0.000001
..:1227 ArgumentParser._registry_get  44     0.000041  0.000055  0.000001
..process.py:1161 Popen.pipe_cloexec  2      0.000009  0.000054  0.000027
..re_parse.py:178 Tokenizer.__init__  11     0.000020  0.000054  0.000005
..process.py:1099 Popen._get_handles  1      0.000009  0.000053  0.000053
../serialutil.py:234 Serial.__init__  1      0.000039  0.000052  0.000052
..7/sre_parse.py:195 Tokenizer.match  73     0.000038  0.000051  0.000001
..on2.7/argparse.py:1778 take_action  2      0.000015  0.000050  0.000025
...7/threading.py:1152 currentThread  4      0.000042  0.000050  0.000013
..eading.py:399 _Condition.notifyAll  3      0.000014  0.000049  0.000016
..serDict.py:18 _Environ.__getitem__  22     0.000027  0.000047  0.000002
..b/python2.7/gettext.py:11 <module>  1      0.000027  0.000042  0.000042
..python2.7/sre_parse.py:257 _escape  20     0.000028  0.000042  0.000002
..se.py:1223 ArgumentParser.register  34     0.000031  0.000040  0.000001
/usr/lib/python2.7/re.py:204 escape   16     0.000035  0.000040  0.000003
...7/locale.py:347 _replace_encoding  3      0.000015  0.000038  0.000013
...7/threading.py:58 Thread.__init__  12     0.000038  0.000038  0.000003
..e_compile.py:207 _optimize_charset  13     0.000037  0.000037  0.000003
..e.py:865 _StoreTrueAction.__init__  8      0.000014  0.000034  0.000004
...7/threading.py:1024 Thread.daemon  3      0.000028  0.000034  0.000011
..b/python2.7/argparse.py:566 format  19     0.000020  0.000034  0.000002
..hon2.7/sre_compile.py:472 isstring  22     0.000026  0.000033  0.000001
..2.7/threading.py:866 Thread.__stop  1      0.000011  0.000033  0.000033
...py:2241 ArgumentParser._get_value  6      0.000014  0.000030  0.000005
..hon2.7/UserDict.py:58 _Environ.get  12     0.000020  0.000030  0.000003
..py:2189 ArgumentParser._get_values  2      0.000014  0.000030  0.000015
..python2.7/Queue.py:197 Queue._init  2      0.000030  0.000030  0.000015
..rialposix.py:526 Serial.flushInput  1      0.000014  0.000030  0.000030
..ss.py:1148 Popen._set_cloexec_flag  4      0.000013  0.000030  0.000007
/usr/lib/python2.7/stat.py:24 S_IFMT  80     0.000029  0.000029  0.000000
..parse.py:807 _StoreAction.__init__  10     0.000017  0.000028  0.000003
..erial_link.py:344 signal_handler_c  1      0.000028  0.000028  0.000028
..re_parse.py:90 SubPattern.__init__  41     0.000026  0.000026  0.000001
..ib/python2.7/posixpath.py:59 isabs  16     0.000015  0.000024  0.000001
..on2.7/threading.py:63 Thread._note  9      0.000024  0.000024  0.000003
..gparse.py:765 _HelpAction.__init__  19     0.000023  0.000023  0.000001
..lib/python2.7/glob.py:94 has_magic  9      0.000011  0.000023  0.000003
..ubprocess.py:1208 _close_in_parent  1      0.000015  0.000021  0.000021
..e.py:842 _StoreTrueAction.__init__  8      0.000011  0.000021  0.000003
../__init__.py:49 normalize_encoding  3      0.000011  0.000018  0.000006
..437 _ArgumentGroup._check_conflict  19     0.000016  0.000016  0.000001
../argparse.py:199 _Section.__init__  19     0.000016  0.000016  0.000001
..python2.7/uuid.py:197 UUID.__str__  1      0.000015  0.000015  0.000015
..ools/serial_link.py:42 logfilename  1      0.000002  0.000014  0.000014
..7 HelpFormatter._metavar_formatter  19     0.000014  0.000014  0.000001
..python2.7/posixpath.py:127 dirname  4      0.000009  0.000013  0.000003
../python2.7/Queue.py:93 Queue.empty  1      0.000008  0.000013  0.000013
..arse.py:134 SubPattern.__setitem__  22     0.000012  0.000012  0.000001
..gparse.py:983 _HelpAction.__init__  1      0.000008  0.000011  0.000011
..n2.7/argparse.py:685 ArgumentError  1      0.000011  0.000011  0.000011
..sre_parse.py:83 Pattern.closegroup  6      0.000008  0.000011  0.000002
../sre_parse.py:72 Pattern.opengroup  6      0.000008  0.000011  0.000002
..gparse.py:1876 consume_positionals  1      0.000006  0.000010  0.000010
..argparse.py:1025 _SubParsersAction  1      0.000010  0.000010  0.000010
..7/sre_parse.py:67 Pattern.__init__  11     0.000010  0.000010  0.000001
.._.py:23 VendorImporter.find_module  2      0.000008  0.000010  0.000005
..on2.7/subprocess.py:802 Popen.poll  1      0.000008  0.000009  0.000009
..erDict.py:70 _Environ.__contains__  12     0.000008  0.000008  0.000001
.. ArgumentParser._get_nargs_pattern  2      0.000005  0.000008  0.000004
..s.py:1330 Popen._handle_exitstatus  1      0.000005  0.000008  0.000008
..y:1428 ArgumentParser._get_handler  3      0.000005  0.000008  0.000003
...7/argparse.py:1527 ArgumentParser  1      0.000006  0.000006  0.000006
..iver.py:23 PySerialDriver.__init__  1      0.000006  0.000006  0.000006
..l/serialutil.py:307 Serial.setPort  2      0.000005  0.000005  0.000003
..lient/framer.py:41 Framer.__iter__  1      0.000005  0.000005  0.000005
...7/subprocess.py:754 Popen.__del__  1      0.000004  0.000005  0.000005
..ools/serial_link.py:151 get_logger  1      0.000005  0.000005  0.000005
...7/gettext.py:173 NullTranslations  1      0.000004  0.000004  0.000004
..l_logger.py:35 NullLogger.__exit__  2      0.000004  0.000004  0.000002
..argparse.py:1169 _ActionsContainer  1      0.000003  0.000003  0.000003
..044 ArgumentParser._parse_optional  4      0.000003  0.000003  0.000001
..parse.py:836 _StoreAction.__call__  2      0.000002  0.000003  0.000002
.._logger.py:20 NullLogger.__enter__  2      0.000003  0.000003  0.000002
..ient/framer.py:45 Framer.breakiter  1      0.000003  0.000003  0.000003
..entParser._match_arguments_partial  1      0.000002  0.000003  0.000003
..arse.py:128 SubPattern.__delitem__  4      0.000003  0.000003  0.000001
..thon2.7/subprocess.py:458 _cleanup  1      0.000002  0.000002  0.000002
..4 _SixMetaPathImporter.find_module  2      0.000002  0.000002  0.000001
..mentParser._get_positional_actions  1      0.000002  0.000002  0.000002
..rialutil.py:354 Serial.setByteSize  1      0.000002  0.000002  0.000002
..on2.7/argparse.py:805 _StoreAction  1      0.000002  0.000002  0.000002
..rial_link.py:171 get_append_logger  1      0.000002  0.000002  0.000002
..ocess.py:1344 Popen._internal_poll  2      0.000002  0.000002  0.000001
..ython2.7/argparse.py:1591 identity  6      0.000002  0.000002  0.000000
..serialutil.py:367 Serial.setParity  1      0.000002  0.000002  0.000002
..rialutil.py:380 Serial.setStopbits  1      0.000002  0.000002  0.000002
..4 _SixMetaPathImporter.find_module  2      0.000002  0.000002  0.000001
..y:2266 ArgumentParser._check_value  2      0.000001  0.000001  0.000001
..2.7/gettext.py:257 GNUTranslations  1      0.000001  0.000001  0.000001
..b/python2.7/argparse.py:714 Action  1      0.000001  0.000001  0.000001
..python2.7/posixpath.py:51 normcase  3      0.000001  0.000001  0.000000
..4 _SixMetaPathImporter.find_module  2      0.000001  0.000001  0.000001
../argparse.py:705 ArgumentTypeError  1      0.000001  0.000001  0.000001
..4 _SixMetaPathImporter.find_module  2      0.000001  0.000001  0.000001
..thon2.7/argparse.py:1146 Namespace  1      0.000001  0.000001  0.000001
..7/argparse.py:112 _AttributeHolder  1      0.000001  0.000001  0.000001
..rgparse.py:1153 Namespace.__init__  1      0.000001  0.000001  0.000001
..util.py:411 Serial.setWriteTimeout  1      0.000001  0.000001  0.000001
..ython2.7/argparse.py:1102 FileType  1      0.000001  0.000001  0.000001
..argparse.py:934 _AppendConstAction  1      0.000001  0.000001  0.000001
..se.py:1507 _MutuallyExclusiveGroup  1      0.000001  0.000001  0.000001
...7/argparse.py:1473 _ArgumentGroup  1      0.000001  0.000001  0.000001
..py:629 RawDescriptionHelpFormatter  1      0.000001  0.000001  0.000001
../argparse.py:840 _StoreConstAction  1      0.000001  0.000001  0.000001
..python2.7/argparse.py:197 _Section  1      0.000001  0.000001  0.000001
..n2.7/argparse.py:897 _AppendAction  1      0.000001  0.000001  0.000001
..on2.7/argparse.py:960 _CountAction  1      0.000001  0.000001  0.000001
..hon2.7/argparse.py:981 _HelpAction  1      0.000001  0.000001  0.000001
../argparse.py:880 _StoreFalseAction  1      0.000001  0.000001  0.000001
..7/argparse.py:863 _StoreTrueAction  1      0.000001  0.000001  0.000001
..serialutil.py:452 Serial.setDsrDtr  1      0.000001  0.000001  0.000001
...7/argparse.py:1000 _VersionAction  1      0.000001  0.000001  0.000001
..:651 ArgumentDefaultsHelpFormatter  1      0.000001  0.000001  0.000001
..gparse.py:640 RawTextHelpFormatter  1      0.000001  0.000001  0.000001
..erialutil.py:430 Serial.setXonXoff  1      0.000001  0.000001  0.000001
..parse.py:1027 _ChoicesPseudoAction  1      0.000001  0.000001  0.000001
...py:468 Serial.setInterCharTimeout  1      0.000001  0.000001  0.000001

name           id     tid              ttot      scnt        
Forwarder      3      140154975020800  0.421855  7402      
Forwarder      2      140154983413504  0.421485  6978      
Thread         1      140155059455744  0.420860  11168     
_MainThread    0      140155139008320  0.107140  35
```