### PR TITLE
Remove explicit Python 2 build in dist/deploy sciprt

### DIFF
--- a/generator/.gitignore
+++ b/generator/.gitignore
@@ -55,3 +55,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.mypy_cache/

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -9,8 +9,6 @@ import tempfile
 import subprocess
 
 #CP27MU = "2.7u"
-
-AMD64_PY_VERSION = ["3.5", "3.6", "3.7"]
 ALL_PY_VERSIONS = ["3.4", "3.5", "3.6", "3.7"]
 AMD64_PY_VERSION = ["3.5", "3.6", "3.7"]
 

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -8,9 +8,11 @@ import platform
 import tempfile
 import subprocess
 
-CP27MU = "2.7u"
-ALL_PY_VERSIONS = ["2.7", CP27MU, "3.4", "3.5", "3.6", "3.7"]
-AMD64_PY_VERSION = ["2.7", "3.5", "3.6", "3.7"]
+#CP27MU = "2.7u"
+
+AMD64_PY_VERSION = ["3.5", "3.6", "3.7"]
+ALL_PY_VERSIONS = ["3.4", "3.5", "3.6", "3.7"]
+AMD64_PY_VERSION = ["3.5", "3.6", "3.7"]
 
 SKIP_PY_VERS = os.environ.get("SKIP_PY_VERS", "").split(",") 
 
@@ -51,11 +53,11 @@ else:
 
 def twine_upload(conda_dir, wheel, py_version="3.7", use_conda=True):
 
-    if platform.machine().startswith("arm") and py_version == CP27MU:
-        cmd_prefix = ["/opt/cp27mu/bin/python2.7", "-m"]
-        if use_conda:
-            raise RuntimeError("Conda with Python {} is not supported on ARM".format(py_version))
-    elif platform.machine().startswith("arm") and py_version in ALL_PY_VERSIONS:
+#    if platform.machine().startswith("arm") and py_version == CP27MU:
+#        cmd_prefix = ["/opt/cp27mu/bin/python2.7", "-m"]
+#        if use_conda:
+#            raise RuntimeError("Conda with Python {} is not supported on ARM".format(py_version))
+    if platform.machine().startswith("arm") and py_version in ALL_PY_VERSIONS:
         cmd_prefix = ["/usr/local/bin/python{}".format(py_version), "-m"]
         if use_conda:
             raise RuntimeError("Conda with Python {} is not supported on ARM".format(py_version))
@@ -84,9 +86,9 @@ def build_wheel_native(conda_dir, deploy_dir, py_version):
     py_version_prefix = "/usr/local"
     py_version_suffix = py_version
 
-    if py_version == CP27MU:
-        py_version_prefix = "/opt/cp27mu"
-        py_version_suffix = "2.7"
+#    if py_version == CP27MU:
+#        py_version_prefix = "/opt/cp27mu"
+#        py_version_suffix = "2.7"
 
     if py_version not in ALL_PY_VERSIONS:
         raise RuntimeError("Unsupported Python version")
@@ -255,11 +257,11 @@ def build_wheel_conda(conda_dir, deploy_dir, py_version):
         "pip", "install", "twine", "numpy"
     ])
 
-    if py_version.startswith("2.7"):
-        subprocess.check_call([
-            "conda", "run", "-p", conda_dir] + DASHDASH + [
-            "pip", "install", "enum34"
-        ])
+#    if py_version.startswith("2.7"):
+#        subprocess.check_call([
+#            "conda", "run", "-p", conda_dir] + DASHDASH + [
+#            "pip", "install", "enum34"
+#        ])
 
     if platform.system() == "Linux" and platform.machine().startswith("x86"):
         subprocess.check_call([

--- a/python/tests/sbp/test_numba.py
+++ b/python/tests/sbp/test_numba.py
@@ -1,14 +1,22 @@
-import numba as nb
-import numpy as np
+import sys
+import pytest
 
-from sbp.file_io import MsgFileioWriteReq
+if sys.version_info >= (3, 0):
 
-from sbp.jit.msg import unpack_payload
+    import numba as nb
+    import numpy as np
 
-from sbp.jit.msg import get_string
-from sbp.jit.msg import get_fixed_string
+    from sbp.file_io import MsgFileioWriteReq
 
-from sbp.jit.table import dispatch
+    from sbp.jit.msg import unpack_payload
+
+    from sbp.jit.msg import get_string
+    from sbp.jit.msg import get_fixed_string
+
+    from sbp.jit.table import dispatch
+
+
+skip_on_py2 = pytest.mark.skipif(sys.version_info < (3, 0), reason="requires python 3")
 
 
 def _mk_string(val, null='\x00'):
@@ -16,6 +24,7 @@ def _mk_string(val, null='\x00'):
     return np.array(ba, dtype=np.uint8)
 
 
+@skip_on_py2
 def test_get_string():
     s = _mk_string('thisisastring')
     out, offset, length = get_string(s, 0, len(s))
@@ -23,6 +32,7 @@ def test_get_string():
     assert out == 'thisisastring'
 
 
+@skip_on_py2
 def test_get_string_no_null():
     s = _mk_string('thisisastring', null=None)
     out, offset, length = get_string(s, 0, len(s))
@@ -30,6 +40,7 @@ def test_get_string_no_null():
     assert out == 'thisisastring'
 
 
+@skip_on_py2
 def test_get_string_offset_no_null():
     s = _mk_string('________thisisastring', null=None)
     out, offset, length = get_string(s, 8, len(s) - 8)
@@ -37,6 +48,7 @@ def test_get_string_offset_no_null():
     assert out == 'thisisastring'
 
 
+@skip_on_py2
 def test_get_string_offset():
     s = _mk_string('________thisisastring')
     out, offset, length = get_string(s, 8, len(s))
@@ -44,6 +56,7 @@ def test_get_string_offset():
     assert out == 'thisisastring'
 
 
+@skip_on_py2
 def test_get_fixed_string():
     s = 'main\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     a = np.fromstring(s, dtype=np.uint8)
@@ -52,6 +65,7 @@ def test_get_fixed_string():
     assert out == s
 
 
+@skip_on_py2
 def test_get_fixed_string_offset():
     s = _mk_string('________thisisastring')
     out, offset, length = get_fixed_string(6)(s, 8, len(s))
@@ -59,6 +73,7 @@ def test_get_fixed_string_offset():
     assert out == 'thisis'
 
 
+@skip_on_py2
 def test_parse():
 
     header_len = 6
@@ -89,6 +104,7 @@ def test_parse():
     assert bytearray(res['data']) == bytearray(data)
 
 
+@skip_on_py2
 def test_jit():
     @nb.jit('Tuple((Tuple((u2,u2)),u2))()', nopython=True, nogil=True)
     def func():


### PR DESCRIPTION
 Don't need separate build on Python since Numba JIT is disabled.