### PR TITLE
Cell Modem Status Message

### DIFF
--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -354,6 +354,20 @@ typedef struct __attribute__((packed)) {
 } msg_network_bandwidth_usage_t;
 
 
+/** Cell modem information update message
+ *
+ * If a cell modem is present on a piksi device, this message
+ * will be send periodically to update the host on the status
+ * of the modem and its various parameters.
+ */
+#define SBP_MSG_CELL_MODEM_STATUS       0x00BE
+typedef struct __attribute__((packed)) {
+  s8 signal_strength;      /**< Received cell signal strength in dBm, zero translates to unknown [dBm] */
+  float signal_error_rate;    /**< BER as reported by the modem, zero translates to unknown */
+  u8 reserved[0];          /**< Unspecified data TBD for this schema */
+} msg_cell_modem_status_t;
+
+
 /** Deprecated
  *
 * Deprecated.

--- a/haskell/src/SwiftNav/SBP/Msg.hs
+++ b/haskell/src/SwiftNav/SBP/Msg.hs
@@ -78,6 +78,7 @@ data SBPMsg =
    | SBPMsgBootloaderHandshakeReq MsgBootloaderHandshakeReq Msg
    | SBPMsgBootloaderHandshakeResp MsgBootloaderHandshakeResp Msg
    | SBPMsgBootloaderJumpToApp MsgBootloaderJumpToApp Msg
+   | SBPMsgCellModemStatus MsgCellModemStatus Msg
    | SBPMsgCommandOutput MsgCommandOutput Msg
    | SBPMsgCommandReq MsgCommandReq Msg
    | SBPMsgCommandResp MsgCommandResp Msg
@@ -234,6 +235,7 @@ instance Binary SBPMsg where
           | _msgSBPType == msgBootloaderHandshakeReq = SBPMsgBootloaderHandshakeReq (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgBootloaderHandshakeResp = SBPMsgBootloaderHandshakeResp (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgBootloaderJumpToApp = SBPMsgBootloaderJumpToApp (decode (fromStrict (unBytes _msgSBPPayload))) m
+          | _msgSBPType == msgCellModemStatus = SBPMsgCellModemStatus (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgCommandOutput = SBPMsgCommandOutput (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgCommandReq = SBPMsgCommandReq (decode (fromStrict (unBytes _msgSBPPayload))) m
           | _msgSBPType == msgCommandResp = SBPMsgCommandResp (decode (fromStrict (unBytes _msgSBPPayload))) m
@@ -382,6 +384,7 @@ instance Binary SBPMsg where
       encoder (SBPMsgBootloaderHandshakeReq _ m) = put m
       encoder (SBPMsgBootloaderHandshakeResp _ m) = put m
       encoder (SBPMsgBootloaderJumpToApp _ m) = put m
+      encoder (SBPMsgCellModemStatus _ m) = put m
       encoder (SBPMsgCommandOutput _ m) = put m
       encoder (SBPMsgCommandReq _ m) = put m
       encoder (SBPMsgCommandResp _ m) = put m
@@ -534,6 +537,7 @@ instance FromJSON SBPMsg where
         | msgType == msgBootloaderHandshakeReq = SBPMsgBootloaderHandshakeReq <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgBootloaderHandshakeResp = SBPMsgBootloaderHandshakeResp <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgBootloaderJumpToApp = SBPMsgBootloaderJumpToApp <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
+        | msgType == msgCellModemStatus = SBPMsgCellModemStatus <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgCommandOutput = SBPMsgCommandOutput <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgCommandReq = SBPMsgCommandReq <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
         | msgType == msgCommandResp = SBPMsgCommandResp <$> pure (decode (fromStrict (unBytes payload))) <*> parseJSON obj
@@ -687,6 +691,7 @@ instance ToJSON SBPMsg where
   toJSON (SBPMsgBootloaderHandshakeReq n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgBootloaderHandshakeResp n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgBootloaderJumpToApp n m) = toJSON n <<>> toJSON m
+  toJSON (SBPMsgCellModemStatus n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgCommandOutput n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgCommandReq n m) = toJSON n <<>> toJSON m
   toJSON (SBPMsgCommandResp n m) = toJSON n <<>> toJSON m
@@ -834,6 +839,7 @@ instance HasMsg SBPMsg where
   msg f (SBPMsgBootloaderHandshakeReq n m) = SBPMsgBootloaderHandshakeReq n <$> f m
   msg f (SBPMsgBootloaderHandshakeResp n m) = SBPMsgBootloaderHandshakeResp n <$> f m
   msg f (SBPMsgBootloaderJumpToApp n m) = SBPMsgBootloaderJumpToApp n <$> f m
+  msg f (SBPMsgCellModemStatus n m) = SBPMsgCellModemStatus n <$> f m
   msg f (SBPMsgCommandOutput n m) = SBPMsgCommandOutput n <$> f m
   msg f (SBPMsgCommandReq n m) = SBPMsgCommandReq n <$> f m
   msg f (SBPMsgCommandResp n m) = SBPMsgCommandResp n <$> f m

--- a/haskell/src/SwiftNav/SBP/Piksi.hs
+++ b/haskell/src/SwiftNav/SBP/Piksi.hs
@@ -772,6 +772,39 @@ $(makeSBP 'msgNetworkBandwidthUsage ''MsgNetworkBandwidthUsage)
 $(makeJSON "_msgNetworkBandwidthUsage_" ''MsgNetworkBandwidthUsage)
 $(makeLenses ''MsgNetworkBandwidthUsage)
 
+msgCellModemStatus :: Word16
+msgCellModemStatus = 0x00BE
+
+-- | SBP class for message MSG_CELL_MODEM_STATUS (0x00BE).
+--
+-- If a cell modem is present on a piksi device, this message will be send
+-- periodically to update the host on the status of the modem and its various
+-- parameters.
+data MsgCellModemStatus = MsgCellModemStatus
+  { _msgCellModemStatus_signal_strength :: !Int8
+    -- ^ Received cell signal strength in dBm, zero translates to unknown
+  , _msgCellModemStatus_signal_error_rate :: !Float
+    -- ^ BER as reported by the modem, zero translates to unknown
+  , _msgCellModemStatus_reserved        :: ![Word8]
+    -- ^ Unspecified data TBD for this schema
+  } deriving ( Show, Read, Eq )
+
+instance Binary MsgCellModemStatus where
+  get = do
+    _msgCellModemStatus_signal_strength <- fromIntegral <$> getWord8
+    _msgCellModemStatus_signal_error_rate <- getFloat32le
+    _msgCellModemStatus_reserved <- whileM (not <$> isEmpty) getWord8
+    pure MsgCellModemStatus {..}
+
+  put MsgCellModemStatus {..} = do
+    putWord8 $ fromIntegral _msgCellModemStatus_signal_strength
+    putFloat32le _msgCellModemStatus_signal_error_rate
+    mapM_ putWord8 _msgCellModemStatus_reserved
+
+$(makeSBP 'msgCellModemStatus ''MsgCellModemStatus)
+$(makeJSON "_msgCellModemStatus_" ''MsgCellModemStatus)
+$(makeLenses ''MsgCellModemStatus)
+
 msgSpecanDep :: Word16
 msgSpecanDep = 0x0050
 

--- a/java/src/com/swiftnav/sbp/client/MessageTable.java
+++ b/java/src/com/swiftnav/sbp/client/MessageTable.java
@@ -15,57 +15,23 @@ import com.swiftnav.sbp.SBPBinaryException;
 import com.swiftnav.sbp.SBPMessage;
 import com.swiftnav.sbp.SBPMessage.Builder;
 import com.swiftnav.sbp.SBPMessage.Parser;
+import com.swiftnav.sbp.acquisition.MsgAcqResult;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepC;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
+import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
+import com.swiftnav.sbp.acquisition.MsgAcqSvProfileDep;
+import com.swiftnav.sbp.user.MsgUserData;
+import com.swiftnav.sbp.mag.MsgMagRaw;
 import com.swiftnav.sbp.system.MsgStartup;
 import com.swiftnav.sbp.system.MsgDgnssStatus;
 import com.swiftnav.sbp.system.MsgHeartbeat;
 import com.swiftnav.sbp.system.MsgInsStatus;
-import com.swiftnav.sbp.settings.MsgSettingsSave;
-import com.swiftnav.sbp.settings.MsgSettingsWrite;
-import com.swiftnav.sbp.settings.MsgSettingsWriteResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
-import com.swiftnav.sbp.settings.MsgSettingsRegister;
-import com.swiftnav.sbp.orientation.MsgBaselineHeading;
-import com.swiftnav.sbp.orientation.MsgOrientQuat;
-import com.swiftnav.sbp.orientation.MsgOrientEuler;
-import com.swiftnav.sbp.orientation.MsgAngularRate;
-import com.swiftnav.sbp.flash.MsgFlashProgram;
-import com.swiftnav.sbp.flash.MsgFlashDone;
-import com.swiftnav.sbp.flash.MsgFlashReadReq;
-import com.swiftnav.sbp.flash.MsgFlashReadResp;
-import com.swiftnav.sbp.flash.MsgFlashErase;
-import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
-import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
-import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
-import com.swiftnav.sbp.piksi.MsgAlmanac;
-import com.swiftnav.sbp.piksi.MsgSetTime;
-import com.swiftnav.sbp.piksi.MsgReset;
-import com.swiftnav.sbp.piksi.MsgResetDep;
-import com.swiftnav.sbp.piksi.MsgCwResults;
-import com.swiftnav.sbp.piksi.MsgCwStart;
-import com.swiftnav.sbp.piksi.MsgResetFilters;
-import com.swiftnav.sbp.piksi.MsgInitBase;
-import com.swiftnav.sbp.piksi.MsgThreadState;
-import com.swiftnav.sbp.piksi.MsgUartState;
-import com.swiftnav.sbp.piksi.MsgUartStateDepa;
-import com.swiftnav.sbp.piksi.MsgIarState;
-import com.swiftnav.sbp.piksi.MsgMaskSatellite;
-import com.swiftnav.sbp.piksi.MsgMaskSatelliteDep;
-import com.swiftnav.sbp.piksi.MsgDeviceMonitor;
-import com.swiftnav.sbp.piksi.MsgCommandReq;
-import com.swiftnav.sbp.piksi.MsgCommandResp;
-import com.swiftnav.sbp.piksi.MsgCommandOutput;
-import com.swiftnav.sbp.piksi.MsgNetworkStateReq;
-import com.swiftnav.sbp.piksi.MsgNetworkStateResp;
-import com.swiftnav.sbp.piksi.MsgNetworkBandwidthUsage;
-import com.swiftnav.sbp.piksi.MsgSpecanDep;
-import com.swiftnav.sbp.piksi.MsgSpecan;
-import com.swiftnav.sbp.user.MsgUserData;
+import com.swiftnav.sbp.ssr.MsgSsrOrbitClock;
+import com.swiftnav.sbp.ssr.MsgSsrCodeBiases;
+import com.swiftnav.sbp.ssr.MsgSsrPhaseBiases;
+import com.swiftnav.sbp.ndb.MsgNdbEvent;
+import com.swiftnav.sbp.ext_events.MsgExtEvent;
 import com.swiftnav.sbp.navigation.MsgGPSTime;
 import com.swiftnav.sbp.navigation.MsgUtcTime;
 import com.swiftnav.sbp.navigation.MsgDops;
@@ -90,6 +56,45 @@ import com.swiftnav.sbp.navigation.MsgBaselineNEDDepA;
 import com.swiftnav.sbp.navigation.MsgVelECEFDepA;
 import com.swiftnav.sbp.navigation.MsgVelNEDDepA;
 import com.swiftnav.sbp.navigation.MsgBaselineHeadingDepA;
+import com.swiftnav.sbp.imu.MsgImuRaw;
+import com.swiftnav.sbp.imu.MsgImuAux;
+import com.swiftnav.sbp.sbas.MsgSbasRaw;
+import com.swiftnav.sbp.orientation.MsgBaselineHeading;
+import com.swiftnav.sbp.orientation.MsgOrientQuat;
+import com.swiftnav.sbp.orientation.MsgOrientEuler;
+import com.swiftnav.sbp.orientation.MsgAngularRate;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDetailedDepA;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDetailedDep;
+import com.swiftnav.sbp.tracking.MsgTrackingState;
+import com.swiftnav.sbp.tracking.MsgTrackingIq;
+import com.swiftnav.sbp.tracking.MsgTrackingIqDep;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDepB;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
+import com.swiftnav.sbp.settings.MsgSettingsSave;
+import com.swiftnav.sbp.settings.MsgSettingsWrite;
+import com.swiftnav.sbp.settings.MsgSettingsWriteResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
+import com.swiftnav.sbp.settings.MsgSettingsRegister;
+import com.swiftnav.sbp.flash.MsgFlashProgram;
+import com.swiftnav.sbp.flash.MsgFlashDone;
+import com.swiftnav.sbp.flash.MsgFlashReadReq;
+import com.swiftnav.sbp.flash.MsgFlashReadResp;
+import com.swiftnav.sbp.flash.MsgFlashErase;
+import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
+import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
+import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
 import com.swiftnav.sbp.observation.MsgObs;
 import com.swiftnav.sbp.observation.MsgBasePosLLH;
 import com.swiftnav.sbp.observation.MsgBasePosECEF;
@@ -118,21 +123,10 @@ import com.swiftnav.sbp.observation.MsgAlmanacGPS;
 import com.swiftnav.sbp.observation.MsgAlmanacGloDep;
 import com.swiftnav.sbp.observation.MsgAlmanacGlo;
 import com.swiftnav.sbp.observation.MsgGloBiases;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
-import com.swiftnav.sbp.ndb.MsgNdbEvent;
-import com.swiftnav.sbp.ext_events.MsgExtEvent;
-import com.swiftnav.sbp.vehicle.MsgOdometry;
-import com.swiftnav.sbp.acquisition.MsgAcqResult;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepC;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
-import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
-import com.swiftnav.sbp.acquisition.MsgAcqSvProfileDep;
+import com.swiftnav.sbp.logging.MsgLog;
+import com.swiftnav.sbp.logging.MsgFwd;
+import com.swiftnav.sbp.logging.MsgTweet;
+import com.swiftnav.sbp.logging.MsgPrintDep;
 import com.swiftnav.sbp.file_io.MsgFileioReadReq;
 import com.swiftnav.sbp.file_io.MsgFileioReadResp;
 import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
@@ -140,28 +134,51 @@ import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
 import com.swiftnav.sbp.file_io.MsgFileioRemove;
 import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
 import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
-import com.swiftnav.sbp.imu.MsgImuRaw;
-import com.swiftnav.sbp.imu.MsgImuAux;
-import com.swiftnav.sbp.logging.MsgLog;
-import com.swiftnav.sbp.logging.MsgFwd;
-import com.swiftnav.sbp.logging.MsgTweet;
-import com.swiftnav.sbp.logging.MsgPrintDep;
-import com.swiftnav.sbp.ssr.MsgSsrOrbitClock;
-import com.swiftnav.sbp.ssr.MsgSsrCodeBiases;
-import com.swiftnav.sbp.ssr.MsgSsrPhaseBiases;
-import com.swiftnav.sbp.mag.MsgMagRaw;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDetailedDepA;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDetailedDep;
-import com.swiftnav.sbp.tracking.MsgTrackingState;
-import com.swiftnav.sbp.tracking.MsgTrackingIq;
-import com.swiftnav.sbp.tracking.MsgTrackingIqDep;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDepB;
-import com.swiftnav.sbp.sbas.MsgSbasRaw;
+import com.swiftnav.sbp.vehicle.MsgOdometry;
+import com.swiftnav.sbp.piksi.MsgAlmanac;
+import com.swiftnav.sbp.piksi.MsgSetTime;
+import com.swiftnav.sbp.piksi.MsgReset;
+import com.swiftnav.sbp.piksi.MsgResetDep;
+import com.swiftnav.sbp.piksi.MsgCwResults;
+import com.swiftnav.sbp.piksi.MsgCwStart;
+import com.swiftnav.sbp.piksi.MsgResetFilters;
+import com.swiftnav.sbp.piksi.MsgInitBase;
+import com.swiftnav.sbp.piksi.MsgThreadState;
+import com.swiftnav.sbp.piksi.MsgUartState;
+import com.swiftnav.sbp.piksi.MsgUartStateDepa;
+import com.swiftnav.sbp.piksi.MsgIarState;
+import com.swiftnav.sbp.piksi.MsgMaskSatellite;
+import com.swiftnav.sbp.piksi.MsgMaskSatelliteDep;
+import com.swiftnav.sbp.piksi.MsgDeviceMonitor;
+import com.swiftnav.sbp.piksi.MsgCommandReq;
+import com.swiftnav.sbp.piksi.MsgCommandResp;
+import com.swiftnav.sbp.piksi.MsgCommandOutput;
+import com.swiftnav.sbp.piksi.MsgNetworkStateReq;
+import com.swiftnav.sbp.piksi.MsgNetworkStateResp;
+import com.swiftnav.sbp.piksi.MsgNetworkBandwidthUsage;
+import com.swiftnav.sbp.piksi.MsgCellModemStatus;
+import com.swiftnav.sbp.piksi.MsgSpecanDep;
+import com.swiftnav.sbp.piksi.MsgSpecan;
 
 final class MessageTable {
     static SBPMessage dispatch(SBPMessage msg) throws SBPBinaryException {
         switch (msg.type) {
+            case MsgAcqResult.TYPE:
+                return new MsgAcqResult(msg);
+            case MsgAcqResultDepC.TYPE:
+                return new MsgAcqResultDepC(msg);
+            case MsgAcqResultDepB.TYPE:
+                return new MsgAcqResultDepB(msg);
+            case MsgAcqResultDepA.TYPE:
+                return new MsgAcqResultDepA(msg);
+            case MsgAcqSvProfile.TYPE:
+                return new MsgAcqSvProfile(msg);
+            case MsgAcqSvProfileDep.TYPE:
+                return new MsgAcqSvProfileDep(msg);
+            case MsgUserData.TYPE:
+                return new MsgUserData(msg);
+            case MsgMagRaw.TYPE:
+                return new MsgMagRaw(msg);
             case MsgStartup.TYPE:
                 return new MsgStartup(msg);
             case MsgDgnssStatus.TYPE:
@@ -170,100 +187,16 @@ final class MessageTable {
                 return new MsgHeartbeat(msg);
             case MsgInsStatus.TYPE:
                 return new MsgInsStatus(msg);
-            case MsgSettingsSave.TYPE:
-                return new MsgSettingsSave(msg);
-            case MsgSettingsWrite.TYPE:
-                return new MsgSettingsWrite(msg);
-            case MsgSettingsWriteResp.TYPE:
-                return new MsgSettingsWriteResp(msg);
-            case MsgSettingsReadReq.TYPE:
-                return new MsgSettingsReadReq(msg);
-            case MsgSettingsReadResp.TYPE:
-                return new MsgSettingsReadResp(msg);
-            case MsgSettingsReadByIndexReq.TYPE:
-                return new MsgSettingsReadByIndexReq(msg);
-            case MsgSettingsReadByIndexResp.TYPE:
-                return new MsgSettingsReadByIndexResp(msg);
-            case MsgSettingsReadByIndexDone.TYPE:
-                return new MsgSettingsReadByIndexDone(msg);
-            case MsgSettingsRegister.TYPE:
-                return new MsgSettingsRegister(msg);
-            case MsgBaselineHeading.TYPE:
-                return new MsgBaselineHeading(msg);
-            case MsgOrientQuat.TYPE:
-                return new MsgOrientQuat(msg);
-            case MsgOrientEuler.TYPE:
-                return new MsgOrientEuler(msg);
-            case MsgAngularRate.TYPE:
-                return new MsgAngularRate(msg);
-            case MsgFlashProgram.TYPE:
-                return new MsgFlashProgram(msg);
-            case MsgFlashDone.TYPE:
-                return new MsgFlashDone(msg);
-            case MsgFlashReadReq.TYPE:
-                return new MsgFlashReadReq(msg);
-            case MsgFlashReadResp.TYPE:
-                return new MsgFlashReadResp(msg);
-            case MsgFlashErase.TYPE:
-                return new MsgFlashErase(msg);
-            case MsgStmFlashLockSector.TYPE:
-                return new MsgStmFlashLockSector(msg);
-            case MsgStmFlashUnlockSector.TYPE:
-                return new MsgStmFlashUnlockSector(msg);
-            case MsgStmUniqueIdReq.TYPE:
-                return new MsgStmUniqueIdReq(msg);
-            case MsgStmUniqueIdResp.TYPE:
-                return new MsgStmUniqueIdResp(msg);
-            case MsgM25FlashWriteStatus.TYPE:
-                return new MsgM25FlashWriteStatus(msg);
-            case MsgAlmanac.TYPE:
-                return new MsgAlmanac(msg);
-            case MsgSetTime.TYPE:
-                return new MsgSetTime(msg);
-            case MsgReset.TYPE:
-                return new MsgReset(msg);
-            case MsgResetDep.TYPE:
-                return new MsgResetDep(msg);
-            case MsgCwResults.TYPE:
-                return new MsgCwResults(msg);
-            case MsgCwStart.TYPE:
-                return new MsgCwStart(msg);
-            case MsgResetFilters.TYPE:
-                return new MsgResetFilters(msg);
-            case MsgInitBase.TYPE:
-                return new MsgInitBase(msg);
-            case MsgThreadState.TYPE:
-                return new MsgThreadState(msg);
-            case MsgUartState.TYPE:
-                return new MsgUartState(msg);
-            case MsgUartStateDepa.TYPE:
-                return new MsgUartStateDepa(msg);
-            case MsgIarState.TYPE:
-                return new MsgIarState(msg);
-            case MsgMaskSatellite.TYPE:
-                return new MsgMaskSatellite(msg);
-            case MsgMaskSatelliteDep.TYPE:
-                return new MsgMaskSatelliteDep(msg);
-            case MsgDeviceMonitor.TYPE:
-                return new MsgDeviceMonitor(msg);
-            case MsgCommandReq.TYPE:
-                return new MsgCommandReq(msg);
-            case MsgCommandResp.TYPE:
-                return new MsgCommandResp(msg);
-            case MsgCommandOutput.TYPE:
-                return new MsgCommandOutput(msg);
-            case MsgNetworkStateReq.TYPE:
-                return new MsgNetworkStateReq(msg);
-            case MsgNetworkStateResp.TYPE:
-                return new MsgNetworkStateResp(msg);
-            case MsgNetworkBandwidthUsage.TYPE:
-                return new MsgNetworkBandwidthUsage(msg);
-            case MsgSpecanDep.TYPE:
-                return new MsgSpecanDep(msg);
-            case MsgSpecan.TYPE:
-                return new MsgSpecan(msg);
-            case MsgUserData.TYPE:
-                return new MsgUserData(msg);
+            case MsgSsrOrbitClock.TYPE:
+                return new MsgSsrOrbitClock(msg);
+            case MsgSsrCodeBiases.TYPE:
+                return new MsgSsrCodeBiases(msg);
+            case MsgSsrPhaseBiases.TYPE:
+                return new MsgSsrPhaseBiases(msg);
+            case MsgNdbEvent.TYPE:
+                return new MsgNdbEvent(msg);
+            case MsgExtEvent.TYPE:
+                return new MsgExtEvent(msg);
             case MsgGPSTime.TYPE:
                 return new MsgGPSTime(msg);
             case MsgUtcTime.TYPE:
@@ -312,6 +245,84 @@ final class MessageTable {
                 return new MsgVelNEDDepA(msg);
             case MsgBaselineHeadingDepA.TYPE:
                 return new MsgBaselineHeadingDepA(msg);
+            case MsgImuRaw.TYPE:
+                return new MsgImuRaw(msg);
+            case MsgImuAux.TYPE:
+                return new MsgImuAux(msg);
+            case MsgSbasRaw.TYPE:
+                return new MsgSbasRaw(msg);
+            case MsgBaselineHeading.TYPE:
+                return new MsgBaselineHeading(msg);
+            case MsgOrientQuat.TYPE:
+                return new MsgOrientQuat(msg);
+            case MsgOrientEuler.TYPE:
+                return new MsgOrientEuler(msg);
+            case MsgAngularRate.TYPE:
+                return new MsgAngularRate(msg);
+            case MsgTrackingStateDetailedDepA.TYPE:
+                return new MsgTrackingStateDetailedDepA(msg);
+            case MsgTrackingStateDetailedDep.TYPE:
+                return new MsgTrackingStateDetailedDep(msg);
+            case MsgTrackingState.TYPE:
+                return new MsgTrackingState(msg);
+            case MsgTrackingIq.TYPE:
+                return new MsgTrackingIq(msg);
+            case MsgTrackingIqDep.TYPE:
+                return new MsgTrackingIqDep(msg);
+            case MsgTrackingStateDepA.TYPE:
+                return new MsgTrackingStateDepA(msg);
+            case MsgTrackingStateDepB.TYPE:
+                return new MsgTrackingStateDepB(msg);
+            case MsgBootloaderHandshakeReq.TYPE:
+                return new MsgBootloaderHandshakeReq(msg);
+            case MsgBootloaderHandshakeResp.TYPE:
+                return new MsgBootloaderHandshakeResp(msg);
+            case MsgBootloaderJumpToApp.TYPE:
+                return new MsgBootloaderJumpToApp(msg);
+            case MsgNapDeviceDnaReq.TYPE:
+                return new MsgNapDeviceDnaReq(msg);
+            case MsgNapDeviceDnaResp.TYPE:
+                return new MsgNapDeviceDnaResp(msg);
+            case MsgBootloaderHandshakeDepA.TYPE:
+                return new MsgBootloaderHandshakeDepA(msg);
+            case MsgSettingsSave.TYPE:
+                return new MsgSettingsSave(msg);
+            case MsgSettingsWrite.TYPE:
+                return new MsgSettingsWrite(msg);
+            case MsgSettingsWriteResp.TYPE:
+                return new MsgSettingsWriteResp(msg);
+            case MsgSettingsReadReq.TYPE:
+                return new MsgSettingsReadReq(msg);
+            case MsgSettingsReadResp.TYPE:
+                return new MsgSettingsReadResp(msg);
+            case MsgSettingsReadByIndexReq.TYPE:
+                return new MsgSettingsReadByIndexReq(msg);
+            case MsgSettingsReadByIndexResp.TYPE:
+                return new MsgSettingsReadByIndexResp(msg);
+            case MsgSettingsReadByIndexDone.TYPE:
+                return new MsgSettingsReadByIndexDone(msg);
+            case MsgSettingsRegister.TYPE:
+                return new MsgSettingsRegister(msg);
+            case MsgFlashProgram.TYPE:
+                return new MsgFlashProgram(msg);
+            case MsgFlashDone.TYPE:
+                return new MsgFlashDone(msg);
+            case MsgFlashReadReq.TYPE:
+                return new MsgFlashReadReq(msg);
+            case MsgFlashReadResp.TYPE:
+                return new MsgFlashReadResp(msg);
+            case MsgFlashErase.TYPE:
+                return new MsgFlashErase(msg);
+            case MsgStmFlashLockSector.TYPE:
+                return new MsgStmFlashLockSector(msg);
+            case MsgStmFlashUnlockSector.TYPE:
+                return new MsgStmFlashUnlockSector(msg);
+            case MsgStmUniqueIdReq.TYPE:
+                return new MsgStmUniqueIdReq(msg);
+            case MsgStmUniqueIdResp.TYPE:
+                return new MsgStmUniqueIdResp(msg);
+            case MsgM25FlashWriteStatus.TYPE:
+                return new MsgM25FlashWriteStatus(msg);
             case MsgObs.TYPE:
                 return new MsgObs(msg);
             case MsgBasePosLLH.TYPE:
@@ -368,36 +379,14 @@ final class MessageTable {
                 return new MsgAlmanacGlo(msg);
             case MsgGloBiases.TYPE:
                 return new MsgGloBiases(msg);
-            case MsgBootloaderHandshakeReq.TYPE:
-                return new MsgBootloaderHandshakeReq(msg);
-            case MsgBootloaderHandshakeResp.TYPE:
-                return new MsgBootloaderHandshakeResp(msg);
-            case MsgBootloaderJumpToApp.TYPE:
-                return new MsgBootloaderJumpToApp(msg);
-            case MsgNapDeviceDnaReq.TYPE:
-                return new MsgNapDeviceDnaReq(msg);
-            case MsgNapDeviceDnaResp.TYPE:
-                return new MsgNapDeviceDnaResp(msg);
-            case MsgBootloaderHandshakeDepA.TYPE:
-                return new MsgBootloaderHandshakeDepA(msg);
-            case MsgNdbEvent.TYPE:
-                return new MsgNdbEvent(msg);
-            case MsgExtEvent.TYPE:
-                return new MsgExtEvent(msg);
-            case MsgOdometry.TYPE:
-                return new MsgOdometry(msg);
-            case MsgAcqResult.TYPE:
-                return new MsgAcqResult(msg);
-            case MsgAcqResultDepC.TYPE:
-                return new MsgAcqResultDepC(msg);
-            case MsgAcqResultDepB.TYPE:
-                return new MsgAcqResultDepB(msg);
-            case MsgAcqResultDepA.TYPE:
-                return new MsgAcqResultDepA(msg);
-            case MsgAcqSvProfile.TYPE:
-                return new MsgAcqSvProfile(msg);
-            case MsgAcqSvProfileDep.TYPE:
-                return new MsgAcqSvProfileDep(msg);
+            case MsgLog.TYPE:
+                return new MsgLog(msg);
+            case MsgFwd.TYPE:
+                return new MsgFwd(msg);
+            case MsgTweet.TYPE:
+                return new MsgTweet(msg);
+            case MsgPrintDep.TYPE:
+                return new MsgPrintDep(msg);
             case MsgFileioReadReq.TYPE:
                 return new MsgFileioReadReq(msg);
             case MsgFileioReadResp.TYPE:
@@ -412,42 +401,56 @@ final class MessageTable {
                 return new MsgFileioWriteReq(msg);
             case MsgFileioWriteResp.TYPE:
                 return new MsgFileioWriteResp(msg);
-            case MsgImuRaw.TYPE:
-                return new MsgImuRaw(msg);
-            case MsgImuAux.TYPE:
-                return new MsgImuAux(msg);
-            case MsgLog.TYPE:
-                return new MsgLog(msg);
-            case MsgFwd.TYPE:
-                return new MsgFwd(msg);
-            case MsgTweet.TYPE:
-                return new MsgTweet(msg);
-            case MsgPrintDep.TYPE:
-                return new MsgPrintDep(msg);
-            case MsgSsrOrbitClock.TYPE:
-                return new MsgSsrOrbitClock(msg);
-            case MsgSsrCodeBiases.TYPE:
-                return new MsgSsrCodeBiases(msg);
-            case MsgSsrPhaseBiases.TYPE:
-                return new MsgSsrPhaseBiases(msg);
-            case MsgMagRaw.TYPE:
-                return new MsgMagRaw(msg);
-            case MsgTrackingStateDetailedDepA.TYPE:
-                return new MsgTrackingStateDetailedDepA(msg);
-            case MsgTrackingStateDetailedDep.TYPE:
-                return new MsgTrackingStateDetailedDep(msg);
-            case MsgTrackingState.TYPE:
-                return new MsgTrackingState(msg);
-            case MsgTrackingIq.TYPE:
-                return new MsgTrackingIq(msg);
-            case MsgTrackingIqDep.TYPE:
-                return new MsgTrackingIqDep(msg);
-            case MsgTrackingStateDepA.TYPE:
-                return new MsgTrackingStateDepA(msg);
-            case MsgTrackingStateDepB.TYPE:
-                return new MsgTrackingStateDepB(msg);
-            case MsgSbasRaw.TYPE:
-                return new MsgSbasRaw(msg);
+            case MsgOdometry.TYPE:
+                return new MsgOdometry(msg);
+            case MsgAlmanac.TYPE:
+                return new MsgAlmanac(msg);
+            case MsgSetTime.TYPE:
+                return new MsgSetTime(msg);
+            case MsgReset.TYPE:
+                return new MsgReset(msg);
+            case MsgResetDep.TYPE:
+                return new MsgResetDep(msg);
+            case MsgCwResults.TYPE:
+                return new MsgCwResults(msg);
+            case MsgCwStart.TYPE:
+                return new MsgCwStart(msg);
+            case MsgResetFilters.TYPE:
+                return new MsgResetFilters(msg);
+            case MsgInitBase.TYPE:
+                return new MsgInitBase(msg);
+            case MsgThreadState.TYPE:
+                return new MsgThreadState(msg);
+            case MsgUartState.TYPE:
+                return new MsgUartState(msg);
+            case MsgUartStateDepa.TYPE:
+                return new MsgUartStateDepa(msg);
+            case MsgIarState.TYPE:
+                return new MsgIarState(msg);
+            case MsgMaskSatellite.TYPE:
+                return new MsgMaskSatellite(msg);
+            case MsgMaskSatelliteDep.TYPE:
+                return new MsgMaskSatelliteDep(msg);
+            case MsgDeviceMonitor.TYPE:
+                return new MsgDeviceMonitor(msg);
+            case MsgCommandReq.TYPE:
+                return new MsgCommandReq(msg);
+            case MsgCommandResp.TYPE:
+                return new MsgCommandResp(msg);
+            case MsgCommandOutput.TYPE:
+                return new MsgCommandOutput(msg);
+            case MsgNetworkStateReq.TYPE:
+                return new MsgNetworkStateReq(msg);
+            case MsgNetworkStateResp.TYPE:
+                return new MsgNetworkStateResp(msg);
+            case MsgNetworkBandwidthUsage.TYPE:
+                return new MsgNetworkBandwidthUsage(msg);
+            case MsgCellModemStatus.TYPE:
+                return new MsgCellModemStatus(msg);
+            case MsgSpecanDep.TYPE:
+                return new MsgSpecanDep(msg);
+            case MsgSpecan.TYPE:
+                return new MsgSpecan(msg);
         }
         return msg;
     }

--- a/java/src/com/swiftnav/sbp/piksi/MsgCellModemStatus.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCellModemStatus.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.swiftnav.sbp.piksi;
+
+import java.math.BigInteger;
+
+import com.swiftnav.sbp.SBPMessage;
+import com.swiftnav.sbp.SBPBinaryException;
+import com.swiftnav.sbp.SBPStruct;
+import com.swiftnav.sbp.gnss.*;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+
+/** SBP class for message MSG_CELL_MODEM_STATUS (0x00BE).
+ *
+ * You can have MSG_CELL_MODEM_STATUS inherent its fields directly from
+ * an inherited SBP object, or construct it inline using a dict of its
+ * fields.
+ *
+ * If a cell modem is present on a piksi device, this message
+ * will be send periodically to update the host on the status
+ * of the modem and its various parameters. */
+
+public class MsgCellModemStatus extends SBPMessage {
+    public static final int TYPE = 0x00BE;
+
+    
+    /** Received cell signal strength in dBm, zero translates to unknown */
+    public int signal_strength;
+    
+    /** BER as reported by the modem, zero translates to unknown */
+    public float signal_error_rate;
+    
+    /** Unspecified data TBD for this schema */
+    public int[] reserved;
+    
+
+    public MsgCellModemStatus (int sender) { super(sender, TYPE); }
+    public MsgCellModemStatus () { super(TYPE); }
+    public MsgCellModemStatus (SBPMessage msg) throws SBPBinaryException {
+        super(msg);
+        assert msg.type != TYPE;
+    }
+
+    @Override
+    protected void parse(Parser parser) throws SBPBinaryException {
+        /* Parse fields from binary */
+        signal_strength = parser.getS8();
+        signal_error_rate = parser.getFloat();
+        reserved = parser.getArrayofU8();
+    }
+
+    @Override
+    protected void build(Builder builder) {
+        builder.putS8(signal_strength);
+        builder.putFloat(signal_error_rate);
+        builder.putArrayofU8(reserved);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject obj = super.toJSON();
+        obj.put("signal_strength", signal_strength);
+        obj.put("signal_error_rate", signal_error_rate);
+        obj.put("reserved", new JSONArray(reserved));
+        return obj;
+    }
+}

--- a/javascript/sbp.bundle.js
+++ b/javascript/sbp.bundle.js
@@ -480,7 +480,7 @@ SBP.prototype.toBase64 = function toBase64 () {
 
 module.exports = SBP;
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6).Buffer))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
 /* 3 */
@@ -755,7 +755,7 @@ Int64.prototype = {
   }
 };
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6).Buffer))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
 /* 4 */
@@ -772,7 +772,7 @@ Int64.prototype = {
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-var Parser = __webpack_require__(12).Parser;
+var Parser = __webpack_require__(13).Parser;
 
 /**
  * Add `uint64` to Parser prototype.
@@ -809,7 +809,7 @@ Parser.prototype.compile = function() {
 
 module.exports = Parser;
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6).Buffer))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
 /* 5 */
@@ -840,6 +840,136 @@ module.exports = g;
 
 /***/ }),
 /* 6 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// a duplex stream is just a stream that is both readable and writable.
+// Since JS doesn't have multiple prototypal inheritance, this class
+// prototypally inherits from Readable, and then parasitically from
+// Writable.
+
+
+
+/*<replacement>*/
+
+var pna = __webpack_require__(11);
+/*</replacement>*/
+
+/*<replacement>*/
+var objectKeys = Object.keys || function (obj) {
+  var keys = [];
+  for (var key in obj) {
+    keys.push(key);
+  }return keys;
+};
+/*</replacement>*/
+
+module.exports = Duplex;
+
+/*<replacement>*/
+var util = __webpack_require__(10);
+util.inherits = __webpack_require__(8);
+/*</replacement>*/
+
+var Readable = __webpack_require__(18);
+var Writable = __webpack_require__(15);
+
+util.inherits(Duplex, Readable);
+
+var keys = objectKeys(Writable.prototype);
+for (var v = 0; v < keys.length; v++) {
+  var method = keys[v];
+  if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
+}
+
+function Duplex(options) {
+  if (!(this instanceof Duplex)) return new Duplex(options);
+
+  Readable.call(this, options);
+  Writable.call(this, options);
+
+  if (options && options.readable === false) this.readable = false;
+
+  if (options && options.writable === false) this.writable = false;
+
+  this.allowHalfOpen = true;
+  if (options && options.allowHalfOpen === false) this.allowHalfOpen = false;
+
+  this.once('end', onend);
+}
+
+// the no-half-open enforcer
+function onend() {
+  // if we allow half-open state, or if the writable side ended,
+  // then we're ok.
+  if (this.allowHalfOpen || this._writableState.ended) return;
+
+  // no more data can be written.
+  // But allow more writes to happen in this tick.
+  pna.nextTick(onEndNT, this);
+}
+
+function onEndNT(self) {
+  self.end();
+}
+
+Object.defineProperty(Duplex.prototype, 'destroyed', {
+  get: function () {
+    if (this._readableState === undefined || this._writableState === undefined) {
+      return false;
+    }
+    return this._readableState.destroyed && this._writableState.destroyed;
+  },
+  set: function (value) {
+    // we ignore the value if the stream
+    // has not been initialized yet
+    if (this._readableState === undefined || this._writableState === undefined) {
+      return;
+    }
+
+    // backward compatibility, the user is explicitly
+    // managing destroyed
+    this._readableState.destroyed = value;
+    this._writableState.destroyed = value;
+  }
+});
+
+Duplex.prototype._destroy = function (err, cb) {
+  this.push(null);
+  this.end();
+
+  pna.nextTick(cb, err);
+};
+
+function forEach(xs, f) {
+  for (var i = 0, l = xs.length; i < l; i++) {
+    f(xs[i], i);
+  }
+}
+
+/***/ }),
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2636,136 +2766,6 @@ function isnan (val) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
 
 /***/ }),
-/* 7 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-// a duplex stream is just a stream that is both readable and writable.
-// Since JS doesn't have multiple prototypal inheritance, this class
-// prototypally inherits from Readable, and then parasitically from
-// Writable.
-
-
-
-/*<replacement>*/
-
-var processNextTick = __webpack_require__(11);
-/*</replacement>*/
-
-/*<replacement>*/
-var objectKeys = Object.keys || function (obj) {
-  var keys = [];
-  for (var key in obj) {
-    keys.push(key);
-  }return keys;
-};
-/*</replacement>*/
-
-module.exports = Duplex;
-
-/*<replacement>*/
-var util = __webpack_require__(10);
-util.inherits = __webpack_require__(8);
-/*</replacement>*/
-
-var Readable = __webpack_require__(19);
-var Writable = __webpack_require__(14);
-
-util.inherits(Duplex, Readable);
-
-var keys = objectKeys(Writable.prototype);
-for (var v = 0; v < keys.length; v++) {
-  var method = keys[v];
-  if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
-}
-
-function Duplex(options) {
-  if (!(this instanceof Duplex)) return new Duplex(options);
-
-  Readable.call(this, options);
-  Writable.call(this, options);
-
-  if (options && options.readable === false) this.readable = false;
-
-  if (options && options.writable === false) this.writable = false;
-
-  this.allowHalfOpen = true;
-  if (options && options.allowHalfOpen === false) this.allowHalfOpen = false;
-
-  this.once('end', onend);
-}
-
-// the no-half-open enforcer
-function onend() {
-  // if we allow half-open state, or if the writable side ended,
-  // then we're ok.
-  if (this.allowHalfOpen || this._writableState.ended) return;
-
-  // no more data can be written.
-  // But allow more writes to happen in this tick.
-  processNextTick(onEndNT, this);
-}
-
-function onEndNT(self) {
-  self.end();
-}
-
-Object.defineProperty(Duplex.prototype, 'destroyed', {
-  get: function () {
-    if (this._readableState === undefined || this._writableState === undefined) {
-      return false;
-    }
-    return this._readableState.destroyed && this._writableState.destroyed;
-  },
-  set: function (value) {
-    // we ignore the value if the stream
-    // has not been initialized yet
-    if (this._readableState === undefined || this._writableState === undefined) {
-      return;
-    }
-
-    // backward compatibility, the user is explicitly
-    // managing destroyed
-    this._readableState.destroyed = value;
-    this._writableState.destroyed = value;
-  }
-});
-
-Duplex.prototype._destroy = function (err, cb) {
-  this.push(null);
-  this.end();
-
-  processNextTick(cb, err);
-};
-
-function forEach(xs, f) {
-  for (var i = 0, l = xs.length; i < l; i++) {
-    f(xs[i], i);
-  }
-}
-
-/***/ }),
 /* 8 */
 /***/ (function(module, exports) {
 
@@ -3096,7 +3096,7 @@ function objectToString(o) {
   return Object.prototype.toString.call(o);
 }
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6).Buffer))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer))
 
 /***/ }),
 /* 11 */
@@ -3108,9 +3108,9 @@ function objectToString(o) {
 if (!process.version ||
     process.version.indexOf('v0.') === 0 ||
     process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
-  module.exports = nextTick;
+  module.exports = { nextTick: nextTick };
 } else {
-  module.exports = process.nextTick;
+  module.exports = process
 }
 
 function nextTick(fn, arg1, arg2, arg3) {
@@ -3147,10 +3147,79 @@ function nextTick(fn, arg1, arg2, arg3) {
   }
 }
 
+
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(9)))
 
 /***/ }),
 /* 12 */
+/***/ (function(module, exports, __webpack_require__) {
+
+/* eslint-disable node/no-deprecated-api */
+var buffer = __webpack_require__(7)
+var Buffer = buffer.Buffer
+
+// alternative to using Object.keys for old browsers
+function copyProps (src, dst) {
+  for (var key in src) {
+    dst[key] = src[key]
+  }
+}
+if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+  module.exports = buffer
+} else {
+  // Copy properties from require('buffer')
+  copyProps(buffer, exports)
+  exports.Buffer = SafeBuffer
+}
+
+function SafeBuffer (arg, encodingOrOffset, length) {
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+// Copy static methods from Buffer
+copyProps(Buffer, SafeBuffer)
+
+SafeBuffer.from = function (arg, encodingOrOffset, length) {
+  if (typeof arg === 'number') {
+    throw new TypeError('Argument must not be a number')
+  }
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+SafeBuffer.alloc = function (size, fill, encoding) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  var buf = Buffer(size)
+  if (fill !== undefined) {
+    if (typeof encoding === 'string') {
+      buf.fill(fill, encoding)
+    } else {
+      buf.fill(fill)
+    }
+  } else {
+    buf.fill(0)
+  }
+  return buf
+}
+
+SafeBuffer.allocUnsafe = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return Buffer(size)
+}
+
+SafeBuffer.allocUnsafeSlow = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return buffer.SlowBuffer(size)
+}
+
+
+/***/ }),
+/* 13 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //========================================================================================
@@ -3729,7 +3798,7 @@ exports.Parser = Parser;
 
 
 /***/ }),
-/* 13 */
+/* 14 */
 /***/ (function(module, exports) {
 
 // Copyright Joyent, Inc. and other Node contributors.
@@ -4037,7 +4106,7 @@ function isUndefined(arg) {
 
 
 /***/ }),
-/* 14 */
+/* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -4070,7 +4139,7 @@ function isUndefined(arg) {
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(11);
+var pna = __webpack_require__(11);
 /*</replacement>*/
 
 module.exports = Writable;
@@ -4097,7 +4166,7 @@ function CorkedRequest(state) {
 /* </replacement> */
 
 /*<replacement>*/
-var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : processNextTick;
+var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : pna.nextTick;
 /*</replacement>*/
 
 /*<replacement>*/
@@ -4118,11 +4187,12 @@ var internalUtil = {
 /*</replacement>*/
 
 /*<replacement>*/
-var Stream = __webpack_require__(22);
+var Stream = __webpack_require__(21);
 /*</replacement>*/
 
 /*<replacement>*/
-var Buffer = __webpack_require__(16).Buffer;
+
+var Buffer = __webpack_require__(12).Buffer;
 var OurUint8Array = global.Uint8Array || function () {};
 function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
@@ -4130,31 +4200,41 @@ function _uint8ArrayToBuffer(chunk) {
 function _isUint8Array(obj) {
   return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
+
 /*</replacement>*/
 
-var destroyImpl = __webpack_require__(21);
+var destroyImpl = __webpack_require__(20);
 
 util.inherits(Writable, Stream);
 
 function nop() {}
 
 function WritableState(options, stream) {
-  Duplex = Duplex || __webpack_require__(7);
+  Duplex = Duplex || __webpack_require__(6);
 
   options = options || {};
+
+  // Duplex streams are both readable and writable, but share
+  // the same options object.
+  // However, some cases require setting options to different
+  // values for the readable and the writable sides of the duplex stream.
+  // These options can be provided separately as readableXXX and writableXXX.
+  var isDuplex = stream instanceof Duplex;
 
   // object stream flag to indicate whether or not this stream
   // contains buffers or objects.
   this.objectMode = !!options.objectMode;
 
-  if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.writableObjectMode;
+  if (isDuplex) this.objectMode = this.objectMode || !!options.writableObjectMode;
 
   // the point at which write() starts returning false
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
+  var writableHwm = options.writableHighWaterMark;
   var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-  this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+
+  if (hwm || hwm === 0) this.highWaterMark = hwm;else if (isDuplex && (writableHwm || writableHwm === 0)) this.highWaterMark = writableHwm;else this.highWaterMark = defaultHwm;
 
   // cast to ints.
   this.highWaterMark = Math.floor(this.highWaterMark);
@@ -4268,6 +4348,7 @@ if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.protot
   Object.defineProperty(Writable, Symbol.hasInstance, {
     value: function (object) {
       if (realHasInstance.call(this, object)) return true;
+      if (this !== Writable) return false;
 
       return object && object._writableState instanceof WritableState;
     }
@@ -4279,7 +4360,7 @@ if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.protot
 }
 
 function Writable(options) {
-  Duplex = Duplex || __webpack_require__(7);
+  Duplex = Duplex || __webpack_require__(6);
 
   // Writable ctor is applied to Duplexes, too.
   // `realHasInstance` is necessary because using plain `instanceof`
@@ -4319,7 +4400,7 @@ function writeAfterEnd(stream, cb) {
   var er = new Error('write after end');
   // TODO: defer error events consistently everywhere, not just the cb
   stream.emit('error', er);
-  processNextTick(cb, er);
+  pna.nextTick(cb, er);
 }
 
 // Checks that a user-supplied chunk is valid, especially for the particular
@@ -4336,7 +4417,7 @@ function validChunk(stream, state, chunk, cb) {
   }
   if (er) {
     stream.emit('error', er);
-    processNextTick(cb, er);
+    pna.nextTick(cb, er);
     valid = false;
   }
   return valid;
@@ -4345,7 +4426,7 @@ function validChunk(stream, state, chunk, cb) {
 Writable.prototype.write = function (chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
-  var isBuf = _isUint8Array(chunk) && !state.objectMode;
+  var isBuf = !state.objectMode && _isUint8Array(chunk);
 
   if (isBuf && !Buffer.isBuffer(chunk)) {
     chunk = _uint8ArrayToBuffer(chunk);
@@ -4456,10 +4537,10 @@ function onwriteError(stream, state, sync, er, cb) {
   if (sync) {
     // defer the callback if we are being called synchronously
     // to avoid piling up things on the stack
-    processNextTick(cb, er);
+    pna.nextTick(cb, er);
     // this can emit finish, and it will always happen
     // after error
-    processNextTick(finishMaybe, stream, state);
+    pna.nextTick(finishMaybe, stream, state);
     stream._writableState.errorEmitted = true;
     stream.emit('error', er);
   } else {
@@ -4557,6 +4638,7 @@ function clearBuffer(stream, state) {
     } else {
       state.corkedRequestsFree = new CorkedRequest(state);
     }
+    state.bufferedRequestCount = 0;
   } else {
     // Slow case, write chunks one-by-one
     while (entry) {
@@ -4567,6 +4649,7 @@ function clearBuffer(stream, state) {
 
       doWrite(stream, state, false, len, chunk, encoding, cb);
       entry = entry.next;
+      state.bufferedRequestCount--;
       // if we didn't call the onwrite immediately, then
       // it means that we need to wait until it does.
       // also, that means that the chunk and cb are currently
@@ -4579,7 +4662,6 @@ function clearBuffer(stream, state) {
     if (entry === null) state.lastBufferedRequest = null;
   }
 
-  state.bufferedRequestCount = 0;
   state.bufferedRequest = entry;
   state.bufferProcessing = false;
 }
@@ -4633,7 +4715,7 @@ function prefinish(stream, state) {
     if (typeof stream._final === 'function') {
       state.pendingcb++;
       state.finalCalled = true;
-      processNextTick(callFinal, stream, state);
+      pna.nextTick(callFinal, stream, state);
     } else {
       state.prefinished = true;
       stream.emit('prefinish');
@@ -4657,7 +4739,7 @@ function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
   if (cb) {
-    if (state.finished) processNextTick(cb);else stream.once('finish', cb);
+    if (state.finished) pna.nextTick(cb);else stream.once('finish', cb);
   }
   state.ended = true;
   stream.writable = false;
@@ -4708,84 +4790,16 @@ Writable.prototype._destroy = function (err, cb) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(9), __webpack_require__(60).setImmediate, __webpack_require__(5)))
 
 /***/ }),
-/* 15 */
-/***/ (function(module, exports, __webpack_require__) {
-
-exports = module.exports = __webpack_require__(19);
-exports.Stream = exports;
-exports.Readable = exports;
-exports.Writable = __webpack_require__(14);
-exports.Duplex = __webpack_require__(7);
-exports.Transform = __webpack_require__(20);
-exports.PassThrough = __webpack_require__(54);
-
-
-/***/ }),
 /* 16 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* eslint-disable node/no-deprecated-api */
-var buffer = __webpack_require__(6)
-var Buffer = buffer.Buffer
-
-// alternative to using Object.keys for old browsers
-function copyProps (src, dst) {
-  for (var key in src) {
-    dst[key] = src[key]
-  }
-}
-if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
-  module.exports = buffer
-} else {
-  // Copy properties from require('buffer')
-  copyProps(buffer, exports)
-  exports.Buffer = SafeBuffer
-}
-
-function SafeBuffer (arg, encodingOrOffset, length) {
-  return Buffer(arg, encodingOrOffset, length)
-}
-
-// Copy static methods from Buffer
-copyProps(Buffer, SafeBuffer)
-
-SafeBuffer.from = function (arg, encodingOrOffset, length) {
-  if (typeof arg === 'number') {
-    throw new TypeError('Argument must not be a number')
-  }
-  return Buffer(arg, encodingOrOffset, length)
-}
-
-SafeBuffer.alloc = function (size, fill, encoding) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  var buf = Buffer(size)
-  if (fill !== undefined) {
-    if (typeof encoding === 'string') {
-      buf.fill(fill, encoding)
-    } else {
-      buf.fill(fill)
-    }
-  } else {
-    buf.fill(0)
-  }
-  return buf
-}
-
-SafeBuffer.allocUnsafe = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return Buffer(size)
-}
-
-SafeBuffer.allocUnsafeSlow = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return buffer.SlowBuffer(size)
-}
+exports = module.exports = __webpack_require__(18);
+exports.Stream = exports;
+exports.Readable = exports;
+exports.Writable = __webpack_require__(15);
+exports.Duplex = __webpack_require__(6);
+exports.Transform = __webpack_require__(19);
+exports.PassThrough = __webpack_require__(54);
 
 
 /***/ }),
@@ -4801,233 +4815,6 @@ module.exports = Array.isArray || function (arr) {
 
 /***/ }),
 /* 18 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-var Buffer = __webpack_require__(6).Buffer;
-
-var isBufferEncoding = Buffer.isEncoding
-  || function(encoding) {
-       switch (encoding && encoding.toLowerCase()) {
-         case 'hex': case 'utf8': case 'utf-8': case 'ascii': case 'binary': case 'base64': case 'ucs2': case 'ucs-2': case 'utf16le': case 'utf-16le': case 'raw': return true;
-         default: return false;
-       }
-     }
-
-
-function assertEncoding(encoding) {
-  if (encoding && !isBufferEncoding(encoding)) {
-    throw new Error('Unknown encoding: ' + encoding);
-  }
-}
-
-// StringDecoder provides an interface for efficiently splitting a series of
-// buffers into a series of JS strings without breaking apart multi-byte
-// characters. CESU-8 is handled as part of the UTF-8 encoding.
-//
-// @TODO Handling all encodings inside a single object makes it very difficult
-// to reason about this code, so it should be split up in the future.
-// @TODO There should be a utf8-strict encoding that rejects invalid UTF-8 code
-// points as used by CESU-8.
-var StringDecoder = exports.StringDecoder = function(encoding) {
-  this.encoding = (encoding || 'utf8').toLowerCase().replace(/[-_]/, '');
-  assertEncoding(encoding);
-  switch (this.encoding) {
-    case 'utf8':
-      // CESU-8 represents each of Surrogate Pair by 3-bytes
-      this.surrogateSize = 3;
-      break;
-    case 'ucs2':
-    case 'utf16le':
-      // UTF-16 represents each of Surrogate Pair by 2-bytes
-      this.surrogateSize = 2;
-      this.detectIncompleteChar = utf16DetectIncompleteChar;
-      break;
-    case 'base64':
-      // Base-64 stores 3 bytes in 4 chars, and pads the remainder.
-      this.surrogateSize = 3;
-      this.detectIncompleteChar = base64DetectIncompleteChar;
-      break;
-    default:
-      this.write = passThroughWrite;
-      return;
-  }
-
-  // Enough space to store all bytes of a single character. UTF-8 needs 4
-  // bytes, but CESU-8 may require up to 6 (3 bytes per surrogate).
-  this.charBuffer = new Buffer(6);
-  // Number of bytes received for the current incomplete multi-byte character.
-  this.charReceived = 0;
-  // Number of bytes expected for the current incomplete multi-byte character.
-  this.charLength = 0;
-};
-
-
-// write decodes the given buffer and returns it as JS string that is
-// guaranteed to not contain any partial multi-byte characters. Any partial
-// character found at the end of the buffer is buffered up, and will be
-// returned when calling write again with the remaining bytes.
-//
-// Note: Converting a Buffer containing an orphan surrogate to a String
-// currently works, but converting a String to a Buffer (via `new Buffer`, or
-// Buffer#write) will replace incomplete surrogates with the unicode
-// replacement character. See https://codereview.chromium.org/121173009/ .
-StringDecoder.prototype.write = function(buffer) {
-  var charStr = '';
-  // if our last write ended with an incomplete multibyte character
-  while (this.charLength) {
-    // determine how many remaining bytes this buffer has to offer for this char
-    var available = (buffer.length >= this.charLength - this.charReceived) ?
-        this.charLength - this.charReceived :
-        buffer.length;
-
-    // add the new bytes to the char buffer
-    buffer.copy(this.charBuffer, this.charReceived, 0, available);
-    this.charReceived += available;
-
-    if (this.charReceived < this.charLength) {
-      // still not enough chars in this buffer? wait for more ...
-      return '';
-    }
-
-    // remove bytes belonging to the current character from the buffer
-    buffer = buffer.slice(available, buffer.length);
-
-    // get the character that was split
-    charStr = this.charBuffer.slice(0, this.charLength).toString(this.encoding);
-
-    // CESU-8: lead surrogate (D800-DBFF) is also the incomplete character
-    var charCode = charStr.charCodeAt(charStr.length - 1);
-    if (charCode >= 0xD800 && charCode <= 0xDBFF) {
-      this.charLength += this.surrogateSize;
-      charStr = '';
-      continue;
-    }
-    this.charReceived = this.charLength = 0;
-
-    // if there are no more bytes in this buffer, just emit our char
-    if (buffer.length === 0) {
-      return charStr;
-    }
-    break;
-  }
-
-  // determine and set charLength / charReceived
-  this.detectIncompleteChar(buffer);
-
-  var end = buffer.length;
-  if (this.charLength) {
-    // buffer the incomplete character bytes we got
-    buffer.copy(this.charBuffer, 0, buffer.length - this.charReceived, end);
-    end -= this.charReceived;
-  }
-
-  charStr += buffer.toString(this.encoding, 0, end);
-
-  var end = charStr.length - 1;
-  var charCode = charStr.charCodeAt(end);
-  // CESU-8: lead surrogate (D800-DBFF) is also the incomplete character
-  if (charCode >= 0xD800 && charCode <= 0xDBFF) {
-    var size = this.surrogateSize;
-    this.charLength += size;
-    this.charReceived += size;
-    this.charBuffer.copy(this.charBuffer, size, 0, size);
-    buffer.copy(this.charBuffer, 0, 0, size);
-    return charStr.substring(0, end);
-  }
-
-  // or just emit the charStr
-  return charStr;
-};
-
-// detectIncompleteChar determines if there is an incomplete UTF-8 character at
-// the end of the given buffer. If so, it sets this.charLength to the byte
-// length that character, and sets this.charReceived to the number of bytes
-// that are available for this character.
-StringDecoder.prototype.detectIncompleteChar = function(buffer) {
-  // determine how many bytes we have to check at the end of this buffer
-  var i = (buffer.length >= 3) ? 3 : buffer.length;
-
-  // Figure out if one of the last i bytes of our buffer announces an
-  // incomplete char.
-  for (; i > 0; i--) {
-    var c = buffer[buffer.length - i];
-
-    // See http://en.wikipedia.org/wiki/UTF-8#Description
-
-    // 110XXXXX
-    if (i == 1 && c >> 5 == 0x06) {
-      this.charLength = 2;
-      break;
-    }
-
-    // 1110XXXX
-    if (i <= 2 && c >> 4 == 0x0E) {
-      this.charLength = 3;
-      break;
-    }
-
-    // 11110XXX
-    if (i <= 3 && c >> 3 == 0x1E) {
-      this.charLength = 4;
-      break;
-    }
-  }
-  this.charReceived = i;
-};
-
-StringDecoder.prototype.end = function(buffer) {
-  var res = '';
-  if (buffer && buffer.length)
-    res = this.write(buffer);
-
-  if (this.charReceived) {
-    var cr = this.charReceived;
-    var buf = this.charBuffer;
-    var enc = this.encoding;
-    res += buf.slice(0, cr).toString(enc);
-  }
-
-  return res;
-};
-
-function passThroughWrite(buffer) {
-  return buffer.toString(this.encoding);
-}
-
-function utf16DetectIncompleteChar(buffer) {
-  this.charReceived = buffer.length % 2;
-  this.charLength = this.charReceived ? 2 : 0;
-}
-
-function base64DetectIncompleteChar(buffer) {
-  this.charReceived = buffer.length % 3;
-  this.charLength = this.charReceived ? 3 : 0;
-}
-
-
-/***/ }),
-/* 19 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5056,7 +4843,7 @@ function base64DetectIncompleteChar(buffer) {
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(11);
+var pna = __webpack_require__(11);
 /*</replacement>*/
 
 module.exports = Readable;
@@ -5072,7 +4859,7 @@ var Duplex;
 Readable.ReadableState = ReadableState;
 
 /*<replacement>*/
-var EE = __webpack_require__(13).EventEmitter;
+var EE = __webpack_require__(14).EventEmitter;
 
 var EElistenerCount = function (emitter, type) {
   return emitter.listeners(type).length;
@@ -5080,13 +4867,12 @@ var EElistenerCount = function (emitter, type) {
 /*</replacement>*/
 
 /*<replacement>*/
-var Stream = __webpack_require__(22);
+var Stream = __webpack_require__(21);
 /*</replacement>*/
 
-// TODO(bmeurer): Change this back to const once hole checks are
-// properly optimized away early in Ignition+TurboFan.
 /*<replacement>*/
-var Buffer = __webpack_require__(16).Buffer;
+
+var Buffer = __webpack_require__(12).Buffer;
 var OurUint8Array = global.Uint8Array || function () {};
 function _uint8ArrayToBuffer(chunk) {
   return Buffer.from(chunk);
@@ -5094,6 +4880,7 @@ function _uint8ArrayToBuffer(chunk) {
 function _isUint8Array(obj) {
   return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
+
 /*</replacement>*/
 
 /*<replacement>*/
@@ -5112,7 +4899,7 @@ if (debugUtil && debugUtil.debuglog) {
 /*</replacement>*/
 
 var BufferList = __webpack_require__(55);
-var destroyImpl = __webpack_require__(21);
+var destroyImpl = __webpack_require__(20);
 var StringDecoder;
 
 util.inherits(Readable, Stream);
@@ -5122,33 +4909,40 @@ var kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
 function prependListener(emitter, event, fn) {
   // Sadly this is not cacheable as some libraries bundle their own
   // event emitter implementation with them.
-  if (typeof emitter.prependListener === 'function') {
-    return emitter.prependListener(event, fn);
-  } else {
-    // This is a hack to make sure that our error handler is attached before any
-    // userland ones.  NEVER DO THIS. This is here only because this code needs
-    // to continue to work with older versions of Node.js that do not include
-    // the prependListener() method. The goal is to eventually remove this hack.
-    if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
-  }
+  if (typeof emitter.prependListener === 'function') return emitter.prependListener(event, fn);
+
+  // This is a hack to make sure that our error handler is attached before any
+  // userland ones.  NEVER DO THIS. This is here only because this code needs
+  // to continue to work with older versions of Node.js that do not include
+  // the prependListener() method. The goal is to eventually remove this hack.
+  if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
 }
 
 function ReadableState(options, stream) {
-  Duplex = Duplex || __webpack_require__(7);
+  Duplex = Duplex || __webpack_require__(6);
 
   options = options || {};
+
+  // Duplex streams are both readable and writable, but share
+  // the same options object.
+  // However, some cases require setting options to different
+  // values for the readable and the writable sides of the duplex stream.
+  // These options can be provided separately as readableXXX and writableXXX.
+  var isDuplex = stream instanceof Duplex;
 
   // object stream flag. Used to make read(n) ignore n and to
   // make all the buffer merging and length checks go away
   this.objectMode = !!options.objectMode;
 
-  if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.readableObjectMode;
+  if (isDuplex) this.objectMode = this.objectMode || !!options.readableObjectMode;
 
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
+  var readableHwm = options.readableHighWaterMark;
   var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-  this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+
+  if (hwm || hwm === 0) this.highWaterMark = hwm;else if (isDuplex && (readableHwm || readableHwm === 0)) this.highWaterMark = readableHwm;else this.highWaterMark = defaultHwm;
 
   // cast to ints.
   this.highWaterMark = Math.floor(this.highWaterMark);
@@ -5195,14 +4989,14 @@ function ReadableState(options, stream) {
   this.decoder = null;
   this.encoding = null;
   if (options.encoding) {
-    if (!StringDecoder) StringDecoder = __webpack_require__(18).StringDecoder;
+    if (!StringDecoder) StringDecoder = __webpack_require__(22).StringDecoder;
     this.decoder = new StringDecoder(options.encoding);
     this.encoding = options.encoding;
   }
 }
 
 function Readable(options) {
-  Duplex = Duplex || __webpack_require__(7);
+  Duplex = Duplex || __webpack_require__(6);
 
   if (!(this instanceof Readable)) return new Readable(options);
 
@@ -5351,7 +5145,7 @@ Readable.prototype.isPaused = function () {
 
 // backwards compatibility.
 Readable.prototype.setEncoding = function (enc) {
-  if (!StringDecoder) StringDecoder = __webpack_require__(18).StringDecoder;
+  if (!StringDecoder) StringDecoder = __webpack_require__(22).StringDecoder;
   this._readableState.decoder = new StringDecoder(enc);
   this._readableState.encoding = enc;
   return this;
@@ -5521,7 +5315,7 @@ function emitReadable(stream) {
   if (!state.emittedReadable) {
     debug('emitReadable', state.flowing);
     state.emittedReadable = true;
-    if (state.sync) processNextTick(emitReadable_, stream);else emitReadable_(stream);
+    if (state.sync) pna.nextTick(emitReadable_, stream);else emitReadable_(stream);
   }
 }
 
@@ -5540,7 +5334,7 @@ function emitReadable_(stream) {
 function maybeReadMore(stream, state) {
   if (!state.readingMore) {
     state.readingMore = true;
-    processNextTick(maybeReadMore_, stream, state);
+    pna.nextTick(maybeReadMore_, stream, state);
   }
 }
 
@@ -5585,7 +5379,7 @@ Readable.prototype.pipe = function (dest, pipeOpts) {
   var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
 
   var endFn = doEnd ? onend : unpipe;
-  if (state.endEmitted) processNextTick(endFn);else src.once('end', endFn);
+  if (state.endEmitted) pna.nextTick(endFn);else src.once('end', endFn);
 
   dest.on('unpipe', onunpipe);
   function onunpipe(readable, unpipeInfo) {
@@ -5775,7 +5569,7 @@ Readable.prototype.on = function (ev, fn) {
       state.readableListening = state.needReadable = true;
       state.emittedReadable = false;
       if (!state.reading) {
-        processNextTick(nReadingNextTick, this);
+        pna.nextTick(nReadingNextTick, this);
       } else if (state.length) {
         emitReadable(this);
       }
@@ -5806,7 +5600,7 @@ Readable.prototype.resume = function () {
 function resume(stream, state) {
   if (!state.resumeScheduled) {
     state.resumeScheduled = true;
-    processNextTick(resume_, stream, state);
+    pna.nextTick(resume_, stream, state);
   }
 }
 
@@ -5843,18 +5637,19 @@ function flow(stream) {
 // This is *not* part of the readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.wrap = function (stream) {
+  var _this = this;
+
   var state = this._readableState;
   var paused = false;
 
-  var self = this;
   stream.on('end', function () {
     debug('wrapped end');
     if (state.decoder && !state.ended) {
       var chunk = state.decoder.end();
-      if (chunk && chunk.length) self.push(chunk);
+      if (chunk && chunk.length) _this.push(chunk);
     }
 
-    self.push(null);
+    _this.push(null);
   });
 
   stream.on('data', function (chunk) {
@@ -5864,7 +5659,7 @@ Readable.prototype.wrap = function (stream) {
     // don't skip over falsy values in objectMode
     if (state.objectMode && (chunk === null || chunk === undefined)) return;else if (!state.objectMode && (!chunk || !chunk.length)) return;
 
-    var ret = self.push(chunk);
+    var ret = _this.push(chunk);
     if (!ret) {
       paused = true;
       stream.pause();
@@ -5885,12 +5680,12 @@ Readable.prototype.wrap = function (stream) {
 
   // proxy certain important events.
   for (var n = 0; n < kProxyEvents.length; n++) {
-    stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+    stream.on(kProxyEvents[n], this.emit.bind(this, kProxyEvents[n]));
   }
 
   // when we try to consume some more bytes, simply unpause the
   // underlying stream.
-  self._read = function (n) {
+  this._read = function (n) {
     debug('wrapped _read', n);
     if (paused) {
       paused = false;
@@ -5898,7 +5693,7 @@ Readable.prototype.wrap = function (stream) {
     }
   };
 
-  return self;
+  return this;
 };
 
 // exposed for testing purposes only.
@@ -6013,7 +5808,7 @@ function endReadable(stream) {
 
   if (!state.endEmitted) {
     state.ended = true;
-    processNextTick(endReadableNT, state, stream);
+    pna.nextTick(endReadableNT, state, stream);
   }
 }
 
@@ -6041,7 +5836,7 @@ function indexOf(xs, x) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5), __webpack_require__(9)))
 
 /***/ }),
-/* 20 */
+/* 19 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6112,7 +5907,7 @@ function indexOf(xs, x) {
 
 module.exports = Transform;
 
-var Duplex = __webpack_require__(7);
+var Duplex = __webpack_require__(6);
 
 /*<replacement>*/
 var util = __webpack_require__(10);
@@ -6121,39 +5916,28 @@ util.inherits = __webpack_require__(8);
 
 util.inherits(Transform, Duplex);
 
-function TransformState(stream) {
-  this.afterTransform = function (er, data) {
-    return afterTransform(stream, er, data);
-  };
-
-  this.needTransform = false;
-  this.transforming = false;
-  this.writecb = null;
-  this.writechunk = null;
-  this.writeencoding = null;
-}
-
-function afterTransform(stream, er, data) {
-  var ts = stream._transformState;
+function afterTransform(er, data) {
+  var ts = this._transformState;
   ts.transforming = false;
 
   var cb = ts.writecb;
 
   if (!cb) {
-    return stream.emit('error', new Error('write callback called multiple times'));
+    return this.emit('error', new Error('write callback called multiple times'));
   }
 
   ts.writechunk = null;
   ts.writecb = null;
 
-  if (data !== null && data !== undefined) stream.push(data);
+  if (data != null) // single equals check for both `null` and `undefined`
+    this.push(data);
 
   cb(er);
 
-  var rs = stream._readableState;
+  var rs = this._readableState;
   rs.reading = false;
   if (rs.needReadable || rs.length < rs.highWaterMark) {
-    stream._read(rs.highWaterMark);
+    this._read(rs.highWaterMark);
   }
 }
 
@@ -6162,9 +5946,14 @@ function Transform(options) {
 
   Duplex.call(this, options);
 
-  this._transformState = new TransformState(this);
-
-  var stream = this;
+  this._transformState = {
+    afterTransform: afterTransform.bind(this),
+    needTransform: false,
+    transforming: false,
+    writecb: null,
+    writechunk: null,
+    writeencoding: null
+  };
 
   // start out asking for a readable event once data is transformed.
   this._readableState.needReadable = true;
@@ -6181,11 +5970,19 @@ function Transform(options) {
   }
 
   // When the writable side finishes, then flush out anything remaining.
-  this.once('prefinish', function () {
-    if (typeof this._flush === 'function') this._flush(function (er, data) {
-      done(stream, er, data);
-    });else done(stream);
-  });
+  this.on('prefinish', prefinish);
+}
+
+function prefinish() {
+  var _this = this;
+
+  if (typeof this._flush === 'function') {
+    this._flush(function (er, data) {
+      done(_this, er, data);
+    });
+  } else {
+    done(this, null, null);
+  }
 }
 
 Transform.prototype.push = function (chunk, encoding) {
@@ -6235,33 +6032,31 @@ Transform.prototype._read = function (n) {
 };
 
 Transform.prototype._destroy = function (err, cb) {
-  var _this = this;
+  var _this2 = this;
 
   Duplex.prototype._destroy.call(this, err, function (err2) {
     cb(err2);
-    _this.emit('close');
+    _this2.emit('close');
   });
 };
 
 function done(stream, er, data) {
   if (er) return stream.emit('error', er);
 
-  if (data !== null && data !== undefined) stream.push(data);
+  if (data != null) // single equals check for both `null` and `undefined`
+    stream.push(data);
 
   // if there's nothing in the write buffer, then that means
   // that nothing more will ever be provided
-  var ws = stream._writableState;
-  var ts = stream._transformState;
+  if (stream._writableState.length) throw new Error('Calling transform done when ws.length != 0');
 
-  if (ws.length) throw new Error('Calling transform done when ws.length != 0');
-
-  if (ts.transforming) throw new Error('Calling transform done when still transforming');
+  if (stream._transformState.transforming) throw new Error('Calling transform done when still transforming');
 
   return stream.push(null);
 }
 
 /***/ }),
-/* 21 */
+/* 20 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6269,7 +6064,7 @@ function done(stream, er, data) {
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(11);
+var pna = __webpack_require__(11);
 /*</replacement>*/
 
 // undocumented cb() API, needed for core, not for public API
@@ -6283,9 +6078,9 @@ function destroy(err, cb) {
     if (cb) {
       cb(err);
     } else if (err && (!this._writableState || !this._writableState.errorEmitted)) {
-      processNextTick(emitErrorNT, this, err);
+      pna.nextTick(emitErrorNT, this, err);
     }
-    return;
+    return this;
   }
 
   // we set destroyed to true before firing error callbacks in order
@@ -6302,7 +6097,7 @@ function destroy(err, cb) {
 
   this._destroy(err || null, function (err) {
     if (!cb && err) {
-      processNextTick(emitErrorNT, _this, err);
+      pna.nextTick(emitErrorNT, _this, err);
       if (_this._writableState) {
         _this._writableState.errorEmitted = true;
       }
@@ -6310,6 +6105,8 @@ function destroy(err, cb) {
       cb(err);
     }
   });
+
+  return this;
 }
 
 function undestroy() {
@@ -6339,11 +6136,289 @@ module.exports = {
 };
 
 /***/ }),
+/* 21 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(14).EventEmitter;
+
+
+/***/ }),
 /* 22 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(13).EventEmitter;
+"use strict";
 
+
+var Buffer = __webpack_require__(12).Buffer;
+
+var isEncoding = Buffer.isEncoding || function (encoding) {
+  encoding = '' + encoding;
+  switch (encoding && encoding.toLowerCase()) {
+    case 'hex':case 'utf8':case 'utf-8':case 'ascii':case 'binary':case 'base64':case 'ucs2':case 'ucs-2':case 'utf16le':case 'utf-16le':case 'raw':
+      return true;
+    default:
+      return false;
+  }
+};
+
+function _normalizeEncoding(enc) {
+  if (!enc) return 'utf8';
+  var retried;
+  while (true) {
+    switch (enc) {
+      case 'utf8':
+      case 'utf-8':
+        return 'utf8';
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return 'utf16le';
+      case 'latin1':
+      case 'binary':
+        return 'latin1';
+      case 'base64':
+      case 'ascii':
+      case 'hex':
+        return enc;
+      default:
+        if (retried) return; // undefined
+        enc = ('' + enc).toLowerCase();
+        retried = true;
+    }
+  }
+};
+
+// Do not cache `Buffer.isEncoding` when checking encoding names as some
+// modules monkey-patch it to support additional encodings
+function normalizeEncoding(enc) {
+  var nenc = _normalizeEncoding(enc);
+  if (typeof nenc !== 'string' && (Buffer.isEncoding === isEncoding || !isEncoding(enc))) throw new Error('Unknown encoding: ' + enc);
+  return nenc || enc;
+}
+
+// StringDecoder provides an interface for efficiently splitting a series of
+// buffers into a series of JS strings without breaking apart multi-byte
+// characters.
+exports.StringDecoder = StringDecoder;
+function StringDecoder(encoding) {
+  this.encoding = normalizeEncoding(encoding);
+  var nb;
+  switch (this.encoding) {
+    case 'utf16le':
+      this.text = utf16Text;
+      this.end = utf16End;
+      nb = 4;
+      break;
+    case 'utf8':
+      this.fillLast = utf8FillLast;
+      nb = 4;
+      break;
+    case 'base64':
+      this.text = base64Text;
+      this.end = base64End;
+      nb = 3;
+      break;
+    default:
+      this.write = simpleWrite;
+      this.end = simpleEnd;
+      return;
+  }
+  this.lastNeed = 0;
+  this.lastTotal = 0;
+  this.lastChar = Buffer.allocUnsafe(nb);
+}
+
+StringDecoder.prototype.write = function (buf) {
+  if (buf.length === 0) return '';
+  var r;
+  var i;
+  if (this.lastNeed) {
+    r = this.fillLast(buf);
+    if (r === undefined) return '';
+    i = this.lastNeed;
+    this.lastNeed = 0;
+  } else {
+    i = 0;
+  }
+  if (i < buf.length) return r ? r + this.text(buf, i) : this.text(buf, i);
+  return r || '';
+};
+
+StringDecoder.prototype.end = utf8End;
+
+// Returns only complete characters in a Buffer
+StringDecoder.prototype.text = utf8Text;
+
+// Attempts to complete a partial non-UTF-8 character using bytes from a Buffer
+StringDecoder.prototype.fillLast = function (buf) {
+  if (this.lastNeed <= buf.length) {
+    buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, this.lastNeed);
+    return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+  }
+  buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, buf.length);
+  this.lastNeed -= buf.length;
+};
+
+// Checks the type of a UTF-8 byte, whether it's ASCII, a leading byte, or a
+// continuation byte.
+function utf8CheckByte(byte) {
+  if (byte <= 0x7F) return 0;else if (byte >> 5 === 0x06) return 2;else if (byte >> 4 === 0x0E) return 3;else if (byte >> 3 === 0x1E) return 4;
+  return -1;
+}
+
+// Checks at most 3 bytes at the end of a Buffer in order to detect an
+// incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
+// needed to complete the UTF-8 character (if applicable) are returned.
+function utf8CheckIncomplete(self, buf, i) {
+  var j = buf.length - 1;
+  if (j < i) return 0;
+  var nb = utf8CheckByte(buf[j]);
+  if (nb >= 0) {
+    if (nb > 0) self.lastNeed = nb - 1;
+    return nb;
+  }
+  if (--j < i) return 0;
+  nb = utf8CheckByte(buf[j]);
+  if (nb >= 0) {
+    if (nb > 0) self.lastNeed = nb - 2;
+    return nb;
+  }
+  if (--j < i) return 0;
+  nb = utf8CheckByte(buf[j]);
+  if (nb >= 0) {
+    if (nb > 0) {
+      if (nb === 2) nb = 0;else self.lastNeed = nb - 3;
+    }
+    return nb;
+  }
+  return 0;
+}
+
+// Validates as many continuation bytes for a multi-byte UTF-8 character as
+// needed or are available. If we see a non-continuation byte where we expect
+// one, we "replace" the validated continuation bytes we've seen so far with
+// UTF-8 replacement characters ('\ufffd'), to match v8's UTF-8 decoding
+// behavior. The continuation byte check is included three times in the case
+// where all of the continuation bytes for a character exist in the same buffer.
+// It is also done this way as a slight performance increase instead of using a
+// loop.
+function utf8CheckExtraBytes(self, buf, p) {
+  if ((buf[0] & 0xC0) !== 0x80) {
+    self.lastNeed = 0;
+    return '\ufffd'.repeat(p);
+  }
+  if (self.lastNeed > 1 && buf.length > 1) {
+    if ((buf[1] & 0xC0) !== 0x80) {
+      self.lastNeed = 1;
+      return '\ufffd'.repeat(p + 1);
+    }
+    if (self.lastNeed > 2 && buf.length > 2) {
+      if ((buf[2] & 0xC0) !== 0x80) {
+        self.lastNeed = 2;
+        return '\ufffd'.repeat(p + 2);
+      }
+    }
+  }
+}
+
+// Attempts to complete a multi-byte UTF-8 character using bytes from a Buffer.
+function utf8FillLast(buf) {
+  var p = this.lastTotal - this.lastNeed;
+  var r = utf8CheckExtraBytes(this, buf, p);
+  if (r !== undefined) return r;
+  if (this.lastNeed <= buf.length) {
+    buf.copy(this.lastChar, p, 0, this.lastNeed);
+    return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+  }
+  buf.copy(this.lastChar, p, 0, buf.length);
+  this.lastNeed -= buf.length;
+}
+
+// Returns all complete UTF-8 characters in a Buffer. If the Buffer ended on a
+// partial character, the character's bytes are buffered until the required
+// number of bytes are available.
+function utf8Text(buf, i) {
+  var total = utf8CheckIncomplete(this, buf, i);
+  if (!this.lastNeed) return buf.toString('utf8', i);
+  this.lastTotal = total;
+  var end = buf.length - (total - this.lastNeed);
+  buf.copy(this.lastChar, 0, end);
+  return buf.toString('utf8', i, end);
+}
+
+// For UTF-8, a replacement character for each buffered byte of a (partial)
+// character needs to be added to the output.
+function utf8End(buf) {
+  var r = buf && buf.length ? this.write(buf) : '';
+  if (this.lastNeed) return r + '\ufffd'.repeat(this.lastTotal - this.lastNeed);
+  return r;
+}
+
+// UTF-16LE typically needs two bytes per character, but even if we have an even
+// number of bytes available, we need to check if we end on a leading/high
+// surrogate. In that case, we need to wait for the next two bytes in order to
+// decode the last character properly.
+function utf16Text(buf, i) {
+  if ((buf.length - i) % 2 === 0) {
+    var r = buf.toString('utf16le', i);
+    if (r) {
+      var c = r.charCodeAt(r.length - 1);
+      if (c >= 0xD800 && c <= 0xDBFF) {
+        this.lastNeed = 2;
+        this.lastTotal = 4;
+        this.lastChar[0] = buf[buf.length - 2];
+        this.lastChar[1] = buf[buf.length - 1];
+        return r.slice(0, -1);
+      }
+    }
+    return r;
+  }
+  this.lastNeed = 1;
+  this.lastTotal = 2;
+  this.lastChar[0] = buf[buf.length - 1];
+  return buf.toString('utf16le', i, buf.length - 1);
+}
+
+// For UTF-16LE we do not explicitly append special replacement characters if we
+// end on a partial character, we simply let v8 handle that.
+function utf16End(buf) {
+  var r = buf && buf.length ? this.write(buf) : '';
+  if (this.lastNeed) {
+    var end = this.lastTotal - this.lastNeed;
+    return r + this.lastChar.toString('utf16le', 0, end);
+  }
+  return r;
+}
+
+function base64Text(buf, i) {
+  var n = (buf.length - i) % 3;
+  if (n === 0) return buf.toString('base64', i);
+  this.lastNeed = 3 - n;
+  this.lastTotal = 3;
+  if (n === 1) {
+    this.lastChar[0] = buf[buf.length - 1];
+  } else {
+    this.lastChar[0] = buf[buf.length - 2];
+    this.lastChar[1] = buf[buf.length - 1];
+  }
+  return buf.toString('base64', i, buf.length - n);
+}
+
+function base64End(buf) {
+  var r = buf && buf.length ? this.write(buf) : '';
+  if (this.lastNeed) return r + this.lastChar.toString('base64', 0, 3 - this.lastNeed);
+  return r;
+}
+
+// Pass bytes on through for single-byte encodings (e.g. ascii, latin1, hex)
+function simpleWrite(buf) {
+  return buf.toString(this.encoding);
+}
+
+function simpleEnd(buf) {
+  return buf && buf.length ? this.write(buf) : '';
+}
 
 /***/ }),
 /* 23 */
@@ -12676,6 +12751,41 @@ MsgNetworkBandwidthUsage.prototype.fieldSpec = [];
 MsgNetworkBandwidthUsage.prototype.fieldSpec.push(['interfaces', 'array', NetworkUsage.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 /**
+ * SBP class for message MSG_CELL_MODEM_STATUS (0x00BE).
+ *
+ * If a cell modem is present on a piksi device, this message will be send
+ * periodically to update the host on the status of the modem and its various
+ * parameters.
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field signal_strength number (signed 8-bit int, 1 byte) Received cell signal strength in dBm, zero translates to unknown
+ * @field signal_error_rate number (float, 4 bytes) BER as reported by the modem, zero translates to unknown
+ * @field reserved array Unspecified data TBD for this schema
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var MsgCellModemStatus = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "MSG_CELL_MODEM_STATUS";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+MsgCellModemStatus.prototype = Object.create(SBP.prototype);
+MsgCellModemStatus.prototype.messageType = "MSG_CELL_MODEM_STATUS";
+MsgCellModemStatus.prototype.msg_type = 0x00BE;
+MsgCellModemStatus.prototype.constructor = MsgCellModemStatus;
+MsgCellModemStatus.prototype.parser = new Parser()
+  .endianess('little')
+  .int8('signal_strength')
+  .floatle('signal_error_rate')
+  .array('reserved', { type: 'uint8', readUntil: 'eof' });
+MsgCellModemStatus.prototype.fieldSpec = [];
+MsgCellModemStatus.prototype.fieldSpec.push(['signal_strength', 'writeInt8', 1]);
+MsgCellModemStatus.prototype.fieldSpec.push(['signal_error_rate', 'writeFloatLE', 4]);
+MsgCellModemStatus.prototype.fieldSpec.push(['reserved', 'array', 'writeUInt8', function () { return 1; }, null]);
+
+/**
  * SBP class for message MSG_SPECAN_DEP (0x0050).
  *
  * Deprecated.
@@ -12812,6 +12922,8 @@ module.exports = {
   NetworkUsage: NetworkUsage,
   0x00BD: MsgNetworkBandwidthUsage,
   MsgNetworkBandwidthUsage: MsgNetworkBandwidthUsage,
+  0x00BE: MsgCellModemStatus,
+  MsgCellModemStatus: MsgCellModemStatus,
   0x0050: MsgSpecanDep,
   MsgSpecanDep: MsgSpecanDep,
   0x0051: MsgSpecan,
@@ -13192,7 +13304,7 @@ module.exports = {
 ***********************/
 
 var SBP = __webpack_require__(2);
-var Parser = __webpack_require__(12).Parser;
+var Parser = __webpack_require__(13).Parser;
 
 /**
  * SBP class for message fragment SBPSignal
@@ -14596,11 +14708,11 @@ var substr = 'ab'.substr(-1) === 'b'
 
 module.exports = Stream;
 
-var EE = __webpack_require__(13).EventEmitter;
+var EE = __webpack_require__(14).EventEmitter;
 var inherits = __webpack_require__(8);
 
 inherits(Stream, EE);
-Stream.Readable = __webpack_require__(15);
+Stream.Readable = __webpack_require__(16);
 Stream.Writable = __webpack_require__(58);
 Stream.Duplex = __webpack_require__(53);
 Stream.Transform = __webpack_require__(57);
@@ -14745,7 +14857,7 @@ module.exports = function(module) {
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-var Parser = __webpack_require__(12).Parser;
+var Parser = __webpack_require__(13).Parser;
 var path = __webpack_require__(43);
 var streams = __webpack_require__(44);
 var SBP = __webpack_require__(2);
@@ -15069,7 +15181,7 @@ function exposeGlobally (x) {
 
 exposeGlobally(module.exports);
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6).Buffer, __webpack_require__(45)(module), __webpack_require__(5)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(7).Buffer, __webpack_require__(45)(module), __webpack_require__(5)))
 
 /***/ }),
 /* 47 */
@@ -15590,6 +15702,8 @@ for (var i = 0, len = code.length; i < len; ++i) {
   revLookup[code.charCodeAt(i)] = i
 }
 
+// Support decoding URL-safe base64 strings, as Node.js does.
+// See: https://en.wikipedia.org/wiki/Base64#URL_applications
 revLookup['-'.charCodeAt(0)] = 62
 revLookup['_'.charCodeAt(0)] = 63
 
@@ -15651,7 +15765,7 @@ function encodeChunk (uint8, start, end) {
   var tmp
   var output = []
   for (var i = start; i < end; i += 3) {
-    tmp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+    tmp = ((uint8[i] << 16) & 0xFF0000) + ((uint8[i + 1] << 8) & 0xFF00) + (uint8[i + 2] & 0xFF)
     output.push(tripletToBase64(tmp))
   }
   return output.join('')
@@ -17002,7 +17116,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 /* 53 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(7);
+module.exports = __webpack_require__(6);
 
 
 /***/ }),
@@ -17039,7 +17153,7 @@ module.exports = __webpack_require__(7);
 
 module.exports = PassThrough;
 
-var Transform = __webpack_require__(20);
+var Transform = __webpack_require__(19);
 
 /*<replacement>*/
 var util = __webpack_require__(10);
@@ -17065,12 +17179,10 @@ PassThrough.prototype._transform = function (chunk, encoding, cb) {
 "use strict";
 
 
-/*<replacement>*/
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var Buffer = __webpack_require__(16).Buffer;
-/*</replacement>*/
+var Buffer = __webpack_require__(12).Buffer;
+var util = __webpack_require__(66);
 
 function copyBuffer(src, target, offset) {
   src.copy(target, offset);
@@ -17138,25 +17250,32 @@ module.exports = function () {
   return BufferList;
 }();
 
+if (util && util.inspect && util.inspect.custom) {
+  module.exports.prototype[util.inspect.custom] = function () {
+    var obj = util.inspect({ length: this.length });
+    return this.constructor.name + ' ' + obj;
+  };
+}
+
 /***/ }),
 /* 56 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(15).PassThrough
+module.exports = __webpack_require__(16).PassThrough
 
 
 /***/ }),
 /* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(15).Transform
+module.exports = __webpack_require__(16).Transform
 
 
 /***/ }),
 /* 58 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(14);
+module.exports = __webpack_require__(15);
 
 
 /***/ }),
@@ -17356,7 +17475,7 @@ module.exports = __webpack_require__(14);
 /* 60 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var apply = Function.prototype.apply;
+/* WEBPACK VAR INJECTION */(function(global) {var apply = Function.prototype.apply;
 
 // DOM APIs, for completeness
 
@@ -17407,9 +17526,17 @@ exports._unrefActive = exports.active = function(item) {
 
 // setimmediate attaches itself to the global object
 __webpack_require__(59);
-exports.setImmediate = setImmediate;
-exports.clearImmediate = clearImmediate;
+// On some exotic environments, it's not clear which object `setimmeidate` was
+// able to install onto.  Search each possibility in the same order as the
+// `setimmediate` library.
+exports.setImmediate = (typeof self !== "undefined" && self.setImmediate) ||
+                       (typeof global !== "undefined" && global.setImmediate) ||
+                       (this && this.setImmediate);
+exports.clearImmediate = (typeof self !== "undefined" && self.clearImmediate) ||
+                         (typeof global !== "undefined" && global.clearImmediate) ||
+                         (this && this.clearImmediate);
 
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
 
 /***/ }),
 /* 61 */
@@ -18120,6 +18247,12 @@ function hasOwnProperty(obj, prop) {
 
 /***/ }),
 /* 65 */
+/***/ (function(module, exports) {
+
+/* (ignored) */
+
+/***/ }),
+/* 66 */
 /***/ (function(module, exports) {
 
 /* (ignored) */

--- a/javascript/sbp/piksi.js
+++ b/javascript/sbp/piksi.js
@@ -827,6 +827,41 @@ MsgNetworkBandwidthUsage.prototype.fieldSpec = [];
 MsgNetworkBandwidthUsage.prototype.fieldSpec.push(['interfaces', 'array', NetworkUsage.prototype.fieldSpec, function () { return this.fields.array.length; }, null]);
 
 /**
+ * SBP class for message MSG_CELL_MODEM_STATUS (0x00BE).
+ *
+ * If a cell modem is present on a piksi device, this message will be send
+ * periodically to update the host on the status of the modem and its various
+ * parameters.
+ *
+ * Fields in the SBP payload (`sbp.payload`):
+ * @field signal_strength number (signed 8-bit int, 1 byte) Received cell signal strength in dBm, zero translates to unknown
+ * @field signal_error_rate number (float, 4 bytes) BER as reported by the modem, zero translates to unknown
+ * @field reserved array Unspecified data TBD for this schema
+ *
+ * @param sbp An SBP object with a payload to be decoded.
+ */
+var MsgCellModemStatus = function (sbp, fields) {
+  SBP.call(this, sbp);
+  this.messageType = "MSG_CELL_MODEM_STATUS";
+  this.fields = (fields || this.parser.parse(sbp.payload));
+
+  return this;
+};
+MsgCellModemStatus.prototype = Object.create(SBP.prototype);
+MsgCellModemStatus.prototype.messageType = "MSG_CELL_MODEM_STATUS";
+MsgCellModemStatus.prototype.msg_type = 0x00BE;
+MsgCellModemStatus.prototype.constructor = MsgCellModemStatus;
+MsgCellModemStatus.prototype.parser = new Parser()
+  .endianess('little')
+  .int8('signal_strength')
+  .floatle('signal_error_rate')
+  .array('reserved', { type: 'uint8', readUntil: 'eof' });
+MsgCellModemStatus.prototype.fieldSpec = [];
+MsgCellModemStatus.prototype.fieldSpec.push(['signal_strength', 'writeInt8', 1]);
+MsgCellModemStatus.prototype.fieldSpec.push(['signal_error_rate', 'writeFloatLE', 4]);
+MsgCellModemStatus.prototype.fieldSpec.push(['reserved', 'array', 'writeUInt8', function () { return 1; }, null]);
+
+/**
  * SBP class for message MSG_SPECAN_DEP (0x0050).
  *
  * Deprecated.
@@ -963,6 +998,8 @@ module.exports = {
   NetworkUsage: NetworkUsage,
   0x00BD: MsgNetworkBandwidthUsage,
   MsgNetworkBandwidthUsage: MsgNetworkBandwidthUsage,
+  0x00BE: MsgCellModemStatus,
+  MsgCellModemStatus: MsgCellModemStatus,
   0x0050: MsgSpecanDep,
   MsgSpecanDep: MsgSpecanDep,
   0x0051: MsgSpecan,

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -42,7 +42,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 140
+  number_of_messages = 141
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -523,6 +523,38 @@ definitions:
             fill: NetworkUsage
             desc: Usage measurement array
 
+ - MSG_CELL_MODEM_STATUS:
+    id: 0x00BE
+    short_desc: Cell modem information update message
+    desc: |
+      If a cell modem is present on a piksi device, this message
+      will be send periodically to update the host on the status
+      of the modem and its various parameters.
+      AT+CPIN? AT+CCID AT+CSQ AT+CREG? AT+CGREG? AT+COPS?
+    fields:
+      - signal_strength:
+          type: s8
+          units: dBm
+          desc: Received cell signal strength in dBm, zero translates to unknown
+      - signal_error_rate:
+          type: float
+          desc: BER as reported by the modem, zero translates to unknown
+      - sim_id:
+          type: string
+          size: 24
+          desc: The unique ID of sim card installed (ICCID or other similiar)
+      - network_operator:
+          type: string
+          size: 28
+          desc: Currently reported network operator
+      - sim_status:
+          type: string
+          desc: Current status of sim whether inserted, ready, etc.
+      - unspecified:
+          type: array
+          fill: u8
+          desc: Unspecified data TBD for this schema
+
  - MSG_SPECAN_DEP:
     id: 0x0050
     short_desc: Deprecated

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -530,7 +530,6 @@ definitions:
       If a cell modem is present on a piksi device, this message
       will be send periodically to update the host on the status
       of the modem and its various parameters.
-      AT+CPIN? AT+CCID AT+CSQ AT+CREG? AT+CGREG? AT+COPS?
     fields:
       - signal_strength:
           type: s8
@@ -539,18 +538,7 @@ definitions:
       - signal_error_rate:
           type: float
           desc: BER as reported by the modem, zero translates to unknown
-      - sim_id:
-          type: string
-          size: 24
-          desc: The unique ID of sim card installed (ICCID or other similiar)
-      - network_operator:
-          type: string
-          size: 28
-          desc: Currently reported network operator
-      - sim_status:
-          type: string
-          desc: Current status of sim whether inserted, ready, etc.
-      - unspecified:
+      - reserved:
           type: array
           fill: u8
           desc: Unspecified data TBD for this schema


### PR DESCRIPTION
This new message facilitates the reporting of cell modem signal levels. As other information may be beneficial I have looked at a few standard commands and added fields accordingly:

AT+CSQ -> signal_strength, signal_error_rate
AT+CCID -> sim_id
AT+COPS? -> network operator (if present)
AT+CPIN?/AT+CREG?/AT+CGREG? - sim_status (roughly mapped to no sim/unregistered/registered on network)

As this may not be exhaustive, an unspecified field as a variable length array allows for extra length left at the end for as-of-yet unknown fields.

If an argument is made to only include what I currently need for cell signal reporting, I am totally fine doing that as well.