### PR TITLE
Add a flag that is high when antenna is shorted, according to MAX4829 IC

### DIFF
--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -105,7 +105,12 @@ definitions:
                   values:
                       - 0: No external antenna detected
                       - 1: External antenna is present
-              - 24-30:
+              - 30:
+                  desc: External antenna short
+                  values:
+                      - 0: External antenna is shorted
+                      - 1: External antenna not shorted
+              - 24-29:
                   desc: Reserved
               - 16-23:
                   desc: SBP major protocol version number

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -108,8 +108,8 @@ definitions:
               - 30:
                   desc: External antenna short
                   values:
-                      - 0: External antenna is shorted
-                      - 1: External antenna not shorted
+                      - 0: External antenna not shorted
+                      - 1: External antenna is shorted
               - 24-29:
                   desc: Reserved
               - 16-23:

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -108,8 +108,8 @@ definitions:
               - 30:
                   desc: External antenna short
                   values:
-                      - 0: External antenna not shorted
-                      - 1: External antenna is shorted
+                      - 0: No short detected
+                      - 1: Short detected
               - 24-29:
                   desc: Reserved
               - 16-23:


### PR DESCRIPTION
# Design Notes

Documents heartbeat message changes introduced in swift-nav/piksi_firmware_private#1497, when fixing swift-nav/firmware_team_planning#394.