### PR TITLE
Add base into_buffer method for messages with no payload [ESD-1154]

### DIFF
--- a/python/sbp/msg.py
+++ b/python/sbp/msg.py
@@ -267,6 +267,11 @@ class SBP(object):
     return d
 
   def _build_payload(self, buf, offset, payload):
-      self.stream_payload.reset(buf, offset)
-      self.parser.build_stream(payload, self.stream_payload)
-      return self.stream_payload.length
+    self.stream_payload.reset(buf, offset)
+    self.parser.build_stream(payload, self.stream_payload)
+    return self.stream_payload.length
+
+  def into_buffer(self, buf, offset):
+    def _empty_payload(_buf, _offset, _payload):
+        return 0
+    return self.pack_into(buf, offset, _empty_payload)


### PR DESCRIPTION
Fixes the following error for messages that have no payload to parse:
```
Traceback (most recent call last):
  File "/Users/jason/miniconda3/envs/dev_piksi_tools/lib/python3.5/site-packages/traits/trait_notifiers.py", line 340, in __call__
    self.handler( *args )
  File "/Users/jason/dev/piksi_tools/piksi_tools/console/sbp_relay_view.py", line 529, in _network_refresh_button_fired
    self.link(MsgNetworkStateReq())
  File "/Users/jason/dev/piksi_tools/libsbp/python/sbp/client/handler.py", line 282, in __call__
    self._source(*msgs, **metadata)
  File "/Users/jason/dev/piksi_tools/libsbp/python/sbp/client/framer.py", line 165, in __call__
    index += msg.into_buffer(self._buffer, index)
AttributeError: 'MsgNetworkStateReq' object has no attribute 'into_buffer'
```