### PR TITLE
Try updating the deploy key for sbp_linux_tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
 deploy:
   provider: releases
   api_key:
-    secure: "kElMZA2rpuSswHZuQuFZYdOllg5b+cOcid+Ac8RZJlqM+EPi+5cDuNWGmqxNka9lvLwwB+Mq37+t9J1PSHuTf/WNcDeI82h//Prll6jP5aHuxrIZA6UTeqTAzhmVGHbcjorvROp5O2MeyJMHtyi3gi9XOf8OlfSLpO4pM37Ad1w="
+    secure: "WDZRT7VevzQidPo8Mn1ozV6azwNFe7qGwKbLCb8rmKpPmiF+wcQ3KrhTnGj0EmqGqQ2q1c3UZzVCr+nLhLvIFLhkvNK42bs8Byc+HolKNX/diPAlB/mczGHI08rV4EJFmJL56vopdoafOAsqtZBnD4hZ8BDETNqMyJefo70pyY8="
   file: haskell/sbp_linux_tools.tar.gz
   skip_cleanup: true
   on:


### PR DESCRIPTION
This is so we can get an up-to-date version of `sbp2json` and friends published whenever libsbp is released/tagged.