### PR TITLE
Frame callback implementation & tests

### DIFF
--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -23,23 +23,23 @@ extern "C" {
  * \{ */
 
 /** Return value indicating success. */
-#define SBP_OK              0
+#define SBP_OK                    0
 /** Return value indicating message decoded and callback executed by sbp_process. */
-#define SBP_OK_CALLBACK_EXECUTED 1
+#define SBP_OK_CALLBACK_EXECUTED  1
 /** Return value indicating message decoded with no associated callback in sbp_process. */
 #define SBP_OK_CALLBACK_UNDEFINED 2
 /** Return value indicating an error with the callback (function defined). */
-#define SBP_CALLBACK_ERROR -1
+#define SBP_CALLBACK_ERROR       -1
 /** Return value indicating a CRC error. */
-#define SBP_CRC_ERROR      -2
+#define SBP_CRC_ERROR            -2
 /** Return value indicating an error occured whilst sending an SBP message. */
-#define SBP_SEND_ERROR     -3
+#define SBP_SEND_ERROR           -3
 /** Return value indicating an error occured because an argument was NULL. */
-#define SBP_NULL_ERROR     -4
+#define SBP_NULL_ERROR           -4
 /** Return value indicating an error occured in the write() operation. */
-#define SBP_WRITE_ERROR     -5
+#define SBP_WRITE_ERROR          -5
 /** Return value indicating an error occured in the read() operation. */
-#define SBP_READ_ERROR     -6
+#define SBP_READ_ERROR           -6
 
 /** Default sender ID. Intended for messages sent from the host to the device. */
 #define SBP_SENDER_ID 0x42
@@ -77,7 +77,8 @@ typedef void (*sbp_msg_callback_t)(u16 sender_id, u8 len, u8 msg[], void *contex
 
 /** SBP callback node.
  * Forms a linked list of callbacks.
- * \note Must be statically allocated for use with sbp_register_callback().
+ * \note Must be statically allocated for use with sbp_register_callback()
+ *       and sbp_register_frame_callback().
  */
 typedef struct sbp_msg_callbacks_node {
   u16 msg_type;                        /**< Message ID associated with callback. */

--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -43,8 +43,36 @@ extern "C" {
 
 /** Default sender ID. Intended for messages sent from the host to the device. */
 #define SBP_SENDER_ID 0x42
+/** Header length in bytes. */
+#define SBP_HEADER_LEN 6
+/** CRC length in bytes. */
+#define SBP_CRC_LEN 2
+/** Max payload length in bytes. */
+#define SBP_MAX_PAYLOAD_LEN (UINT8_MAX)
+/** Max frame length in bytes. */
+#define SBP_MAX_FRAME_LEN (SBP_HEADER_LEN + SBP_MAX_PAYLOAD_LEN + SBP_CRC_LEN)
 
-/** SBP callback function prototype definition. */
+/** Frame offset for the preamble. */
+#define SBP_FRAME_OFFSET_PREAMBLE (0u)
+/** Frame offset for the preamble. */
+#define SBP_FRAME_OFFSET_MSGTYPE (SBP_FRAME_OFFSET_PREAMBLE + sizeof(u8))
+/** Frame offset for the preamble. */
+#define SBP_FRAME_OFFSET_SENDERID (SBP_FRAME_OFFSET_MSGTYPE + sizeof(u16))
+/** Frame offset for the preamble. */
+#define SBP_FRAME_OFFSET_MSGLEN (SBP_FRAME_OFFSET_SENDERID + sizeof(u16))
+/** Frame offset for the preamble. */
+#define SBP_FRAME_OFFSET_MSG (SBP_FRAME_OFFSET_MSGLEN + sizeof(u8))
+/** Frame offset for the CRC is a function of msg length. */
+#define SBP_FRAME_OFFSET_CRC(msg_len) (SBP_FRAME_OFFSET_MSG + msg_len)
+#define SBP_FRAME_CALC_LEN(msg_len) (SBP_HEADER_LEN + msg_len + SBP_CRC_LEN)
+
+/** Get message payload pointer from frame */
+#define SBP_FRAME_MSG_PAYLOAD(frame_ptr) (&(frame_ptr[SBP_FRAME_OFFSET_MSG]))
+
+/** SBP_MSG_ID to use to register frame callback for ALL messages. */
+#define SBP_MSG_ALL 0
+
+/** SBP callback function prototype definitions. */
 typedef void (*sbp_msg_callback_t)(u16 sender_id, u8 len, u8 msg[], void *context);
 
 /** SBP callback node.

--- a/c/test/check_sbp.c
+++ b/c/test/check_sbp.c
@@ -83,11 +83,28 @@ u8 last_msg[256];
 void* last_context;
 
 
+u32 n_frame_callbacks_logged;
+u16 last_frame_sender_id;
+u16 last_frame_msg_type;
+u8 last_frame_payload_len;
+u16 last_frame_len;
+u8 last_frame[256 + 8];
+void* last_frame_context;
+
 void logging_reset(void)
 {
   n_callbacks_logged = 0;
+  n_frame_callbacks_logged = 0;
   last_context = 0;
+  last_sender_id = 0;
+  last_len = 0;
+  last_frame_context = 0;
+  last_frame_sender_id = 0;
+  last_frame_len = 0;
+  last_frame_sender_id = 0;
+  last_frame_msg_type = 0;
   memset(last_msg, 0, sizeof(last_msg));
+  memset(last_frame, 0, sizeof(last_frame));
 }
 
 void logging_callback(u16 sender_id, u8 len, u8 msg[], void* context)
@@ -97,6 +114,20 @@ void logging_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   last_len = len;
   last_context = context;
   memcpy(last_msg, msg, len);
+
+  /*printy_callback(sender_id, len, msg);*/
+}
+
+void frame_logging_callback(u16 sender_id, u16 msg_type, u8 payload_len,
+                            u8 payload[], u16 frame_len, u8 frame[],
+                            void *context) {
+  n_frame_callbacks_logged++;
+  last_frame_sender_id = sender_id;
+  last_frame_msg_type = msg_type;
+  last_frame_payload_len = payload_len;
+  last_frame_context = context;
+  last_frame_len = frame_len;
+  memcpy(last_frame, frame, frame_len);
 
   /*printy_callback(sender_id, len, msg);*/
 }
@@ -115,6 +146,34 @@ void test_callback2(u16 sender_id, u8 len, u8 msg[], void* context)
   (void)sender_id;
   (void)len;
   (void)msg;
+  (void)context;
+}
+
+void test_frame_callback(u16 sender_id, u16 msg_type, u8 payload_len,
+                         u8 payload[], u16 frame_len, u8 frame[],
+                         void *context)
+{
+  /* Do nothing. */
+  (void)sender_id;
+  (void)msg_type;
+  (void)payload_len;
+  (void)payload;
+  (void)frame_len;
+  (void)frame;
+  (void)context;
+}
+
+void test_frame_callback2(u16 sender_id, u16 msg_type, u8 payload_len,
+                          u8 payload[], u16 frame_len, u8 frame[],
+                          void *context)
+{
+  /* Do nothing. */
+  (void)sender_id;
+  (void)msg_type;
+  (void)payload_len;
+  (void)payload;
+  (void)frame_len;
+  (void)frame;
   (void)context;
 }
 
@@ -328,6 +387,227 @@ START_TEST(test_sbp_process)
 }
 END_TEST
 
+START_TEST(test_sbp_frame)
+{
+  /* TODO: Tests with different read function behaviour. */
+
+  sbp_state_t s;
+  sbp_state_init(&s);
+  sbp_state_set_io_context(&s, &DUMMY_MEMORY_FOR_IO);
+
+  static sbp_msg_callbacks_node_t n;
+  static sbp_msg_callbacks_node_t n2;
+
+  sbp_register_frame_callback(&s, 0x2269, &frame_logging_callback, &DUMMY_MEMORY_FOR_CALLBACKS, &n);
+
+  u8 test_data[] = { 0x01, 0x02, 0x03, 0x04 };
+  u8 test_frame[] = { 0x55, 0x69, 0x22, 0x42, 0x00, 0x04, 0x01, 0x02, 0x03, 0x04, 0x3D, 0xF7 };
+
+  dummy_reset();
+  sbp_send_message(&s, 0x2269, 0x42, sizeof(test_data), test_data, &dummy_write);
+
+  while (dummy_rd < dummy_wr) {
+    fail_unless(sbp_process(&s, &dummy_read) >= SBP_OK,
+        "sbp_process threw an error!");
+  }
+
+  fail_unless(n_frame_callbacks_logged == 1,
+      "one frame callback should have been logged");
+  fail_unless(last_frame_sender_id == 0x42,
+      "sender_id decoded incorrectly");
+  fail_unless(last_frame_payload_len == sizeof(test_data),
+      "len decoded incorrectly");
+  fail_unless(last_frame_len == sizeof(test_data) + 8,
+      "frame len decoded incorrectly");
+  fail_unless(last_frame_msg_type == 0x2269,
+      "msg_type decoded incorrectly");
+  char test[1024];
+  char* ptr = test;
+  for (int i = 0; i < last_frame_len; i++) {
+    ptr += sprintf(ptr, "%02X", last_frame[i]);
+  }
+  fail_unless(memcmp(last_frame, test_frame, sizeof(test_frame)-1)
+        == 0,
+      "decoded incorrectly %s", test);
+  fail_unless(last_frame_context == &DUMMY_MEMORY_FOR_CALLBACKS,
+      "context pointer incorrectly passed");
+
+  sbp_register_frame_callback(&s, 0x2270, &frame_logging_callback, &DUMMY_MEMORY_FOR_CALLBACKS, &n2);
+  fail_unless(sbp_find_callback(&s, 0x2270) != 0,
+    "second callback not found");
+
+  sbp_remove_callback(&s, &n2);
+  fail_unless(sbp_find_callback(&s, 0x2270) == 0,
+    "callback not removed");
+
+  /* Test sbp_process with both a frame callback and a not frame callback */
+
+  static sbp_msg_callbacks_node_t n3;
+  static sbp_msg_callbacks_node_t n4;
+
+  logging_reset();
+  dummy_reset();
+  sbp_clear_callbacks(&s);
+
+  static sbp_msg_callbacks_node_t q;
+  sbp_register_callback(&s, 0x2269, &logging_callback, 0, &n3);
+  sbp_register_frame_callback(&s, 0x2269, &frame_logging_callback, &DUMMY_MEMORY_FOR_CALLBACKS, &n4);
+  sbp_send_message(&s, 0x2269, 0x42, sizeof(test_data), test_data, &dummy_write);
+
+  while (dummy_rd < dummy_wr) {
+    fail_unless(sbp_process(&s, &dummy_read_single_byte) >= SBP_OK,
+        "sbp_process threw an error! (3)");
+  }
+
+  fail_unless(n_callbacks_logged == 1,
+      "one regular callback should have been logged (3)");
+  fail_unless(n_frame_callbacks_logged == 1,
+      "one frame callback should have been logged (3)");
+
+  /* now remove frame callback and make sure that the regular callback is still there */
+  sbp_remove_callback(&s, &n4);
+  dummy_reset();
+  sbp_send_message(&s, 0x2269, 0x42, sizeof(test_data), test_data, &dummy_write);
+  while (dummy_rd < dummy_wr) {
+    fail_unless(sbp_process(&s, &dummy_read_single_byte) >= SBP_OK,
+        "sbp_process threw an error! (3)");
+  }
+
+  fail_unless(n_callbacks_logged == 2,
+      "two regular callback should have been logged (3)");
+
+  /* now test that no frame callback with bad msg and direct writing to buffer */
+  u8 awesome_message[] = {0x55, 0x33, 0x22, 0x77, 0x66,
+                          0x02, 0x22, 0x33, 0x8A, 0x33};
+  logging_reset();
+  dummy_reset();
+  dummy_rd = 0;
+  dummy_wr = sizeof(awesome_message);
+  memcpy(dummy_buff, awesome_message, sizeof(awesome_message));
+
+  static sbp_msg_callbacks_node_t m;
+  sbp_register_frame_callback(&s, 0x2233, &frame_logging_callback, 0, &m);
+
+  while (dummy_rd < dummy_wr) {
+    fail_unless(sbp_process(&s, &dummy_read) >= SBP_OK,
+        "sbp_process threw an error! (3)");
+  }
+
+  fail_unless(n_frame_callbacks_logged == 1,
+      "one callback should have been logged (3)");
+  fail_unless(last_frame_sender_id == 0x6677,
+      "sender_id decoded incorrectly (3)");
+  fail_unless(last_frame_payload_len == 2,
+      "len decoded incorrectly (3)");
+  fail_unless(memcmp(last_frame, awesome_message, sizeof(awesome_message))
+        == 0,
+      "test data decoded incorrectly (3) %x", last_frame[sizeof(awesome_message)-1]);
+
+  awesome_message[4] = 0xAA;
+  logging_reset();
+  dummy_reset();
+  dummy_rd = 0;
+  dummy_wr = sizeof(awesome_message);
+  memcpy(dummy_buff, awesome_message, sizeof(awesome_message));
+
+  s8 ret = 0;
+  while (dummy_rd < dummy_wr) {
+    ret |= sbp_process(&s, &dummy_read);
+  }
+
+  fail_unless(ret == SBP_CRC_ERROR,
+      "sbp_process should have returned SBP_CRC_ERROR "
+      "for malformed message");
+
+  fail_unless(n_frame_callbacks_logged == 0,
+      "no frame callbacks should have been logged (2)");
+
+}
+END_TEST
+
+START_TEST(test_sbp_all_msg)
+{
+  /* Tests registering for all messages */
+
+  sbp_state_t s;
+  sbp_state_init(&s);
+  sbp_state_set_io_context(&s, &DUMMY_MEMORY_FOR_IO);
+
+  static sbp_msg_callbacks_node_t n;
+
+  sbp_register_all_msg_callback(&s, &frame_logging_callback, &DUMMY_MEMORY_FOR_CALLBACKS, &n);
+
+  u8 msg_1[] = { 0x01, 0x02, 0x03, 0x04 };
+  u8 msg_2[] = { 0x05, 0x06, 0x07 };
+
+  dummy_reset();
+  logging_reset();
+  sbp_send_message(&s, 0x2269, 0x42, sizeof(msg_1), msg_1, &dummy_write);
+  sbp_send_message(&s, 0x2270, 0x43, sizeof(msg_2), msg_2, &dummy_write);
+
+  while (dummy_rd < dummy_wr) {
+    fail_unless(sbp_process(&s, &dummy_read) >= SBP_OK,
+        "sbp_process threw an error!");
+  }
+
+  fail_unless(n_frame_callbacks_logged == 2,
+      "two frame callback should have been logged, %u were", n_frame_callbacks_logged);
+  fail_unless(last_frame_sender_id == 0x43,
+      "sender_id decoded incorrectly");
+  fail_unless(last_frame_payload_len == sizeof(msg_2),
+      "len decoded incorrectly");
+  fail_unless(last_frame_len == sizeof(msg_2) + 8,
+      "frame len decoded incorrectly");
+}
+END_TEST
+
+START_TEST(test_sbp_big_msg)
+{
+  /* Tests registering for max size message SBP_MAX_PAYLOAD_LEN (255) */
+
+  sbp_state_t s;
+  sbp_state_init(&s);
+  sbp_state_set_io_context(&s, &DUMMY_MEMORY_FOR_IO);
+
+  static sbp_msg_callbacks_node_t n;
+  static sbp_msg_callbacks_node_t n2;
+
+  sbp_register_frame_callback(&s, 0x2269, &frame_logging_callback, &DUMMY_MEMORY_FOR_CALLBACKS, &n);
+  sbp_register_callback(&s, 0x2269, &logging_callback, &DUMMY_MEMORY_FOR_CALLBACKS, &n2);
+
+  u8 big_msg[SBP_MAX_PAYLOAD_LEN];
+  for(int i = 0; i < sizeof(big_msg); i++) { big_msg[i]=i;}
+
+  dummy_reset();
+  logging_reset();
+  sbp_send_message(&s, 0x2269, 0x42, sizeof(big_msg), big_msg, &dummy_write);
+
+  s8 ret = SBP_OK;
+  while (dummy_rd < dummy_wr) {
+    ret = sbp_process(&s, &dummy_read);
+    fail_unless(ret >= SBP_OK,
+        "sbp_process threw an error! error_code: %d", ret);
+  }
+
+  fail_unless(n_frame_callbacks_logged == 1,
+      "one frame callback should have been logged, %u were", n_frame_callbacks_logged);
+  fail_unless(n_callbacks_logged == 1,
+      "one callbackx should have been logged, %u were", n_frame_callbacks_logged);
+  fail_unless(last_frame_sender_id == 0x42,
+      "sender_id decoded incorrectly");
+  fail_unless(last_frame_payload_len == sizeof(big_msg),
+      "len decoded incorrectly");
+  fail_unless(last_frame_len == SBP_MAX_FRAME_LEN,
+      "frame len decoded incorrectly");
+  fail_unless(memcmp(SBP_FRAME_MSG_PAYLOAD(last_frame), big_msg, sizeof(big_msg))
+        == 0,
+      "frame data decoded incorrectly (3) %x");
+  /* check that CRC wasn't chopped off */
+  fail_unless((last_frame[262]  == 0x35 && last_frame[261] == 0xA6),
+      "CRC was incorrect. Should be %x and was %x", 0x35A6,  *((u16*) &(last_frame[261])));
+}
+END_TEST
+
 START_TEST(test_sbp_send_message)
 {
   /* TODO: Tests with different write function behaviour. */
@@ -451,6 +731,89 @@ START_TEST(test_callbacks)
 }
 END_TEST
 
+START_TEST(test_frame_callbacks)
+{
+
+  sbp_state_t s;
+  sbp_state_init(&s);
+
+  /* Start with no callbacks registered.  */
+  sbp_clear_callbacks(&s);
+
+  fail_unless(sbp_find_callback(&s, 0x1234) == 0,
+      "sbp_find_callback should return NULL if no callbacks registered");
+
+  fail_unless(sbp_register_frame_callback(&s, 0x2233, &test_frame_callback, 0, 0) == SBP_NULL_ERROR,
+      "sbp_register_frame_callback should return an error if node is NULL");
+
+  /* Add a first callback. */
+
+  static sbp_msg_callbacks_node_t n;
+
+  int NUMBER = 42;
+
+  fail_unless(sbp_register_frame_callback(&s, 0x2233, 0, 0, &n) == SBP_NULL_ERROR,
+      "sbp_register_callback should return an error if cb is NULL");
+
+  fail_unless(sbp_register_frame_callback(&s, 0x2233, &test_frame_callback, &NUMBER, &n) == SBP_OK,
+      "sbp_register_callback should return success if everything is groovy");
+
+  fail_unless(sbp_register_frame_callback(&s, 0x2233, &test_frame_callback, 0, &n)
+        == SBP_CALLBACK_ERROR,
+      "sbp_register_callback should return SBP_CALLBACK_ERROR if a callback "
+      "of the same type is already registered");
+
+  fail_unless(sbp_find_callback(&s, 0x1234) == 0,
+      "sbp_find_callback should return NULL if callback not registered");
+
+  fail_unless(sbp_find_callback(&s, 0x2233) == &n,
+      "sbp_find_callback didn't return the correct callback node pointer");
+
+  fail_unless(sbp_find_callback(&s, 0x2233)->context == &NUMBER,
+      "sbp_find_callback didn't return the correct context pointer");
+
+  /* Add a second callback. */
+
+  static sbp_msg_callbacks_node_t m;
+
+  int NUMBER2 = 84;
+
+  fail_unless(sbp_register_frame_callback(&s, 0x1234, &test_frame_callback2, &NUMBER2, &m) == SBP_OK,
+      "sbp_register_callback should return success if everything is groovy (2)");
+
+  fail_unless(sbp_find_callback(&s, 0x2233) == &n,
+      "sbp_find_callback didn't return the correct callback function pointer (2)");
+
+  fail_unless(sbp_find_callback(&s, 0x2233)->context == &NUMBER,
+      "sbp_find_callback didn't return the correct context pointer");
+
+  fail_unless(sbp_find_callback(&s, 0x1234) == &m,
+      "sbp_find_callback didn't return the correct callback function pointer (3)");
+
+  fail_unless(sbp_find_callback(&s, 0x1234)->context == &NUMBER2,
+      "sbp_find_callback didn't return the correct context pointer");
+
+  fail_unless(sbp_register_frame_callback(&s, 0x1234, &test_frame_callback, 0, &n)
+        == SBP_CALLBACK_ERROR,
+      "sbp_register_callback should return SBP_CALLBACK_ERROR if a callback "
+      "of the same type is already registered (2)");
+
+  fail_unless(sbp_find_callback(&s, 0x7788) == 0,
+      "sbp_find_callback should return NULL if callback not registered (2)");
+
+  /* Clear all the registered callbacks and check they can no longer be found. */
+
+  sbp_clear_callbacks(&s);
+
+  fail_unless(sbp_find_callback(&s, 0x1234) == 0,
+      "sbp_find_callback should return NULL if no callbacks registered (2)");
+
+  fail_unless(sbp_find_callback(&s, 0x2233) == 0,
+      "sbp_find_callback should return NULL if no callbacks registered (3)");
+
+}
+END_TEST
+
 Suite* sbp_suite(void)
 {
   Suite *s = suite_create("SBP");
@@ -461,6 +824,10 @@ Suite* sbp_suite(void)
   tcase_add_test(tc_core, test_callbacks);
   tcase_add_test(tc_core, test_sbp_send_message);
   tcase_add_test(tc_core, test_sbp_process);
+  tcase_add_test(tc_core, test_sbp_frame);
+  tcase_add_test(tc_core, test_frame_callbacks);
+  tcase_add_test(tc_core, test_sbp_all_msg);
+  tcase_add_test(tc_core, test_sbp_big_msg);
 
   suite_add_tcase(s, tc_core);
 


### PR DESCRIPTION
This PR adds a new type of callback to the c SBP Library to handle the entire SBP frame.  It leaves the external API unchanged except for these additions.

This new frame callback feature will allow for easier raw logging in applications including Piksi Multi's standalone logger.  It also allows adding a frame callback of type SBP_MSG_ALL to fire a callback for any msg_type.  A convenient helper function is added to the API for registering a callback for every msg_type.  Implementation details were discussed internally quite a bit and I think this represents the consensus.  

I've added unit tests for the new functionality and some missing unit tests like testing the max_size of SBP messages.