### PR TITLE
Windows c again

### DIFF
--- a/c/include/libsbp/acquisition.h
+++ b/c/include/libsbp/acquisition.h
@@ -26,6 +26,8 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** Satellite acquisition result
  *
@@ -36,7 +38,7 @@
  * ratio.
  */
 #define SBP_MSG_ACQ_RESULT         0x002F
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   float cn0;    /**< CN/0 of best point [dB Hz] */
   float cp;     /**< Code phase of best point [chips] */
   float cf;     /**< Carrier frequency of best point [hz] */
@@ -49,7 +51,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_ACQ_RESULT_DEP_C   0x001F
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   float cn0;    /**< CN/0 of best point [dB Hz] */
   float cp;     /**< Code phase of best point [chips] */
   float cf;     /**< Carrier frequency of best point [hz] */
@@ -62,7 +64,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_ACQ_RESULT_DEP_B   0x0014
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   float snr;    /**< SNR of best point. Currently in arbitrary SNR points, but will
 be in units of dB Hz in a later revision of this message.
  */
@@ -77,7 +79,7 @@ be in units of dB Hz in a later revision of this message.
 * Deprecated.
  */
 #define SBP_MSG_ACQ_RESULT_DEP_A   0x0015
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   float snr;    /**< SNR of best point. Currently dimensonless, but will have
 units of dB Hz in the revision of this message.
  */
@@ -95,7 +97,7 @@ acquisition was attempted
  * The message describes SV profile during acquisition time.
  * The message is used to debug and measure the performance.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 job_type;      /**< SV search job type (deep, fallback, etc) */
   u8 status;        /**< Acquisition status 1 is Success, 0 is Failure */
   u16 cn0;           /**< CN0 value. Only valid if status is '1' [dB-Hz*10] */
@@ -115,7 +117,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 job_type;      /**< SV search job type (deep, fallback, etc) */
   u8 status;        /**< Acquisition status 1 is Success, 0 is Failure */
   u16 cn0;           /**< CN0 value. Only valid if status is '1' [dB-Hz*10] */
@@ -137,7 +139,7 @@ typedef struct __attribute__((packed)) {
  * The message is used to debug and measure the performance.
  */
 #define SBP_MSG_ACQ_SV_PROFILE     0x002E
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   acq_sv_profile_t acq_sv_profile[0]; /**< SV profiles during acquisition time */
 } msg_acq_sv_profile_t;
 
@@ -147,11 +149,13 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_ACQ_SV_PROFILE_DEP 0x001E
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   acq_sv_profile_dep_t acq_sv_profile[0]; /**< SV profiles during acquisition time */
 } msg_acq_sv_profile_dep_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_ACQUISITION_MESSAGES_H */

--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -29,6 +29,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Bootloading handshake request (host => device)
  *
@@ -48,7 +50,7 @@
  * protocol version number.
  */
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_RESP  0x00B4
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 flags;      /**< Bootloader flags */
   char version[0]; /**< Bootloader version number */
 } msg_bootloader_handshake_resp_t;
@@ -59,7 +61,7 @@ typedef struct __attribute__((packed)) {
  * The host initiates the bootloader to jump to the application.
  */
 #define SBP_MSG_BOOTLOADER_JUMP_TO_APP     0x00B1
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 jump;    /**< Ignored by the device */
 } msg_bootloader_jump_to_app_t;
 
@@ -86,7 +88,7 @@ typedef struct __attribute__((packed)) {
  * and not related to the Piksi's serial number.
  */
 #define SBP_MSG_NAP_DEVICE_DNA_RESP        0x00DD
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 dna[8]; /**< 57-bit SwiftNAP FPGA Device ID. Remaining bits are padded
 on the right.
  */
@@ -98,11 +100,13 @@ on the right.
 * Deprecated.
  */
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A 0x00B0
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 handshake[0]; /**< Version number string (not NULL terminated) */
 } msg_bootloader_handshake_dep_a_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_BOOTLOAD_MESSAGES_H */

--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -22,6 +22,16 @@
 #ifndef COMMON_INT_TYPES
 #define COMMON_INT_TYPES
 
+/* Determine Toolchain */
+
+#if defined _MSC_VER
+#define TOOLCHAIN_ATTR_PACKED    /* Intentionally empty */
+#define TOOLCHAIN_PRAGMA_PACK
+#else
+#define TOOLCHAIN_ATTR_PACKED  __attribute__((packed))
+#undef TOOLCHAIN_PRAGMA_PACK 
+#endif
+
 /** \defgroup common_inttypes Integer types
  * Specified-width integer type definitions for shorter and nicer code.
  *

--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -22,15 +22,30 @@
 #ifndef COMMON_INT_TYPES
 #define COMMON_INT_TYPES
 
-/* Determine Toolchain */
+/* Set packing based upon toolchain */
 
-#if defined _MSC_VER
-#define TOOLCHAIN_ATTR_PACKED    /* Intentionally empty */
-#define TOOLCHAIN_PRAGMA_PACK
+#if defined(__GNUC__) || defined(__clang__)
+
+#define SBP_PACK_START /* Intentionally empty */
+#define SBP_PACK_END /* Intentionally empty */
+
+#define SBP_ATTR_PACKED __attribute__((packed))
+
+#elif defined(_MSC_VER)
+
+#define SBP_PACK_START __pragma(pack(1));
+
+#define SBP_PACK_END __pragma(pack());
+
+#define SBP_ATTR_PACKED /* Intentionally empty */
+
 #else
-#define TOOLCHAIN_ATTR_PACKED  __attribute__((packed))
-#undef TOOLCHAIN_PRAGMA_PACK 
-#endif
+
+#if !defined(SBP_PACK_START) || !defined(SBP_PACK_END) || !defined(SBP_ATTR_PACKED)
+#error Unknown compiler, please override SBP_PACK_START, SBP_PACK_END, and SBP_ATTR_PACKED
+#endif 
+
+#endif /* toolchaing packing macros */
 
 /** \defgroup common_inttypes Integer types
  * Specified-width integer type definitions for shorter and nicer code.
@@ -57,8 +72,6 @@ typedef uint32_t u32;
 typedef uint64_t u64;
 
 #endif
-
-/** \} */
 
 /** \} */
 

--- a/c/include/libsbp/ext_events.h
+++ b/c/include/libsbp/ext_events.h
@@ -26,6 +26,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Reports timestamped external pin event
  *
@@ -33,7 +35,7 @@
  * which pin it was and whether it was rising or falling.
  */
 #define SBP_MSG_EXT_EVENT 0x0101
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 wn;             /**< GPS week number [weeks] */
   u32 tow;            /**< GPS time of week rounded to the nearest millisecond [ms] */
   s32 ns_residual;    /**< Nanosecond residual of millisecond-rounded TOW (ranges
@@ -45,5 +47,7 @@ from -500000 to 500000)
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_EXT_EVENTS_MESSAGES_H */

--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -32,6 +32,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Read file from the file system (host => device)
  *
@@ -45,7 +47,7 @@
  * to this message when it is received from sender ID 0x42.
  */
 #define SBP_MSG_FILEIO_READ_REQ      0x00A8
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;      /**< Read sequence number */
   u32 offset;        /**< File offset [bytes] */
   u8 chunk_size;    /**< Chunk size to read [bytes] */
@@ -62,7 +64,7 @@ typedef struct __attribute__((packed)) {
  * preserved from the request.
  */
 #define SBP_MSG_FILEIO_READ_RESP     0x00A3
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
   u8 contents[0]; /**< Contents of read file */
 } msg_fileio_read_resp_t;
@@ -82,7 +84,7 @@ typedef struct __attribute__((packed)) {
  * from sender ID 0x42.
  */
 #define SBP_MSG_FILEIO_READ_DIR_REQ  0x00A9
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
   u32 offset;      /**< The offset to skip the first n elements of the file list
  */
@@ -100,7 +102,7 @@ typedef struct __attribute__((packed)) {
  * the response is preserved from the request.
  */
 #define SBP_MSG_FILEIO_READ_DIR_RESP 0x00AA
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
   u8 contents[0]; /**< Contents of read directory */
 } msg_fileio_read_dir_resp_t;
@@ -114,7 +116,7 @@ typedef struct __attribute__((packed)) {
  * process this message when it is received from sender ID 0x42.
  */
 #define SBP_MSG_FILEIO_REMOVE        0x00AC
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char filename[0]; /**< Name of the file to delete */
 } msg_fileio_remove_t;
 
@@ -131,7 +133,7 @@ typedef struct __attribute__((packed)) {
  * 0x42.
  */
 #define SBP_MSG_FILEIO_WRITE_REQ     0x00AD
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Write sequence number */
   u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
   char filename[0]; /**< Name of the file to write to */
@@ -148,11 +150,13 @@ typedef struct __attribute__((packed)) {
  * request.
  */
 #define SBP_MSG_FILEIO_WRITE_RESP    0x00AB
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Write sequence number */
 } msg_fileio_write_resp_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_FILE_IO_MESSAGES_H */

--- a/c/include/libsbp/flash.h
+++ b/c/include/libsbp/flash.h
@@ -29,6 +29,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Program flash addresses
  *
@@ -40,7 +42,7 @@
  * erased before addresses can be programmed.
  */
 #define SBP_MSG_FLASH_PROGRAM           0x00E6
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 target;        /**< Target flags */
   u8 addr_start[3]; /**< Starting address offset to program [bytes] */
   u8 addr_len;      /**< Length of set of addresses to program, counting up from
@@ -58,7 +60,7 @@ starting address
  * MSG_FLASH_PROGRAM, may return this message on failure.
  */
 #define SBP_MSG_FLASH_DONE              0x00E0
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 response;    /**< Response flags */
 } msg_flash_done_t;
 
@@ -74,7 +76,7 @@ typedef struct __attribute__((packed)) {
  * range.
  */
 #define SBP_MSG_FLASH_READ_REQ          0x00E7
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 target;        /**< Target flags */
   u8 addr_start[3]; /**< Starting address offset to read from [bytes] */
   u8 addr_len;      /**< Length of set of addresses to read, counting up from
@@ -94,7 +96,7 @@ starting address
  * range.
  */
 #define SBP_MSG_FLASH_READ_RESP         0x00E1
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 target;        /**< Target flags */
   u8 addr_start[3]; /**< Starting address offset to read from [bytes] */
   u8 addr_len;      /**< Length of set of addresses to read, counting up from
@@ -112,7 +114,7 @@ starting address
  * invalid.
  */
 #define SBP_MSG_FLASH_ERASE             0x00E2
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 target;        /**< Target flags */
   u32 sector_num;    /**< Flash sector number to erase (0-11 for the STM, 0-15 for
 the M25)
@@ -126,7 +128,7 @@ the M25)
  * memory. The device replies with a MSG_FLASH_DONE message.
  */
 #define SBP_MSG_STM_FLASH_LOCK_SECTOR   0x00E3
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sector;    /**< Flash sector number to lock */
 } msg_stm_flash_lock_sector_t;
 
@@ -137,7 +139,7 @@ typedef struct __attribute__((packed)) {
  * memory. The device replies with a MSG_FLASH_DONE message.
  */
 #define SBP_MSG_STM_FLASH_UNLOCK_SECTOR 0x00E4
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sector;    /**< Flash sector number to unlock */
 } msg_stm_flash_unlock_sector_t;
 
@@ -162,7 +164,7 @@ typedef struct __attribute__((packed)) {
  * ID in the payload..
  */
 #define SBP_MSG_STM_UNIQUE_ID_RESP      0x00E5
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 stm_id[12]; /**< Device unique ID */
 } msg_stm_unique_id_resp_t;
 
@@ -173,11 +175,13 @@ typedef struct __attribute__((packed)) {
  * register. The device replies with a MSG_FLASH_DONE message.
  */
 #define SBP_MSG_M25_FLASH_WRITE_STATUS  0x00F3
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 status[1]; /**< Byte to write to the M25 flash status register */
 } msg_m25_flash_write_status_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_FLASH_MESSAGES_H */

--- a/c/include/libsbp/gnss.h
+++ b/c/include/libsbp/gnss.h
@@ -25,12 +25,14 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Represents all the relevant information about the signal
  *
  * Signal identifier containing constellation, band, and satellite identifier
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 sat;     /**< Constellation-specific satellite identifier. This field for Glonass can  
 either be (100+FCN) where FCN is in [-7,+6] or 
 the Slot ID in [1,28]
@@ -43,7 +45,7 @@ the Slot ID in [1,28]
  *
 * Deprecated.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 sat;         /**< Constellation-specific satellite identifier.
 
 Note: unlike GnssSignal, GPS satellites are encoded as
@@ -60,7 +62,7 @@ Note: unlike GnssSignal, GPS satellites are encoded as
  * milliseconds since beginning of the week on the Saturday/Sunday
  * transition.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;    /**< Milliseconds since start of GPS week [ms] */
   u16 wn;     /**< GPS week number [week] */
 } gps_time_dep_t;
@@ -72,7 +74,7 @@ typedef struct __attribute__((packed)) {
  * seconds since beginning of the week on the Saturday/Sunday
  * transition.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;    /**< Seconds since start of GPS week [s] */
   u16 wn;     /**< GPS week number [week] */
 } gps_time_sec_t;
@@ -85,7 +87,7 @@ typedef struct __attribute__((packed)) {
  * transition. In most cases, observations are epoch aligned
  * so ns field will be 0.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;            /**< Milliseconds since start of GPS week [ms] */
   s32 ns_residual;    /**< Nanosecond residual of millisecond-rounded TOW (ranges
 from -500000 to 500000)
@@ -101,12 +103,14 @@ from -500000 to 500000)
  * cycles and 8-bits of fractional cycles. This phase has the
  * same sign as the pseudorange.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s32 i;    /**< Carrier phase whole cycles [cycles] */
   u8 f;    /**< Carrier phase fractional part [cycles / 256] */
 } carrier_phase_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_GNSS_MESSAGES_H */

--- a/c/include/libsbp/imu.h
+++ b/c/include/libsbp/imu.h
@@ -25,6 +25,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Raw IMU data
  *
@@ -33,7 +35,7 @@
  * the indications on the device itself.
  */
 #define SBP_MSG_IMU_RAW 0x0900
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;      /**< Milliseconds since start of GPS week. If the high bit is set, the
 time is unknown or invalid.
  [ms] */
@@ -55,7 +57,7 @@ time is unknown or invalid.
  * depends on the value of `imu_type`.
  */
 #define SBP_MSG_IMU_AUX 0x0901
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 imu_type;    /**< IMU type */
   s16 temp;        /**< Raw IMU temperature */
   u8 imu_conf;    /**< IMU configuration */
@@ -63,5 +65,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_IMU_MESSAGES_H */

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -25,6 +25,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Plaintext logging messages with levels
  *
@@ -33,7 +35,7 @@
  * ERROR, WARNING, DEBUG, INFO logging levels.
  */
 #define SBP_MSG_LOG       0x0401
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 level;    /**< Logging level */
   char text[0];  /**< Human-readable string */
 } msg_log_t;
@@ -50,7 +52,7 @@ typedef struct __attribute__((packed)) {
  * Protocol 0 represents SBP and the remaining values are implementation defined.
  */
 #define SBP_MSG_FWD       0x0402
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 source;         /**< source identifier */
   u8 protocol;       /**< protocol identifier */
   char fwd_payload[0]; /**< variable length wrapped binary message */
@@ -62,7 +64,7 @@ typedef struct __attribute__((packed)) {
 * All the news fit to tweet.
  */
 #define SBP_MSG_TWEET     0x0012
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char tweet[140]; /**< Human-readable string */
 } msg_tweet_t;
 
@@ -72,11 +74,13 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_PRINT_DEP 0x0010
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char text[0]; /**< Human-readable string */
 } msg_print_dep_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_LOGGING_MESSAGES_H */

--- a/c/include/libsbp/mag.h
+++ b/c/include/libsbp/mag.h
@@ -25,13 +25,15 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Raw magnetometer data
  *
  * Raw data from the magnetometer.
  */
 #define SBP_MSG_MAG_RAW 0x0902
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;      /**< Milliseconds since start of GPS week. If the high bit is set, the
 time is unknown or invalid.
  [ms] */
@@ -44,5 +46,7 @@ time is unknown or invalid.
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_MAG_MESSAGES_H */

--- a/c/include/libsbp/navigation.h
+++ b/c/include/libsbp/navigation.h
@@ -41,6 +41,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** GPS Time
  *
@@ -59,7 +61,7 @@
  * these messages.
  */
 #define SBP_MSG_GPS_TIME               0x0102
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 wn;             /**< GPS week number [weeks] */
   u32 tow;            /**< GPS time of week rounded to the nearest millisecond [ms] */
   s32 ns_residual;    /**< Nanosecond residual of millisecond-rounded TOW (ranges
@@ -75,7 +77,7 @@ from -500000 to 500000)
  * which indicate the source of the UTC offset value and source of the time fix.
  */
 #define SBP_MSG_UTC_TIME               0x0103
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 flags;      /**< Indicates source and time validity */
   u32 tow;        /**< GPS time of week rounded to the nearest millisecond [ms] */
   u16 year;       /**< Year [year] */
@@ -96,7 +98,7 @@ typedef struct __attribute__((packed)) {
  * corresponds to differential or SPP solution.
  */
 #define SBP_MSG_DOPS                   0x0208
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;      /**< GPS Time of Week [ms] */
   u16 gdop;     /**< Geometric Dilution of Precision [0.01] */
   u16 pdop;     /**< Position Dilution of Precision [0.01] */
@@ -119,7 +121,7 @@ typedef struct __attribute__((packed)) {
  * MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_POS_ECEF               0x0209
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< GPS Time of Week [ms] */
   double x;           /**< ECEF X coordinate [m] */
   double y;           /**< ECEF Y coordinate [m] */
@@ -143,7 +145,7 @@ typedef struct __attribute__((packed)) {
  * MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_POS_ECEF_COV           0x0214
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   double x;          /**< ECEF X coordinate [m] */
   double y;          /**< ECEF Y coordinate [m] */
@@ -171,7 +173,7 @@ typedef struct __attribute__((packed)) {
  * matching time-of-week (tow).
  */
 #define SBP_MSG_POS_LLH                0x020A
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   double lat;           /**< Latitude [deg] */
   double lon;           /**< Longitude [deg] */
@@ -195,7 +197,7 @@ typedef struct __attribute__((packed)) {
  * measurement and care should be taken with the sign convention.
  */
 #define SBP_MSG_POS_LLH_COV            0x0211
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   double lat;        /**< Latitude [deg] */
   double lon;        /**< Longitude [deg] */
@@ -220,7 +222,7 @@ typedef struct __attribute__((packed)) {
  * matching time-of-week (tow).
  */
 #define SBP_MSG_BASELINE_ECEF          0x020B
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< GPS Time of Week [ms] */
   s32 x;           /**< Baseline ECEF X coordinate [mm] */
   s32 y;           /**< Baseline ECEF Y coordinate [mm] */
@@ -241,7 +243,7 @@ typedef struct __attribute__((packed)) {
  * preceding MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_BASELINE_NED           0x020C
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   s32 n;             /**< Baseline North coordinate [mm] */
   s32 e;             /**< Baseline East coordinate [mm] */
@@ -260,7 +262,7 @@ typedef struct __attribute__((packed)) {
  * MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_VEL_ECEF               0x020D
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< GPS Time of Week [ms] */
   s32 x;           /**< Velocity ECEF X coordinate [mm/s] */
   s32 y;           /**< Velocity ECEF Y coordinate [mm/s] */
@@ -279,7 +281,7 @@ typedef struct __attribute__((packed)) {
  * MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_VEL_ECEF_COV           0x0215
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   s32 x;          /**< Velocity ECEF X coordinate [mm/s] */
   s32 y;          /**< Velocity ECEF Y coordinate [mm/s] */
@@ -303,7 +305,7 @@ typedef struct __attribute__((packed)) {
  * given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_VEL_NED                0x020E
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   s32 n;             /**< Velocity North coordinate [mm/s] */
   s32 e;             /**< Velocity East coordinate [mm/s] */
@@ -327,7 +329,7 @@ typedef struct __attribute__((packed)) {
  * portion of the 3x3 covariance matrix.
  */
 #define SBP_MSG_VEL_NED_COV            0x0212
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   s32 n;          /**< Velocity North coordinate [mm/s] */
   s32 e;          /**< Velocity East coordinate [mm/s] */
@@ -354,7 +356,7 @@ typedef struct __attribute__((packed)) {
  * matching time-of-week (tow).
  */
 #define SBP_MSG_VEL_BODY               0x0213
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   s32 x;          /**< Velocity in x direction [mm/s] */
   s32 y;          /**< Velocity in y direction [mm/s] */
@@ -376,7 +378,7 @@ typedef struct __attribute__((packed)) {
  * Differential solution
  */
 #define SBP_MSG_AGE_CORRECTIONS        0x0210
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;    /**< GPS Time of Week [ms] */
   u16 age;    /**< Age of the corrections (0xFFFF indicates invalid) [deciseconds] */
 } msg_age_corrections_t;
@@ -399,7 +401,7 @@ typedef struct __attribute__((packed)) {
  * these messages.
  */
 #define SBP_MSG_GPS_TIME_DEP_A         0x0100
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 wn;             /**< GPS week number [weeks] */
   u32 tow;            /**< GPS time of week rounded to the nearest millisecond [ms] */
   s32 ns_residual;    /**< Nanosecond residual of millisecond-rounded TOW (ranges
@@ -416,7 +418,7 @@ from -500000 to 500000)
  * precision.
  */
 #define SBP_MSG_DOPS_DEP_A             0x0206
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;     /**< GPS Time of Week [ms] */
   u16 gdop;    /**< Geometric Dilution of Precision [0.01] */
   u16 pdop;    /**< Position Dilution of Precision [0.01] */
@@ -438,7 +440,7 @@ typedef struct __attribute__((packed)) {
  * MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_POS_ECEF_DEP_A         0x0200
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< GPS Time of Week [ms] */
   double x;           /**< ECEF X coordinate [m] */
   double y;           /**< ECEF Y coordinate [m] */
@@ -463,7 +465,7 @@ to 0.
  * matching time-of-week (tow).
  */
 #define SBP_MSG_POS_LLH_DEP_A          0x0201
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   double lat;           /**< Latitude [deg] */
   double lon;           /**< Longitude [deg] */
@@ -488,7 +490,7 @@ implemented). Defaults to 0.
  * matching time-of-week (tow).
  */
 #define SBP_MSG_BASELINE_ECEF_DEP_A    0x0202
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< GPS Time of Week [ms] */
   s32 x;           /**< Baseline ECEF X coordinate [mm] */
   s32 y;           /**< Baseline ECEF Y coordinate [mm] */
@@ -510,7 +512,7 @@ typedef struct __attribute__((packed)) {
  * preceding MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_BASELINE_NED_DEP_A     0x0203
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   s32 n;             /**< Baseline North coordinate [mm] */
   s32 e;             /**< Baseline East coordinate [mm] */
@@ -533,7 +535,7 @@ implemented). Defaults to 0.
  * MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_VEL_ECEF_DEP_A         0x0204
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< GPS Time of Week [ms] */
   s32 x;           /**< Velocity ECEF X coordinate [mm/s] */
   s32 y;           /**< Velocity ECEF Y coordinate [mm/s] */
@@ -554,7 +556,7 @@ to 0.
  * given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_VEL_NED_DEP_A          0x0205
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   s32 n;             /**< Velocity North coordinate [mm/s] */
   s32 e;             /**< Velocity East coordinate [mm/s] */
@@ -577,7 +579,7 @@ implemented). Defaults to 0.
  * preceding MSG_GPS_TIME with the matching time-of-week (tow).
  */
 #define SBP_MSG_BASELINE_HEADING_DEP_A 0x0207
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   u32 heading;    /**< Heading [mdeg] */
   u8 n_sats;     /**< Number of satellites used in solution */
@@ -586,5 +588,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_NAVIGATION_MESSAGES_H */

--- a/c/include/libsbp/ndb.h
+++ b/c/include/libsbp/ndb.h
@@ -26,6 +26,8 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** Navigation DataBase Event
  *
@@ -33,7 +35,7 @@
  * message could also be sent out when fetching an object from NDB.
  */
 #define SBP_MSG_NDB_EVENT 0x0400
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u64 recv_time;          /**< HW time in milliseconds. [ms] */
   u8 event;              /**< Event type. */
   u8 object_type;        /**< Event object type. */
@@ -57,5 +59,7 @@ of other data_source.
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_NDB_MESSAGES_H */

--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -26,12 +26,14 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** Header for observation message.
  *
 * Header of a GNSS observation message.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gps_time_t t;        /**< GNSS time of this observation */
   u8 n_obs;    /**< Total number of observations. First nibble is the size
 of the sequence (n), second nibble is the zero-indexed
@@ -47,7 +49,7 @@ counter (ith packet of n)
  * doppler and 8-bits of fractional doppler. This doppler is defined
  * as positive for approaching satellites.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s16 i;    /**< Doppler whole Hz [Hz] */
   u8 f;    /**< Doppler fractional part [Hz / 256] */
 } doppler_t;
@@ -59,7 +61,7 @@ typedef struct __attribute__((packed)) {
  * tracked. The observations are interoperable with 3rd party
  * receivers and conform with typical RTCMv3 GNSS observations.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 P;        /**< Pseudorange observation [2 cm] */
   carrier_phase_t L;        /**< Carrier phase observation with typical sign convention. [cycles] */
   doppler_t D;        /**< Doppler observation with typical sign convention. [Hz] */
@@ -90,7 +92,7 @@ estimate for the signal is valid.
  * with typical RTCMv3 GNSS observations.
  */
 #define SBP_MSG_OBS                      0x004A
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   observation_header_t header;    /**< Header of a GPS observation message */
   packed_obs_content_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
@@ -107,7 +109,7 @@ satellite being tracked.
  * error in the pseudo-absolute position output.
  */
 #define SBP_MSG_BASE_POS_LLH             0x0044
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   double lat;       /**< Latitude [deg] */
   double lon;       /**< Longitude [deg] */
   double height;    /**< Height [m] */
@@ -124,14 +126,14 @@ typedef struct __attribute__((packed)) {
  * pseudo-absolute position output.
  */
 #define SBP_MSG_BASE_POS_ECEF            0x0048
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   double x;    /**< ECEF X coodinate [m] */
   double y;    /**< ECEF Y coordinate [m] */
   double z;    /**< ECEF Z coordinate [m] */
 } msg_base_pos_ecef_t;
 
 
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gnss_signal_t sid;             /**< GNSS signal identifier (16 bit) */
   gps_time_sec_t toe;             /**< Time of Ephemerides */
   float ura;             /**< User Range Accuracy [m] */
@@ -145,7 +147,7 @@ GLO: 0 = valid, non-zero = invalid
 } ephemeris_common_content_t;
 
 
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gnss_signal_t sid;             /**< GNSS signal identifier (16 bit) */
   gps_time_sec_t toe;             /**< Time of Ephemerides */
   double ura;             /**< User Range Accuracy [m] */
@@ -158,7 +160,7 @@ Others: 0 = valid, non-zero = invalid
 } ephemeris_common_content_dep_b_t;
 
 
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gnss_signal_dep_t sid;             /**< GNSS signal identifier */
   gps_time_dep_t toe;             /**< Time of Ephemerides */
   double ura;             /**< User Range Accuracy [m] */
@@ -181,7 +183,7 @@ GLO: 0 = valid, non-zero = invalid
  * 20-III) for more details.
  */
 #define SBP_MSG_EPHEMERIS_GPS_DEP_E      0x0081
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_a_t common;      /**< Values common for all ephemeris types */
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
@@ -214,7 +216,7 @@ typedef struct __attribute__((packed)) {
  * ephemeris message using floats for size reduction.
  */
 #define SBP_MSG_EPHEMERIS_GPS_DEP_F      0x0086
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_b_t common;      /**< Values common for all ephemeris types */
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
@@ -250,7 +252,7 @@ typedef struct __attribute__((packed)) {
  * 20-III) for more details.
  */
 #define SBP_MSG_EPHEMERIS_GPS            0x008A
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_t common;      /**< Values common for all ephemeris types */
   float tgd;         /**< Group delay differential between L1 and L2 [s] */
   float c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
@@ -285,7 +287,7 @@ typedef struct __attribute__((packed)) {
  * Satellite System SIS-ICD Version 2.1, Table 5-9 for more details.
  */
 #define SBP_MSG_EPHEMERIS_BDS            0x0089
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_t common;      /**< Values common for all ephemeris types */
   float tgd1;        /**< Group delay differential for B1 [s] */
   float tgd2;        /**< Group delay differential for B2 [s] */
@@ -321,7 +323,7 @@ typedef struct __attribute__((packed)) {
  * OS SIS ICD, Issue 1.3, December 2016 for more details.
  */
 #define SBP_MSG_EPHEMERIS_GAL            0x0095
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_t common;       /**< Values common for all ephemeris types */
   float bgd_e1e5a;    /**< E1-E5a Broadcast Group Delay [s] */
   float bgd_e1e5b;    /**< E1-E5b Broadcast Group Delay [s] */
@@ -350,7 +352,7 @@ typedef struct __attribute__((packed)) {
 
 
 #define SBP_MSG_EPHEMERIS_SBAS_DEP_A     0x0082
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_a_t common;    /**< Values common for all ephemeris types */
   double pos[3];    /**< Position of the GEO at time toe [m] */
   double vel[3];    /**< Velocity of the GEO at time toe [m/s] */
@@ -369,7 +371,7 @@ typedef struct __attribute__((packed)) {
  * for more details.
  */
 #define SBP_MSG_EPHEMERIS_GLO_DEP_A      0x0083
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_a_t common;    /**< Values common for all ephemeris types */
   double gamma;     /**< Relative deviation of predicted carrier frequency from nominal */
   double tau;       /**< Correction to the SV time [s] */
@@ -385,7 +387,7 @@ typedef struct __attribute__((packed)) {
  * ephemeris message using floats for size reduction.
  */
 #define SBP_MSG_EPHEMERIS_SBAS_DEP_B     0x0084
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_b_t common;    /**< Values common for all ephemeris types */
   double pos[3];    /**< Position of the GEO at time toe [m] */
   double vel[3];    /**< Velocity of the GEO at time toe [m/s] */
@@ -396,7 +398,7 @@ typedef struct __attribute__((packed)) {
 
 
 #define SBP_MSG_EPHEMERIS_SBAS           0x008C
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_t common;    /**< Values common for all ephemeris types */
   double pos[3];    /**< Position of the GEO at time toe [m] */
   float vel[3];    /**< Velocity of the GEO at time toe [m/s] */
@@ -415,7 +417,7 @@ typedef struct __attribute__((packed)) {
  * for more details.
  */
 #define SBP_MSG_EPHEMERIS_GLO_DEP_B      0x0085
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_b_t common;    /**< Values common for all ephemeris types */
   double gamma;     /**< Relative deviation of predicted carrier frequency from nominal */
   double tau;       /**< Correction to the SV time [s] */
@@ -434,7 +436,7 @@ typedef struct __attribute__((packed)) {
  * for more details.
  */
 #define SBP_MSG_EPHEMERIS_GLO_DEP_C      0x0087
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_b_t common;    /**< Values common for all ephemeris types */
   double gamma;     /**< Relative deviation of predicted carrier frequency from nominal */
   double tau;       /**< Correction to the SV time [s] */
@@ -452,7 +454,7 @@ typedef struct __attribute__((packed)) {
  * ephemeris message using floats for size reduction.
  */
 #define SBP_MSG_EPHEMERIS_GLO_DEP_D      0x0088
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_dep_b_t common;    /**< Values common for all ephemeris types */
   double gamma;     /**< Relative deviation of predicted carrier frequency from nominal */
   double tau;       /**< Correction to the SV time [s] */
@@ -474,7 +476,7 @@ typedef struct __attribute__((packed)) {
  * for more details.
  */
 #define SBP_MSG_EPHEMERIS_GLO            0x008B
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   ephemeris_common_content_t common;    /**< Values common for all ephemeris types */
   float gamma;     /**< Relative deviation of predicted carrier frequency from nominal */
   float tau;       /**< Correction to the SV time [s] */
@@ -496,7 +498,7 @@ typedef struct __attribute__((packed)) {
  * 20-III) for more details.
  */
 #define SBP_MSG_EPHEMERIS_DEP_D          0x0080
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
   double c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
@@ -534,7 +536,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_EPHEMERIS_DEP_A          0x001A
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
   double c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
@@ -569,7 +571,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_EPHEMERIS_DEP_B          0x0046
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
   double c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
@@ -609,7 +611,7 @@ typedef struct __attribute__((packed)) {
  * 20-III) for more details.
  */
 #define SBP_MSG_EPHEMERIS_DEP_C          0x0047
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   double tgd;         /**< Group delay differential between L1 and L2 [s] */
   double c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
   double c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
@@ -646,7 +648,7 @@ typedef struct __attribute__((packed)) {
  *
 * Header of a GPS observation message.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_dep_t t;        /**< GPS time of this observation */
   u8 n_obs;    /**< Total number of observations. First nibble is the size
 of the sequence (n), second nibble is the zero-indexed
@@ -663,7 +665,7 @@ counter (ith packet of n)
  * sign convention than a typical GPS receiver and the phase has
  * the opposite sign as the pseudorange.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s32 i;    /**< Carrier phase whole cycles [cycles] */
   u8 f;    /**< Carrier phase fractional part [cycles / 256] */
 } carrier_phase_dep_a_t;
@@ -673,7 +675,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 P;       /**< Pseudorange observation [cm] */
   carrier_phase_dep_a_t L;       /**< Carrier phase observation with opposite sign from typical convention */
   u8 cn0;     /**< Carrier-to-Noise density [dB Hz / 4] */
@@ -690,7 +692,7 @@ carrier phase ambiguity may have changed.
  * Pseudorange and carrier phase observation for a satellite being
  * tracked.  Pseudoranges are referenced to a nominal pseudorange.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 P;       /**< Pseudorange observation [cm] */
   carrier_phase_dep_a_t L;       /**< Carrier phase observation with opposite sign from typical convention. */
   u8 cn0;     /**< Carrier-to-Noise density [dB Hz / 4] */
@@ -708,7 +710,7 @@ carrier phase ambiguity may have changed.
  * tracked. The observations are be interoperable with 3rd party
  * receivers and conform with typical RTCMv3 GNSS observations.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 P;       /**< Pseudorange observation [2 cm] */
   carrier_phase_t L;       /**< Carrier phase observation with typical sign convention. [cycles] */
   u8 cn0;     /**< Carrier-to-Noise density [dB Hz / 4] */
@@ -725,7 +727,7 @@ carrier phase ambiguity may have changed.
 * Deprecated.
  */
 #define SBP_MSG_OBS_DEP_A                0x0045
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
   packed_obs_content_dep_a_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
@@ -743,7 +745,7 @@ satellite being tracked.
  * observations.
  */
 #define SBP_MSG_OBS_DEP_B                0x0043
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
   packed_obs_content_dep_b_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
@@ -762,7 +764,7 @@ satellite being tracked.
  * with typical RTCMv3 GNSS observations.
  */
 #define SBP_MSG_OBS_DEP_C                0x0049
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
   packed_obs_content_dep_c_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
@@ -777,7 +779,7 @@ satellite being tracked.
  * Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
  */
 #define SBP_MSG_IONO                     0x0090
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t t_nmct;    /**< Navigation Message Correction Table Valitidy Time */
   double a0;       
   double a1;       
@@ -795,13 +797,13 @@ typedef struct __attribute__((packed)) {
  * Please see ICD-GPS-200 (Chapter 20.3.3.5.1.4) for more details.
  */
 #define SBP_MSG_SV_CONFIGURATION_GPS_DEP 0x0091
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t t_nmct;      /**< Navigation Message Correction Table Valitidy Time */
   u32 l2c_mask;    /**< L2C capability mask, SV32 bit being MSB, SV1 bit being LSB */
 } msg_sv_configuration_gps_dep_t;
 
 
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u64 gps_active;     /**< GPS SV active mask */
   u64 gps_l2c;        /**< GPS L2C active mask */
   u64 gps_l5;         /**< GPS L5 active mask */
@@ -825,7 +827,7 @@ https://www.caat.or.th/wp-content/uploads/2018/03/SL-2018.18.E-1.pdf)
 
 
 #define SBP_MSG_GNSS_CAPB                0x0096
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t t_nmct;    /**< Navigation Message Correction Table Validity Time */
   gnss_capb_t gc;        /**< GNSS capabilities masks */
 } msg_gnss_capb_t;
@@ -836,7 +838,7 @@ typedef struct __attribute__((packed)) {
 * Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
  */
 #define SBP_MSG_GROUP_DELAY_DEP_A        0x0092
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_dep_t t_op;        /**< Data Predict Time of Week */
   u8 prn;         /**< Satellite number */
   u8 valid;       /**< bit-field indicating validity of the values,
@@ -854,7 +856,7 @@ LSB indicating tgd validity etc.
 * Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
  */
 #define SBP_MSG_GROUP_DELAY_DEP_B        0x0093
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t t_op;        /**< Data Predict Time of Week */
   gnss_signal_dep_t sid;         /**< GNSS signal identifier */
   u8 valid;       /**< bit-field indicating validity of the values,
@@ -872,7 +874,7 @@ LSB indicating tgd validity etc.
 * Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
  */
 #define SBP_MSG_GROUP_DELAY              0x0094
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t t_op;        /**< Data Predict Time of Week */
   sbp_gnss_signal_t sid;         /**< GNSS signal identifier */
   u8 valid;       /**< bit-field indicating validity of the values,
@@ -885,7 +887,7 @@ LSB indicating tgd validity etc.
 } msg_group_delay_t;
 
 
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gnss_signal_t sid;             /**< GNSS signal identifier */
   gps_time_sec_t toa;             /**< Reference time of almanac */
   double ura;             /**< User Range Accuracy [m] */
@@ -910,7 +912,7 @@ Satellite health status for GLO:
 } almanac_common_content_t;
 
 
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gnss_signal_dep_t sid;             /**< GNSS signal identifier */
   gps_time_sec_t toa;             /**< Reference time of almanac */
   double ura;             /**< User Range Accuracy [m] */
@@ -943,7 +945,7 @@ Satellite health status for GLO:
  * (ICD-GPS-200, Chapter 20.3.3.5.1.2 Almanac Data) for more details.
  */
 #define SBP_MSG_ALMANAC_GPS_DEP          0x0070
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   almanac_common_content_dep_t common;      /**< Values common for all almanac types */
   double m0;          /**< Mean anomaly at reference time [rad] */
   double ecc;         /**< Eccentricity of satellite orbit */
@@ -965,7 +967,7 @@ typedef struct __attribute__((packed)) {
  * (ICD-GPS-200, Chapter 20.3.3.5.1.2 Almanac Data) for more details.
  */
 #define SBP_MSG_ALMANAC_GPS              0x0072
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   almanac_common_content_t common;      /**< Values common for all almanac types */
   double m0;          /**< Mean anomaly at reference time [rad] */
   double ecc;         /**< Eccentricity of satellite orbit */
@@ -987,7 +989,7 @@ typedef struct __attribute__((packed)) {
  * almanac" for details.
  */
 #define SBP_MSG_ALMANAC_GLO_DEP          0x0071
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   almanac_common_content_dep_t common;         /**< Values common for all almanac types */
   double lambda_na;      /**< Longitude of the first ascending node of the orbit in PZ-90.02
 coordinate system
@@ -1009,7 +1011,7 @@ coordinate system
  * almanac" for details.
  */
 #define SBP_MSG_ALMANAC_GLO              0x0073
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   almanac_common_content_t common;         /**< Values common for all almanac types */
   double lambda_na;      /**< Longitude of the first ascending node of the orbit in PZ-90.02
 coordinate system
@@ -1031,7 +1033,7 @@ coordinate system
  * manufacturers)
  */
 #define SBP_MSG_GLO_BIASES               0x0075
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 mask;         /**< GLONASS FDMA signals mask [boolean] */
   s16 l1ca_bias;    /**< GLONASS L1 C/A Code-Phase Bias [m * 0.02] */
   s16 l1p_bias;     /**< GLONASS L1 P Code-Phase Bias [m * 0.02] */
@@ -1041,5 +1043,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_OBSERVATION_MESSAGES_H */

--- a/c/include/libsbp/orientation.h
+++ b/c/include/libsbp/orientation.h
@@ -25,6 +25,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Heading relative to True North
  *
@@ -34,7 +36,7 @@
  * that time-matched RTK mode is used when the base station is moving.
  */
 #define SBP_MSG_BASELINE_HEADING 0x020F
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;        /**< GPS Time of Week [ms] */
   u32 heading;    /**< Heading [mdeg] */
   u8 n_sats;     /**< Number of satellites used in solution */
@@ -49,7 +51,7 @@ typedef struct __attribute__((packed)) {
  * vector assuming that the LSB of each component as a value of 2^-31. 
  */
 #define SBP_MSG_ORIENT_QUAT      0x0220
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;           /**< GPS Time of Week [ms] */
   s32 w;             /**< Real component [2^-31] */
   s32 x;             /**< 1st imaginary component [2^-31] */
@@ -71,7 +73,7 @@ typedef struct __attribute__((packed)) {
  * to the vehicle body frame.
  */
 #define SBP_MSG_ORIENT_EULER     0x0221
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;               /**< GPS Time of Week [ms] */
   s32 roll;              /**< rotation about the forward axis of the vehicle [microdegrees] */
   s32 pitch;             /**< rotation about the rightward axis of the vehicle [microdegrees] */
@@ -94,7 +96,7 @@ typedef struct __attribute__((packed)) {
  * direction, and the vehicle z-axis should be aligned with the down direction.
  */
 #define SBP_MSG_ANGULAR_RATE     0x0222
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;      /**< GPS Time of Week [ms] */
   s32 x;        /**< angular rate about x axis [microdegrees/s] */
   s32 y;        /**< angular rate about y axis [microdegrees/s] */
@@ -104,5 +106,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_ORIENTATION_MESSAGES_H */

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -28,6 +28,8 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** Legacy message to load satellite almanac (host => Piksi)
  *
@@ -51,7 +53,7 @@
  * bootloader.
  */
 #define SBP_MSG_RESET                   0x00B6
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 flags;    /**< Reset flags */
 } msg_reset_t;
 
@@ -88,7 +90,7 @@ typedef struct __attribute__((packed)) {
  * Ambiguity Resolution (IAR) process.
  */
 #define SBP_MSG_RESET_FILTERS           0x0022
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 filter;    /**< Filter flags */
 } msg_reset_filters_t;
 
@@ -111,7 +113,7 @@ typedef struct __attribute__((packed)) {
  * thread. The reported percentage values must be normalized.
  */
 #define SBP_MSG_THREAD_STATE            0x0017
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char name[20];      /**< Thread name (NULL terminated) */
   u16 cpu;           /**< Percentage cpu use for this thread. Values range from 0
 - 1000 and needs to be renormalized to 100
@@ -126,7 +128,7 @@ typedef struct __attribute__((packed)) {
  * of this UART channel. The reported percentage values must
  * be normalized.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   float tx_throughput;      /**< UART transmit throughput [kB/s] */
   float rx_throughput;      /**< UART receive throughput [kB/s] */
   u16 crc_error_count;    /**< UART CRC error count */
@@ -149,7 +151,7 @@ typedef struct __attribute__((packed)) {
  * or missing sets will increase the period.  Long periods
  * can cause momentary RTK solution outages.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s32 avg;        /**< Average period [ms] */
   s32 pmin;       /**< Minimum period [ms] */
   s32 pmax;       /**< Maximum period [ms] */
@@ -165,7 +167,7 @@ typedef struct __attribute__((packed)) {
  * receiver to give a precise measurement of the end-to-end
  * communication latency in the system.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s32 avg;        /**< Average latency [ms] */
   s32 lmin;       /**< Minimum latency [ms] */
   s32 lmax;       /**< Maximum latency [ms] */
@@ -186,7 +188,7 @@ typedef struct __attribute__((packed)) {
  * period indicates their likelihood of transmission.
  */
 #define SBP_MSG_UART_STATE              0x001D
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   uart_channel_t uart_a;        /**< State of UART A */
   uart_channel_t uart_b;        /**< State of UART B */
   uart_channel_t uart_ftdi;     /**< State of UART FTDI (USB logger) */
@@ -200,7 +202,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated
  */
 #define SBP_MSG_UART_STATE_DEPA         0x0018
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   uart_channel_t uart_a;       /**< State of UART A */
   uart_channel_t uart_b;       /**< State of UART B */
   uart_channel_t uart_ftdi;    /**< State of UART FTDI (USB logger) */
@@ -216,7 +218,7 @@ typedef struct __attribute__((packed)) {
  * from satellite observations.
  */
 #define SBP_MSG_IAR_STATE               0x0019
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 num_hyps;    /**< Number of integer ambiguity hypotheses remaining */
 } msg_iar_state_t;
 
@@ -227,7 +229,7 @@ typedef struct __attribute__((packed)) {
  * from being used in various Piksi subsystems.
  */
 #define SBP_MSG_MASK_SATELLITE          0x002B
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 mask;    /**< Mask of systems that should ignore this satellite. */
   sbp_gnss_signal_t sid;     /**< GNSS signal for which the mask is applied */
 } msg_mask_satellite_t;
@@ -238,7 +240,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_MASK_SATELLITE_DEP      0x001B
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 mask;    /**< Mask of systems that should ignore this satellite. */
   gnss_signal_dep_t sid;     /**< GNSS signal for which the mask is applied */
 } msg_mask_satellite_dep_t;
@@ -251,7 +253,7 @@ typedef struct __attribute__((packed)) {
  * available.
  */
 #define SBP_MSG_DEVICE_MONITOR          0x00B5
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s16 dev_vin;            /**< Device V_in [V / 1000] */
   s16 cpu_vint;           /**< Processor V_int [V / 1000] */
   s16 cpu_vaux;           /**< Processor V_aux [V / 1000] */
@@ -267,7 +269,7 @@ typedef struct __attribute__((packed)) {
  * code will be returned with MSG_COMMAND_RESP.
  */
 #define SBP_MSG_COMMAND_REQ             0x00B8
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
   char command[0];  /**< Command line to execute */
 } msg_command_req_t;
@@ -279,7 +281,7 @@ typedef struct __attribute__((packed)) {
  * the command.  A return code of zero indicates success.
  */
 #define SBP_MSG_COMMAND_RESP            0x00B9
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
   s32 code;        /**< Exit code */
 } msg_command_resp_t;
@@ -293,7 +295,7 @@ typedef struct __attribute__((packed)) {
  * the correct command.
  */
 #define SBP_MSG_COMMAND_OUTPUT          0x00BC
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
   char line[0];     /**< Line of standard output or standard error */
 } msg_command_output_t;
@@ -314,7 +316,7 @@ typedef struct __attribute__((packed)) {
  * in c.
  */
 #define SBP_MSG_NETWORK_STATE_RESP      0x00BB
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 ipv4_address[4];   /**< IPv4 address (all zero when unavailable) */
   u8 ipv4_mask_size;    /**< IPv4 netmask CIDR notation */
   u8 ipv6_address[16];  /**< IPv6 address (all zero when unavailable) */
@@ -335,7 +337,7 @@ typedef struct __attribute__((packed)) {
  * may vary, both a timestamp and period field is provided,
  * though may not necessarily be populated with a value. 
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u64 duration;          /**< Duration over which the measurement was collected [ms] */
   u64 total_bytes;       /**< Number of bytes handled in total within period */
   u32 rx_bytes;          /**< Number of bytes transmitted within period */
@@ -349,7 +351,7 @@ typedef struct __attribute__((packed)) {
  * The bandwidth usage, a list of usage by interface. 
  */
 #define SBP_MSG_NETWORK_BANDWIDTH_USAGE 0x00BD
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   network_usage_t interfaces[0]; /**< Usage measurement array */
 } msg_network_bandwidth_usage_t;
 
@@ -361,7 +363,7 @@ typedef struct __attribute__((packed)) {
  * of the modem and its various parameters.
  */
 #define SBP_MSG_CELL_MODEM_STATUS       0x00BE
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s8 signal_strength;      /**< Received cell signal strength in dBm, zero translates to unknown [dBm] */
   float signal_error_rate;    /**< BER as reported by the modem, zero translates to unknown */
   u8 reserved[0];          /**< Unspecified data TBD for this schema */
@@ -373,7 +375,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_SPECAN_DEP              0x0050
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 channel_tag;        /**< Channel ID */
   gps_time_dep_t t;                  /**< Receiver time of this observation */
   float freq_ref;           /**< Reference frequency of this packet
@@ -394,7 +396,7 @@ typedef struct __attribute__((packed)) {
  * Spectrum analyzer packet.
  */
 #define SBP_MSG_SPECAN                  0x0051
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 channel_tag;        /**< Channel ID */
   sbp_gps_time_t t;                  /**< Receiver time of this observation */
   float freq_ref;           /**< Reference frequency of this packet
@@ -411,5 +413,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_PIKSI_MESSAGES_H */

--- a/c/include/libsbp/sbas.h
+++ b/c/include/libsbp/sbas.h
@@ -26,6 +26,8 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** Raw SBAS data
  *
@@ -33,7 +35,7 @@
  * parity of the data block and sends only blocks that pass the check.
  */
 #define SBP_MSG_SBAS_RAW 0x7777
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gnss_signal_t sid;             /**< GNSS signal identifier. */
   u32 tow;             /**< GPS time-of-week at the start of the data block. [ms] */
   u8 message_type;    /**< SBAS message type (0-63) */
@@ -42,5 +44,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_SBAS_MESSAGES_H */

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -50,6 +50,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Save settings to flash (host => device)
  *
@@ -70,7 +72,7 @@
  * "solution\0soln_freq\010\0".
  */
 #define SBP_MSG_SETTINGS_WRITE              0x00A0
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0"
  */
@@ -88,7 +90,7 @@ typedef struct __attribute__((packed)) {
  * "solution\0soln_freq\010\0".
  */
 #define SBP_MSG_SETTINGS_WRITE_RESP         0x00AF
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 status;     /**< Write status */
   char setting[0]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0" 
@@ -108,7 +110,7 @@ typedef struct __attribute__((packed)) {
  * message (msg_id 0x00A5).
  */
 #define SBP_MSG_SETTINGS_READ_REQ           0x00A4
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0"
  */
@@ -126,7 +128,7 @@ typedef struct __attribute__((packed)) {
  * "solution\0soln_freq\010\0".
  */
 #define SBP_MSG_SETTINGS_READ_RESP          0x00A5
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0"
  
@@ -141,7 +143,7 @@ typedef struct __attribute__((packed)) {
  * "MSG_SETTINGS_READ_BY_INDEX_RESP".
  */
 #define SBP_MSG_SETTINGS_READ_BY_INDEX_REQ  0x00A2
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 index;    /**< An index into the device settings, with values ranging from
 0 to length(settings)
  */
@@ -162,7 +164,7 @@ typedef struct __attribute__((packed)) {
  * the device is "simulator\0enabled\0True\0enum:True,False\0"
  */
 #define SBP_MSG_SETTINGS_READ_BY_INDEX_RESP 0x00A7
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u16 index;      /**< An index into the device settings, with values ranging from
 0 to length(settings)
  */
@@ -186,7 +188,7 @@ typedef struct __attribute__((packed)) {
  * for this setting to set the initial value.
  */
 #define SBP_MSG_SETTINGS_REGISTER           0x00AE
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE".
  */
@@ -194,5 +196,7 @@ typedef struct __attribute__((packed)) {
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_SETTINGS_MESSAGES_H */

--- a/c/include/libsbp/ssr.h
+++ b/c/include/libsbp/ssr.h
@@ -26,13 +26,15 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** SSR code biases corrections for a particular satellite.
  *
  * Code biases are to be added to pseudorange.
  * The corrections are conform with typical RTCMv3 MT1059 and 1065.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 code;     /**< Signal constellation, band and code */
   s16 value;    /**< Code bias value [0.01 m] */
 } code_biases_content_t;
@@ -43,7 +45,7 @@ typedef struct __attribute__((packed)) {
  * Phase biases are to be added to carrier phase measurements.
  * The corrections are conform with typical RTCMv3 MT1059 and 1065.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 code;                          /**< Signal constellation, band and code */
   u8 integer_indicator;             /**< Indicator for integer property */
   u8 widelane_integer_indicator;    /**< Indicator for two groups of Wide-Lane(s) integer property */
@@ -62,7 +64,7 @@ Increased for every discontinuity in phase.
  * and 1066 RTCM message types
  */
 #define SBP_MSG_SSR_ORBIT_CLOCK  0x05DC
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t time;               /**< GNSS reference time of the correction */
   sbp_gnss_signal_t sid;                /**< GNSS signal identifier (16 bit) */
   u8 update_interval;    /**< Update interval between consecutive corrections [s] */
@@ -91,7 +93,7 @@ generating configuration
  * an equivalent to the 1059 and 1065 RTCM message types
  */
 #define SBP_MSG_SSR_CODE_BIASES  0x05E1
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t time;               /**< GNSS reference time of the correction */
   sbp_gnss_signal_t sid;                /**< GNSS signal identifier (16 bit) */
   u8 update_interval;    /**< Update interval between consecutive corrections [s] */
@@ -113,7 +115,7 @@ generating configuration
  * It is typically an equivalent to the 1265 RTCM message types
  */
 #define SBP_MSG_SSR_PHASE_BIASES 0x05E6
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   gps_time_sec_t time;               /**< GNSS reference time of the correction */
   sbp_gnss_signal_t sid;                /**< GNSS signal identifier (16 bit) */
   u8 update_interval;    /**< Update interval between consecutive corrections [s] */
@@ -134,5 +136,7 @@ satellite being tracked.
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_SSR_MESSAGES_H */

--- a/c/include/libsbp/system.h
+++ b/c/include/libsbp/system.h
@@ -25,6 +25,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** System start-up message
  *
@@ -34,7 +36,7 @@
  * or configuration requests.
  */
 #define SBP_MSG_STARTUP      0xFF00
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 cause;           /**< Cause of startup */
   u8 startup_type;    /**< Startup type */
   u16 reserved;        /**< Reserved */
@@ -48,7 +50,7 @@ typedef struct __attribute__((packed)) {
  * corrections packet.
  */
 #define SBP_MSG_DGNSS_STATUS 0xFF02
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 flags;          /**< Status flags */
   u16 latency;        /**< Latency of observation receipt [deci-seconds] */
   u8 num_signals;    /**< Number of signals from base station */
@@ -70,7 +72,7 @@ typedef struct __attribute__((packed)) {
  * the remaining error flags should be inspected.
  */
 #define SBP_MSG_HEARTBEAT    0xFFFF
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 flags;    /**< Status flags */
 } msg_heartbeat_t;
 
@@ -81,11 +83,13 @@ typedef struct __attribute__((packed)) {
  * and initialization of the inertial navigation system. 
  */
 #define SBP_MSG_INS_STATUS   0xFF03
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 flags;    /**< Status flags */
 } msg_ins_status_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_SYSTEM_MESSAGES_H */

--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -26,6 +26,8 @@
 #include "common.h"
 #include "gnss.h"
 
+SBP_PACK_START
+
 
 /** Detailed signal tracking channel states. DEPRECATED.
  *
@@ -33,7 +35,7 @@
  * single tracking channel useful for debugging issues.
  */
 #define SBP_MSG_TRACKING_STATE_DETAILED_DEP_A 0x0021
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u64 recv_time;       /**< Receiver clock time. [ns] */
   sbp_gps_time_t tot;             /**< Time of transmission of signal from satellite. TOW only valid when
 TOW status is decoded or propagated. WN only valid when week
@@ -78,7 +80,7 @@ signal is in continuous track.
 * Deprecated.
  */
 #define SBP_MSG_TRACKING_STATE_DETAILED_DEP   0x0011
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u64 recv_time;       /**< Receiver clock time. [ns] */
   gps_time_dep_t tot;             /**< Time of transmission of signal from satellite. TOW only valid when
 TOW status is decoded or propagated. WN only valid when week
@@ -123,7 +125,7 @@ signal is in continuous track.
  * Tracking channel state for a specific satellite signal and
  * measured signal power.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gnss_signal_t sid;    /**< GNSS signal being tracked */
   u8 fcn;    /**< Frequency channel number (GLONASS only) */
   u8 cn0;    /**< Carrier-to-Noise density.  Zero implies invalid cn0. [dB Hz / 4] */
@@ -137,7 +139,7 @@ typedef struct __attribute__((packed)) {
  * measurements for all tracked satellites.
  */
 #define SBP_MSG_TRACKING_STATE                0x0041
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   tracking_channel_state_t states[0]; /**< Signal tracking channel state */
 } msg_tracking_state_t;
 
@@ -150,7 +152,7 @@ typedef struct __attribute__((packed)) {
  * carry the FCN as 100 + FCN where FCN is in [-7, +6] or 
  * the Slot ID (from 1 to 28)
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   sbp_gnss_signal_t mesid;    /**< Measurement Engine GNSS signal being tracked (carries either Glonass FCN or SLOT) */
   u8 cn0;      /**< Carrier-to-Noise density.  Zero implies invalid cn0. [dB Hz / 4] */
 } measurement_state_t;
@@ -163,7 +165,7 @@ typedef struct __attribute__((packed)) {
  * measurements for all tracked satellites.
  */
 #define SBP_MSG_MEASUREMENT_STATE             0x0061
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   measurement_state_t states[0]; /**< ME signal tracking channel state */
 } msg_measurement_state_t;
 
@@ -172,7 +174,7 @@ typedef struct __attribute__((packed)) {
  *
  * Structure containing in-phase and quadrature correlation components.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   s32 I;    /**< In-phase correlation */
   s32 Q;    /**< Quadrature correlation */
 } tracking_channel_correlation_t;
@@ -184,7 +186,7 @@ typedef struct __attribute__((packed)) {
  * update interval.
  */
 #define SBP_MSG_TRACKING_IQ                   0x002C
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 channel;    /**< Tracking channel of origin */
   sbp_gnss_signal_t sid;        /**< GNSS signal identifier */
   tracking_channel_correlation_t corrs[3];   /**< Early, Prompt and Late correlations */
@@ -196,7 +198,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_TRACKING_IQ_DEP               0x001C
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 channel;    /**< Tracking channel of origin */
   gnss_signal_dep_t sid;        /**< GNSS signal identifier */
   tracking_channel_correlation_t corrs[3];   /**< Early, Prompt and Late correlations */
@@ -207,7 +209,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 state;    /**< Status of tracking channel */
   u8 prn;      /**< PRN-1 being tracked */
   float cn0;      /**< Carrier-to-noise density [dB Hz] */
@@ -219,7 +221,7 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_TRACKING_STATE_DEP_A          0x0016
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   tracking_channel_state_dep_a_t states[0]; /**< Satellite tracking channel state */
 } msg_tracking_state_dep_a_t;
 
@@ -228,7 +230,7 @@ typedef struct __attribute__((packed)) {
  *
 * Deprecated.
  */
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 state;    /**< Status of tracking channel */
   gnss_signal_dep_t sid;      /**< GNSS signal being tracked */
   float cn0;      /**< Carrier-to-noise density [dB Hz] */
@@ -240,11 +242,13 @@ typedef struct __attribute__((packed)) {
 * Deprecated.
  */
 #define SBP_MSG_TRACKING_STATE_DEP_B          0x0013
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   tracking_channel_state_dep_b_t states[0]; /**< Signal tracking channel state */
 } msg_tracking_state_dep_b_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_TRACKING_MESSAGES_H */

--- a/c/include/libsbp/user.h
+++ b/c/include/libsbp/user.h
@@ -25,6 +25,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** User data
  *
@@ -32,11 +34,13 @@
  * maximum length of 255 bytes per message.
  */
 #define SBP_MSG_USER_DATA 0x0800
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u8 contents[0]; /**< User data payload */
 } msg_user_data_t;
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_USER_MESSAGES_H */

--- a/c/include/libsbp/vehicle.h
+++ b/c/include/libsbp/vehicle.h
@@ -25,6 +25,8 @@
 
 #include "common.h"
 
+SBP_PACK_START
+
 
 /** Vehicle forward (x-axis) velocity
  *
@@ -35,7 +37,7 @@
  * source 0 through 3.
  */
 #define SBP_MSG_ODOMETRY 0x0903
-typedef struct __attribute__((packed)) {
+typedef struct SBP_ATTR_PACKED {
   u32 tow;         /**< Time field representing either milliseconds in the GPS Week or local CPU
 time from the producing system in milliseconds.  See the tow_source flag
 for the exact source of this timestamp.
@@ -47,5 +49,7 @@ for the exact source of this timestamp.
 
 
 /** \} */
+
+SBP_PACK_END
 
 #endif /* LIBSBP_VEHICLE_MESSAGES_H */

--- a/generator/sbpg/targets/resources/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/sbp_messages_template.h
@@ -29,9 +29,7 @@
 #include "(((i)))"
 ((*- endfor *))
 
-#ifdef TOOLCHAIN_PRAGMA_PACK
-#pragma pack(1)
-#endif
+SBP_PACK_START
 
 ((* for m in msgs *))
 ((*- if m.desc *))
@@ -44,7 +42,7 @@
 #define SBP_(((m.identifier.ljust(max_msgid_len)))) ((('0x%04X'|format(m.sbp_id))))
 ((*- endif *))
 ((*- if m.fields *))
-typedef struct TOOLCHAIN_ATTR_PACKED {
+typedef struct SBP_ATTR_PACKED {
   ((*- for f in m.fields *))
   ((*- if f.desc *))
   (((f|mk_id))) ((((f|mk_size).ljust(m.max_fid_len+4)))) /**< (((f.desc))) ((* if f.units *))[(((f.units)))] ((* endif *))*/
@@ -57,7 +55,7 @@ typedef struct TOOLCHAIN_ATTR_PACKED {
 
 ((* endfor *))
 /** \} */
-#ifdef TOOLCHAIN_PRAGMA_PACK
-#pragma pack()
-#endif
+
+SBP_PACK_END
+
 #endif /* LIBSBP_(((pkg_name|upper)))_MESSAGES_H */

--- a/generator/sbpg/targets/resources/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/sbp_messages_template.h
@@ -24,9 +24,14 @@
 #define LIBSBP_(((pkg_name|upper)))_MESSAGES_H
 
 #include "common.h"
+
 ((*- for i in include *))
 #include "(((i)))"
 ((*- endfor *))
+
+#ifdef TOOLCHAIN_PRAGMA_PACK
+#pragma pack(1)
+#endif
 
 ((* for m in msgs *))
 ((*- if m.desc *))
@@ -39,7 +44,7 @@
 #define SBP_(((m.identifier.ljust(max_msgid_len)))) ((('0x%04X'|format(m.sbp_id))))
 ((*- endif *))
 ((*- if m.fields *))
-typedef struct __attribute__((packed)) {
+typedef struct TOOLCHAIN_ATTR_PACKED {
   ((*- for f in m.fields *))
   ((*- if f.desc *))
   (((f|mk_id))) ((((f|mk_size).ljust(m.max_fid_len+4)))) /**< (((f.desc))) ((* if f.units *))[(((f.units)))] ((* endif *))*/
@@ -52,5 +57,7 @@ typedef struct __attribute__((packed)) {
 
 ((* endfor *))
 /** \} */
-
+#ifdef TOOLCHAIN_PRAGMA_PACK
+#pragma pack()
+#endif
 #endif /* LIBSBP_(((pkg_name|upper)))_MESSAGES_H */


### PR DESCRIPTION
Supercedes #479  @silverjam  How does this suite you based upon feedback from #479?

In Common.h we define TOOLCHAIN_ATTR_PACK.  If MSC is used ,it also defines TOOLCHAIN_PRAGMA PACK.  Header files use these macros. 

I think this is the way to go and it is what I had originally.

I really want to get this in, and afterwards then some tests on appveyor and a fleshed out example that Stefan has written.