### PR TITLE
Close serial port fd when piksi disconnects [ESD-1111]

### DIFF
--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -81,6 +81,7 @@ class PySerialDriver(BaseDriver):
             print()
             print("Piksi disconnected")
             print()
+            self.handle.close()
             raise IOError
 
     def write(self, s):
@@ -103,6 +104,7 @@ class PySerialDriver(BaseDriver):
                 print()
                 print("Piksi disconnected")
                 print()
+                self.handle.close()
                 raise IOError
 
     def __enter__(self):

--- a/python/tests/sbp/client/test_driver.py
+++ b/python/tests/sbp/client/test_driver.py
@@ -30,7 +30,7 @@ class MockServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
   pass
 
 def tcp_server(handler):
-  server = MockServer(("127.0.0.1", 0), handler)
+  server = MockServer(("localhost", 0), handler)
   ip, port = server.server_address
   server_thread = threading.Thread(target=server.serve_forever)
   server_thread.daemon = True


### PR DESCRIPTION
When a piksi is connected to a host via USB cable it will create
3 virtual serial ports which appear on linux systems as /dev/ttyACM*.
When Piksi resets or the USB cable is disconnected the kernel will
remove these device nodes automatically.

When console connects to Piksi via one of these ports is will
detect the disconnect event and raise a message in the log. However
it will not close the file descriptor. The kernel will be unable to
fully remove the device since a FD is still open.

When the Piksi reboots and tries to recreate its virtual ports the
linux kernel will be unable to reuse the same device number as before
so long as the previous console process is still running.

Solution - When console detects the piksi disconnect event it should
close the handle. This allows the kernel to reuse the previous device
node as soon as piksi reboots.


# Testing

1. Open console, connect to a running Piksi via USB cable, eg /dev/ttyACM0
2. Keep console open, reset Piksi
3. Observe "Piksi disconnected" log
4. When Piksi reboots check /dev or the output of dmesg for the serial ports. /dev/ttyACM0 should have been recreated