### PR TITLE
Use OpenJDK 8 so we aren't chasing Oracle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ addons:
     - cmake
     - gradle
     - libgmp-dev
-    - oracle-java8-installer
-    - oracle-java8-set-default
 
 env:
-  - JAVA_HOME=/usr/lib/jvm/java-8-oracle
+  - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 cache:
   apt: true
@@ -39,6 +37,10 @@ before_install:
   - npm/.bin/npm --version
   - npm/.bin/npm install
   - sudo pip install tox
+  - sudo add-apt-repository -y ppa:openjdk-r/ppa
+  - sudo apt-get -qq update
+  - sudo apt-get install -y openjdk-8-jdk --no-install-recommends
+  - sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 matrix:
   include:
@@ -73,6 +75,5 @@ install:
   - npm install
 
 script:
-  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
   - make test
   # - make docs


### PR DESCRIPTION
See:
 - https://github.com/travis-ci/travis-ci/issues/10247
 - https://github.com/travis-ci/travis-ci/issues/9512

Since we're not using the travis java template, manually install OpenJDK 8 per:
- https://github.com/travis-ci/travis-ci/issues/6483#issuecomment-274311218