### PR TITLE
Compile c library with -fPIC.

### DIFF
--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -30,9 +30,11 @@ set(libsbp_HEADERS
 set(libsbp_SRCS
   edc.c
   sbp.c
-)
+  )
+set(LIBSBP_CFLAGS "-fpic" CACHE STRING "Compile flags for libsbp.")
 
 add_library(sbp ${libsbp_SRCS})
+target_compile_options(sbp PRIVATE "${LIBSBP_CFLAGS}")
 target_include_directories(sbp PUBLIC "${PROJECT_SOURCE_DIR}/include")
 install(TARGETS sbp DESTINATION lib${LIB_SUFFIX})
 install(FILES ${libsbp_HEADERS} DESTINATION include/libsbp)


### PR DESCRIPTION
As I was moving things around in the repo refactor, I got an error related to this.  Seems like a good thing to have in a library and I am not aware of any downsides.