### PR TITLE
Add Z to end of timestamp

### DIFF
--- a/python/sbp/client/framer.py
+++ b/python/sbp/client/framer.py
@@ -59,7 +59,7 @@ class Framer(object):
         -------
         str : ISO 8601 format timestamp
         """
-        return datetime.datetime.utcnow().isoformat()
+        return datetime.datetime.utcnow().isoformat() + 'Z'
 
     def next(self):
         msg = None


### PR DESCRIPTION
Append the missing Z to the end of the timestamp. This seems to be the optimal way to handle this in python.

/cc @jck @denniszollo 