### PR TITLE
[WIP] Add NetworkUsage struct and MSG_NETWORK_BANDWIDTH_USAGE

### DIFF
--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -34,7 +34,7 @@
  * This is a legacy message for sending and loading a satellite
  * alamanac onto the Piksi's flash memory from the host.
  */
-#define SBP_MSG_ALMANAC            0x0069
+#define SBP_MSG_ALMANAC                 0x0069
 
 
 /** Send GPS time from host (host => Piksi)
@@ -42,7 +42,7 @@
  * This message sets up timing functionality using a coarse GPS
  * time estimate sent by the host.
  */
-#define SBP_MSG_SET_TIME           0x0068
+#define SBP_MSG_SET_TIME                0x0068
 
 
 /** Reset the device (host => Piksi)
@@ -50,7 +50,7 @@
  * This message from the host resets the Piksi back into the
  * bootloader.
  */
-#define SBP_MSG_RESET              0x00B6
+#define SBP_MSG_RESET                   0x00B6
 typedef struct __attribute__((packed)) {
   u32 flags;    /**< Reset flags */
 } msg_reset_t;
@@ -61,7 +61,7 @@ typedef struct __attribute__((packed)) {
  * This message from the host resets the Piksi back into the
  * bootloader.
  */
-#define SBP_MSG_RESET_DEP          0x00B2
+#define SBP_MSG_RESET_DEP               0x00B2
 
 
 /** Legacy message for CW interference channel (Piksi => host)
@@ -70,7 +70,7 @@ typedef struct __attribute__((packed)) {
  * CW interference channel on the SwiftNAP. This message will be
  * removed in a future release.
  */
-#define SBP_MSG_CW_RESULTS         0x00C0
+#define SBP_MSG_CW_RESULTS              0x00C0
 
 
 /** Legacy message for CW interference channel (host => Piksi)
@@ -79,7 +79,7 @@ typedef struct __attribute__((packed)) {
  * the CW interference channel on the SwiftNAP. This message will
  * be removed in a future release.
  */
-#define SBP_MSG_CW_START           0x00C1
+#define SBP_MSG_CW_START                0x00C1
 
 
 /** Reset IAR filters (host => Piksi)
@@ -87,7 +87,7 @@ typedef struct __attribute__((packed)) {
  * This message resets either the DGNSS Kalman filters or Integer
  * Ambiguity Resolution (IAR) process.
  */
-#define SBP_MSG_RESET_FILTERS      0x0022
+#define SBP_MSG_RESET_FILTERS           0x0022
 typedef struct __attribute__((packed)) {
   u8 filter;    /**< Filter flags */
 } msg_reset_filters_t;
@@ -101,7 +101,7 @@ typedef struct __attribute__((packed)) {
  * there aren't a shared minimum number (4) of satellite
  * observations between the two.
  */
-#define SBP_MSG_INIT_BASE          0x0023
+#define SBP_MSG_INIT_BASE               0x0023
 
 
 /** State of an RTOS thread
@@ -110,7 +110,7 @@ typedef struct __attribute__((packed)) {
  * operating system (RTOS) thread usage statistics for the named
  * thread. The reported percentage values must be normalized.
  */
-#define SBP_MSG_THREAD_STATE       0x0017
+#define SBP_MSG_THREAD_STATE            0x0017
 typedef struct __attribute__((packed)) {
   char name[20];      /**< Thread name (NULL terminated) */
   u16 cpu;           /**< Percentage cpu use for this thread. Values range from 0
@@ -185,7 +185,7 @@ typedef struct __attribute__((packed)) {
  * the timeliness of received base observations while the
  * period indicates their likelihood of transmission.
  */
-#define SBP_MSG_UART_STATE         0x001D
+#define SBP_MSG_UART_STATE              0x001D
 typedef struct __attribute__((packed)) {
   uart_channel_t uart_a;        /**< State of UART A */
   uart_channel_t uart_b;        /**< State of UART B */
@@ -199,7 +199,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated
  */
-#define SBP_MSG_UART_STATE_DEPA    0x0018
+#define SBP_MSG_UART_STATE_DEPA         0x0018
 typedef struct __attribute__((packed)) {
   uart_channel_t uart_a;       /**< State of UART A */
   uart_channel_t uart_b;       /**< State of UART B */
@@ -215,7 +215,7 @@ typedef struct __attribute__((packed)) {
  * ambiguities from double-differenced carrier-phase measurements
  * from satellite observations.
  */
-#define SBP_MSG_IAR_STATE          0x0019
+#define SBP_MSG_IAR_STATE               0x0019
 typedef struct __attribute__((packed)) {
   u32 num_hyps;    /**< Number of integer ambiguity hypotheses remaining */
 } msg_iar_state_t;
@@ -226,7 +226,7 @@ typedef struct __attribute__((packed)) {
  * This message allows setting a mask to prevent a particular satellite
  * from being used in various Piksi subsystems.
  */
-#define SBP_MSG_MASK_SATELLITE     0x002B
+#define SBP_MSG_MASK_SATELLITE          0x002B
 typedef struct __attribute__((packed)) {
   u8 mask;    /**< Mask of systems that should ignore this satellite. */
   sbp_gnss_signal_t sid;     /**< GNSS signal for which the mask is applied */
@@ -237,7 +237,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated.
  */
-#define SBP_MSG_MASK_SATELLITE_DEP 0x001B
+#define SBP_MSG_MASK_SATELLITE_DEP      0x001B
 typedef struct __attribute__((packed)) {
   u8 mask;    /**< Mask of systems that should ignore this satellite. */
   gnss_signal_dep_t sid;     /**< GNSS signal for which the mask is applied */
@@ -250,7 +250,7 @@ typedef struct __attribute__((packed)) {
  * processor's monitoring system and the RF frontend die temperature if
  * available.
  */
-#define SBP_MSG_DEVICE_MONITOR     0x00B5
+#define SBP_MSG_DEVICE_MONITOR          0x00B5
 typedef struct __attribute__((packed)) {
   s16 dev_vin;            /**< Device V_in [V / 1000] */
   s16 cpu_vint;           /**< Processor V_int [V / 1000] */
@@ -266,7 +266,7 @@ typedef struct __attribute__((packed)) {
  * Output will be sent in MSG_LOG messages, and the exit
  * code will be returned with MSG_COMMAND_RESP.
  */
-#define SBP_MSG_COMMAND_REQ        0x00B8
+#define SBP_MSG_COMMAND_REQ             0x00B8
 typedef struct __attribute__((packed)) {
   u32 sequence;    /**< Sequence number */
   char command[0];  /**< Command line to execute */
@@ -278,7 +278,7 @@ typedef struct __attribute__((packed)) {
  * The response to MSG_COMMAND_REQ with the return code of
  * the command.  A return code of zero indicates success.
  */
-#define SBP_MSG_COMMAND_RESP       0x00B9
+#define SBP_MSG_COMMAND_RESP            0x00B9
 typedef struct __attribute__((packed)) {
   u32 sequence;    /**< Sequence number */
   s32 code;        /**< Exit code */
@@ -292,7 +292,7 @@ typedef struct __attribute__((packed)) {
  * The sequence number can be used to filter for filtering
  * the correct command.
  */
-#define SBP_MSG_COMMAND_OUTPUT     0x00BC
+#define SBP_MSG_COMMAND_OUTPUT          0x00BC
 typedef struct __attribute__((packed)) {
   u32 sequence;    /**< Sequence number */
   char line[0];     /**< Line of standard output or standard error */
@@ -304,7 +304,7 @@ typedef struct __attribute__((packed)) {
  * Request state of Piksi network interfaces.
  * Output will be sent in MSG_NETWORK_STATE_RESP messages
  */
-#define SBP_MSG_NETWORK_STATE_REQ  0x00BA
+#define SBP_MSG_NETWORK_STATE_REQ       0x00BA
 
 
 /** State of network interface
@@ -313,7 +313,7 @@ typedef struct __attribute__((packed)) {
  * Data is made to reflect output of ifaddrs struct returned by getifaddrs
  * in c.
  */
-#define SBP_MSG_NETWORK_STATE_RESP 0x00BB
+#define SBP_MSG_NETWORK_STATE_RESP      0x00BB
 typedef struct __attribute__((packed)) {
   u8 ipv4_address[4];   /**< IPv4 address (all zero when unavailable) */
   u8 ipv4_mask_size;    /**< IPv4 netmask CIDR notation */
@@ -326,11 +326,39 @@ typedef struct __attribute__((packed)) {
 } msg_network_state_resp_t;
 
 
+/** Bandwidth usage measurement for a single interface.
+ *
+ * The bandwidth usage for each interface can be reported
+ * within this struct and utilize multiple fields to fully
+ * specify the type of traffic that is being tracked. As
+ * either the interval of collection or the collection time
+ * may vary, both a timestamp and period field is provided,
+ * though may not necessarily be populated with a value. 
+ */
+typedef struct __attribute__((packed)) {
+  u64 duration;          /**< Duration over which the measurement was collected [ms] */
+  u64 total_bytes;       /**< Number of bytes handled in total within period */
+  u32 rx_bytes;          /**< Number of bytes transmitted within period */
+  u32 tx_bytes;          /**< Number of bytes received within period */
+  char interface_name[16]; /**< Interface Name */
+} network_usage_t;
+
+
+/** Bandwidth usage reporting message
+ *
+ * The bandwidth usage, a list of usage by interface. 
+ */
+#define SBP_MSG_NETWORK_BANDWIDTH_USAGE 0x00BD
+typedef struct __attribute__((packed)) {
+  network_usage_t interfaces[0]; /**< Usage measurement array */
+} msg_network_bandwidth_usage_t;
+
+
 /** Deprecated
  *
 * Deprecated.
  */
-#define SBP_MSG_SPECAN_DEP         0x0050
+#define SBP_MSG_SPECAN_DEP              0x0050
 typedef struct __attribute__((packed)) {
   u16 channel_tag;        /**< Channel ID */
   gps_time_dep_t t;                  /**< Receiver time of this observation */
@@ -351,7 +379,7 @@ typedef struct __attribute__((packed)) {
  *
  * Spectrum analyzer packet.
  */
-#define SBP_MSG_SPECAN             0x0051
+#define SBP_MSG_SPECAN                  0x0051
 typedef struct __attribute__((packed)) {
   u16 channel_tag;        /**< Channel ID */
   sbp_gps_time_t t;                  /**< Receiver time of this observation */

--- a/haskell/src/SwiftNav/SBP/Msg.hs
+++ b/haskell/src/SwiftNav/SBP/Msg.hs
@@ -134,6 +134,7 @@ data SBPMsg =
    | SBPMsgNapDeviceDnaReq MsgNapDeviceDnaReq Msg
    | SBPMsgNapDeviceDnaResp MsgNapDeviceDnaResp Msg
    | SBPMsgNdbEvent MsgNdbEvent Msg
+   | SBPMsgNetworkBandwidthUsage MsgNetworkBandwidthUsage Msg
    | SBPMsgNetworkStateReq MsgNetworkStateReq Msg
    | SBPMsgNetworkStateResp MsgNetworkStateResp Msg
    | SBPMsgObs MsgObs Msg
@@ -289,6 +290,7 @@ instance Binary SBPMsg where
           | _msgSBPType == msgNapDeviceDnaReq = SBPMsgNapDeviceDnaReq (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgNapDeviceDnaResp = SBPMsgNapDeviceDnaResp (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgNdbEvent = SBPMsgNdbEvent (decode (fromStrict (unBytes _msgSBPPayload))) m
+          | _msgSBPType == msgNetworkBandwidthUsage = SBPMsgNetworkBandwidthUsage (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgNetworkStateReq = SBPMsgNetworkStateReq (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgNetworkStateResp = SBPMsgNetworkStateResp (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgObs = SBPMsgObs (decode (fromStrict (unBytes _msgSBPPayload))) m
@@ -436,6 +438,7 @@ instance Binary SBPMsg where
       encoder (SBPMsgNapDeviceDnaReq _ m) = put m
       encoder (SBPMsgNapDeviceDnaResp _ m) = put m
       encoder (SBPMsgNdbEvent _ m) = put m
+      encoder (SBPMsgNetworkBandwidthUsage _ m) = put m
       encoder (SBPMsgNetworkStateReq _ m) = put m
       encoder (SBPMsgNetworkStateResp _ m) = put m
       encoder (SBPMsgObs _ m) = put m
@@ -587,6 +590,7 @@ instance FromJSON SBPMsg where
         | msgType == msgNapDeviceDnaReq = SBPMsgNapDeviceDnaReq <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgNapDeviceDnaResp = SBPMsgNapDeviceDnaResp <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgNdbEvent = SBPMsgNdbEvent <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
+        | msgType == msgNetworkBandwidthUsage = SBPMsgNetworkBandwidthUsage <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgNetworkStateReq = SBPMsgNetworkStateReq <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgNetworkStateResp = SBPMsgNetworkStateResp <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgObs = SBPMsgObs <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
@@ -739,6 +743,7 @@ instance ToJSON SBPMsg where
   toJSON (SBPMsgNapDeviceDnaReq n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgNapDeviceDnaResp n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgNdbEvent n m) = toJSON n <<>> toJSON m
+  toJSON (SBPMsgNetworkBandwidthUsage n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgNetworkStateReq n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgNetworkStateResp n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgObs n m) = toJSON n <<>> toJSON m
@@ -885,6 +890,7 @@ instance HasMsg SBPMsg where
   msg f (SBPMsgNapDeviceDnaReq n m) = SBPMsgNapDeviceDnaReq n <$> f m
   msg f (SBPMsgNapDeviceDnaResp n m) = SBPMsgNapDeviceDnaResp n <$> f m
   msg f (SBPMsgNdbEvent n m) = SBPMsgNdbEvent n <$> f m
+  msg f (SBPMsgNetworkBandwidthUsage n m) = SBPMsgNetworkBandwidthUsage n <$> f m
   msg f (SBPMsgNetworkStateReq n m) = SBPMsgNetworkStateReq n <$> f m
   msg f (SBPMsgNetworkStateResp n m) = SBPMsgNetworkStateResp n <$> f m
   msg f (SBPMsgObs n m) = SBPMsgObs n <$> f m

--- a/java/src/com/swiftnav/sbp/client/MessageTable.java
+++ b/java/src/com/swiftnav/sbp/client/MessageTable.java
@@ -15,6 +15,33 @@ import com.swiftnav.sbp.SBPBinaryException;
 import com.swiftnav.sbp.SBPMessage;
 import com.swiftnav.sbp.SBPMessage.Builder;
 import com.swiftnav.sbp.SBPMessage.Parser;
+import com.swiftnav.sbp.sbas.MsgSbasRaw;
+import com.swiftnav.sbp.file_io.MsgFileioReadReq;
+import com.swiftnav.sbp.file_io.MsgFileioReadResp;
+import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
+import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
+import com.swiftnav.sbp.file_io.MsgFileioRemove;
+import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
+import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
+import com.swiftnav.sbp.settings.MsgSettingsSave;
+import com.swiftnav.sbp.settings.MsgSettingsWrite;
+import com.swiftnav.sbp.settings.MsgSettingsWriteResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
+import com.swiftnav.sbp.settings.MsgSettingsRegister;
+import com.swiftnav.sbp.flash.MsgFlashProgram;
+import com.swiftnav.sbp.flash.MsgFlashDone;
+import com.swiftnav.sbp.flash.MsgFlashReadReq;
+import com.swiftnav.sbp.flash.MsgFlashReadResp;
+import com.swiftnav.sbp.flash.MsgFlashErase;
+import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
+import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
+import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
 import com.swiftnav.sbp.tracking.MsgTrackingStateDetailedDepA;
 import com.swiftnav.sbp.tracking.MsgTrackingStateDetailedDep;
 import com.swiftnav.sbp.tracking.MsgTrackingState;
@@ -22,7 +49,45 @@ import com.swiftnav.sbp.tracking.MsgTrackingIq;
 import com.swiftnav.sbp.tracking.MsgTrackingIqDep;
 import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
 import com.swiftnav.sbp.tracking.MsgTrackingStateDepB;
+import com.swiftnav.sbp.logging.MsgLog;
+import com.swiftnav.sbp.logging.MsgFwd;
+import com.swiftnav.sbp.logging.MsgTweet;
+import com.swiftnav.sbp.logging.MsgPrintDep;
+import com.swiftnav.sbp.mag.MsgMagRaw;
+import com.swiftnav.sbp.vehicle.MsgOdometry;
+import com.swiftnav.sbp.orientation.MsgBaselineHeading;
+import com.swiftnav.sbp.orientation.MsgOrientQuat;
+import com.swiftnav.sbp.orientation.MsgOrientEuler;
+import com.swiftnav.sbp.orientation.MsgAngularRate;
+import com.swiftnav.sbp.imu.MsgImuRaw;
+import com.swiftnav.sbp.imu.MsgImuAux;
 import com.swiftnav.sbp.ext_events.MsgExtEvent;
+import com.swiftnav.sbp.piksi.MsgAlmanac;
+import com.swiftnav.sbp.piksi.MsgSetTime;
+import com.swiftnav.sbp.piksi.MsgReset;
+import com.swiftnav.sbp.piksi.MsgResetDep;
+import com.swiftnav.sbp.piksi.MsgCwResults;
+import com.swiftnav.sbp.piksi.MsgCwStart;
+import com.swiftnav.sbp.piksi.MsgResetFilters;
+import com.swiftnav.sbp.piksi.MsgInitBase;
+import com.swiftnav.sbp.piksi.MsgThreadState;
+import com.swiftnav.sbp.piksi.MsgUartState;
+import com.swiftnav.sbp.piksi.MsgUartStateDepa;
+import com.swiftnav.sbp.piksi.MsgIarState;
+import com.swiftnav.sbp.piksi.MsgMaskSatellite;
+import com.swiftnav.sbp.piksi.MsgMaskSatelliteDep;
+import com.swiftnav.sbp.piksi.MsgDeviceMonitor;
+import com.swiftnav.sbp.piksi.MsgCommandReq;
+import com.swiftnav.sbp.piksi.MsgCommandResp;
+import com.swiftnav.sbp.piksi.MsgCommandOutput;
+import com.swiftnav.sbp.piksi.MsgNetworkStateReq;
+import com.swiftnav.sbp.piksi.MsgNetworkStateResp;
+import com.swiftnav.sbp.piksi.MsgNetworkBandwidthUsage;
+import com.swiftnav.sbp.piksi.MsgSpecanDep;
+import com.swiftnav.sbp.piksi.MsgSpecan;
+import com.swiftnav.sbp.ssr.MsgSsrOrbitClock;
+import com.swiftnav.sbp.ssr.MsgSsrCodeBiases;
+import com.swiftnav.sbp.ssr.MsgSsrPhaseBiases;
 import com.swiftnav.sbp.observation.MsgObs;
 import com.swiftnav.sbp.observation.MsgBasePosLLH;
 import com.swiftnav.sbp.observation.MsgBasePosECEF;
@@ -51,87 +116,6 @@ import com.swiftnav.sbp.observation.MsgAlmanacGPS;
 import com.swiftnav.sbp.observation.MsgAlmanacGloDep;
 import com.swiftnav.sbp.observation.MsgAlmanacGlo;
 import com.swiftnav.sbp.observation.MsgGloBiases;
-import com.swiftnav.sbp.ssr.MsgSsrOrbitClock;
-import com.swiftnav.sbp.ssr.MsgSsrCodeBiases;
-import com.swiftnav.sbp.ssr.MsgSsrPhaseBiases;
-import com.swiftnav.sbp.orientation.MsgBaselineHeading;
-import com.swiftnav.sbp.orientation.MsgOrientQuat;
-import com.swiftnav.sbp.orientation.MsgOrientEuler;
-import com.swiftnav.sbp.orientation.MsgAngularRate;
-import com.swiftnav.sbp.ndb.MsgNdbEvent;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
-import com.swiftnav.sbp.sbas.MsgSbasRaw;
-import com.swiftnav.sbp.logging.MsgLog;
-import com.swiftnav.sbp.logging.MsgFwd;
-import com.swiftnav.sbp.logging.MsgTweet;
-import com.swiftnav.sbp.logging.MsgPrintDep;
-import com.swiftnav.sbp.system.MsgStartup;
-import com.swiftnav.sbp.system.MsgDgnssStatus;
-import com.swiftnav.sbp.system.MsgHeartbeat;
-import com.swiftnav.sbp.system.MsgInsStatus;
-import com.swiftnav.sbp.acquisition.MsgAcqResult;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepC;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
-import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
-import com.swiftnav.sbp.acquisition.MsgAcqSvProfileDep;
-import com.swiftnav.sbp.imu.MsgImuRaw;
-import com.swiftnav.sbp.imu.MsgImuAux;
-import com.swiftnav.sbp.vehicle.MsgOdometry;
-import com.swiftnav.sbp.flash.MsgFlashProgram;
-import com.swiftnav.sbp.flash.MsgFlashDone;
-import com.swiftnav.sbp.flash.MsgFlashReadReq;
-import com.swiftnav.sbp.flash.MsgFlashReadResp;
-import com.swiftnav.sbp.flash.MsgFlashErase;
-import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
-import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
-import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
-import com.swiftnav.sbp.piksi.MsgAlmanac;
-import com.swiftnav.sbp.piksi.MsgSetTime;
-import com.swiftnav.sbp.piksi.MsgReset;
-import com.swiftnav.sbp.piksi.MsgResetDep;
-import com.swiftnav.sbp.piksi.MsgCwResults;
-import com.swiftnav.sbp.piksi.MsgCwStart;
-import com.swiftnav.sbp.piksi.MsgResetFilters;
-import com.swiftnav.sbp.piksi.MsgInitBase;
-import com.swiftnav.sbp.piksi.MsgThreadState;
-import com.swiftnav.sbp.piksi.MsgUartState;
-import com.swiftnav.sbp.piksi.MsgUartStateDepa;
-import com.swiftnav.sbp.piksi.MsgIarState;
-import com.swiftnav.sbp.piksi.MsgMaskSatellite;
-import com.swiftnav.sbp.piksi.MsgMaskSatelliteDep;
-import com.swiftnav.sbp.piksi.MsgDeviceMonitor;
-import com.swiftnav.sbp.piksi.MsgCommandReq;
-import com.swiftnav.sbp.piksi.MsgCommandResp;
-import com.swiftnav.sbp.piksi.MsgCommandOutput;
-import com.swiftnav.sbp.piksi.MsgNetworkStateReq;
-import com.swiftnav.sbp.piksi.MsgNetworkStateResp;
-import com.swiftnav.sbp.piksi.MsgSpecanDep;
-import com.swiftnav.sbp.piksi.MsgSpecan;
-import com.swiftnav.sbp.settings.MsgSettingsSave;
-import com.swiftnav.sbp.settings.MsgSettingsWrite;
-import com.swiftnav.sbp.settings.MsgSettingsWriteResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
-import com.swiftnav.sbp.settings.MsgSettingsRegister;
-import com.swiftnav.sbp.user.MsgUserData;
-import com.swiftnav.sbp.file_io.MsgFileioReadReq;
-import com.swiftnav.sbp.file_io.MsgFileioReadResp;
-import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
-import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
-import com.swiftnav.sbp.file_io.MsgFileioRemove;
-import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
-import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
 import com.swiftnav.sbp.navigation.MsgGPSTime;
 import com.swiftnav.sbp.navigation.MsgUtcTime;
 import com.swiftnav.sbp.navigation.MsgDops;
@@ -156,11 +140,82 @@ import com.swiftnav.sbp.navigation.MsgBaselineNEDDepA;
 import com.swiftnav.sbp.navigation.MsgVelECEFDepA;
 import com.swiftnav.sbp.navigation.MsgVelNEDDepA;
 import com.swiftnav.sbp.navigation.MsgBaselineHeadingDepA;
-import com.swiftnav.sbp.mag.MsgMagRaw;
+import com.swiftnav.sbp.user.MsgUserData;
+import com.swiftnav.sbp.acquisition.MsgAcqResult;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepC;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
+import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
+import com.swiftnav.sbp.acquisition.MsgAcqSvProfileDep;
+import com.swiftnav.sbp.ndb.MsgNdbEvent;
+import com.swiftnav.sbp.system.MsgStartup;
+import com.swiftnav.sbp.system.MsgDgnssStatus;
+import com.swiftnav.sbp.system.MsgHeartbeat;
+import com.swiftnav.sbp.system.MsgInsStatus;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
 
 final class MessageTable {
     static SBPMessage dispatch(SBPMessage msg) throws SBPBinaryException {
         switch (msg.type) {
+            case MsgSbasRaw.TYPE:
+                return new MsgSbasRaw(msg);
+            case MsgFileioReadReq.TYPE:
+                return new MsgFileioReadReq(msg);
+            case MsgFileioReadResp.TYPE:
+                return new MsgFileioReadResp(msg);
+            case MsgFileioReadDirReq.TYPE:
+                return new MsgFileioReadDirReq(msg);
+            case MsgFileioReadDirResp.TYPE:
+                return new MsgFileioReadDirResp(msg);
+            case MsgFileioRemove.TYPE:
+                return new MsgFileioRemove(msg);
+            case MsgFileioWriteReq.TYPE:
+                return new MsgFileioWriteReq(msg);
+            case MsgFileioWriteResp.TYPE:
+                return new MsgFileioWriteResp(msg);
+            case MsgSettingsSave.TYPE:
+                return new MsgSettingsSave(msg);
+            case MsgSettingsWrite.TYPE:
+                return new MsgSettingsWrite(msg);
+            case MsgSettingsWriteResp.TYPE:
+                return new MsgSettingsWriteResp(msg);
+            case MsgSettingsReadReq.TYPE:
+                return new MsgSettingsReadReq(msg);
+            case MsgSettingsReadResp.TYPE:
+                return new MsgSettingsReadResp(msg);
+            case MsgSettingsReadByIndexReq.TYPE:
+                return new MsgSettingsReadByIndexReq(msg);
+            case MsgSettingsReadByIndexResp.TYPE:
+                return new MsgSettingsReadByIndexResp(msg);
+            case MsgSettingsReadByIndexDone.TYPE:
+                return new MsgSettingsReadByIndexDone(msg);
+            case MsgSettingsRegister.TYPE:
+                return new MsgSettingsRegister(msg);
+            case MsgFlashProgram.TYPE:
+                return new MsgFlashProgram(msg);
+            case MsgFlashDone.TYPE:
+                return new MsgFlashDone(msg);
+            case MsgFlashReadReq.TYPE:
+                return new MsgFlashReadReq(msg);
+            case MsgFlashReadResp.TYPE:
+                return new MsgFlashReadResp(msg);
+            case MsgFlashErase.TYPE:
+                return new MsgFlashErase(msg);
+            case MsgStmFlashLockSector.TYPE:
+                return new MsgStmFlashLockSector(msg);
+            case MsgStmFlashUnlockSector.TYPE:
+                return new MsgStmFlashUnlockSector(msg);
+            case MsgStmUniqueIdReq.TYPE:
+                return new MsgStmUniqueIdReq(msg);
+            case MsgStmUniqueIdResp.TYPE:
+                return new MsgStmUniqueIdResp(msg);
+            case MsgM25FlashWriteStatus.TYPE:
+                return new MsgM25FlashWriteStatus(msg);
             case MsgTrackingStateDetailedDepA.TYPE:
                 return new MsgTrackingStateDetailedDepA(msg);
             case MsgTrackingStateDetailedDep.TYPE:
@@ -175,8 +230,84 @@ final class MessageTable {
                 return new MsgTrackingStateDepA(msg);
             case MsgTrackingStateDepB.TYPE:
                 return new MsgTrackingStateDepB(msg);
+            case MsgLog.TYPE:
+                return new MsgLog(msg);
+            case MsgFwd.TYPE:
+                return new MsgFwd(msg);
+            case MsgTweet.TYPE:
+                return new MsgTweet(msg);
+            case MsgPrintDep.TYPE:
+                return new MsgPrintDep(msg);
+            case MsgMagRaw.TYPE:
+                return new MsgMagRaw(msg);
+            case MsgOdometry.TYPE:
+                return new MsgOdometry(msg);
+            case MsgBaselineHeading.TYPE:
+                return new MsgBaselineHeading(msg);
+            case MsgOrientQuat.TYPE:
+                return new MsgOrientQuat(msg);
+            case MsgOrientEuler.TYPE:
+                return new MsgOrientEuler(msg);
+            case MsgAngularRate.TYPE:
+                return new MsgAngularRate(msg);
+            case MsgImuRaw.TYPE:
+                return new MsgImuRaw(msg);
+            case MsgImuAux.TYPE:
+                return new MsgImuAux(msg);
             case MsgExtEvent.TYPE:
                 return new MsgExtEvent(msg);
+            case MsgAlmanac.TYPE:
+                return new MsgAlmanac(msg);
+            case MsgSetTime.TYPE:
+                return new MsgSetTime(msg);
+            case MsgReset.TYPE:
+                return new MsgReset(msg);
+            case MsgResetDep.TYPE:
+                return new MsgResetDep(msg);
+            case MsgCwResults.TYPE:
+                return new MsgCwResults(msg);
+            case MsgCwStart.TYPE:
+                return new MsgCwStart(msg);
+            case MsgResetFilters.TYPE:
+                return new MsgResetFilters(msg);
+            case MsgInitBase.TYPE:
+                return new MsgInitBase(msg);
+            case MsgThreadState.TYPE:
+                return new MsgThreadState(msg);
+            case MsgUartState.TYPE:
+                return new MsgUartState(msg);
+            case MsgUartStateDepa.TYPE:
+                return new MsgUartStateDepa(msg);
+            case MsgIarState.TYPE:
+                return new MsgIarState(msg);
+            case MsgMaskSatellite.TYPE:
+                return new MsgMaskSatellite(msg);
+            case MsgMaskSatelliteDep.TYPE:
+                return new MsgMaskSatelliteDep(msg);
+            case MsgDeviceMonitor.TYPE:
+                return new MsgDeviceMonitor(msg);
+            case MsgCommandReq.TYPE:
+                return new MsgCommandReq(msg);
+            case MsgCommandResp.TYPE:
+                return new MsgCommandResp(msg);
+            case MsgCommandOutput.TYPE:
+                return new MsgCommandOutput(msg);
+            case MsgNetworkStateReq.TYPE:
+                return new MsgNetworkStateReq(msg);
+            case MsgNetworkStateResp.TYPE:
+                return new MsgNetworkStateResp(msg);
+            case MsgNetworkBandwidthUsage.TYPE:
+                return new MsgNetworkBandwidthUsage(msg);
+            case MsgSpecanDep.TYPE:
+                return new MsgSpecanDep(msg);
+            case MsgSpecan.TYPE:
+                return new MsgSpecan(msg);
+            case MsgSsrOrbitClock.TYPE:
+                return new MsgSsrOrbitClock(msg);
+            case MsgSsrCodeBiases.TYPE:
+                return new MsgSsrCodeBiases(msg);
+            case MsgSsrPhaseBiases.TYPE:
+                return new MsgSsrPhaseBiases(msg);
             case MsgObs.TYPE:
                 return new MsgObs(msg);
             case MsgBasePosLLH.TYPE:
@@ -233,168 +364,6 @@ final class MessageTable {
                 return new MsgAlmanacGlo(msg);
             case MsgGloBiases.TYPE:
                 return new MsgGloBiases(msg);
-            case MsgSsrOrbitClock.TYPE:
-                return new MsgSsrOrbitClock(msg);
-            case MsgSsrCodeBiases.TYPE:
-                return new MsgSsrCodeBiases(msg);
-            case MsgSsrPhaseBiases.TYPE:
-                return new MsgSsrPhaseBiases(msg);
-            case MsgBaselineHeading.TYPE:
-                return new MsgBaselineHeading(msg);
-            case MsgOrientQuat.TYPE:
-                return new MsgOrientQuat(msg);
-            case MsgOrientEuler.TYPE:
-                return new MsgOrientEuler(msg);
-            case MsgAngularRate.TYPE:
-                return new MsgAngularRate(msg);
-            case MsgNdbEvent.TYPE:
-                return new MsgNdbEvent(msg);
-            case MsgBootloaderHandshakeReq.TYPE:
-                return new MsgBootloaderHandshakeReq(msg);
-            case MsgBootloaderHandshakeResp.TYPE:
-                return new MsgBootloaderHandshakeResp(msg);
-            case MsgBootloaderJumpToApp.TYPE:
-                return new MsgBootloaderJumpToApp(msg);
-            case MsgNapDeviceDnaReq.TYPE:
-                return new MsgNapDeviceDnaReq(msg);
-            case MsgNapDeviceDnaResp.TYPE:
-                return new MsgNapDeviceDnaResp(msg);
-            case MsgBootloaderHandshakeDepA.TYPE:
-                return new MsgBootloaderHandshakeDepA(msg);
-            case MsgSbasRaw.TYPE:
-                return new MsgSbasRaw(msg);
-            case MsgLog.TYPE:
-                return new MsgLog(msg);
-            case MsgFwd.TYPE:
-                return new MsgFwd(msg);
-            case MsgTweet.TYPE:
-                return new MsgTweet(msg);
-            case MsgPrintDep.TYPE:
-                return new MsgPrintDep(msg);
-            case MsgStartup.TYPE:
-                return new MsgStartup(msg);
-            case MsgDgnssStatus.TYPE:
-                return new MsgDgnssStatus(msg);
-            case MsgHeartbeat.TYPE:
-                return new MsgHeartbeat(msg);
-            case MsgInsStatus.TYPE:
-                return new MsgInsStatus(msg);
-            case MsgAcqResult.TYPE:
-                return new MsgAcqResult(msg);
-            case MsgAcqResultDepC.TYPE:
-                return new MsgAcqResultDepC(msg);
-            case MsgAcqResultDepB.TYPE:
-                return new MsgAcqResultDepB(msg);
-            case MsgAcqResultDepA.TYPE:
-                return new MsgAcqResultDepA(msg);
-            case MsgAcqSvProfile.TYPE:
-                return new MsgAcqSvProfile(msg);
-            case MsgAcqSvProfileDep.TYPE:
-                return new MsgAcqSvProfileDep(msg);
-            case MsgImuRaw.TYPE:
-                return new MsgImuRaw(msg);
-            case MsgImuAux.TYPE:
-                return new MsgImuAux(msg);
-            case MsgOdometry.TYPE:
-                return new MsgOdometry(msg);
-            case MsgFlashProgram.TYPE:
-                return new MsgFlashProgram(msg);
-            case MsgFlashDone.TYPE:
-                return new MsgFlashDone(msg);
-            case MsgFlashReadReq.TYPE:
-                return new MsgFlashReadReq(msg);
-            case MsgFlashReadResp.TYPE:
-                return new MsgFlashReadResp(msg);
-            case MsgFlashErase.TYPE:
-                return new MsgFlashErase(msg);
-            case MsgStmFlashLockSector.TYPE:
-                return new MsgStmFlashLockSector(msg);
-            case MsgStmFlashUnlockSector.TYPE:
-                return new MsgStmFlashUnlockSector(msg);
-            case MsgStmUniqueIdReq.TYPE:
-                return new MsgStmUniqueIdReq(msg);
-            case MsgStmUniqueIdResp.TYPE:
-                return new MsgStmUniqueIdResp(msg);
-            case MsgM25FlashWriteStatus.TYPE:
-                return new MsgM25FlashWriteStatus(msg);
-            case MsgAlmanac.TYPE:
-                return new MsgAlmanac(msg);
-            case MsgSetTime.TYPE:
-                return new MsgSetTime(msg);
-            case MsgReset.TYPE:
-                return new MsgReset(msg);
-            case MsgResetDep.TYPE:
-                return new MsgResetDep(msg);
-            case MsgCwResults.TYPE:
-                return new MsgCwResults(msg);
-            case MsgCwStart.TYPE:
-                return new MsgCwStart(msg);
-            case MsgResetFilters.TYPE:
-                return new MsgResetFilters(msg);
-            case MsgInitBase.TYPE:
-                return new MsgInitBase(msg);
-            case MsgThreadState.TYPE:
-                return new MsgThreadState(msg);
-            case MsgUartState.TYPE:
-                return new MsgUartState(msg);
-            case MsgUartStateDepa.TYPE:
-                return new MsgUartStateDepa(msg);
-            case MsgIarState.TYPE:
-                return new MsgIarState(msg);
-            case MsgMaskSatellite.TYPE:
-                return new MsgMaskSatellite(msg);
-            case MsgMaskSatelliteDep.TYPE:
-                return new MsgMaskSatelliteDep(msg);
-            case MsgDeviceMonitor.TYPE:
-                return new MsgDeviceMonitor(msg);
-            case MsgCommandReq.TYPE:
-                return new MsgCommandReq(msg);
-            case MsgCommandResp.TYPE:
-                return new MsgCommandResp(msg);
-            case MsgCommandOutput.TYPE:
-                return new MsgCommandOutput(msg);
-            case MsgNetworkStateReq.TYPE:
-                return new MsgNetworkStateReq(msg);
-            case MsgNetworkStateResp.TYPE:
-                return new MsgNetworkStateResp(msg);
-            case MsgSpecanDep.TYPE:
-                return new MsgSpecanDep(msg);
-            case MsgSpecan.TYPE:
-                return new MsgSpecan(msg);
-            case MsgSettingsSave.TYPE:
-                return new MsgSettingsSave(msg);
-            case MsgSettingsWrite.TYPE:
-                return new MsgSettingsWrite(msg);
-            case MsgSettingsWriteResp.TYPE:
-                return new MsgSettingsWriteResp(msg);
-            case MsgSettingsReadReq.TYPE:
-                return new MsgSettingsReadReq(msg);
-            case MsgSettingsReadResp.TYPE:
-                return new MsgSettingsReadResp(msg);
-            case MsgSettingsReadByIndexReq.TYPE:
-                return new MsgSettingsReadByIndexReq(msg);
-            case MsgSettingsReadByIndexResp.TYPE:
-                return new MsgSettingsReadByIndexResp(msg);
-            case MsgSettingsReadByIndexDone.TYPE:
-                return new MsgSettingsReadByIndexDone(msg);
-            case MsgSettingsRegister.TYPE:
-                return new MsgSettingsRegister(msg);
-            case MsgUserData.TYPE:
-                return new MsgUserData(msg);
-            case MsgFileioReadReq.TYPE:
-                return new MsgFileioReadReq(msg);
-            case MsgFileioReadResp.TYPE:
-                return new MsgFileioReadResp(msg);
-            case MsgFileioReadDirReq.TYPE:
-                return new MsgFileioReadDirReq(msg);
-            case MsgFileioReadDirResp.TYPE:
-                return new MsgFileioReadDirResp(msg);
-            case MsgFileioRemove.TYPE:
-                return new MsgFileioRemove(msg);
-            case MsgFileioWriteReq.TYPE:
-                return new MsgFileioWriteReq(msg);
-            case MsgFileioWriteResp.TYPE:
-                return new MsgFileioWriteResp(msg);
             case MsgGPSTime.TYPE:
                 return new MsgGPSTime(msg);
             case MsgUtcTime.TYPE:
@@ -443,8 +412,42 @@ final class MessageTable {
                 return new MsgVelNEDDepA(msg);
             case MsgBaselineHeadingDepA.TYPE:
                 return new MsgBaselineHeadingDepA(msg);
-            case MsgMagRaw.TYPE:
-                return new MsgMagRaw(msg);
+            case MsgUserData.TYPE:
+                return new MsgUserData(msg);
+            case MsgAcqResult.TYPE:
+                return new MsgAcqResult(msg);
+            case MsgAcqResultDepC.TYPE:
+                return new MsgAcqResultDepC(msg);
+            case MsgAcqResultDepB.TYPE:
+                return new MsgAcqResultDepB(msg);
+            case MsgAcqResultDepA.TYPE:
+                return new MsgAcqResultDepA(msg);
+            case MsgAcqSvProfile.TYPE:
+                return new MsgAcqSvProfile(msg);
+            case MsgAcqSvProfileDep.TYPE:
+                return new MsgAcqSvProfileDep(msg);
+            case MsgNdbEvent.TYPE:
+                return new MsgNdbEvent(msg);
+            case MsgStartup.TYPE:
+                return new MsgStartup(msg);
+            case MsgDgnssStatus.TYPE:
+                return new MsgDgnssStatus(msg);
+            case MsgHeartbeat.TYPE:
+                return new MsgHeartbeat(msg);
+            case MsgInsStatus.TYPE:
+                return new MsgInsStatus(msg);
+            case MsgBootloaderHandshakeReq.TYPE:
+                return new MsgBootloaderHandshakeReq(msg);
+            case MsgBootloaderHandshakeResp.TYPE:
+                return new MsgBootloaderHandshakeResp(msg);
+            case MsgBootloaderJumpToApp.TYPE:
+                return new MsgBootloaderJumpToApp(msg);
+            case MsgNapDeviceDnaReq.TYPE:
+                return new MsgNapDeviceDnaReq(msg);
+            case MsgNapDeviceDnaResp.TYPE:
+                return new MsgNapDeviceDnaResp(msg);
+            case MsgBootloaderHandshakeDepA.TYPE:
+                return new MsgBootloaderHandshakeDepA(msg);
         }
         return msg;
     }

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkBandwidthUsage.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkBandwidthUsage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import java.math.BigInteger;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+
+/** SBP class for message MSG_NETWORK_BANDWIDTH_USAGE (0x00BD).
+ *
+ * You can have MSG_NETWORK_BANDWIDTH_USAGE inherent its fields directly from
+ * an inherited SBP object, or construct it inline using a dict of its
+ * fields.
+ *
+ * The bandwidth usage, a list of usage by interface.  */
+
+public class MsgNetworkBandwidthUsage extends SBPMessage {
+    public static final int TYPE = 0x00BD;
+
+    
+    /** Usage measurement array */
+    public NetworkUsage[] interfaces;
+    
+
+    public MsgNetworkBandwidthUsage (int sender) { super(sender, TYPE); }
+    public MsgNetworkBandwidthUsage () { super(TYPE); }
+    public MsgNetworkBandwidthUsage (SBPMessage msg) throws SBPBinaryException {
+        super(msg);
+        assert msg.type != TYPE;
+    }
+
+    @Override
+    protected void parse(Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+        interfaces = parser.getArray(NetworkUsage.class);
+    }
+
+    @Override
+    protected void build(Builder builder) {
+        builder.putArray(interfaces);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = super.toJSON();
+        obj.put("interfaces", SBPStruct.toJSONArray(interfaces));
+        return obj;
+    }
+}

--- a/java/src/com/swiftnav/sbp/piksi/NetworkUsage.java
+++ b/java/src/com/swiftnav/sbp/piksi/NetworkUsage.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import java.math.BigInteger;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+import com.swiftnav.sbp.SBPStruct;
+
+public class NetworkUsage extends SBPStruct {
+    
+    /** Duration over which the measurement was collected */
+    public BigInteger duration;
+    
+    /** Number of bytes handled in total within period */
+    public BigInteger total_bytes;
+    
+    /** Number of bytes transmitted within period */
+    public long rx_bytes;
+    
+    /** Number of bytes received within period */
+    public long tx_bytes;
+    
+    /** Interface Name */
+    public String interface_name;
+    
+
+    public NetworkUsage () {}
+
+    @Override
+    public NetworkUsage parse(SBPMessage.Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+        duration = parser.getU64();
+        total_bytes = parser.getU64();
+        rx_bytes = parser.getU32();
+        tx_bytes = parser.getU32();
+        interface_name = parser.getString(16);
+        return this;
+    }
+
+    @Override
+    public void build(SBPMessage.Builder builder) {
+        /* Build fields into binary */
+        builder.putU64(duration);
+        builder.putU64(total_bytes);
+        builder.putU32(rx_bytes);
+        builder.putU32(tx_bytes);
+        builder.putString(interface_name, 16);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = new JSONObject();
+        obj.put("duration", duration);
+        obj.put("total_bytes", total_bytes);
+        obj.put("rx_bytes", rx_bytes);
+        obj.put("tx_bytes", tx_bytes);
+        obj.put("interface_name", interface_name);
+        return obj;
+    }
+}

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -758,6 +758,75 @@ MsgNetworkStateResp.prototype.fieldSpec.push(['interface_name', 'string', 16]);
 MsgNetworkStateResp.prototype.fieldSpec.push(['flags', 'writeUInt32LE', 4]);
 
 /**
+ * SBP class for message fragment NetworkUsage
+ *
+ * The bandwidth usage for each interface can be reported within this struct and
+ * utilize multiple fields to fully specify the type of traffic that is being
+ * tracked. As either the interval of collection or the collection time may vary,
+ * both a timestamp and period field is provided, though may not necessarily be
+ * populated with a value.
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field duration number (unsigned 64-bit int, 8 bytes) Duration over which the measurement was collected
+ * @field total_bytes number (unsigned 64-bit int, 8 bytes) Number of bytes handled in total within period
+ * @field rx_bytes number (unsigned 32-bit int, 4 bytes) Number of bytes transmitted within period
+ * @field tx_bytes number (unsigned 32-bit int, 4 bytes) Number of bytes received within period
+ * @field interface_name string Interface Name
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var NetworkUsage = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "NetworkUsage";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+NetworkUsage.prototype = Object.create(SBP.prototype);
+NetworkUsage.prototype.messageType = "NetworkUsage";
+NetworkUsage.prototype.constructor = NetworkUsage;
+NetworkUsage.prototype.parser = new Parser()
+  .endianess('little')
+  .uint64('duration')
+  .uint64('total_bytes')
+  .uint32('rx_bytes')
+  .uint32('tx_bytes')
+  .string('interface_name', { length: 16 });
+NetworkUsage.prototype.fieldSpec = [];
+NetworkUsage.prototype.fieldSpec.push(['duration', 'writeUInt64LE', 8]);
+NetworkUsage.prototype.fieldSpec.push(['total_bytes', 'writeUInt64LE', 8]);
+NetworkUsage.prototype.fieldSpec.push(['rx_bytes', 'writeUInt32LE', 4]);
+NetworkUsage.prototype.fieldSpec.push(['tx_bytes', 'writeUInt32LE', 4]);
+NetworkUsage.prototype.fieldSpec.push(['interface_name', 'string', 16]);
+
+/**
+ * SBP class for message MSG_NETWORK_BANDWIDTH_USAGE (0x00BD).
+ *
+ * The bandwidth usage, a list of usage by interface.
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field interfaces array Usage measurement array
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var MsgNetworkBandwidthUsage = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "MSG_NETWORK_BANDWIDTH_USAGE";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+MsgNetworkBandwidthUsage.prototype = Object.create(SBP.prototype);
+MsgNetworkBandwidthUsage.prototype.messageType = "MSG_NETWORK_BANDWIDTH_USAGE";
+MsgNetworkBandwidthUsage.prototype.msg_type = 0x00BD;
+MsgNetworkBandwidthUsage.prototype.constructor = MsgNetworkBandwidthUsage;
+MsgNetworkBandwidthUsage.prototype.parser = new Parser()
+  .endianess('little')
+  .array('interfaces', { type: NetworkUsage.prototype.parser, readUntil: 'eof' });
+MsgNetworkBandwidthUsage.prototype.fieldSpec = [];
+MsgNetworkBandwidthUsage.prototype.fieldSpec.push(['interfaces', 'array', NetworkUsage.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
+
+/**
  * SBP class for message MSG_SPECAN_DEP (0x0050).
  *
  * Deprecated.
@@ -891,6 +960,9 @@ module.exports = {
   MsgNetworkStateReq: MsgNetworkStateReq,
   0x00BB: MsgNetworkStateResp,
   MsgNetworkStateResp: MsgNetworkStateResp,
+  NetworkUsage: NetworkUsage,
+  0x00BD: MsgNetworkBandwidthUsage,
+  MsgNetworkBandwidthUsage: MsgNetworkBandwidthUsage,
   0x0050: MsgSpecanDep,
   MsgSpecanDep: MsgSpecanDep,
   0x0051: MsgSpecan,

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -29,7 +29,7 @@ from sbp import ext_events as ext_events
 from sbp import ndb as ndb
 from sbp import mag as mag
 from sbp import vehicle as vehicle
-from sbp import orientation as orientation 
+from sbp import orientation as orientation
 from sbp import sbas as sbas
 
 import pytest
@@ -42,7 +42,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 139
+  number_of_messages = 140
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -484,6 +484,45 @@ definitions:
             - 0:
                 desc: IFF_UP - interface is up
 
+ - NetworkUsage:
+    short_desc: Bandwidth usage measurement for a single interface.
+    desc: |
+      The bandwidth usage for each interface can be reported
+      within this struct and utilize multiple fields to fully
+      specify the type of traffic that is being tracked. As
+      either the interval of collection or the collection time
+      may vary, both a timestamp and period field is provided,
+      though may not necessarily be populated with a value. 
+    fields:
+      - duration:
+          type: u64
+          units: ms
+          desc: Duration over which the measurement was collected
+      - total_bytes:
+          type: u64
+          desc: Number of bytes handled in total within period
+      - rx_bytes:
+          type: u32
+          desc: Number of bytes transmitted within period
+      - tx_bytes:
+          type: u32
+          desc: Number of bytes received within period
+      - interface_name:
+          type: string
+          size: 16
+          desc: Interface Name
+
+ - MSG_NETWORK_BANDWIDTH_USAGE:
+    id: 0x00BD
+    short_desc: Bandwidth usage reporting message
+    desc: |
+      The bandwidth usage, a list of usage by interface. 
+    fields:
+        - interfaces:
+            type: array
+            fill: NetworkUsage
+            desc: Usage measurement array
+
  - MSG_SPECAN_DEP:
     id: 0x0050
     short_desc: Deprecated


### PR DESCRIPTION
To support async bandwidth metrics to be reported to the console the following message is being added to the piksi module:

MSG_NETWORK_BANDWIDTH_USAGE 0x00BD

While there is alignment to some degree with the MSG_NETWORK_STATE_* messages, the interface string being a common field, this is meant to me emitted as streaming data from the system to indicate real time data usage.