### PR TITLE
py3 compat: use errno attribute for socket.error

### DIFF
--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -76,9 +76,9 @@ class TCPDriver(BaseDriver):
             return data
         except socket.timeout:
             self._connect()
-        except socket.error as e:
+        except socket.error as socket_exception:
             # this is fine
-            if e[0] == errno.EINTR:
+            if socket_exception.errno == errno.EINTR:
                 return
             # we really shouldn't be doing this
             raise IOError

--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -76,9 +76,9 @@ class TCPDriver(BaseDriver):
             return data
         except socket.timeout:
             self._connect()
-        except socket.error as socket_exception:
+        except socket.error as socket_error:
             # this is fine
-            if socket_exception.errno == errno.EINTR:
+            if socket_error.errno == errno.EINTR:
                 return
             # we really shouldn't be doing this
             raise IOError


### PR DESCRIPTION
In Python version 2.6 socket.error was changed to be a subclass of IOError, which supports a `.errno` attribute, in Python 3 support for treating `socket.error` as a tuple was dropped.