### PR TITLE
python: handle bad exception from pyserial on EINTR.

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -76,7 +76,9 @@ class PySerialDriver(BaseDriver):
     """
     try:
       return self.handle.read(size)
-    except (OSError, serial.SerialException):
+    except (OSError, serial.SerialException) as e:
+      if e.message.find('Interrupted system call') >= 0:
+        return ''
       print
       print "Piksi disconnected"
       print


### PR DESCRIPTION
The port is still perfectly usable after an interrupted system call.  This should be handled internally in pyserial, but here's a workaround.