### PR TITLE
Conditional use of pthread library.

### DIFF
--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -7,7 +7,7 @@ else (CMAKE_CROSSCOMPILING)
     message(STATUS "Skipping unit tests, Check library not found!")
   else (NOT CHECK_FOUND)
 
-    if(LIBSBP_BUILTIN_PTHREADS) # In Android's libc implementation (bionic), pthreads is not a separate library
+    if (LIBSBP_BUILTIN_PTHREADS) # In Android's libc implementation (bionic), pthreads is not a separate library
       set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} sbp m)
     else()
       set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} pthread sbp m)

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -7,10 +7,10 @@ else (CMAKE_CROSSCOMPILING)
     message(STATUS "Skipping unit tests, Check library not found!")
   else (NOT CHECK_FOUND)
 
-    if(PLATFORM_IMPLEMENTATION_NO_PTHREAD)
-      set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} pthread sbp m)
-    else()
+    if(PLATFORM_IMPLEMENTATION_HAS_PTHREAD)
       set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} sbp m)
+    else()
+      set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} pthread sbp m)
     endif()
 
     # Check needs to be linked against Librt on Linux

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -7,7 +7,7 @@ else (CMAKE_CROSSCOMPILING)
     message(STATUS "Skipping unit tests, Check library not found!")
   else (NOT CHECK_FOUND)
 
-    if(PLATFORM_IMPLEMENTATION_HAS_PTHREAD)
+    if(LIBSBP_BUILTIN_PTHREADS) # In Android's libc implementation (bionic), pthreads is not a separate library
       set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} sbp m)
     else()
       set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} pthread sbp m)

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -7,7 +7,11 @@ else (CMAKE_CROSSCOMPILING)
     message(STATUS "Skipping unit tests, Check library not found!")
   else (NOT CHECK_FOUND)
 
-    set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} pthread sbp m)
+    if(PLATFORM_IMPLEMENTATION_NO_PTHREAD)
+      set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} pthread sbp m)
+    else()
+      set(TEST_LIBS ${TEST_LIBS} ${CHECK_LIBRARIES} sbp m)
+    endif()
 
     # Check needs to be linked against Librt on Linux
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")


### PR DESCRIPTION
Library pthread should be used only when PLATFORM_IMPLEMENTATION_NO_PTHREAD is ON. It was found while building starling for Android where pthread is included into libandroid.