### PR TITLE
Use system defined install paths

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -3,6 +3,8 @@ project(libsbp)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+include(GNUInstallDirs)
+
 ##########################################################
 # Set some reasonable default compiler flags.
 # Users of LibSbp that need different flags to be used can specify them

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -49,8 +49,8 @@ set_target_properties(sbp PROPERTIES
 
 install(TARGETS sbp
         EXPORT sbp-export
-        DESTINATION lib${LIB_SUFFIX})
-install(FILES ${libsbp_HEADERS} DESTINATION include/libsbp)
+        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+install(FILES ${libsbp_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/libsbp)
 
 export(EXPORT sbp-export
         NAMESPACE LibSbp::


### PR DESCRIPTION
Use the cmake module GNUInstallDirs to define standard system install paths. This module works well when providing an installation prefix or destdir to cmake/make. This will replace all hard coded installation paths