### PR TITLE
Don't use hardcoded include/link paths

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -22,7 +22,6 @@ if(MSVC)
     set(LIBSBP_CFLAGS "/Wall" CACHE STRING "Compile flags for libsbp.")
 else()
     set(LIBSBP_CFLAGS "-Wall -Werror" CACHE STRING "Compile flags for libsbp.")
-    link_directories("/usr/local/lib")
 endif()
 
 add_subdirectory(src)

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -8,7 +8,7 @@ endif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 FILE(GLOB generated_c_sources auto*.c)
 add_executable(test_libsbp check_main.c check_edc.c check_sbp.c ${generated_c_sources})
 
-target_link_libraries(test_libsbp ${TEST_LIBS})
+target_link_libraries(test_libsbp PRIVATE ${TEST_LIBS})
 set_target_properties(test_libsbp PROPERTIES
         C_STANDARD 99
         C_STANDARD_REQUIRED ON)
@@ -17,6 +17,18 @@ if(MSVC)
   target_include_directories(test_libsbp PRIVATE ${PROJECT_SOURCE_DIR}/include/libsbp/)
 else()
   target_include_directories(test_libsbp PRIVATE ${PROJECT_SOURCE_DIR}/include/libsbp/)
+  if(APPLE)
+    # Some libraries are available in non-standard places on apple.
+    target_include_directories(test_libsbp PRIVATE /usr/local/include)
+
+    # This is not a great way of doing this, but the proper cmake function
+    # target_link_directories() was introduced in version 3.13 and we need to support
+    # older versions for the moment. We can use target_link_libraries to pass arbitrary
+    # linker flags, making sure that this instance is well protected and only applies
+    # to a single platform. Don't use the extant link_directories() function since
+    # that leaks the path to other targets.
+    target_link_libraries(test_libsbp PRIVATE "-L/usr/local/lib")
+  endif()
 endif()
 
 add_custom_command(

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -16,7 +16,7 @@ set_target_properties(test_libsbp PROPERTIES
 if(MSVC)
   target_include_directories(test_libsbp PRIVATE ${PROJECT_SOURCE_DIR}/include/libsbp/)
 else()
-  target_include_directories(test_libsbp PRIVATE ${PROJECT_SOURCE_DIR}/include/libsbp/ /usr/local/include/)
+  target_include_directories(test_libsbp PRIVATE ${PROJECT_SOURCE_DIR}/include/libsbp/)
 endif()
 
 add_custom_command(


### PR DESCRIPTION
/usr/local/(include|lib) are hardcoded in to the cmake system. This throws an error when trying to cross compile using buildroot. These paths should not be needed anyway.