### PR TITLE
Add SSR messages to Libsbp

### DIFF
--- a/python/sbp/table.py
+++ b/python/sbp/table.py
@@ -34,6 +34,7 @@ from . import ndb as ndb
 from . import vehicle as vehicle
 from . import orientation as orientation
 from . import sbas as sbas
+from . import ssr as ssr
 
 import warnings
 
@@ -56,6 +57,7 @@ _SBP_TABLE = dict(acq.msg_classes.items()
                   + vehicle.msg_classes.items()
                   + orientation.msg_classes.items()
                   + sbas.msg_classes.items()
+                  + ssr.msg_classes.items()
                   )
 
 class InvalidSBPMessageType(NotImplementedError):

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -31,6 +31,7 @@ from sbp import mag as mag
 from sbp import vehicle as vehicle
 from sbp import orientation as orientation
 from sbp import sbas as sbas
+from sbp import ssr as ssr
 
 import pytest
 import sbp.acquisition as acq
@@ -42,7 +43,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 148
+  number_of_messages = 151
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():
@@ -68,6 +69,7 @@ def test_table_unqiue_count():
                         + len(vehicle.msg_classes)
                         + len(orientation.msg_classes)
                         + len(sbas.msg_classes)
+                        + len(ssr.msg_classes)
                          )
   assert len(_SBP_TABLE) == number_of_messages
 


### PR DESCRIPTION
SSR messages are currently rejected by GNSS analysis:
```
No message found for msg_type id 1510 for msg <SBP...
```
as they are not in the sbp table