### PR TITLE
Setup Travis CI to build Haskell based SBP tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,15 @@ matrix:
         docker run --rm --name sbp2json sbp2json >sbp_linux_tools.tar
         gzip sbp_linux_tools.tar
 
+deploy:
+  provider: releases
+  api_key:
+    secure: "EbM5FzcjE5waVpl0fl3J/rorE3UbhbX+gyhbjIv35GqHU5Ifwo5oMo2xno8G8y83PTzVFvpF9n/AWxRtKUEB2j5gtK1uljBheeBHmXIs6G7LdBZPq2bexPRpO2N7GgS1huWd8Z8YSwsoxC5/OR/hwIU1KgEY/ol2q15XiZLsl4c="
+  file: haskell/sbp_linux_tools.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true
+
 install:
   # - tlmgr update --self
   # - tlmgr install standalone #standalone.sty

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,21 @@ before_install:
   - npm/.bin/npm install
   - pip install --user tox
 
+matrix:
+  include:
+    - env:
+        - TRAVIS_TARGET=default
+    - env:
+        - TRAVIS_TARGET=haskell-tools
+      before_install: |
+        sudo apt-get update
+        sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+      script: |
+        cd haskell
+        docker build -t sbp2json .
+        docker run --rm --name sbp2json sbp2json >sbp_linux_tools.tar
+        gzip sbp_linux_tools.tar
+
 install:
   # - tlmgr update --self
   # - tlmgr install standalone #standalone.sty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-sudo: false
+sudo: required
 
-language: c
+dist: trusty
+language: python
+python: 2.7.13
 
 addons:
   apt:
     packages:
+    - build-essential
     - check
     - doxygen
     - cmake
@@ -35,7 +38,7 @@ before_install:
   - mv node_modules npm
   - npm/.bin/npm --version
   - npm/.bin/npm install
-  - pip install --user tox
+  - sudo pip install tox
 
 matrix:
   include:
@@ -65,7 +68,7 @@ install:
   # - tlmgr update --self
   # - tlmgr install standalone #standalone.sty
   # - tlmgr install cmbright #cmbright font
-  - pip install --upgrade --user Sphinx
+  - sudo pip install --upgrade Sphinx
   - npm install -g mocha
   - npm install
 

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stretch
+
+ADD . /app
+WORKDIR /app
+
+RUN \
+  apt-get update && \
+  apt-get install curl make ca-certificates xz-utils -y --no-install-recommends && \
+  curl -sSL https://get.haskellstack.org/ | sh && \
+  stack build
+
+CMD \
+  tar -C $(find .stack-work/install -name bin) -cf - \
+    sbp2json \
+    sbp2yaml \
+    json2sbp \
+    json2json


### PR DESCRIPTION
+ Setup Travis CI so we can publish Debian Stretch based builds of sbp2json, sbp2yaml, json2sbp, and json2json

+ Fix the Python version on Travis to 2.7.13, Travis seemed to have regressed to a version prior to 2.7.9 (or possibly 2.7.14) where the SSLContext object was not present in the ssl package.  See https://github.com/travis-ci/travis-ci/issues/8097 and https://github.com/gabrielfalcao/HTTPretty/issues/340.