### PR TITLE
python: pin pyftdi version to 0.13.4

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 construct==2.8.12
 futures>=2.2.0
 httpretty
-pyftdi
+pyftdi==0.13.4
 pylibftdi
 pyserial
 requests>=2.8.1


### PR DESCRIPTION
This is the last version of pyftdi which supports python 2.