### PR TITLE
Add option to annotate with timestamp (simulate Swift Console output)

### DIFF
--- a/python/sbp/sbp2json.py
+++ b/python/sbp/sbp2json.py
@@ -11,7 +11,6 @@ from sbp import msg as msg_nojit
 from sbp.navigation import SBP_MSG_UTC_TIME
 from sbp.table import dispatch as dispatch_nojit
 
-CURRENT_MSG_INDEX = 0
 LAST_UTC_TIME = datetime.fromtimestamp(0)
 
 NORM = os.environ.get('NOJIT') is not None
@@ -164,18 +163,12 @@ def store_time_from_msg(m):
 
 
 def get_jsonable(args, res):
-    global CURRENT_MSG_INDEX
     def _get_jsonable(res):
         if hasattr(res, 'to_json_dict'):
             return res.to_json_dict()
         return res
     if args.annotate:
         data = _get_jsonable(res)
-        # Should warn that this will corrupt Linux system monitor messages
-        if 'index' in data:
-            data['index_orig'] = data['index']
-        data['index'] = CURRENT_MSG_INDEX
-        CURRENT_MSG_INDEX += 1
         return {
             'data': data,
             'time': LAST_UTC_TIME.isoformat() + 'Z',

--- a/python/sbp/sbp2json.py
+++ b/python/sbp/sbp2json.py
@@ -12,7 +12,7 @@ from sbp.navigation import SBP_MSG_UTC_TIME
 from sbp.table import dispatch as dispatch_nojit
 
 CURRENT_MSG_INDEX = 0
-LAST_UTC_TIME = datetime.fromtimestamp(0, timezone.utc)
+LAST_UTC_TIME = datetime.fromtimestamp(0)
 
 NORM = os.environ.get('NOJIT') is not None
 try:
@@ -160,7 +160,7 @@ def store_time_from_msg(m):
     NS_PER_MS = 1000
     LAST_UTC_TIME = datetime(
         m.year, m.month, m.day, m.hours, m.minutes,
-        m.seconds, m.ns // NS_PER_MS, timezone.utc)
+        m.seconds, m.ns // NS_PER_MS)
 
 
 def get_jsonable(args, res):
@@ -178,7 +178,7 @@ def get_jsonable(args, res):
         CURRENT_MSG_INDEX += 1
         return {
             'data': data,
-            'time': LAST_UTC_TIME.isoformat(),
+            'time': LAST_UTC_TIME.isoformat() + 'Z',
             'session-uid': FAKE_UUID
         }
     else:


### PR DESCRIPTION
Attempting to add an option to the Python sbp2json to take in SBP binary and output something similar to what the console outputs.  Timestamps are somewhat synthetic since they follow a GPS epoch rather than the current system time.  The UUID is completely synthetic and fixed, with the intent that it could be used to identify a file that was converted using this tool rather than coming from the Swift Console.