### PR TITLE
Add C++ support

### DIFF
--- a/c/example/cpp_example/CMakeLists.txt
+++ b/c/example/cpp_example/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.9)
+project(libsbp_cpp_example)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Wno-unknown-warning-option -Werror -std=gnu99 ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Wno-unknown-warning-option -Werror -std=c++11 ${CMAKE_CXX_FLAGS}")
+
+add_executable(libsbp_cpp_example cpp_example.cc)
+
+find_package(PkgConfig)
+
+link_directories("/usr/local/lib/")
+include_directories("/usr/local/include/")
+
+target_link_libraries(libsbp_cpp_example sbp)

--- a/c/example/cpp_example/README.md
+++ b/c/example/cpp_example/README.md
@@ -1,0 +1,49 @@
+## Example of using the C++ classes for libsbp
+
+This example demonstrates parsing SBP from a file using the C++ classes
+
+## Requirements
+On Debian-based systems (including Ubuntu 12.10 or later) you can get all
+the requirements with:
+
+```shell
+sudo apt-get install build-essential pkg-config cmake
+```
+
+On mac:
+
+```shell
+brew install cmake
+```
+
+On other systems, you can obtain CMake from your operating system
+package manager or from http://www.cmake.org/.
+
+## Installation
+
+Once you have the dependencies installed, create a build directory where the example will be built:
+
+```shell
+mkdir build
+cd build
+```
+
+Then invoke CMake to configure the build, and then build,
+
+```shell
+cmake ../
+make
+```
+
+## Usage
+
+```shell
+./libsbp_cpp_example
+usage: ./libsbp_cpp_example [filename.sbp]
+```
+
+## LICENSE
+
+Copyright © 2019 Swift Navigation
+
+Distributed under LGPLv3.0.

--- a/c/example/cpp_example/cpp_example.cc
+++ b/c/example/cpp_example/cpp_example.cc
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <fstream>
+
+#include <libsbp/cpp/state.h>
+#include <libsbp/cpp/message_handler.h>
+
+void usage(char *prog_name) {
+  fprintf(stderr, "usage: %s [filename]\n", prog_name);
+}
+
+class SbpFileReader : public sbp::IReader {
+ public:
+  SbpFileReader(const char *file_path) : file_stream_(file_path, std::ios::binary | std::ios_base::in) { }
+
+  bool is_open() const { return file_stream_.is_open(); }
+  bool eof() const { return file_stream_.eof(); }
+
+  s32 read(u8 *buffer, u32 buffer_length) override {
+    auto start_index = file_stream_.tellg();
+    if (start_index == -1) {
+      return -1;
+    }
+    file_stream_.read(reinterpret_cast<char *>(buffer), buffer_length);
+    auto end_index = file_stream_.tellg();
+    if (end_index == -1 || file_stream_.fail()) {
+      return -1;
+    }
+
+    return static_cast<s32>(end_index - start_index);
+  }
+
+ private:
+  std::ifstream file_stream_;
+};
+
+class ECEFHandler : private sbp::MessageHandler<msg_gps_time_t, msg_pos_ecef_t> {
+  public:
+    ECEFHandler(sbp::State *state) : sbp::MessageHandler<msg_gps_time_t, msg_pos_ecef_t>(state) {
+    }
+
+    void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_gps_time_t& msg) {
+      (void)sender_id;
+      (void)message_length;
+      std::cout << "Received new GPS_TME message with WN = " << msg.wn << ", TOW = " << msg.tow << "\n";
+    }
+
+    void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_pos_ecef_t& msg) {
+      (void)sender_id;
+      (void)message_length;
+      std::cout << "Received new POS_ECEF message with TOW = " << msg.tow;
+      std::cout << ", (X,Y,Z) = (" << msg.x << "," << msg.y << "," << msg.z << ")\n";
+    }
+};
+
+int main(int argc, char **argv)
+{
+  if (argc <= 1) {
+    usage(argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  const char *file_path = argv[1];
+
+  SbpFileReader reader(file_path);
+  if (!reader.is_open()) {
+    usage(argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  sbp::State s;
+  ECEFHandler handler(&s);
+
+  s.set_reader(&reader);
+
+  while(!reader.eof()) {
+    s.process();
+  }
+
+  return 0;
+}

--- a/c/include/libsbp/cpp/message_handler.h
+++ b/c/include/libsbp/cpp/message_handler.h
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SBP_CPP_MESSAGE_HANDLER_H_
+#define SBP_CPP_MESSAGE_HANDLER_H_
+
+#include <cassert>
+#include <array>
+
+#include <libsbp/cpp/state.h>
+#include <libsbp/cpp/message_traits.h>
+
+namespace sbp {
+
+/**
+ * A convenience type alias for class member functions that accept SBP message callbacks
+ */
+template<typename ClassT, typename ArgT>
+using CallbackMemFn = void (ClassT::*)(uint16_t, uint8_t, const ArgT &);
+
+/**
+ * A helper function for calling a C++ object member function from a libsbp callback.
+ *
+ * This function is registered with libsbp as a callback and calls a specific member function
+ * of an object from that callback with the SBP message decoded. The member function pointer
+ * is encoded into the template parameter, and the instance of the object is passed in via
+ * the `context` parameter.
+ *
+ * @tparam MsgT The message type to decode the payload as
+ * @tparam ClassT The class type to call the function on
+ * @tparam func Pointer to the member function to call
+ *
+ * @param sender_id The decoded sender ID, is forwarded on to `func`
+ * @param len The length of the message, is forwarded on to `func`
+ * @param msg The raw message payload
+ * @param context Pointer to an instance of `ClassT` to call `func` on
+ */
+template<typename MsgT, typename ClassT, CallbackMemFn<ClassT, MsgT> func>
+inline void sbp_cb_passthrough(uint16_t sender_id, uint8_t len, uint8_t msg[], void *context) {
+  assert(nullptr != context);
+
+  auto instance = static_cast<ClassT *>(context);
+  auto val = reinterpret_cast<MsgT *>(msg);
+  ((*instance).*(func))(sender_id, len, *val);
+}
+
+namespace details {
+
+/**
+ * Recursive interface type for defining the interface functions for `MessageHandler`.
+ *
+ * These types define a virtual `operator()` for handling a specific SBP message type,
+ * as well as a function for registering it as a SBP callback.
+ *
+ * @note These types aren't meant to be used directly by application code.
+ *
+ * @tparam MsgType The type of SBP message to define an interface for
+ * @tparam OtherTypes Other types to recursively define interfaces for
+ */
+template<typename MsgType, typename... OtherTypes>
+class CallbackInterface : CallbackInterface<OtherTypes...> {
+ public:
+  CallbackInterface() = default;
+  virtual ~CallbackInterface() = default;
+
+  using CallbackInterface<OtherTypes...>::handle_sbp_msg;
+  virtual void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const MsgType& msg) = 0;
+
+ protected:
+  void register_callback(sbp_state_t *state, sbp_msg_callbacks_node_t nodes[]) {
+    sbp_register_callback(state,
+        sbp::MessageTraits<MsgType>::id,
+        &sbp_cb_passthrough<MsgType, CallbackInterface, &CallbackInterface::handle_sbp_msg>,
+        this,
+        &nodes[0]);
+    CallbackInterface<OtherTypes...>::register_callback(state, &nodes[1]);
+  }
+};
+
+template<typename MsgType>
+class CallbackInterface<MsgType> {
+ public:
+  CallbackInterface() = default;
+  virtual ~CallbackInterface() = default;
+
+  virtual void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const MsgType& msg) = 0;
+ protected:
+  void register_callback(sbp_state_t *state, sbp_msg_callbacks_node_t nodes[]) {
+    sbp_register_callback(state,
+                          sbp::MessageTraits<MsgType>::id,
+                          &sbp_cb_passthrough<MsgType, CallbackInterface, &CallbackInterface::handle_sbp_msg>,
+                          this,
+                          &nodes[0]);
+  }
+};
+
+} // namespace details
+
+/**
+ * Base type for defining classes that handle SBP messages
+ *
+ * Application classes should derive from this class if they wish to handle
+ * SBP messages with a member function. `MessageHandler` instantiates all of
+ * the callback nodes, and registers the member functions with the given
+ * `sbp_state_t`.
+ *
+ * Classes that derive from `MessageHandler` need to implement
+ *   void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const MsgType& msg) const;
+ * for each `MsgType` in the list of message types given as template parameters.
+ *
+ * Due to the nature of the callback registration in libsbp we dissallow copying or
+ * moving of `MessageHandler`.
+ *
+ * @note It should not matter if the class derives publicly or privately from `MessageHandler`
+ * or if the `handle_sbp_msg` functions are public or private.
+ *
+ * @example
+ * class ECEFHandler : private sbp::MessageHandler<msg_gps_time_t, msg_pos_ecef_t> {
+ *   public:
+ *     ECEFHandler(sbp::State *state) : sbp::MessageHandler<msg_gps_time_t, msg_pos_ecef_t>(state) {
+ *       // The callbacks have already been registered
+ *       // Perform other initialization tasks
+ *     }
+ *
+ *     void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_gps_time_t& msg) {
+ *       // handle GPS time message
+ *     }
+ *
+ *     void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_pos_ecef_t& msg) {
+ *       // handle pos ECEF message
+ *     }
+ * };
+ *
+ * @tparam MsgTypes List of SBP message types to register callbacks for
+ */
+template<typename... MsgTypes>
+ class MessageHandler : public details::CallbackInterface<MsgTypes...> {
+    static constexpr size_t kMsgCount = sizeof...(MsgTypes);
+
+    State &state_;
+    std::array<sbp_msg_callbacks_node_t, kMsgCount> callback_nodes_;
+
+  public:
+
+    explicit MessageHandler(State *state) : details::CallbackInterface<MsgTypes...>(), state_(*state), callback_nodes_() {
+      details::CallbackInterface<MsgTypes...>::register_callback(state_.get_state(), callback_nodes_.data());
+    }
+
+    virtual ~MessageHandler() {
+        for (auto& node : callback_nodes_) {
+            sbp_remove_callback(state_.get_state(), &node);
+        }
+    }
+
+    MessageHandler(const MessageHandler&) = delete;
+    MessageHandler(MessageHandler&& other) = delete;
+    MessageHandler& operator=(const MessageHandler&) = delete;
+    MessageHandler& operator=(MessageHandler&&) = delete;
+
+    using details::CallbackInterface<MsgTypes...>::handle_sbp_msg;
+};
+
+} /* namespace sbp */
+
+#endif /* SBP_CPP_MESSAGE_HANDLER_H_ */

--- a/c/include/libsbp/cpp/message_traits.h
+++ b/c/include/libsbp/cpp/message_traits.h
@@ -1,0 +1,1026 @@
+/**
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SBP_CPP_MESSAGE_TRAITS_H
+#define SBP_CPP_MESSAGE_TRAITS_H
+#include <libsbp/acquisition.h>
+#include <libsbp/bootload.h>
+#include <libsbp/ext_events.h>
+#include <libsbp/file_io.h>
+#include <libsbp/flash.h>
+#include <libsbp/gnss.h>
+#include <libsbp/imu.h>
+#include <libsbp/linux.h>
+#include <libsbp/logging.h>
+#include <libsbp/mag.h>
+#include <libsbp/navigation.h>
+#include <libsbp/ndb.h>
+#include <libsbp/observation.h>
+#include <libsbp/orientation.h>
+#include <libsbp/piksi.h>
+#include <libsbp/sbas.h>
+#include <libsbp/settings.h>
+#include <libsbp/ssr.h>
+#include <libsbp/system.h>
+#include <libsbp/tracking.h>
+#include <libsbp/user.h>
+#include <libsbp/vehicle.h>
+
+namespace sbp {
+
+template<typename>
+struct MessageTraits { };
+
+
+template<>
+struct MessageTraits<msg_print_dep_t> {
+  static constexpr u16 id = 16;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_state_detailed_dep_t> {
+  static constexpr u16 id = 17;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_state_dep_b_t> {
+  static constexpr u16 id = 19;
+};
+
+
+template<>
+struct MessageTraits<msg_acq_result_dep_b_t> {
+  static constexpr u16 id = 20;
+};
+
+
+template<>
+struct MessageTraits<msg_acq_result_dep_a_t> {
+  static constexpr u16 id = 21;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_state_dep_a_t> {
+  static constexpr u16 id = 22;
+};
+
+
+template<>
+struct MessageTraits<msg_thread_state_t> {
+  static constexpr u16 id = 23;
+};
+
+
+template<>
+struct MessageTraits<msg_uart_state_depa_t> {
+  static constexpr u16 id = 24;
+};
+
+
+template<>
+struct MessageTraits<msg_iar_state_t> {
+  static constexpr u16 id = 25;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_dep_a_t> {
+  static constexpr u16 id = 26;
+};
+
+
+template<>
+struct MessageTraits<msg_mask_satellite_dep_t> {
+  static constexpr u16 id = 27;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_iq_dep_a_t> {
+  static constexpr u16 id = 28;
+};
+
+
+template<>
+struct MessageTraits<msg_uart_state_t> {
+  static constexpr u16 id = 29;
+};
+
+
+template<>
+struct MessageTraits<msg_acq_sv_profile_dep_t> {
+  static constexpr u16 id = 30;
+};
+
+
+template<>
+struct MessageTraits<msg_acq_result_dep_c_t> {
+  static constexpr u16 id = 31;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_state_detailed_dep_a_t> {
+  static constexpr u16 id = 33;
+};
+
+
+template<>
+struct MessageTraits<msg_reset_filters_t> {
+  static constexpr u16 id = 34;
+};
+
+
+
+template<>
+struct MessageTraits<msg_mask_satellite_t> {
+  static constexpr u16 id = 43;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_iq_dep_b_t> {
+  static constexpr u16 id = 44;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_iq_t> {
+  static constexpr u16 id = 45;
+};
+
+
+template<>
+struct MessageTraits<msg_acq_sv_profile_t> {
+  static constexpr u16 id = 46;
+};
+
+
+template<>
+struct MessageTraits<msg_acq_result_t> {
+  static constexpr u16 id = 47;
+};
+
+
+template<>
+struct MessageTraits<msg_tracking_state_t> {
+  static constexpr u16 id = 65;
+};
+
+
+template<>
+struct MessageTraits<msg_obs_dep_b_t> {
+  static constexpr u16 id = 67;
+};
+
+
+template<>
+struct MessageTraits<msg_base_pos_llh_t> {
+  static constexpr u16 id = 68;
+};
+
+
+template<>
+struct MessageTraits<msg_obs_dep_a_t> {
+  static constexpr u16 id = 69;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_dep_b_t> {
+  static constexpr u16 id = 70;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_dep_c_t> {
+  static constexpr u16 id = 71;
+};
+
+
+template<>
+struct MessageTraits<msg_base_pos_ecef_t> {
+  static constexpr u16 id = 72;
+};
+
+
+template<>
+struct MessageTraits<msg_obs_dep_c_t> {
+  static constexpr u16 id = 73;
+};
+
+
+template<>
+struct MessageTraits<msg_obs_t> {
+  static constexpr u16 id = 74;
+};
+
+
+template<>
+struct MessageTraits<msg_specan_dep_t> {
+  static constexpr u16 id = 80;
+};
+
+
+template<>
+struct MessageTraits<msg_specan_t> {
+  static constexpr u16 id = 81;
+};
+
+
+template<>
+struct MessageTraits<msg_measurement_state_t> {
+  static constexpr u16 id = 97;
+};
+
+
+
+
+template<>
+struct MessageTraits<msg_almanac_gps_dep_t> {
+  static constexpr u16 id = 112;
+};
+
+
+template<>
+struct MessageTraits<msg_almanac_glo_dep_t> {
+  static constexpr u16 id = 113;
+};
+
+
+template<>
+struct MessageTraits<msg_almanac_gps_t> {
+  static constexpr u16 id = 114;
+};
+
+
+template<>
+struct MessageTraits<msg_almanac_glo_t> {
+  static constexpr u16 id = 115;
+};
+
+
+template<>
+struct MessageTraits<msg_glo_biases_t> {
+  static constexpr u16 id = 117;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_dep_d_t> {
+  static constexpr u16 id = 128;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_gps_dep_e_t> {
+  static constexpr u16 id = 129;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_sbas_dep_a_t> {
+  static constexpr u16 id = 130;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_glo_dep_a_t> {
+  static constexpr u16 id = 131;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_sbas_dep_b_t> {
+  static constexpr u16 id = 132;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_glo_dep_b_t> {
+  static constexpr u16 id = 133;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_gps_dep_f_t> {
+  static constexpr u16 id = 134;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_glo_dep_c_t> {
+  static constexpr u16 id = 135;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_glo_dep_d_t> {
+  static constexpr u16 id = 136;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_bds_t> {
+  static constexpr u16 id = 137;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_gps_t> {
+  static constexpr u16 id = 138;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_glo_t> {
+  static constexpr u16 id = 139;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_sbas_t> {
+  static constexpr u16 id = 140;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_gal_t> {
+  static constexpr u16 id = 141;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_qzss_t> {
+  static constexpr u16 id = 142;
+};
+
+
+template<>
+struct MessageTraits<msg_iono_t> {
+  static constexpr u16 id = 144;
+};
+
+
+template<>
+struct MessageTraits<msg_sv_configuration_gps_dep_t> {
+  static constexpr u16 id = 145;
+};
+
+
+template<>
+struct MessageTraits<msg_group_delay_dep_a_t> {
+  static constexpr u16 id = 146;
+};
+
+
+template<>
+struct MessageTraits<msg_group_delay_dep_b_t> {
+  static constexpr u16 id = 147;
+};
+
+
+template<>
+struct MessageTraits<msg_group_delay_t> {
+  static constexpr u16 id = 148;
+};
+
+
+template<>
+struct MessageTraits<msg_ephemeris_gal_dep_a_t> {
+  static constexpr u16 id = 149;
+};
+
+
+template<>
+struct MessageTraits<msg_gnss_capb_t> {
+  static constexpr u16 id = 150;
+};
+
+
+template<>
+struct MessageTraits<msg_sv_az_el_t> {
+  static constexpr u16 id = 151;
+};
+
+
+template<>
+struct MessageTraits<msg_settings_write_t> {
+  static constexpr u16 id = 160;
+};
+
+
+
+template<>
+struct MessageTraits<msg_settings_read_by_index_req_t> {
+  static constexpr u16 id = 162;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_read_resp_t> {
+  static constexpr u16 id = 163;
+};
+
+
+template<>
+struct MessageTraits<msg_settings_read_req_t> {
+  static constexpr u16 id = 164;
+};
+
+
+template<>
+struct MessageTraits<msg_settings_read_resp_t> {
+  static constexpr u16 id = 165;
+};
+
+
+
+template<>
+struct MessageTraits<msg_settings_read_by_index_resp_t> {
+  static constexpr u16 id = 167;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_read_req_t> {
+  static constexpr u16 id = 168;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_read_dir_req_t> {
+  static constexpr u16 id = 169;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_read_dir_resp_t> {
+  static constexpr u16 id = 170;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_write_resp_t> {
+  static constexpr u16 id = 171;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_remove_t> {
+  static constexpr u16 id = 172;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_write_req_t> {
+  static constexpr u16 id = 173;
+};
+
+
+template<>
+struct MessageTraits<msg_settings_register_t> {
+  static constexpr u16 id = 174;
+};
+
+
+template<>
+struct MessageTraits<msg_settings_write_resp_t> {
+  static constexpr u16 id = 175;
+};
+
+
+template<>
+struct MessageTraits<msg_bootloader_handshake_dep_a_t> {
+  static constexpr u16 id = 176;
+};
+
+
+template<>
+struct MessageTraits<msg_bootloader_jump_to_app_t> {
+  static constexpr u16 id = 177;
+};
+
+
+
+
+template<>
+struct MessageTraits<msg_bootloader_handshake_resp_t> {
+  static constexpr u16 id = 180;
+};
+
+
+template<>
+struct MessageTraits<msg_device_monitor_t> {
+  static constexpr u16 id = 181;
+};
+
+
+template<>
+struct MessageTraits<msg_reset_t> {
+  static constexpr u16 id = 182;
+};
+
+
+template<>
+struct MessageTraits<msg_command_req_t> {
+  static constexpr u16 id = 184;
+};
+
+
+template<>
+struct MessageTraits<msg_command_resp_t> {
+  static constexpr u16 id = 185;
+};
+
+
+
+template<>
+struct MessageTraits<msg_network_state_resp_t> {
+  static constexpr u16 id = 187;
+};
+
+
+template<>
+struct MessageTraits<msg_command_output_t> {
+  static constexpr u16 id = 188;
+};
+
+
+template<>
+struct MessageTraits<msg_network_bandwidth_usage_t> {
+  static constexpr u16 id = 189;
+};
+
+
+template<>
+struct MessageTraits<msg_cell_modem_status_t> {
+  static constexpr u16 id = 190;
+};
+
+
+template<>
+struct MessageTraits<msg_front_end_gain_t> {
+  static constexpr u16 id = 191;
+};
+
+
+
+
+template<>
+struct MessageTraits<msg_nap_device_dna_resp_t> {
+  static constexpr u16 id = 221;
+};
+
+
+
+template<>
+struct MessageTraits<msg_flash_done_t> {
+  static constexpr u16 id = 224;
+};
+
+
+template<>
+struct MessageTraits<msg_flash_read_resp_t> {
+  static constexpr u16 id = 225;
+};
+
+
+template<>
+struct MessageTraits<msg_flash_erase_t> {
+  static constexpr u16 id = 226;
+};
+
+
+template<>
+struct MessageTraits<msg_stm_flash_lock_sector_t> {
+  static constexpr u16 id = 227;
+};
+
+
+template<>
+struct MessageTraits<msg_stm_flash_unlock_sector_t> {
+  static constexpr u16 id = 228;
+};
+
+
+template<>
+struct MessageTraits<msg_stm_unique_id_resp_t> {
+  static constexpr u16 id = 229;
+};
+
+
+template<>
+struct MessageTraits<msg_flash_program_t> {
+  static constexpr u16 id = 230;
+};
+
+
+template<>
+struct MessageTraits<msg_flash_read_req_t> {
+  static constexpr u16 id = 231;
+};
+
+
+
+template<>
+struct MessageTraits<msg_m25_flash_write_status_t> {
+  static constexpr u16 id = 243;
+};
+
+
+template<>
+struct MessageTraits<msg_gps_time_dep_a_t> {
+  static constexpr u16 id = 256;
+};
+
+
+template<>
+struct MessageTraits<msg_ext_event_t> {
+  static constexpr u16 id = 257;
+};
+
+
+template<>
+struct MessageTraits<msg_gps_time_t> {
+  static constexpr u16 id = 258;
+};
+
+
+template<>
+struct MessageTraits<msg_utc_time_t> {
+  static constexpr u16 id = 259;
+};
+
+
+template<>
+struct MessageTraits<msg_settings_register_resp_t> {
+  static constexpr u16 id = 431;
+};
+
+
+template<>
+struct MessageTraits<msg_pos_ecef_dep_a_t> {
+  static constexpr u16 id = 512;
+};
+
+
+template<>
+struct MessageTraits<msg_pos_llh_dep_a_t> {
+  static constexpr u16 id = 513;
+};
+
+
+template<>
+struct MessageTraits<msg_baseline_ecef_dep_a_t> {
+  static constexpr u16 id = 514;
+};
+
+
+template<>
+struct MessageTraits<msg_baseline_ned_dep_a_t> {
+  static constexpr u16 id = 515;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_ecef_dep_a_t> {
+  static constexpr u16 id = 516;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_ned_dep_a_t> {
+  static constexpr u16 id = 517;
+};
+
+
+template<>
+struct MessageTraits<msg_dops_dep_a_t> {
+  static constexpr u16 id = 518;
+};
+
+
+template<>
+struct MessageTraits<msg_baseline_heading_dep_a_t> {
+  static constexpr u16 id = 519;
+};
+
+
+template<>
+struct MessageTraits<msg_dops_t> {
+  static constexpr u16 id = 520;
+};
+
+
+template<>
+struct MessageTraits<msg_pos_ecef_t> {
+  static constexpr u16 id = 521;
+};
+
+
+template<>
+struct MessageTraits<msg_pos_llh_t> {
+  static constexpr u16 id = 522;
+};
+
+
+template<>
+struct MessageTraits<msg_baseline_ecef_t> {
+  static constexpr u16 id = 523;
+};
+
+
+template<>
+struct MessageTraits<msg_baseline_ned_t> {
+  static constexpr u16 id = 524;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_ecef_t> {
+  static constexpr u16 id = 525;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_ned_t> {
+  static constexpr u16 id = 526;
+};
+
+
+template<>
+struct MessageTraits<msg_baseline_heading_t> {
+  static constexpr u16 id = 527;
+};
+
+
+template<>
+struct MessageTraits<msg_age_corrections_t> {
+  static constexpr u16 id = 528;
+};
+
+
+template<>
+struct MessageTraits<msg_pos_llh_cov_t> {
+  static constexpr u16 id = 529;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_ned_cov_t> {
+  static constexpr u16 id = 530;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_body_t> {
+  static constexpr u16 id = 531;
+};
+
+
+template<>
+struct MessageTraits<msg_pos_ecef_cov_t> {
+  static constexpr u16 id = 532;
+};
+
+
+template<>
+struct MessageTraits<msg_vel_ecef_cov_t> {
+  static constexpr u16 id = 533;
+};
+
+
+template<>
+struct MessageTraits<msg_orient_quat_t> {
+  static constexpr u16 id = 544;
+};
+
+
+template<>
+struct MessageTraits<msg_orient_euler_t> {
+  static constexpr u16 id = 545;
+};
+
+
+template<>
+struct MessageTraits<msg_angular_rate_t> {
+  static constexpr u16 id = 546;
+};
+
+
+template<>
+struct MessageTraits<msg_ndb_event_t> {
+  static constexpr u16 id = 1024;
+};
+
+
+template<>
+struct MessageTraits<msg_log_t> {
+  static constexpr u16 id = 1025;
+};
+
+
+template<>
+struct MessageTraits<msg_fwd_t> {
+  static constexpr u16 id = 1026;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_orbit_clock_dep_a_t> {
+  static constexpr u16 id = 1500;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_orbit_clock_t> {
+  static constexpr u16 id = 1501;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_code_biases_t> {
+  static constexpr u16 id = 1505;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_phase_biases_t> {
+  static constexpr u16 id = 1510;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_stec_correction_t> {
+  static constexpr u16 id = 1515;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_gridded_correction_t> {
+  static constexpr u16 id = 1520;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_grid_definition_t> {
+  static constexpr u16 id = 1525;
+};
+
+
+template<>
+struct MessageTraits<msg_osr_t> {
+  static constexpr u16 id = 1600;
+};
+
+
+template<>
+struct MessageTraits<msg_user_data_t> {
+  static constexpr u16 id = 2048;
+};
+
+
+template<>
+struct MessageTraits<msg_imu_raw_t> {
+  static constexpr u16 id = 2304;
+};
+
+
+template<>
+struct MessageTraits<msg_imu_aux_t> {
+  static constexpr u16 id = 2305;
+};
+
+
+template<>
+struct MessageTraits<msg_mag_raw_t> {
+  static constexpr u16 id = 2306;
+};
+
+
+template<>
+struct MessageTraits<msg_odometry_t> {
+  static constexpr u16 id = 2307;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_config_req_t> {
+  static constexpr u16 id = 4097;
+};
+
+
+template<>
+struct MessageTraits<msg_fileio_config_resp_t> {
+  static constexpr u16 id = 4098;
+};
+
+
+template<>
+struct MessageTraits<msg_sbas_raw_t> {
+  static constexpr u16 id = 30583;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_cpu_state_t> {
+  static constexpr u16 id = 32512;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_mem_state_t> {
+  static constexpr u16 id = 32513;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_sys_state_t> {
+  static constexpr u16 id = 32514;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_process_socket_counts_t> {
+  static constexpr u16 id = 32515;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_process_socket_queues_t> {
+  static constexpr u16 id = 32516;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_socket_usage_t> {
+  static constexpr u16 id = 32517;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_process_fd_count_t> {
+  static constexpr u16 id = 32518;
+};
+
+
+template<>
+struct MessageTraits<msg_linux_process_fd_summary_t> {
+  static constexpr u16 id = 32519;
+};
+
+
+template<>
+struct MessageTraits<msg_startup_t> {
+  static constexpr u16 id = 65280;
+};
+
+
+template<>
+struct MessageTraits<msg_dgnss_status_t> {
+  static constexpr u16 id = 65282;
+};
+
+
+template<>
+struct MessageTraits<msg_ins_status_t> {
+  static constexpr u16 id = 65283;
+};
+
+
+template<>
+struct MessageTraits<msg_csac_telemetry_t> {
+  static constexpr u16 id = 65284;
+};
+
+
+template<>
+struct MessageTraits<msg_csac_telemetry_labels_t> {
+  static constexpr u16 id = 65285;
+};
+
+
+template<>
+struct MessageTraits<msg_heartbeat_t> {
+  static constexpr u16 id = 65535;
+};
+
+
+
+
+} // namespace sbp
+
+#endif //SBP_CPP_MESSAGE_TRAITS_H

--- a/c/include/libsbp/cpp/state.h
+++ b/c/include/libsbp/cpp/state.h
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SBP_CPP_STATE_H
+#define SBP_CPP_STATE_H
+
+#include <libsbp/sbp.h>
+
+namespace sbp {
+
+class IReader {
+ public:
+  virtual ~IReader() = default;
+
+  virtual s32 read(u8 *buffer, u32 buffer_length) = 0;
+};
+
+class IWriter {
+ public:
+  virtual ~IWriter() = default;
+
+  virtual s32 write(const u8 *buffer, u32 buffer_length) = 0;
+};
+
+class State {
+ private:
+  sbp_state_t state_;
+  IReader *reader_;
+  IWriter *writer_;
+
+  static s32 read_func(u8 *buff, u32 n, void *ctx) {
+    State *instance = static_cast<State *>(ctx);
+    return instance->reader_->read(buff, n);
+  }
+
+  static s32 write_func(u8 *buff, u32 n, void *ctx) {
+    State *instance = static_cast<State *>(ctx);
+    return instance->writer_->write(buff, n);
+  }
+
+ public:
+  State() : state_(), reader_(nullptr), writer_(nullptr) {
+    sbp_state_init(&state_);
+    sbp_state_set_io_context(&state_, this);
+  }
+
+  explicit State(IReader *reader, IWriter *writer) : State() {
+    reader_ = reader;
+    writer_ = writer;
+  }
+
+  sbp_state_t *get_state() { return &state_; }
+
+  void set_reader(IReader *reader) { reader_ = reader; }
+
+  void set_writer(IWriter *writer) { writer_ = writer; }
+
+  s8 process() {
+    return sbp_process(&state_, &read_func);
+  }
+
+  s8 send_message(u16 msg_type, u16 sender_id, u8 length, u8 payload[]) {
+    return sbp_send_message(&state_, msg_type, sender_id, length, payload, &write_func);
+  }
+
+  s8 process_payload(u16 sender_id, u16 msg_type, u8 msg_length, u8 payload[]) {
+    return sbp_process_payload(&state_, sender_id, msg_type, msg_length, payload);
+  }
+};
+
+}
+
+#endif //SBP_CPP_STATE_H

--- a/generator/sbpg/generator.py
+++ b/generator/sbpg/generator.py
@@ -148,6 +148,8 @@ def main():
           pb.render_source(output_dir, parsed)
       if args.c:
         c.render_version(output_dir, args.release[0])
+        parsed = [yaml.parse_spec(spec) for spec in file_index.values()]
+        c.render_traits(output_dir, parsed)
       elif args.python:
         py.render_version(output_dir, args.release[0])
       elif args.haskell:

--- a/generator/sbpg/targets/resources/sbp_message_traits_template.h
+++ b/generator/sbpg/targets/resources/sbp_message_traits_template.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SBP_CPP_MESSAGE_TRAITS_H
+#define SBP_CPP_MESSAGE_TRAITS_H
+
+((*- for i in includes *))
+#include <libsbp/(((i))).h>
+((*- endfor *))
+
+namespace sbp {
+
+/**
+ * Type traits containing meta-information for each SBP message type.
+ *
+ * These are only meant to be used by the C++ library at compile time.
+ * These are automatically generated, DO NOT EDIT.
+ */
+template<typename>
+struct MessageTraits;
+
+((* for m in msgs *))
+((*- if m.fields *))
+template<>
+struct MessageTraits<(((m.identifier|convert)))> {
+  static constexpr u16 id = (((m.sbp_id)));
+};
+((* endif *))
+((* endfor *))
+
+
+} // namespace sbp
+
+#endif //SBP_CPP_MESSAGE_TRAITS_H


### PR DESCRIPTION
This PR adds a few lightweight C++ classes that wrap around the existing libsbp C interface. The main item of interest here is the `MessageHandler`. This class automates the infrastructure for registering a callback to have a member function called upon receipt of a sbp message.

Here is an example of how it would be used
```
class ECEFHandler : private sbp::MessageHandler<msg_gps_time_t, msg_pos_ecef_t, msg_pos_ecef_cov_t> {
 public:
  ECEFHandler(sbp::State *state) : private sbp::MessageHandler<msg_gps_time_t, msg_pos_ecef_t, msg_pos_ecef_cov_t>(state)
  {
    /* Do other constructor stuff */
  }

 private:
  void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_gps_time_t& msg)
  {
    /* handle GPS time message */
  }

  void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_pos_ecef_t& msg)
  {
    /* handle pos ECEF message */
  }

  void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_pos_ecef_cov_t& msg)
  {
    /* handle pos ecef cov message */
  }
};
```

The instantiation and registration of the `sbp_msg_callbacks_node_t` objects are all taken care of automatically by the `sbp::MessageHandler` constructor, and are unregistered in the destructor. The derived class is able to publicly or privately inherit from `sbp::MessageHandler`, and the `handle_sbp_msg` member functions can be public or private. Each `handle_sbp_msg` is a virtual member function so additional levels of inheritance can be employed, though we do incur the overhead of the vtable lookup at run time. The mapping of message struct to message ID is achieved via a set of type traits that are automatically generated from the specification YAML. Currently only the message ID is included in the message type traits, but additional information could be added in the future if deemed useful.

The other classes are thin wrappers around the existing C structs, and probably don't need much explanation.