### PR TITLE
[WIP] win32 build for GTT

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -50,7 +50,9 @@ cmake_minimum_required(VERSION 2.8)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Some compiler options used globally
-set(CMAKE_C_FLAGS "-Wall -Werror -std=gnu99 ${CMAKE_C_FLAGS}")
+if (NOT MSVC)
+  set(CMAKE_C_FLAGS "-Wall -Werror -std=gnu99 ${CMAKE_C_FLAGS}")
+endif (NOT MSVC)
 
 add_subdirectory(src)
 add_subdirectory(docs)

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -31,7 +31,10 @@ set(libsbp_SRCS
   edc.c
   sbp.c
   )
-set(LIBSBP_CFLAGS "-fpic" CACHE STRING "Compile flags for libsbp.")
+
+if (NOT MSVC)
+  set(LIBSBP_CFLAGS "-fpic" CACHE STRING "Compile flags for libsbp.")
+endif (NOT MSVC)
 
 add_library(sbp ${libsbp_SRCS})
 target_compile_options(sbp PRIVATE "${LIBSBP_CFLAGS}")


### PR DESCRIPTION
Currently GTT has SBP module as statically copied files, which is not good. Some investigations for providing SBP as actual library on win32 platform.

Initial build produces only static `sbp.lib`. See if `sbp.dll` should be build also.

How to build in 'Native Tools Command Prompt for VS 2017':

Short:
```
md build
cd build
cmake ..
msbuild libsbp.sln /p:Configuration="Release" 
```

Details:
```
c:\xoodi\github\sn\libsettings\libsbp\c>md build

c:\xoodi\github\sn\libsettings\libsbp\c>cd build

c:\xoodi\github\sn\libsettings\libsbp\c\build>cmake ..
-- Building for: Visual Studio 15 2017
-- Selecting Windows SDK version 10.0.17763.0 to target Windows 10.0.17134.
-- The C compiler identification is MSVC 19.16.27026.1
-- The CXX compiler identification is MSVC 19.16.27026.1
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x86/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x86/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x86/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x86/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- libsbp version: v2.4.9-dirty
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
CMake Warning at docs/CMakeLists.txt:7 (message):
  Doxygen not found, the documentation will not be built.


-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Checking for one of the modules 'check'
-- Could NOT find CHECK
-- Skipping unit tests, Check library not found!
-- Configuring done
-- Generating done
-- Build files have been written to: C:/xoodi/github/sn/libsettings/libsbp/c/build

c:\xoodi\github\sn\libsettings\libsbp\c\build>msbuild libsbp.sln /p:Configuration="Release" /p:Platform="Win32"
Microsoft (R) Build Engine version 15.9.21+g9802d43bc3 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
Build started 13.2.2019 9:31:12.
Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\libsbp.sln" on node 1 (default targets).
ValidateSolutionConfiguration:
  Building solution configuration "Release|Win32".
ValidateProjects:
  The project "INSTALL" is not selected for building in solution configuration "Release|Win32".
Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\libsbp.sln" (1) is building "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcxproj.metaproj" (
2) on node 1 (default targets).
Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcxproj.metaproj" (2) is building "c:\xoodi\github\sn\libsettings\libsbp\c\build\ZERO_CHECK.vc
xproj" (3) on node 1 (default targets).
PrepareForBuild:
  Creating directory "Win32\Release\ZERO_CHECK\".
  Creating directory "c:\xoodi\github\sn\libsettings\libsbp\c\build\Release\".
  Creating directory "Win32\Release\ZERO_CHECK\ZERO_CHECK.tlog\".
InitializeBuildStatus:
  Creating "Win32\Release\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Checking Build System
  CMake does not need to re-run because C:/xoodi/github/sn/libsettings/libsbp/c/build/CMakeFiles/generate.stamp is up-to-date.
  CMake does not need to re-run because C:/xoodi/github/sn/libsettings/libsbp/c/build/src/CMakeFiles/generate.stamp is up-to-date.
  CMake does not need to re-run because C:/xoodi/github/sn/libsettings/libsbp/c/build/docs/CMakeFiles/generate.stamp is up-to-date.
  CMake does not need to re-run because C:/xoodi/github/sn/libsettings/libsbp/c/build/test/CMakeFiles/generate.stamp is up-to-date.
FinalizeBuildStatus:
  Deleting file "Win32\Release\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild".
  Touching "Win32\Release\ZERO_CHECK\ZERO_CHECK.tlog\ZERO_CHECK.lastbuildstate".
Done Building Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\ZERO_CHECK.vcxproj" (default targets).

Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcxproj.metaproj" (2) is building "c:\xoodi\github\sn\libsettings\libsbp\c\build\src\sbp.vcxpr
oj.metaproj" (4) on node 1 (default targets).
Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\src\sbp.vcxproj.metaproj" (4) is building "c:\xoodi\github\sn\libsettings\libsbp\c\build\src\sbp.vcxproj
" (5) on node 1 (default targets).
PrepareForBuild:
  Creating directory "sbp.dir\Release\".
  Creating directory "C:\xoodi\github\sn\libsettings\libsbp\c\build\src\Release\".
  Creating directory "sbp.dir\Release\sbp.tlog\".
InitializeBuildStatus:
  Creating "sbp.dir\Release\sbp.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Building Custom Rule C:/xoodi/github/sn/libsettings/libsbp/c/src/CMakeLists.txt
  CMake does not need to re-run because C:/xoodi/github/sn/libsettings/libsbp/c/build/src/CMakeFiles/generate.stamp is up-to-date.
ClCompile:
  C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\HostX86\x86\CL.exe /c /IC:\xoodi\github\sn\libsettings\libsbp\c\
  include /nologo /W3 /WX- /diagnostics:classic /O2 /Ob2 /Oy- /D WIN32 /D _WINDOWS /D NDEBUG /D "CMAKE_INTDIR=\"Release\"" /D _MBCS /Gm- /MD /GS /fp:precise /Z
  c:wchar_t /Zc:forScope /Zc:inline /Fo"sbp.dir\Release\\" /Fd"sbp.dir\Release\sbp.pdb" /Gd /TC /analyze- /errorReport:queue C:\xoodi\github\sn\libsettings\lib
  sbp\c\src\edc.c C:\xoodi\github\sn\libsettings\libsbp\c\src\sbp.c
  edc.c
  sbp.c
  Generating Code...
Lib:
  C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\HostX86\x86\Lib.exe /OUT:"C:\xoodi\github\sn\libsettings\libsbp\
  c\build\src\Release\sbp.lib" /NOLOGO  /machine:X86 sbp.dir\Release\edc.obj
  sbp.dir\Release\sbp.obj
  sbp.vcxproj -> C:\xoodi\github\sn\libsettings\libsbp\c\build\src\Release\sbp.lib
FinalizeBuildStatus:
  Deleting file "sbp.dir\Release\sbp.tlog\unsuccessfulbuild".
  Touching "sbp.dir\Release\sbp.tlog\sbp.lastbuildstate".
Done Building Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\src\sbp.vcxproj" (default targets).

Done Building Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\src\sbp.vcxproj.metaproj" (default targets).

Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcxproj.metaproj" (2) is building "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcx
proj" (6) on node 1 (default targets).
PrepareForBuild:
  Creating directory "Win32\Release\ALL_BUILD\".
  Creating directory "Win32\Release\ALL_BUILD\ALL_BUILD.tlog\".
InitializeBuildStatus:
  Creating "Win32\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
CustomBuild:
  Building Custom Rule C:/xoodi/github/sn/libsettings/libsbp/c/CMakeLists.txt
  CMake does not need to re-run because C:/xoodi/github/sn/libsettings/libsbp/c/build/CMakeFiles/generate.stamp is up-to-date.
FinalizeBuildStatus:
  Deleting file "Win32\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild".
  Touching "Win32\Release\ALL_BUILD\ALL_BUILD.tlog\ALL_BUILD.lastbuildstate".
Done Building Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcxproj" (default targets).

Done Building Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\ALL_BUILD.vcxproj.metaproj" (default targets).

Done Building Project "c:\xoodi\github\sn\libsettings\libsbp\c\build\libsbp.sln" (default targets).


Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.09
```

Output:
![image](https://user-images.githubusercontent.com/16404179/52694939-eb7b9480-2f73-11e9-9b5d-a97ae2f17c8b.png)
