### PR TITLE
Changing java CRC16 class modifiers to enable external access (#720)

### DIFF
--- a/java/src/com/swiftnav/sbp/client/CRC16.java
+++ b/java/src/com/swiftnav/sbp/client/CRC16.java
@@ -11,7 +11,7 @@
  */
 package com.swiftnav.sbp.client;
 
-final class CRC16 {
+public final class CRC16 {
     private final static int[] tab = {
             0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
             0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
@@ -46,14 +46,14 @@ final class CRC16 {
             0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
             0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0};
 
-    static int crc16(byte[] data, int crc) {
+    public static int crc16(byte[] data, int crc) {
         for (byte b : data) {
             crc = ((crc << 8) & 0xFFFF) ^ tab[((crc >> 8) ^ b) & 0xFF];
         }
         return crc;
     }
 
-    static int crc16(byte[] data) {
+    public static int crc16(byte[] data) {
         return crc16(data, 0);
     }
 }


### PR DESCRIPTION
Changing the CRC16 class and methods modifiers to public, to allow the CRC16 calculation from softwares that are using this library.