### PR TITLE
Build `libsbp.a` instead of `libsbp-static.a`

### DIFF
--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -11,14 +11,12 @@ set(libsbp_SRCS
   sbp.c
 )
 
-add_library(sbp STATIC ${libsbp_SRCS})
-install(TARGETS sbp DESTINATION lib${LIB_SUFFIX})
-
 if(BUILD_SHARED_LIBS)
   add_library(sbp SHARED ${libsbp_SRCS})
   install(TARGETS sbp DESTINATION lib${LIB_SUFFIX})
 else(BUILD_SHARED_LIBS)
-  message(STATUS "Not building shared libraries")
+  add_library(sbp STATIC ${libsbp_SRCS})
+  install(TARGETS sbp DESTINATION lib${LIB_SUFFIX})
 endif(BUILD_SHARED_LIBS)
 
 install(FILES ${libsbp_HEADERS} DESTINATION include/libsbp)

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -11,8 +11,8 @@ set(libsbp_SRCS
   sbp.c
 )
 
-add_library(sbp-static STATIC ${libsbp_SRCS})
-install(TARGETS sbp-static DESTINATION lib${LIB_SUFFIX})
+add_library(sbp STATIC ${libsbp_SRCS})
+install(TARGETS sbp DESTINATION lib${LIB_SUFFIX})
 
 if(BUILD_SHARED_LIBS)
   add_library(sbp SHARED ${libsbp_SRCS})

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (CMAKE_CROSSCOMPILING)
-  message(STATUS "Skipping unit tests, cross compiling")
+  message(STATUS "LIBSBP: Skipping unit tests, cross compiling")
 else (CMAKE_CROSSCOMPILING)
 
   find_package(Check)


### PR DESCRIPTION
This works better for me in a CMake driven build system where specifying `cmake ../ -DCMAKE_SYSTEM_NAME=Linux -DBUILD_SHARED_LIBS=OFF` naturally links statically LIBSBP.
Without this, the linker needs to know the libsbp static library is called something else (`libsbp-static.a`). I am not sure why that would be as the name wouldn't conflict with the dynamically linked one..