### PR TITLE
Add option for explicit start [ESD-1166]

### DIFF
--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -31,9 +31,15 @@ class Handler(object):
     ----------
     source : Iterable of tuple(SBP message, {'time':'ISO 8601 str'})
       Stream of SBP messages
+    autostart : Boolean
+      If false, start() shall be skipped when entering context scope and it
+      should be explicitly called by the parent. This will prevent losing
+      messages in case where receive thread would otherwise be started before
+      consumers are ready.
     """
 
-    def __init__(self, source):
+    def __init__(self, source, autostart=True):
+        self._autostart = autostart
         self._source = source
         self._callbacks = collections.defaultdict(set)
         self._receive_thread = threading.Thread(
@@ -58,7 +64,8 @@ class Handler(object):
         self._dead = True
 
     def __enter__(self):
-        self.start()
+        if self._autostart:
+            self.start()
         return self
 
     def __exit__(self, *args):

--- a/python/tests/sbp/client/test_driver.py
+++ b/python/tests/sbp/client/test_driver.py
@@ -55,8 +55,9 @@ def test_tcp_logger():
     assert s.payload==b'abc'
     assert s.crc==0xDAEE
   with PySerialDriver(port, baud) as driver:
-    with Handler(Framer(driver.read, None, verbose=False)) as link:
+    with Handler(Framer(driver.read, None, verbose=False), autostart=False) as link:
       link.add_callback(assert_logger)
+      link.start()
       while True:
         if time.time() - t0 > timeout or cb_context['assert_logger_called']:
           break


### PR DESCRIPTION
If receive thread is started before all the callbacks are added and sink is ready it is highly probable that some of the messages at start are lost.