### PR TITLE
Added optional serialize feature to rust crate

### DIFF
--- a/generator/sbpg/targets/resources/sbp_messages_mod.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_mod.rs
@@ -36,8 +36,8 @@ pub enum SBP {
 }
 
 impl SBP {
-    pub fn parse(msg_id: u16, sender_id: u16, payload: &mut &[u8]) -> Result<SBP, ::Error> {
-        let x: Result<SBP, ::Error> = match msg_id {
+    pub fn parse(msg_id: u16, sender_id: u16, payload: &mut &[u8]) -> Result<SBP, crate::Error> {
+        let x: Result<SBP, crate::Error> = match msg_id {
             ((*- for m in msgs *))
             (((m.sbp_id))) => {
                 let mut msg = (((m.identifier|camel_case)))::parse(payload)?;
@@ -49,7 +49,7 @@ impl SBP {
         };
         match x {
             Ok(x) => Ok(x),
-            Err(_) => Err(::Error::ParseError),
+            Err(_) => Err(crate::Error::ParseError),
         }
     }
 }

--- a/generator/sbpg/targets/resources/sbp_messages_mod.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_mod.rs
@@ -20,6 +20,9 @@ use self::(((p.identifier|mod_name)))::(((m.identifier|camel_case)));
 ((*- endfor *))
 ((*- endfor *))
 
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Deserialize};
+
 pub trait SBPMessage {
     const MSG_ID: u16;
 
@@ -27,6 +30,7 @@ pub trait SBPMessage {
     fn set_sender_id(&mut self, new_id: u16);
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum SBP {
     Unknown { msg_id: u16, sender_id: u16, payload: Vec<u8> },

--- a/generator/sbpg/targets/resources/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_template.rs
@@ -45,7 +45,7 @@ pub struct (((m.identifier|camel_case))) {
 }
 
 impl (((m.identifier|camel_case))) {
-    pub fn parse(_buf: &mut &[u8]) -> Result<(((m.identifier|camel_case))), ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<(((m.identifier|camel_case))), crate::Error> {
         Ok( (((m.identifier|camel_case))){
             ((*- if m.sbp_id *))
             sender_id: None,
@@ -57,7 +57,7 @@ impl (((m.identifier|camel_case))) {
     }
 
     ((*- if not m.sbp_id *))
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<(((m.identifier|camel_case)))>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<(((m.identifier|camel_case)))>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push( (((m.identifier|camel_case)))::parse(buf)? );
@@ -65,7 +65,7 @@ impl (((m.identifier|camel_case))) {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<(((m.identifier|camel_case)))>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<(((m.identifier|camel_case)))>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push( (((m.identifier|camel_case)))::parse(buf)? );

--- a/generator/sbpg/targets/resources/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_template.rs
@@ -18,6 +18,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian,ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Deserialize};
 
 ((*- for i in includes *))
 use super::(((i)))::*;
@@ -30,6 +32,7 @@ use super::(((i)))::*;
 (((m.desc|commentify)))
 ///
 ((*- endif *))
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct (((m.identifier|camel_case))) {

--- a/generator/sbpg/targets/rust.py
+++ b/generator/sbpg/targets/rust.py
@@ -70,9 +70,9 @@ def parse_type(field):
   """
   if field.type_id == 'string':
     if 'size' in field.options:
-      return "::parser::read_string_limit(_buf, %s)" % field.options['size'].value
+      return "crate::parser::read_string_limit(_buf, %s)" % field.options['size'].value
     else:
-      return "::parser::read_string(_buf)"
+      return "crate::parser::read_string(_buf)"
   elif field.type_id == 'u8':
     return '_buf.read_u8()'
   elif field.type_id == 's8':
@@ -85,9 +85,9 @@ def parse_type(field):
     t = field.options['fill'].value
     if t in TYPE_MAP.keys():
       if 'size' in field.options:
-        return '::parser::read_%s_array_limit(_buf, %d)' % (t, field.options['size'].value)
+        return 'crate::parser::read_%s_array_limit(_buf, %d)' % (t, field.options['size'].value)
       else:
-        return '::parser::read_%s_array(_buf)' % t
+        return 'crate::parser::read_%s_array(_buf)' % t
     else:
       if 'size' in field.options:
         return '%s::parse_array_limit(_buf, %d)' % (t, field.options['size'].value)

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Swift Navigation <dev@swiftnav.com>"]
 repository = "https://github.com/swift-nav/libsbp"
 license = "LGPL-3.0"
 categories = ["parsing"]
+edition = "2018"
 
 [dependencies]
 byteorder = "1.2.1"

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -8,10 +8,14 @@ license = "LGPL-3.0"
 categories = ["parsing"]
 edition = "2018"
 
+[features]
+serialize = ["serde"]
+
 [dependencies]
 byteorder = "1.2.1"
 crc16 = "*"
 nom = "5.0.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [badges]
 travis-ci = { repository = "swift-nav/libsbp" }

--- a/rust/sbp/src/lib.rs
+++ b/rust/sbp/src/lib.rs
@@ -17,7 +17,7 @@ mod tests {
             0x28u8, 0xf4, 0x7a, 0x13, 0x96, 0x62, 0xee, 0xff, 0xbe, 0x40, 0x14, 0x00, 0xf6, 0xa3,
             0x09, 0x00, 0x00, 0x00, 0x0e, 0x00,
         ];
-        let baseline_ecef_expectation = ::messages::navigation::MsgBaselineECEF {
+        let baseline_ecef_expectation = crate::messages::navigation::MsgBaselineECEF {
             sender_id: Some(1234),
             accuracy: 0,
             flags: 0,
@@ -27,9 +27,9 @@ mod tests {
             y: 1327294,
             z: 631798,
         };
-        let sbp_result = ::messages::SBP::parse(0x20b, 1234, &mut &baseline_ecef_payload[..]);
+        let sbp_result = crate::messages::SBP::parse(0x20b, 1234, &mut &baseline_ecef_payload[..]);
         assert!(sbp_result.is_ok());
-        if let ::messages::SBP::MsgBaselineECEF(msg) = sbp_result.unwrap() {
+        if let crate::messages::SBP::MsgBaselineECEF(msg) = sbp_result.unwrap() {
             assert_eq!(msg.sender_id, baseline_ecef_expectation.sender_id);
             assert_eq!(msg.accuracy, baseline_ecef_expectation.accuracy);
             assert_eq!(msg.flags, baseline_ecef_expectation.flags);
@@ -49,7 +49,7 @@ mod tests {
             0x55u8, 0x0b, 0x02, 0xd3, 0x88, 0x14, 0x28, 0xf4, 0x7a, 0x13, 0x96, 0x62, 0xee, 0xff,
             0xbe, 0x40, 0x14, 0x00, 0xf6, 0xa3, 0x09, 0x00, 0x00, 0x00, 0x0e, 0x00, 0xdb, 0xbf,
         ];
-        let baseline_ecef_expectation = ::messages::navigation::MsgBaselineECEF {
+        let baseline_ecef_expectation = crate::messages::navigation::MsgBaselineECEF {
             sender_id: Some(0x88d3),
             accuracy: 0,
             flags: 0,
@@ -59,9 +59,9 @@ mod tests {
             y: 1327294,
             z: 631798,
         };
-        let (sbp_result, _remaining_data) = ::parser::frame(&packet[..]);
+        let (sbp_result, _remaining_data) = crate::parser::frame(&packet[..]);
         assert!(sbp_result.is_ok());
-        if let ::messages::SBP::MsgBaselineECEF(msg) = sbp_result.unwrap() {
+        if let crate::messages::SBP::MsgBaselineECEF(msg) = sbp_result.unwrap() {
             assert_eq!(msg.sender_id, baseline_ecef_expectation.sender_id);
             assert_eq!(msg.accuracy, baseline_ecef_expectation.accuracy);
             assert_eq!(msg.flags, baseline_ecef_expectation.flags);
@@ -83,7 +83,7 @@ mod tests {
             0x00, 0xdb, 0xbf, 0xde, 0xad, 0xbe, 0xef,
         ];
         let mut reader = std::io::Cursor::new(packet);
-        let baseline_ecef_expectation = ::messages::navigation::MsgBaselineECEF {
+        let baseline_ecef_expectation = crate::messages::navigation::MsgBaselineECEF {
             sender_id: Some(0x88d3),
             accuracy: 0,
             flags: 0,
@@ -93,12 +93,12 @@ mod tests {
             y: 1327294,
             z: 631798,
         };
-        let mut parser = ::parser::Parser::new();
+        let mut parser = crate::parser::Parser::new();
         // Iterate through the data until we hit something that is
         // parsable
         let sbp_result = parser.parse(&mut reader);
         assert!(sbp_result.is_ok());
-        if let ::messages::SBP::MsgBaselineECEF(msg) = sbp_result.unwrap() {
+        if let crate::messages::SBP::MsgBaselineECEF(msg) = sbp_result.unwrap() {
             assert_eq!(msg.sender_id, baseline_ecef_expectation.sender_id);
             assert_eq!(msg.accuracy, baseline_ecef_expectation.accuracy);
             assert_eq!(msg.flags, baseline_ecef_expectation.flags);

--- a/rust/sbp/src/messages/acquisition.rs
+++ b/rust/sbp/src/messages/acquisition.rs
@@ -18,6 +18,8 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Acq perfomance measurement and debug
 ///
@@ -25,6 +27,7 @@ use super::gnss::*;
 /// The message describes SV profile during acquisition time.
 /// The message is used to debug and measure the performance.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct AcqSvProfile {
@@ -55,7 +58,7 @@ pub struct AcqSvProfile {
 }
 
 impl AcqSvProfile {
-    pub fn parse(_buf: &mut &[u8]) -> Result<AcqSvProfile, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<AcqSvProfile, crate::Error> {
         Ok(AcqSvProfile {
             job_type: _buf.read_u8()?,
             status: _buf.read_u8()?,
@@ -71,7 +74,7 @@ impl AcqSvProfile {
             cp: _buf.read_u32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AcqSvProfile>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AcqSvProfile>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(AcqSvProfile::parse(buf)?);
@@ -79,7 +82,7 @@ impl AcqSvProfile {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<AcqSvProfile>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<AcqSvProfile>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(AcqSvProfile::parse(buf)?);
@@ -92,6 +95,7 @@ impl AcqSvProfile {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct AcqSvProfileDep {
@@ -122,7 +126,7 @@ pub struct AcqSvProfileDep {
 }
 
 impl AcqSvProfileDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<AcqSvProfileDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<AcqSvProfileDep, crate::Error> {
         Ok(AcqSvProfileDep {
             job_type: _buf.read_u8()?,
             status: _buf.read_u8()?,
@@ -138,7 +142,7 @@ impl AcqSvProfileDep {
             cp: _buf.read_u32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AcqSvProfileDep>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AcqSvProfileDep>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(AcqSvProfileDep::parse(buf)?);
@@ -146,7 +150,10 @@ impl AcqSvProfileDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<AcqSvProfileDep>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<AcqSvProfileDep>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(AcqSvProfileDep::parse(buf)?);
@@ -159,6 +166,7 @@ impl AcqSvProfileDep {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAcqResultDepB {
@@ -175,7 +183,7 @@ pub struct MsgAcqResultDepB {
 }
 
 impl MsgAcqResultDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepB, crate::Error> {
         Ok(MsgAcqResultDepB {
             sender_id: None,
             snr: _buf.read_f32::<LittleEndian>()?,
@@ -201,6 +209,7 @@ impl super::SBPMessage for MsgAcqResultDepB {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAcqResultDepA {
@@ -218,7 +227,7 @@ pub struct MsgAcqResultDepA {
 }
 
 impl MsgAcqResultDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepA, crate::Error> {
         Ok(MsgAcqResultDepA {
             sender_id: None,
             snr: _buf.read_f32::<LittleEndian>()?,
@@ -244,6 +253,7 @@ impl super::SBPMessage for MsgAcqResultDepA {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAcqSvProfileDep {
@@ -253,7 +263,7 @@ pub struct MsgAcqSvProfileDep {
 }
 
 impl MsgAcqSvProfileDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqSvProfileDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqSvProfileDep, crate::Error> {
         Ok(MsgAcqSvProfileDep {
             sender_id: None,
             acq_sv_profile: AcqSvProfileDep::parse_array(_buf)?,
@@ -276,6 +286,7 @@ impl super::SBPMessage for MsgAcqSvProfileDep {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAcqResultDepC {
@@ -291,7 +302,7 @@ pub struct MsgAcqResultDepC {
 }
 
 impl MsgAcqResultDepC {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepC, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepC, crate::Error> {
         Ok(MsgAcqResultDepC {
             sender_id: None,
             cn0: _buf.read_f32::<LittleEndian>()?,
@@ -318,6 +329,7 @@ impl super::SBPMessage for MsgAcqResultDepC {
 /// The message describes all SV profiles during acquisition time.
 /// The message is used to debug and measure the performance.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAcqSvProfile {
@@ -327,7 +339,7 @@ pub struct MsgAcqSvProfile {
 }
 
 impl MsgAcqSvProfile {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqSvProfile, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqSvProfile, crate::Error> {
         Ok(MsgAcqSvProfile {
             sender_id: None,
             acq_sv_profile: AcqSvProfile::parse_array(_buf)?,
@@ -354,6 +366,7 @@ impl super::SBPMessage for MsgAcqSvProfile {
 /// acquisition search space with the best carrier-to-noise (CN/0)
 /// ratio.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAcqResult {
@@ -369,7 +382,7 @@ pub struct MsgAcqResult {
 }
 
 impl MsgAcqResult {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResult, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResult, crate::Error> {
         Ok(MsgAcqResult {
             sender_id: None,
             cn0: _buf.read_f32::<LittleEndian>()?,

--- a/rust/sbp/src/messages/bootload.rs
+++ b/rust/sbp/src/messages/bootload.rs
@@ -22,11 +22,14 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Deprecated
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBootloaderHandshakeDepA {
@@ -36,10 +39,10 @@ pub struct MsgBootloaderHandshakeDepA {
 }
 
 impl MsgBootloaderHandshakeDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeDepA, crate::Error> {
         Ok(MsgBootloaderHandshakeDepA {
             sender_id: None,
-            handshake: ::parser::read_u8_array(_buf)?,
+            handshake: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -59,6 +62,7 @@ impl super::SBPMessage for MsgBootloaderHandshakeDepA {
 ///
 /// The host initiates the bootloader to jump to the application.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBootloaderJumpToApp {
@@ -68,7 +72,7 @@ pub struct MsgBootloaderJumpToApp {
 }
 
 impl MsgBootloaderJumpToApp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderJumpToApp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderJumpToApp, crate::Error> {
         Ok(MsgBootloaderJumpToApp {
             sender_id: None,
             jump: _buf.read_u8()?,
@@ -93,6 +97,7 @@ impl super::SBPMessage for MsgBootloaderJumpToApp {
 /// handshake between the device bootloader and the host. The
 /// response from the device is MSG_BOOTLOADER_HANDSHAKE_RESP.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBootloaderHandshakeReq {
@@ -100,7 +105,7 @@ pub struct MsgBootloaderHandshakeReq {
 }
 
 impl MsgBootloaderHandshakeReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeReq, crate::Error> {
         Ok(MsgBootloaderHandshakeReq { sender_id: None })
     }
 }
@@ -124,6 +129,7 @@ impl super::SBPMessage for MsgBootloaderHandshakeReq {
 /// payload contains the bootloader version number and the SBP
 /// protocol version number.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBootloaderHandshakeResp {
@@ -135,11 +141,11 @@ pub struct MsgBootloaderHandshakeResp {
 }
 
 impl MsgBootloaderHandshakeResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeResp, crate::Error> {
         Ok(MsgBootloaderHandshakeResp {
             sender_id: None,
             flags: _buf.read_u32::<LittleEndian>()?,
-            version: ::parser::read_string(_buf)?,
+            version: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -164,6 +170,7 @@ impl super::SBPMessage for MsgBootloaderHandshakeResp {
 /// device ID in the payload. Note that this ID is tied to the FPGA,
 /// and not related to the Piksi's serial number.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgNapDeviceDnaResp {
@@ -173,10 +180,10 @@ pub struct MsgNapDeviceDnaResp {
 }
 
 impl MsgNapDeviceDnaResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaResp, crate::Error> {
         Ok(MsgNapDeviceDnaResp {
             sender_id: None,
-            dna: ::parser::read_u8_array_limit(_buf, 8)?,
+            dna: crate::parser::read_u8_array_limit(_buf, 8)?,
         })
     }
 }
@@ -201,6 +208,7 @@ impl super::SBPMessage for MsgNapDeviceDnaResp {
 /// device ID in the payload. Note that this ID is tied to the FPGA,
 /// and not related to the Piksi's serial number.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgNapDeviceDnaReq {
@@ -208,7 +216,7 @@ pub struct MsgNapDeviceDnaReq {
 }
 
 impl MsgNapDeviceDnaReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaReq, crate::Error> {
         Ok(MsgNapDeviceDnaReq { sender_id: None })
     }
 }

--- a/rust/sbp/src/messages/ext_events.rs
+++ b/rust/sbp/src/messages/ext_events.rs
@@ -19,12 +19,15 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Reports timestamped external pin event
 ///
 /// Reports detection of an external event, the GPS time it occurred,
 /// which pin it was and whether it was rising or falling.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgExtEvent {
@@ -43,7 +46,7 @@ pub struct MsgExtEvent {
 }
 
 impl MsgExtEvent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgExtEvent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgExtEvent, crate::Error> {
         Ok(MsgExtEvent {
             sender_id: None,
             wn: _buf.read_u16::<LittleEndian>()?,

--- a/rust/sbp/src/messages/file_io.rs
+++ b/rust/sbp/src/messages/file_io.rs
@@ -25,6 +25,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// File read from the file system (host <= device)
 ///
@@ -34,6 +36,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// were succesfully read. The sequence number in the response is
 /// preserved from the request.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioReadResp {
@@ -45,11 +48,11 @@ pub struct MsgFileioReadResp {
 }
 
 impl MsgFileioReadResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadResp, crate::Error> {
         Ok(MsgFileioReadResp {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
-            contents: ::parser::read_u8_array(_buf)?,
+            contents: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -76,6 +79,7 @@ impl super::SBPMessage for MsgFileioReadResp {
 /// print "Invalid fileio read message". A device will only respond
 /// to this message when it is received from sender ID 0x42.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioReadReq {
@@ -91,13 +95,13 @@ pub struct MsgFileioReadReq {
 }
 
 impl MsgFileioReadReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadReq, crate::Error> {
         Ok(MsgFileioReadReq {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
             offset: _buf.read_u32::<LittleEndian>()?,
             chunk_size: _buf.read_u8()?,
-            filename: ::parser::read_string(_buf)?,
+            filename: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -126,6 +130,7 @@ impl super::SBPMessage for MsgFileioReadReq {
 /// A device will only respond to this message when it is received
 /// from sender ID 0x42.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioReadDirReq {
@@ -139,12 +144,12 @@ pub struct MsgFileioReadDirReq {
 }
 
 impl MsgFileioReadDirReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadDirReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadDirReq, crate::Error> {
         Ok(MsgFileioReadDirReq {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
             offset: _buf.read_u32::<LittleEndian>()?,
-            dirname: ::parser::read_string(_buf)?,
+            dirname: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -169,6 +174,7 @@ impl super::SBPMessage for MsgFileioReadDirReq {
 /// entry containing just the character 0xFF. The sequence number in
 /// the response is preserved from the request.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioReadDirResp {
@@ -180,11 +186,11 @@ pub struct MsgFileioReadDirResp {
 }
 
 impl MsgFileioReadDirResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadDirResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadDirResp, crate::Error> {
         Ok(MsgFileioReadDirResp {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
-            contents: ::parser::read_u8_array(_buf)?,
+            contents: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -208,6 +214,7 @@ impl super::SBPMessage for MsgFileioReadDirResp {
 /// write. The sequence number in the response is preserved from the
 /// request.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioWriteResp {
@@ -217,7 +224,7 @@ pub struct MsgFileioWriteResp {
 }
 
 impl MsgFileioWriteResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioWriteResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioWriteResp, crate::Error> {
         Ok(MsgFileioWriteResp {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
@@ -243,6 +250,7 @@ impl super::SBPMessage for MsgFileioWriteResp {
 /// print "Invalid fileio remove message". A device will only
 /// process this message when it is received from sender ID 0x42.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioRemove {
@@ -252,10 +260,10 @@ pub struct MsgFileioRemove {
 }
 
 impl MsgFileioRemove {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioRemove, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioRemove, crate::Error> {
         Ok(MsgFileioRemove {
             sender_id: None,
-            filename: ::parser::read_string(_buf)?,
+            filename: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -282,6 +290,7 @@ impl super::SBPMessage for MsgFileioRemove {
 /// only  process this message when it is received from sender ID
 /// 0x42.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioWriteReq {
@@ -297,13 +306,13 @@ pub struct MsgFileioWriteReq {
 }
 
 impl MsgFileioWriteReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioWriteReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioWriteReq, crate::Error> {
         Ok(MsgFileioWriteReq {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
             offset: _buf.read_u32::<LittleEndian>()?,
-            filename: ::parser::read_string(_buf)?,
-            data: ::parser::read_u8_array(_buf)?,
+            filename: crate::parser::read_string(_buf)?,
+            data: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -326,6 +335,7 @@ impl super::SBPMessage for MsgFileioWriteReq {
 /// throughput by supporting a large window of FileIO data
 /// that can be in-flight during read or write operations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioConfigReq {
@@ -335,7 +345,7 @@ pub struct MsgFileioConfigReq {
 }
 
 impl MsgFileioConfigReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioConfigReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioConfigReq, crate::Error> {
         Ok(MsgFileioConfigReq {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
@@ -362,6 +372,7 @@ impl super::SBPMessage for MsgFileioConfigReq {
 /// throughput by supporting a large window of FileIO data
 /// that can be in-flight during read or write operations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFileioConfigResp {
@@ -377,7 +388,7 @@ pub struct MsgFileioConfigResp {
 }
 
 impl MsgFileioConfigResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioConfigResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioConfigResp, crate::Error> {
         Ok(MsgFileioConfigResp {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,

--- a/rust/sbp/src/messages/flash.rs
+++ b/rust/sbp/src/messages/flash.rs
@@ -22,6 +22,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Flash response message (host <= device).
 ///
@@ -30,6 +32,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// and write messages, such as MSG_FLASH_READ_REQ, or
 /// MSG_FLASH_PROGRAM, may return this message on failure.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFlashDone {
@@ -39,7 +42,7 @@ pub struct MsgFlashDone {
 }
 
 impl MsgFlashDone {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashDone, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashDone, crate::Error> {
         Ok(MsgFlashDone {
             sender_id: None,
             response: _buf.read_u8()?,
@@ -68,6 +71,7 @@ impl super::SBPMessage for MsgFlashDone {
 /// FLASH_INVALID_ADDR (3) if the address is outside of the allowed
 /// range.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFlashReadResp {
@@ -81,11 +85,11 @@ pub struct MsgFlashReadResp {
 }
 
 impl MsgFlashReadResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashReadResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashReadResp, crate::Error> {
         Ok(MsgFlashReadResp {
             sender_id: None,
             target: _buf.read_u8()?,
-            addr_start: ::parser::read_u8_array_limit(_buf, 3)?,
+            addr_start: crate::parser::read_u8_array_limit(_buf, 3)?,
             addr_len: _buf.read_u8()?,
         })
     }
@@ -110,6 +114,7 @@ impl super::SBPMessage for MsgFlashReadResp {
 /// on success or FLASH_INVALID_FLASH (1) if the flash specified is
 /// invalid.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFlashErase {
@@ -121,7 +126,7 @@ pub struct MsgFlashErase {
 }
 
 impl MsgFlashErase {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashErase, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashErase, crate::Error> {
         Ok(MsgFlashErase {
             sender_id: None,
             target: _buf.read_u8()?,
@@ -146,6 +151,7 @@ impl super::SBPMessage for MsgFlashErase {
 /// The flash lock message locks a sector of the STM flash
 /// memory. The device replies with a MSG_FLASH_DONE message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgStmFlashLockSector {
@@ -155,7 +161,7 @@ pub struct MsgStmFlashLockSector {
 }
 
 impl MsgStmFlashLockSector {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmFlashLockSector, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmFlashLockSector, crate::Error> {
         Ok(MsgStmFlashLockSector {
             sender_id: None,
             sector: _buf.read_u32::<LittleEndian>()?,
@@ -179,6 +185,7 @@ impl super::SBPMessage for MsgStmFlashLockSector {
 /// The flash unlock message unlocks a sector of the STM flash
 /// memory. The device replies with a MSG_FLASH_DONE message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgStmFlashUnlockSector {
@@ -188,7 +195,7 @@ pub struct MsgStmFlashUnlockSector {
 }
 
 impl MsgStmFlashUnlockSector {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmFlashUnlockSector, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmFlashUnlockSector, crate::Error> {
         Ok(MsgStmFlashUnlockSector {
             sender_id: None,
             sector: _buf.read_u32::<LittleEndian>()?,
@@ -215,6 +222,7 @@ impl super::SBPMessage for MsgStmFlashUnlockSector {
 /// responds with a MSG_STM_UNIQUE_ID_RESP with the 12-byte unique
 /// ID in the payload..
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgStmUniqueIdResp {
@@ -224,10 +232,10 @@ pub struct MsgStmUniqueIdResp {
 }
 
 impl MsgStmUniqueIdResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdResp, crate::Error> {
         Ok(MsgStmUniqueIdResp {
             sender_id: None,
-            stm_id: ::parser::read_u8_array_limit(_buf, 12)?,
+            stm_id: crate::parser::read_u8_array_limit(_buf, 12)?,
         })
     }
 }
@@ -252,6 +260,7 @@ impl super::SBPMessage for MsgStmUniqueIdResp {
 /// is exceeded. Note that the sector-containing addresses must be
 /// erased before addresses can be programmed.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFlashProgram {
@@ -267,13 +276,13 @@ pub struct MsgFlashProgram {
 }
 
 impl MsgFlashProgram {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashProgram, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashProgram, crate::Error> {
         Ok(MsgFlashProgram {
             sender_id: None,
             target: _buf.read_u8()?,
-            addr_start: ::parser::read_u8_array_limit(_buf, 3)?,
+            addr_start: crate::parser::read_u8_array_limit(_buf, 3)?,
             addr_len: _buf.read_u8()?,
-            data: ::parser::read_u8_array(_buf)?,
+            data: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -299,6 +308,7 @@ impl super::SBPMessage for MsgFlashProgram {
 /// FLASH_INVALID_ADDR (3) if the address is outside of the allowed
 /// range.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFlashReadReq {
@@ -312,11 +322,11 @@ pub struct MsgFlashReadReq {
 }
 
 impl MsgFlashReadReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashReadReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashReadReq, crate::Error> {
         Ok(MsgFlashReadReq {
             sender_id: None,
             target: _buf.read_u8()?,
-            addr_start: ::parser::read_u8_array_limit(_buf, 3)?,
+            addr_start: crate::parser::read_u8_array_limit(_buf, 3)?,
             addr_len: _buf.read_u8()?,
         })
     }
@@ -341,6 +351,7 @@ impl super::SBPMessage for MsgFlashReadReq {
 /// responds with a MSG_STM_UNIQUE_ID_RESP with the 12-byte unique
 /// ID in the payload.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgStmUniqueIdReq {
@@ -348,7 +359,7 @@ pub struct MsgStmUniqueIdReq {
 }
 
 impl MsgStmUniqueIdReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdReq, crate::Error> {
         Ok(MsgStmUniqueIdReq { sender_id: None })
     }
 }
@@ -369,6 +380,7 @@ impl super::SBPMessage for MsgStmUniqueIdReq {
 /// The flash status message writes to the 8-bit M25 flash status
 /// register. The device replies with a MSG_FLASH_DONE message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgM25FlashWriteStatus {
@@ -378,10 +390,10 @@ pub struct MsgM25FlashWriteStatus {
 }
 
 impl MsgM25FlashWriteStatus {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgM25FlashWriteStatus, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgM25FlashWriteStatus, crate::Error> {
         Ok(MsgM25FlashWriteStatus {
             sender_id: None,
-            status: ::parser::read_u8_array_limit(_buf, 1)?,
+            status: crate::parser::read_u8_array_limit(_buf, 1)?,
         })
     }
 }

--- a/rust/sbp/src/messages/gnss.rs
+++ b/rust/sbp/src/messages/gnss.rs
@@ -17,11 +17,14 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Represents all the relevant information about the signal
 ///
 /// Signal identifier containing constellation, band, and satellite identifier
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GnssSignal {
@@ -33,13 +36,13 @@ pub struct GnssSignal {
 }
 
 impl GnssSignal {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GnssSignal, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GnssSignal, crate::Error> {
         Ok(GnssSignal {
             sat: _buf.read_u8()?,
             code: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssSignal>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssSignal>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GnssSignal::parse(buf)?);
@@ -47,7 +50,7 @@ impl GnssSignal {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssSignal>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssSignal>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GnssSignal::parse(buf)?);
@@ -61,6 +64,7 @@ impl GnssSignal {
 /// A (Constellation ID, satellite ID) tuple that uniquely identifies
 /// a space vehicle
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct SvId {
@@ -71,13 +75,13 @@ pub struct SvId {
 }
 
 impl SvId {
-    pub fn parse(_buf: &mut &[u8]) -> Result<SvId, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<SvId, crate::Error> {
         Ok(SvId {
             satId: _buf.read_u8()?,
             constellation: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SvId>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SvId>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(SvId::parse(buf)?);
@@ -85,7 +89,7 @@ impl SvId {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<SvId>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<SvId>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(SvId::parse(buf)?);
@@ -98,6 +102,7 @@ impl SvId {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GnssSignalDep {
@@ -112,14 +117,14 @@ pub struct GnssSignalDep {
 }
 
 impl GnssSignalDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GnssSignalDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GnssSignalDep, crate::Error> {
         Ok(GnssSignalDep {
             sat: _buf.read_u16::<LittleEndian>()?,
             code: _buf.read_u8()?,
             reserved: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssSignalDep>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssSignalDep>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GnssSignalDep::parse(buf)?);
@@ -127,7 +132,10 @@ impl GnssSignalDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssSignalDep>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<GnssSignalDep>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GnssSignalDep::parse(buf)?);
@@ -142,6 +150,7 @@ impl GnssSignalDep {
 /// milliseconds since beginning of the week on the Saturday/Sunday
 /// transition.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GPSTimeDep {
@@ -152,13 +161,13 @@ pub struct GPSTimeDep {
 }
 
 impl GPSTimeDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTimeDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTimeDep, crate::Error> {
         Ok(GPSTimeDep {
             tow: _buf.read_u32::<LittleEndian>()?,
             wn: _buf.read_u16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTimeDep>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTimeDep>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GPSTimeDep::parse(buf)?);
@@ -166,7 +175,7 @@ impl GPSTimeDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTimeDep>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTimeDep>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GPSTimeDep::parse(buf)?);
@@ -181,6 +190,7 @@ impl GPSTimeDep {
 /// seconds since beginning of the week on the Saturday/Sunday
 /// transition.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GPSTimeSec {
@@ -191,13 +201,13 @@ pub struct GPSTimeSec {
 }
 
 impl GPSTimeSec {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTimeSec, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTimeSec, crate::Error> {
         Ok(GPSTimeSec {
             tow: _buf.read_u32::<LittleEndian>()?,
             wn: _buf.read_u16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTimeSec>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTimeSec>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GPSTimeSec::parse(buf)?);
@@ -205,7 +215,7 @@ impl GPSTimeSec {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTimeSec>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTimeSec>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GPSTimeSec::parse(buf)?);
@@ -221,6 +231,7 @@ impl GPSTimeSec {
 /// transition. In most cases, observations are epoch aligned
 /// so ns field will be 0.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GPSTime {
@@ -234,14 +245,14 @@ pub struct GPSTime {
 }
 
 impl GPSTime {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTime, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTime, crate::Error> {
         Ok(GPSTime {
             tow: _buf.read_u32::<LittleEndian>()?,
             ns_residual: _buf.read_i32::<LittleEndian>()?,
             wn: _buf.read_u16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTime>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTime>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GPSTime::parse(buf)?);
@@ -249,7 +260,7 @@ impl GPSTime {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTime>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTime>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GPSTime::parse(buf)?);
@@ -265,6 +276,7 @@ impl GPSTime {
 /// cycles and 8-bits of fractional cycles. This phase has the
 /// same sign as the pseudorange.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct CarrierPhase {
@@ -275,13 +287,13 @@ pub struct CarrierPhase {
 }
 
 impl CarrierPhase {
-    pub fn parse(_buf: &mut &[u8]) -> Result<CarrierPhase, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<CarrierPhase, crate::Error> {
         Ok(CarrierPhase {
             i: _buf.read_i32::<LittleEndian>()?,
             f: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CarrierPhase>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CarrierPhase>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(CarrierPhase::parse(buf)?);
@@ -289,7 +301,7 @@ impl CarrierPhase {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<CarrierPhase>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<CarrierPhase>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(CarrierPhase::parse(buf)?);

--- a/rust/sbp/src/messages/imu.rs
+++ b/rust/sbp/src/messages/imu.rs
@@ -17,6 +17,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Raw IMU data
 ///
@@ -25,6 +27,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// the indications on the device itself. Measurement units, which are specific to the
 /// device hardware and settings, are communicated via the MSG_IMU_AUX message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgImuRaw {
@@ -49,7 +52,7 @@ pub struct MsgImuRaw {
 }
 
 impl MsgImuRaw {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgImuRaw, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgImuRaw, crate::Error> {
         Ok(MsgImuRaw {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -81,6 +84,7 @@ impl super::SBPMessage for MsgImuRaw {
 /// always be consistent but the rest of the payload is device specific and
 /// depends on the value of `imu_type`.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgImuAux {
@@ -94,7 +98,7 @@ pub struct MsgImuAux {
 }
 
 impl MsgImuAux {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgImuAux, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgImuAux, crate::Error> {
         Ok(MsgImuAux {
             sender_id: None,
             imu_type: _buf.read_u8()?,

--- a/rust/sbp/src/messages/linux.rs
+++ b/rust/sbp/src/messages/linux.rs
@@ -18,12 +18,15 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// List CPU state on the system
 ///
 /// This message indicates the process state of the top 10 heaviest
 /// consumers of CPU on the system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxCpuState {
@@ -41,14 +44,14 @@ pub struct MsgLinuxCpuState {
 }
 
 impl MsgLinuxCpuState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxCpuState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxCpuState, crate::Error> {
         Ok(MsgLinuxCpuState {
             sender_id: None,
             index: _buf.read_u8()?,
             pid: _buf.read_u16::<LittleEndian>()?,
             pcpu: _buf.read_u8()?,
-            tname: ::parser::read_string_limit(_buf, 15)?,
-            cmdline: ::parser::read_string(_buf)?,
+            tname: crate::parser::read_string_limit(_buf, 15)?,
+            cmdline: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -69,6 +72,7 @@ impl super::SBPMessage for MsgLinuxCpuState {
 /// This message indicates the process state of the top 10 heaviest
 /// consumers of memory on the system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxMemState {
@@ -86,14 +90,14 @@ pub struct MsgLinuxMemState {
 }
 
 impl MsgLinuxMemState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxMemState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxMemState, crate::Error> {
         Ok(MsgLinuxMemState {
             sender_id: None,
             index: _buf.read_u8()?,
             pid: _buf.read_u16::<LittleEndian>()?,
             pmem: _buf.read_u8()?,
-            tname: ::parser::read_string_limit(_buf, 15)?,
-            cmdline: ::parser::read_string(_buf)?,
+            tname: crate::parser::read_string_limit(_buf, 15)?,
+            cmdline: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -113,6 +117,7 @@ impl super::SBPMessage for MsgLinuxMemState {
 ///
 /// This presents a summary of CPU and memory utilization.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxSysState {
@@ -132,7 +137,7 @@ pub struct MsgLinuxSysState {
 }
 
 impl MsgLinuxSysState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxSysState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxSysState, crate::Error> {
         Ok(MsgLinuxSysState {
             sender_id: None,
             mem_total: _buf.read_u16::<LittleEndian>()?,
@@ -160,6 +165,7 @@ impl super::SBPMessage for MsgLinuxSysState {
 ///
 /// Top 10 list of processes with high socket counts.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxProcessSocketCounts {
@@ -183,7 +189,7 @@ pub struct MsgLinuxProcessSocketCounts {
 }
 
 impl MsgLinuxProcessSocketCounts {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessSocketCounts, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessSocketCounts, crate::Error> {
         Ok(MsgLinuxProcessSocketCounts {
             sender_id: None,
             index: _buf.read_u8()?,
@@ -191,7 +197,7 @@ impl MsgLinuxProcessSocketCounts {
             socket_count: _buf.read_u16::<LittleEndian>()?,
             socket_types: _buf.read_u16::<LittleEndian>()?,
             socket_states: _buf.read_u16::<LittleEndian>()?,
-            cmdline: ::parser::read_string(_buf)?,
+            cmdline: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -211,6 +217,7 @@ impl super::SBPMessage for MsgLinuxProcessSocketCounts {
 ///
 /// Top 10 list of sockets with deep queues.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxProcessSocketQueues {
@@ -239,7 +246,7 @@ pub struct MsgLinuxProcessSocketQueues {
 }
 
 impl MsgLinuxProcessSocketQueues {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessSocketQueues, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessSocketQueues, crate::Error> {
         Ok(MsgLinuxProcessSocketQueues {
             sender_id: None,
             index: _buf.read_u8()?,
@@ -248,8 +255,8 @@ impl MsgLinuxProcessSocketQueues {
             send_queued: _buf.read_u16::<LittleEndian>()?,
             socket_types: _buf.read_u16::<LittleEndian>()?,
             socket_states: _buf.read_u16::<LittleEndian>()?,
-            address_of_largest: ::parser::read_string_limit(_buf, 64)?,
-            cmdline: ::parser::read_string(_buf)?,
+            address_of_largest: crate::parser::read_string_limit(_buf, 64)?,
+            cmdline: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -269,6 +276,7 @@ impl super::SBPMessage for MsgLinuxProcessSocketQueues {
 ///
 /// Summaries the socket usage across the system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxSocketUsage {
@@ -288,13 +296,13 @@ pub struct MsgLinuxSocketUsage {
 }
 
 impl MsgLinuxSocketUsage {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxSocketUsage, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxSocketUsage, crate::Error> {
         Ok(MsgLinuxSocketUsage {
             sender_id: None,
             avg_queue_depth: _buf.read_u32::<LittleEndian>()?,
             max_queue_depth: _buf.read_u32::<LittleEndian>()?,
-            socket_state_counts: ::parser::read_u16_array_limit(_buf, 16)?,
-            socket_type_counts: ::parser::read_u16_array_limit(_buf, 16)?,
+            socket_state_counts: crate::parser::read_u16_array_limit(_buf, 16)?,
+            socket_type_counts: crate::parser::read_u16_array_limit(_buf, 16)?,
         })
     }
 }
@@ -314,6 +322,7 @@ impl super::SBPMessage for MsgLinuxSocketUsage {
 ///
 /// Top 10 list of processes with a large number of open file descriptors.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxProcessFdCount {
@@ -329,13 +338,13 @@ pub struct MsgLinuxProcessFdCount {
 }
 
 impl MsgLinuxProcessFdCount {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessFdCount, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessFdCount, crate::Error> {
         Ok(MsgLinuxProcessFdCount {
             sender_id: None,
             index: _buf.read_u8()?,
             pid: _buf.read_u16::<LittleEndian>()?,
             fd_count: _buf.read_u16::<LittleEndian>()?,
-            cmdline: ::parser::read_string(_buf)?,
+            cmdline: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -355,6 +364,7 @@ impl super::SBPMessage for MsgLinuxProcessFdCount {
 ///
 /// Summary of open file descriptors on the system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLinuxProcessFdSummary {
@@ -370,11 +380,11 @@ pub struct MsgLinuxProcessFdSummary {
 }
 
 impl MsgLinuxProcessFdSummary {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessFdSummary, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessFdSummary, crate::Error> {
         Ok(MsgLinuxProcessFdSummary {
             sender_id: None,
             sys_fd_count: _buf.read_u32::<LittleEndian>()?,
-            most_opened: ::parser::read_string(_buf)?,
+            most_opened: crate::parser::read_string(_buf)?,
         })
     }
 }

--- a/rust/sbp/src/messages/logging.rs
+++ b/rust/sbp/src/messages/logging.rs
@@ -18,11 +18,14 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Deprecated
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPrintDep {
@@ -32,10 +35,10 @@ pub struct MsgPrintDep {
 }
 
 impl MsgPrintDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPrintDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPrintDep, crate::Error> {
         Ok(MsgPrintDep {
             sender_id: None,
-            text: ::parser::read_string(_buf)?,
+            text: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -57,6 +60,7 @@ impl super::SBPMessage for MsgPrintDep {
 /// device containing errors, warnings and informational messages at
 /// ERROR, WARNING, DEBUG, INFO logging levels.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgLog {
@@ -68,11 +72,11 @@ pub struct MsgLog {
 }
 
 impl MsgLog {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLog, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLog, crate::Error> {
         Ok(MsgLog {
             sender_id: None,
             level: _buf.read_u8()?,
-            text: ::parser::read_string(_buf)?,
+            text: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -98,6 +102,7 @@ impl super::SBPMessage for MsgLog {
 /// The protocol identifier identifies what the expected protocol the forwarded msg contains.
 /// Protocol 0 represents SBP and the remaining values are implementation defined.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFwd {
@@ -111,12 +116,12 @@ pub struct MsgFwd {
 }
 
 impl MsgFwd {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFwd, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFwd, crate::Error> {
         Ok(MsgFwd {
             sender_id: None,
             source: _buf.read_u8()?,
             protocol: _buf.read_u8()?,
-            fwd_payload: ::parser::read_string(_buf)?,
+            fwd_payload: crate::parser::read_string(_buf)?,
         })
     }
 }

--- a/rust/sbp/src/messages/mag.rs
+++ b/rust/sbp/src/messages/mag.rs
@@ -17,11 +17,14 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Raw magnetometer data
 ///
 /// Raw data from the magnetometer.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgMagRaw {
@@ -40,7 +43,7 @@ pub struct MsgMagRaw {
 }
 
 impl MsgMagRaw {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMagRaw, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMagRaw, crate::Error> {
         Ok(MsgMagRaw {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,

--- a/rust/sbp/src/messages/mod.rs
+++ b/rust/sbp/src/messages/mod.rs
@@ -204,6 +204,9 @@ use self::tracking::MsgTrackingStateDetailedDepA;
 use self::user::MsgUserData;
 use self::vehicle::MsgOdometry;
 
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
+
 pub trait SBPMessage {
     const MSG_ID: u16;
 
@@ -211,6 +214,7 @@ pub trait SBPMessage {
     fn set_sender_id(&mut self, new_id: u16);
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum SBP {
     Unknown {
@@ -395,8 +399,8 @@ pub enum SBP {
 }
 
 impl SBP {
-    pub fn parse(msg_id: u16, sender_id: u16, payload: &mut &[u8]) -> Result<SBP, ::Error> {
-        let x: Result<SBP, ::Error> = match msg_id {
+    pub fn parse(msg_id: u16, sender_id: u16, payload: &mut &[u8]) -> Result<SBP, crate::Error> {
+        let x: Result<SBP, crate::Error> = match msg_id {
             16 => {
                 let mut msg = MsgPrintDep::parse(payload)?;
                 msg.set_sender_id(sender_id);
@@ -1275,7 +1279,7 @@ impl SBP {
         };
         match x {
             Ok(x) => Ok(x),
-            Err(_) => Err(::Error::ParseError),
+            Err(_) => Err(crate::Error::ParseError),
         }
     }
 }

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -35,6 +35,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// GPS Time (v1.0)
 ///
@@ -52,6 +54,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// (but lacking the ns field) and indicates a more precise time of
 /// these messages.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGPSTimeDepA {
@@ -68,7 +71,7 @@ pub struct MsgGPSTimeDepA {
 }
 
 impl MsgGPSTimeDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTimeDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTimeDepA, crate::Error> {
         Ok(MsgGPSTimeDepA {
             sender_id: None,
             wn: _buf.read_u16::<LittleEndian>()?,
@@ -106,6 +109,7 @@ impl super::SBPMessage for MsgGPSTimeDepA {
 /// (but lacking the ns field) and indicates a more precise time of
 /// these messages.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGPSTime {
@@ -122,7 +126,7 @@ pub struct MsgGPSTime {
 }
 
 impl MsgGPSTime {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTime, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTime, crate::Error> {
         Ok(MsgGPSTime {
             sender_id: None,
             wn: _buf.read_u16::<LittleEndian>()?,
@@ -149,6 +153,7 @@ impl super::SBPMessage for MsgGPSTime {
 /// This message reports the Universal Coordinated Time (UTC).  Note the flags
 /// which indicate the source of the UTC offset value and source of the time fix.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgUtcTime {
@@ -174,7 +179,7 @@ pub struct MsgUtcTime {
 }
 
 impl MsgUtcTime {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUtcTime, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUtcTime, crate::Error> {
         Ok(MsgUtcTime {
             sender_id: None,
             flags: _buf.read_u8()?,
@@ -212,6 +217,7 @@ impl super::SBPMessage for MsgUtcTime {
 /// baseline vector. The full GPS time is given by the preceding
 /// MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPosECEFDepA {
@@ -233,7 +239,7 @@ pub struct MsgPosECEFDepA {
 }
 
 impl MsgPosECEFDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFDepA, crate::Error> {
         Ok(MsgPosECEFDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -269,6 +275,7 @@ impl super::SBPMessage for MsgPosECEFDepA {
 /// GPS time is given by the preceding MSG_GPS_TIME with the
 /// matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPosLLHDepA {
@@ -292,7 +299,7 @@ pub struct MsgPosLLHDepA {
 }
 
 impl MsgPosLLHDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHDepA, crate::Error> {
         Ok(MsgPosLLHDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -326,6 +333,7 @@ impl super::SBPMessage for MsgPosLLHDepA {
 /// full GPS time is given by the preceding MSG_GPS_TIME with the
 /// matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBaselineECEFDepA {
@@ -347,7 +355,7 @@ pub struct MsgBaselineECEFDepA {
 }
 
 impl MsgBaselineECEFDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineECEFDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineECEFDepA, crate::Error> {
         Ok(MsgBaselineECEFDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -381,6 +389,7 @@ impl super::SBPMessage for MsgBaselineECEFDepA {
 /// base station position.  The full GPS time is given by the
 /// preceding MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBaselineNEDDepA {
@@ -404,7 +413,7 @@ pub struct MsgBaselineNEDDepA {
 }
 
 impl MsgBaselineNEDDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineNEDDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineNEDDepA, crate::Error> {
         Ok(MsgBaselineNEDDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -436,6 +445,7 @@ impl super::SBPMessage for MsgBaselineNEDDepA {
 /// (ECEF) coordinates. The full GPS time is given by the preceding
 /// MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelECEFDepA {
@@ -457,7 +467,7 @@ pub struct MsgVelECEFDepA {
 }
 
 impl MsgVelECEFDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFDepA, crate::Error> {
         Ok(MsgVelECEFDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -489,6 +499,7 @@ impl super::SBPMessage for MsgVelECEFDepA {
 /// tangent plane centered at the current position. The full GPS time is
 /// given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelNEDDepA {
@@ -512,7 +523,7 @@ pub struct MsgVelNEDDepA {
 }
 
 impl MsgVelNEDDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDDepA, crate::Error> {
         Ok(MsgVelNEDDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -544,6 +555,7 @@ impl super::SBPMessage for MsgVelNEDDepA {
 /// navigation satellite geometry on positional measurement
 /// precision.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgDopsDepA {
@@ -563,7 +575,7 @@ pub struct MsgDopsDepA {
 }
 
 impl MsgDopsDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDopsDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDopsDepA, crate::Error> {
         Ok(MsgDopsDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -593,6 +605,7 @@ impl super::SBPMessage for MsgDopsDepA {
 /// to the rover relative to True North. The full GPS time is given by the
 /// preceding MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBaselineHeadingDepA {
@@ -608,7 +621,7 @@ pub struct MsgBaselineHeadingDepA {
 }
 
 impl MsgBaselineHeadingDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineHeadingDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineHeadingDepA, crate::Error> {
         Ok(MsgBaselineHeadingDepA {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -637,6 +650,7 @@ impl super::SBPMessage for MsgBaselineHeadingDepA {
 /// precision.  The flags field indicated whether the DOP reported
 /// corresponds to differential or SPP solution.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgDops {
@@ -658,7 +672,7 @@ pub struct MsgDops {
 }
 
 impl MsgDops {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDops, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDops, crate::Error> {
         Ok(MsgDops {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -694,6 +708,7 @@ impl super::SBPMessage for MsgDops {
 /// baseline vector. The full GPS time is given by the preceding
 /// MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPosECEF {
@@ -715,7 +730,7 @@ pub struct MsgPosECEF {
 }
 
 impl MsgPosECEF {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEF, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEF, crate::Error> {
         Ok(MsgPosECEF {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -751,6 +766,7 @@ impl super::SBPMessage for MsgPosECEF {
 /// GPS time is given by the preceding MSG_GPS_TIME with the
 /// matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPosLLH {
@@ -774,7 +790,7 @@ pub struct MsgPosLLH {
 }
 
 impl MsgPosLLH {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLH, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLH, crate::Error> {
         Ok(MsgPosLLH {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -808,6 +824,7 @@ impl super::SBPMessage for MsgPosLLH {
 /// full GPS time is given by the preceding MSG_GPS_TIME with the
 /// matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBaselineECEF {
@@ -829,7 +846,7 @@ pub struct MsgBaselineECEF {
 }
 
 impl MsgBaselineECEF {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineECEF, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineECEF, crate::Error> {
         Ok(MsgBaselineECEF {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -863,6 +880,7 @@ impl super::SBPMessage for MsgBaselineECEF {
 /// base station position.  The full GPS time is given by the
 /// preceding MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBaselineNED {
@@ -886,7 +904,7 @@ pub struct MsgBaselineNED {
 }
 
 impl MsgBaselineNED {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineNED, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineNED, crate::Error> {
         Ok(MsgBaselineNED {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -918,6 +936,7 @@ impl super::SBPMessage for MsgBaselineNED {
 /// (ECEF) coordinates. The full GPS time is given by the preceding
 /// MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelECEF {
@@ -939,7 +958,7 @@ pub struct MsgVelECEF {
 }
 
 impl MsgVelECEF {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEF, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEF, crate::Error> {
         Ok(MsgVelECEF {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -971,6 +990,7 @@ impl super::SBPMessage for MsgVelECEF {
 /// tangent plane centered at the current position. The full GPS time is
 /// given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelNED {
@@ -994,7 +1014,7 @@ pub struct MsgVelNED {
 }
 
 impl MsgVelNED {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNED, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNED, crate::Error> {
         Ok(MsgVelNED {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1025,6 +1045,7 @@ impl super::SBPMessage for MsgVelNED {
 /// This message reports the Age of the corrections used for the current
 /// Differential solution
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAgeCorrections {
@@ -1036,7 +1057,7 @@ pub struct MsgAgeCorrections {
 }
 
 impl MsgAgeCorrections {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAgeCorrections, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAgeCorrections, crate::Error> {
         Ok(MsgAgeCorrections {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1067,6 +1088,7 @@ impl super::SBPMessage for MsgAgeCorrections {
 /// with that convention. Thus, covariances are reported against the "downward"
 /// measurement and care should be taken with the sign convention.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPosLLHCov {
@@ -1098,7 +1120,7 @@ pub struct MsgPosLLHCov {
 }
 
 impl MsgPosLLHCov {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHCov, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHCov, crate::Error> {
         Ok(MsgPosLLHCov {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1137,6 +1159,7 @@ impl super::SBPMessage for MsgPosLLHCov {
 /// This message is similar to the MSG_VEL_NED, but it includes the upper triangular
 /// portion of the 3x3 covariance matrix.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelNEDCov {
@@ -1168,7 +1191,7 @@ pub struct MsgVelNEDCov {
 }
 
 impl MsgVelNEDCov {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDCov, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDCov, crate::Error> {
         Ok(MsgVelNEDCov {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1209,6 +1232,7 @@ impl super::SBPMessage for MsgVelNEDCov {
 /// matching time-of-week (tow). This message is only produced by inertial versions of Swift
 /// products and is not available from Piksi Multi or Duro.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelBody {
@@ -1240,7 +1264,7 @@ pub struct MsgVelBody {
 }
 
 impl MsgVelBody {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelBody, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelBody, crate::Error> {
         Ok(MsgVelBody {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1282,6 +1306,7 @@ impl super::SBPMessage for MsgVelBody {
 /// baseline vector. The full GPS time is given by the preceding
 /// MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgPosECEFCov {
@@ -1313,7 +1338,7 @@ pub struct MsgPosECEFCov {
 }
 
 impl MsgPosECEFCov {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFCov, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFCov, crate::Error> {
         Ok(MsgPosECEFCov {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1349,6 +1374,7 @@ impl super::SBPMessage for MsgPosECEFCov {
 /// (ECEF) coordinates. The full GPS time is given by the preceding
 /// MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgVelECEFCov {
@@ -1380,7 +1406,7 @@ pub struct MsgVelECEFCov {
 }
 
 impl MsgVelECEFCov {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFCov, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFCov, crate::Error> {
         Ok(MsgVelECEFCov {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -1416,6 +1442,7 @@ impl super::SBPMessage for MsgVelECEFCov {
 /// associated with a given LLH position solution. The full GPS time is given
 /// by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgProtectionLevel {
@@ -1437,7 +1464,7 @@ pub struct MsgProtectionLevel {
 }
 
 impl MsgProtectionLevel {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgProtectionLevel, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgProtectionLevel, crate::Error> {
         Ok(MsgProtectionLevel {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,

--- a/rust/sbp/src/messages/ndb.rs
+++ b/rust/sbp/src/messages/ndb.rs
@@ -19,12 +19,15 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Navigation DataBase Event
 ///
 /// This message is sent out when an object is stored into NDB. If needed
 /// message could also be sent out when fetching an object from NDB.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgNdbEvent {
@@ -54,7 +57,7 @@ pub struct MsgNdbEvent {
 }
 
 impl MsgNdbEvent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNdbEvent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNdbEvent, crate::Error> {
         Ok(MsgNdbEvent {
             sender_id: None,
             recv_time: _buf.read_u64::<LittleEndian>()?,

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -18,11 +18,14 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Header for observation message.
 ///
 /// Header of a GNSS observation message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct ObservationHeader {
@@ -34,13 +37,13 @@ pub struct ObservationHeader {
 }
 
 impl ObservationHeader {
-    pub fn parse(_buf: &mut &[u8]) -> Result<ObservationHeader, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<ObservationHeader, crate::Error> {
         Ok(ObservationHeader {
             t: GPSTime::parse(_buf)?,
             n_obs: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<ObservationHeader>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<ObservationHeader>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(ObservationHeader::parse(buf)?);
@@ -48,7 +51,10 @@ impl ObservationHeader {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<ObservationHeader>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<ObservationHeader>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(ObservationHeader::parse(buf)?);
@@ -64,6 +70,7 @@ impl ObservationHeader {
 /// doppler and 8-bits of fractional doppler. This doppler is defined
 /// as positive for approaching satellites.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct Doppler {
@@ -74,13 +81,13 @@ pub struct Doppler {
 }
 
 impl Doppler {
-    pub fn parse(_buf: &mut &[u8]) -> Result<Doppler, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<Doppler, crate::Error> {
         Ok(Doppler {
             i: _buf.read_i16::<LittleEndian>()?,
             f: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Doppler>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Doppler>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(Doppler::parse(buf)?);
@@ -88,7 +95,7 @@ impl Doppler {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Doppler>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Doppler>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(Doppler::parse(buf)?);
@@ -107,6 +114,7 @@ impl Doppler {
 /// or RTCM 3.3 MSM reference signal and no 1/4 cycle adjustments are currently
 /// peformed.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct PackedObsContent {
@@ -134,7 +142,7 @@ pub struct PackedObsContent {
 }
 
 impl PackedObsContent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContent, crate::Error> {
         Ok(PackedObsContent {
             P: _buf.read_u32::<LittleEndian>()?,
             L: CarrierPhase::parse(_buf)?,
@@ -145,7 +153,7 @@ impl PackedObsContent {
             sid: GnssSignal::parse(_buf)?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContent>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContent>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(PackedObsContent::parse(buf)?);
@@ -153,7 +161,10 @@ impl PackedObsContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<PackedObsContent>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<PackedObsContent>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(PackedObsContent::parse(buf)?);
@@ -166,6 +177,7 @@ impl PackedObsContent {
 ///
 /// Pseudorange and carrier phase network corrections for a satellite signal.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct PackedOsrContent {
@@ -193,7 +205,7 @@ pub struct PackedOsrContent {
 }
 
 impl PackedOsrContent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedOsrContent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<PackedOsrContent, crate::Error> {
         Ok(PackedOsrContent {
             P: _buf.read_u32::<LittleEndian>()?,
             L: CarrierPhase::parse(_buf)?,
@@ -205,7 +217,7 @@ impl PackedOsrContent {
             range_std: _buf.read_u16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedOsrContent>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedOsrContent>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(PackedOsrContent::parse(buf)?);
@@ -213,7 +225,10 @@ impl PackedOsrContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<PackedOsrContent>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<PackedOsrContent>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(PackedOsrContent::parse(buf)?);
@@ -222,6 +237,7 @@ impl PackedOsrContent {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct EphemerisCommonContent {
@@ -241,7 +257,7 @@ pub struct EphemerisCommonContent {
 }
 
 impl EphemerisCommonContent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContent, crate::Error> {
         Ok(EphemerisCommonContent {
             sid: GnssSignal::parse(_buf)?,
             toe: GPSTimeSec::parse(_buf)?,
@@ -251,7 +267,7 @@ impl EphemerisCommonContent {
             health_bits: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContent>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContent>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(EphemerisCommonContent::parse(buf)?);
@@ -262,7 +278,7 @@ impl EphemerisCommonContent {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<EphemerisCommonContent>, ::Error> {
+    ) -> Result<Vec<EphemerisCommonContent>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(EphemerisCommonContent::parse(buf)?);
@@ -271,6 +287,7 @@ impl EphemerisCommonContent {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct EphemerisCommonContentDepB {
@@ -290,7 +307,7 @@ pub struct EphemerisCommonContentDepB {
 }
 
 impl EphemerisCommonContentDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContentDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContentDepB, crate::Error> {
         Ok(EphemerisCommonContentDepB {
             sid: GnssSignal::parse(_buf)?,
             toe: GPSTimeSec::parse(_buf)?,
@@ -300,7 +317,7 @@ impl EphemerisCommonContentDepB {
             health_bits: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContentDepB>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContentDepB>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(EphemerisCommonContentDepB::parse(buf)?);
@@ -311,7 +328,7 @@ impl EphemerisCommonContentDepB {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<EphemerisCommonContentDepB>, ::Error> {
+    ) -> Result<Vec<EphemerisCommonContentDepB>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(EphemerisCommonContentDepB::parse(buf)?);
@@ -320,6 +337,7 @@ impl EphemerisCommonContentDepB {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct EphemerisCommonContentDepA {
@@ -339,7 +357,7 @@ pub struct EphemerisCommonContentDepA {
 }
 
 impl EphemerisCommonContentDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContentDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContentDepA, crate::Error> {
         Ok(EphemerisCommonContentDepA {
             sid: GnssSignalDep::parse(_buf)?,
             toe: GPSTimeDep::parse(_buf)?,
@@ -349,7 +367,7 @@ impl EphemerisCommonContentDepA {
             health_bits: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContentDepA>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContentDepA>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(EphemerisCommonContentDepA::parse(buf)?);
@@ -360,7 +378,7 @@ impl EphemerisCommonContentDepA {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<EphemerisCommonContentDepA>, ::Error> {
+    ) -> Result<Vec<EphemerisCommonContentDepA>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(EphemerisCommonContentDepA::parse(buf)?);
@@ -373,6 +391,7 @@ impl EphemerisCommonContentDepA {
 ///
 /// Header of a GPS observation message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct ObservationHeaderDep {
@@ -384,13 +403,13 @@ pub struct ObservationHeaderDep {
 }
 
 impl ObservationHeaderDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<ObservationHeaderDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<ObservationHeaderDep, crate::Error> {
         Ok(ObservationHeaderDep {
             t: GPSTimeDep::parse(_buf)?,
             n_obs: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<ObservationHeaderDep>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<ObservationHeaderDep>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(ObservationHeaderDep::parse(buf)?);
@@ -401,7 +420,7 @@ impl ObservationHeaderDep {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<ObservationHeaderDep>, ::Error> {
+    ) -> Result<Vec<ObservationHeaderDep>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(ObservationHeaderDep::parse(buf)?);
@@ -418,6 +437,7 @@ impl ObservationHeaderDep {
 /// sign convention than a typical GPS receiver and the phase has
 /// the opposite sign as the pseudorange.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct CarrierPhaseDepA {
@@ -428,13 +448,13 @@ pub struct CarrierPhaseDepA {
 }
 
 impl CarrierPhaseDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<CarrierPhaseDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<CarrierPhaseDepA, crate::Error> {
         Ok(CarrierPhaseDepA {
             i: _buf.read_i32::<LittleEndian>()?,
             f: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CarrierPhaseDepA>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CarrierPhaseDepA>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(CarrierPhaseDepA::parse(buf)?);
@@ -442,7 +462,10 @@ impl CarrierPhaseDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<CarrierPhaseDepA>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<CarrierPhaseDepA>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(CarrierPhaseDepA::parse(buf)?);
@@ -455,6 +478,7 @@ impl CarrierPhaseDepA {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct PackedObsContentDepA {
@@ -473,7 +497,7 @@ pub struct PackedObsContentDepA {
 }
 
 impl PackedObsContentDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepA, crate::Error> {
         Ok(PackedObsContentDepA {
             P: _buf.read_u32::<LittleEndian>()?,
             L: CarrierPhaseDepA::parse(_buf)?,
@@ -482,7 +506,7 @@ impl PackedObsContentDepA {
             prn: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepA>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepA>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(PackedObsContentDepA::parse(buf)?);
@@ -493,7 +517,7 @@ impl PackedObsContentDepA {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<PackedObsContentDepA>, ::Error> {
+    ) -> Result<Vec<PackedObsContentDepA>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(PackedObsContentDepA::parse(buf)?);
@@ -507,6 +531,7 @@ impl PackedObsContentDepA {
 /// Pseudorange and carrier phase observation for a satellite being
 /// tracked.  Pseudoranges are referenced to a nominal pseudorange.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct PackedObsContentDepB {
@@ -525,7 +550,7 @@ pub struct PackedObsContentDepB {
 }
 
 impl PackedObsContentDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepB, crate::Error> {
         Ok(PackedObsContentDepB {
             P: _buf.read_u32::<LittleEndian>()?,
             L: CarrierPhaseDepA::parse(_buf)?,
@@ -534,7 +559,7 @@ impl PackedObsContentDepB {
             sid: GnssSignalDep::parse(_buf)?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepB>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepB>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(PackedObsContentDepB::parse(buf)?);
@@ -545,7 +570,7 @@ impl PackedObsContentDepB {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<PackedObsContentDepB>, ::Error> {
+    ) -> Result<Vec<PackedObsContentDepB>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(PackedObsContentDepB::parse(buf)?);
@@ -560,6 +585,7 @@ impl PackedObsContentDepB {
 /// tracked. The observations are be interoperable with 3rd party
 /// receivers and conform with typical RTCMv3 GNSS observations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct PackedObsContentDepC {
@@ -578,7 +604,7 @@ pub struct PackedObsContentDepC {
 }
 
 impl PackedObsContentDepC {
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepC, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepC, crate::Error> {
         Ok(PackedObsContentDepC {
             P: _buf.read_u32::<LittleEndian>()?,
             L: CarrierPhase::parse(_buf)?,
@@ -587,7 +613,7 @@ impl PackedObsContentDepC {
             sid: GnssSignalDep::parse(_buf)?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepC>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepC>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(PackedObsContentDepC::parse(buf)?);
@@ -598,7 +624,7 @@ impl PackedObsContentDepC {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<PackedObsContentDepC>, ::Error> {
+    ) -> Result<Vec<PackedObsContentDepC>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(PackedObsContentDepC::parse(buf)?);
@@ -607,6 +633,7 @@ impl PackedObsContentDepC {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GnssCapb {
@@ -645,7 +672,7 @@ pub struct GnssCapb {
 }
 
 impl GnssCapb {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GnssCapb, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GnssCapb, crate::Error> {
         Ok(GnssCapb {
             gps_active: _buf.read_u64::<LittleEndian>()?,
             gps_l2c: _buf.read_u64::<LittleEndian>()?,
@@ -664,7 +691,7 @@ impl GnssCapb {
             gal_e5: _buf.read_u64::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssCapb>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssCapb>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GnssCapb::parse(buf)?);
@@ -672,7 +699,7 @@ impl GnssCapb {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssCapb>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssCapb>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GnssCapb::parse(buf)?);
@@ -681,6 +708,7 @@ impl GnssCapb {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct AlmanacCommonContent {
@@ -708,7 +736,7 @@ pub struct AlmanacCommonContent {
 }
 
 impl AlmanacCommonContent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<AlmanacCommonContent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<AlmanacCommonContent, crate::Error> {
         Ok(AlmanacCommonContent {
             sid: GnssSignal::parse(_buf)?,
             toa: GPSTimeSec::parse(_buf)?,
@@ -718,7 +746,7 @@ impl AlmanacCommonContent {
             health_bits: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AlmanacCommonContent>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AlmanacCommonContent>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(AlmanacCommonContent::parse(buf)?);
@@ -729,7 +757,7 @@ impl AlmanacCommonContent {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<AlmanacCommonContent>, ::Error> {
+    ) -> Result<Vec<AlmanacCommonContent>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(AlmanacCommonContent::parse(buf)?);
@@ -738,6 +766,7 @@ impl AlmanacCommonContent {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct AlmanacCommonContentDep {
@@ -765,7 +794,7 @@ pub struct AlmanacCommonContentDep {
 }
 
 impl AlmanacCommonContentDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<AlmanacCommonContentDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<AlmanacCommonContentDep, crate::Error> {
         Ok(AlmanacCommonContentDep {
             sid: GnssSignalDep::parse(_buf)?,
             toa: GPSTimeSec::parse(_buf)?,
@@ -775,7 +804,7 @@ impl AlmanacCommonContentDep {
             health_bits: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AlmanacCommonContentDep>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AlmanacCommonContentDep>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(AlmanacCommonContentDep::parse(buf)?);
@@ -786,7 +815,7 @@ impl AlmanacCommonContentDep {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<AlmanacCommonContentDep>, ::Error> {
+    ) -> Result<Vec<AlmanacCommonContentDep>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(AlmanacCommonContentDep::parse(buf)?);
@@ -799,6 +828,7 @@ impl AlmanacCommonContentDep {
 ///
 /// Satellite azimuth and elevation.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct SvAzEl {
@@ -811,14 +841,14 @@ pub struct SvAzEl {
 }
 
 impl SvAzEl {
-    pub fn parse(_buf: &mut &[u8]) -> Result<SvAzEl, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<SvAzEl, crate::Error> {
         Ok(SvAzEl {
             sid: GnssSignal::parse(_buf)?,
             az: _buf.read_u8()?,
             el: _buf.read_i8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SvAzEl>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SvAzEl>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(SvAzEl::parse(buf)?);
@@ -826,7 +856,7 @@ impl SvAzEl {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<SvAzEl>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<SvAzEl>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(SvAzEl::parse(buf)?);
@@ -839,6 +869,7 @@ impl SvAzEl {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisDepA {
@@ -902,7 +933,7 @@ pub struct MsgEphemerisDepA {
 }
 
 impl MsgEphemerisDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepA, crate::Error> {
         Ok(MsgEphemerisDepA {
             sender_id: None,
             tgd: _buf.read_f64::<LittleEndian>()?,
@@ -955,6 +986,7 @@ impl super::SBPMessage for MsgEphemerisDepA {
 /// most 3rd party GNSS receievers or typical RTCMv3
 /// observations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgObsDepB {
@@ -966,7 +998,7 @@ pub struct MsgObsDepB {
 }
 
 impl MsgObsDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepB, crate::Error> {
         Ok(MsgObsDepB {
             sender_id: None,
             header: ObservationHeaderDep::parse(_buf)?,
@@ -994,6 +1026,7 @@ impl super::SBPMessage for MsgObsDepB {
 /// location of the base station. Any error here will result in an
 /// error in the pseudo-absolute position output.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBasePosLLH {
@@ -1007,7 +1040,7 @@ pub struct MsgBasePosLLH {
 }
 
 impl MsgBasePosLLH {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBasePosLLH, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBasePosLLH, crate::Error> {
         Ok(MsgBasePosLLH {
             sender_id: None,
             lat: _buf.read_f64::<LittleEndian>()?,
@@ -1032,6 +1065,7 @@ impl super::SBPMessage for MsgBasePosLLH {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgObsDepA {
@@ -1043,7 +1077,7 @@ pub struct MsgObsDepA {
 }
 
 impl MsgObsDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepA, crate::Error> {
         Ok(MsgObsDepA {
             sender_id: None,
             header: ObservationHeaderDep::parse(_buf)?,
@@ -1067,6 +1101,7 @@ impl super::SBPMessage for MsgObsDepA {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisDepB {
@@ -1132,7 +1167,7 @@ pub struct MsgEphemerisDepB {
 }
 
 impl MsgEphemerisDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepB, crate::Error> {
         Ok(MsgEphemerisDepB {
             sender_id: None,
             tgd: _buf.read_f64::<LittleEndian>()?,
@@ -1185,6 +1220,7 @@ impl super::SBPMessage for MsgEphemerisDepB {
 /// Space Segment/Navigation user interfaces (ICD-GPS-200, Table
 /// 20-III) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisDepC {
@@ -1254,7 +1290,7 @@ pub struct MsgEphemerisDepC {
 }
 
 impl MsgEphemerisDepC {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepC, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepC, crate::Error> {
         Ok(MsgEphemerisDepC {
             sender_id: None,
             tgd: _buf.read_f64::<LittleEndian>()?,
@@ -1310,6 +1346,7 @@ impl super::SBPMessage for MsgEphemerisDepC {
 /// station. Any error here will result in an error in the
 /// pseudo-absolute position output.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBasePosECEF {
@@ -1323,7 +1360,7 @@ pub struct MsgBasePosECEF {
 }
 
 impl MsgBasePosECEF {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBasePosECEF, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBasePosECEF, crate::Error> {
         Ok(MsgBasePosECEF {
             sender_id: None,
             x: _buf.read_f64::<LittleEndian>()?,
@@ -1354,6 +1391,7 @@ impl super::SBPMessage for MsgBasePosECEF {
 /// are interoperable with 3rd party receivers and conform
 /// with typical RTCMv3 GNSS observations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgObsDepC {
@@ -1365,7 +1403,7 @@ pub struct MsgObsDepC {
 }
 
 impl MsgObsDepC {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepC, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepC, crate::Error> {
         Ok(MsgObsDepC {
             sender_id: None,
             header: ObservationHeaderDep::parse(_buf)?,
@@ -1395,6 +1433,7 @@ impl super::SBPMessage for MsgObsDepC {
 /// are be interoperable with 3rd party receivers and conform
 /// with typical RTCMv3 GNSS observations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgObs {
@@ -1406,7 +1445,7 @@ pub struct MsgObs {
 }
 
 impl MsgObs {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObs, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObs, crate::Error> {
         Ok(MsgObs {
             sender_id: None,
             header: ObservationHeader::parse(_buf)?,
@@ -1433,6 +1472,7 @@ impl super::SBPMessage for MsgObs {
 /// Please see the Navstar GPS Space Segment/Navigation user interfaces
 /// (ICD-GPS-200, Chapter 20.3.3.5.1.2 Almanac Data) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAlmanacGPSDep {
@@ -1460,7 +1500,7 @@ pub struct MsgAlmanacGPSDep {
 }
 
 impl MsgAlmanacGPSDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGPSDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGPSDep, crate::Error> {
         Ok(MsgAlmanacGPSDep {
             sender_id: None,
             common: AlmanacCommonContentDep::parse(_buf)?,
@@ -1495,6 +1535,7 @@ impl super::SBPMessage for MsgAlmanacGPSDep {
 /// Please see the GLO ICD 5.1 "Chapter 4.5 Non-immediate information and
 /// almanac" for details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAlmanacGloDep {
@@ -1519,7 +1560,7 @@ pub struct MsgAlmanacGloDep {
 }
 
 impl MsgAlmanacGloDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGloDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGloDep, crate::Error> {
         Ok(MsgAlmanacGloDep {
             sender_id: None,
             common: AlmanacCommonContentDep::parse(_buf)?,
@@ -1552,6 +1593,7 @@ impl super::SBPMessage for MsgAlmanacGloDep {
 /// Please see the Navstar GPS Space Segment/Navigation user interfaces
 /// (ICD-GPS-200, Chapter 20.3.3.5.1.2 Almanac Data) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAlmanacGPS {
@@ -1579,7 +1621,7 @@ pub struct MsgAlmanacGPS {
 }
 
 impl MsgAlmanacGPS {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGPS, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGPS, crate::Error> {
         Ok(MsgAlmanacGPS {
             sender_id: None,
             common: AlmanacCommonContent::parse(_buf)?,
@@ -1614,6 +1656,7 @@ impl super::SBPMessage for MsgAlmanacGPS {
 /// Please see the GLO ICD 5.1 "Chapter 4.5 Non-immediate information and
 /// almanac" for details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAlmanacGlo {
@@ -1638,7 +1681,7 @@ pub struct MsgAlmanacGlo {
 }
 
 impl MsgAlmanacGlo {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGlo, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGlo, crate::Error> {
         Ok(MsgAlmanacGlo {
             sender_id: None,
             common: AlmanacCommonContent::parse(_buf)?,
@@ -1671,6 +1714,7 @@ impl super::SBPMessage for MsgAlmanacGlo {
 /// with mixed receiver types (e.g. receiver of different
 /// manufacturers)
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGloBiases {
@@ -1688,7 +1732,7 @@ pub struct MsgGloBiases {
 }
 
 impl MsgGloBiases {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGloBiases, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGloBiases, crate::Error> {
         Ok(MsgGloBiases {
             sender_id: None,
             mask: _buf.read_u8()?,
@@ -1719,6 +1763,7 @@ impl super::SBPMessage for MsgGloBiases {
 /// Space Segment/Navigation user interfaces (ICD-GPS-200, Table
 /// 20-III) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisDepD {
@@ -1788,7 +1833,7 @@ pub struct MsgEphemerisDepD {
 }
 
 impl MsgEphemerisDepD {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepD, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepD, crate::Error> {
         Ok(MsgEphemerisDepD {
             sender_id: None,
             tgd: _buf.read_f64::<LittleEndian>()?,
@@ -1843,6 +1888,7 @@ impl super::SBPMessage for MsgEphemerisDepD {
 /// Space Segment/Navigation user interfaces (ICD-GPS-200, Table
 /// 20-III) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGPSDepE {
@@ -1900,7 +1946,7 @@ pub struct MsgEphemerisGPSDepE {
 }
 
 impl MsgEphemerisGPSDepE {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPSDepE, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPSDepE, crate::Error> {
         Ok(MsgEphemerisGPSDepE {
             sender_id: None,
             common: EphemerisCommonContentDepA::parse(_buf)?,
@@ -1941,6 +1987,7 @@ impl super::SBPMessage for MsgEphemerisGPSDepE {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisSbasDepA {
@@ -1960,13 +2007,13 @@ pub struct MsgEphemerisSbasDepA {
 }
 
 impl MsgEphemerisSbasDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbasDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbasDepA, crate::Error> {
         Ok(MsgEphemerisSbasDepA {
             sender_id: None,
             common: EphemerisCommonContentDepA::parse(_buf)?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_double_array_limit(_buf, 3)?,
             a_gf0: _buf.read_f64::<LittleEndian>()?,
             a_gf1: _buf.read_f64::<LittleEndian>()?,
         })
@@ -1992,6 +2039,7 @@ impl super::SBPMessage for MsgEphemerisSbasDepA {
 /// Characteristics of words of immediate information (ephemeris parameters)"
 /// for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGloDepA {
@@ -2011,15 +2059,15 @@ pub struct MsgEphemerisGloDepA {
 }
 
 impl MsgEphemerisGloDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepA, crate::Error> {
         Ok(MsgEphemerisGloDepA {
             sender_id: None,
             common: EphemerisCommonContentDepA::parse(_buf)?,
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_double_array_limit(_buf, 3)?,
         })
     }
 }
@@ -2040,6 +2088,7 @@ impl super::SBPMessage for MsgEphemerisGloDepA {
 /// This observation message has been deprecated in favor of
 /// ephemeris message using floats for size reduction.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisSbasDepB {
@@ -2059,13 +2108,13 @@ pub struct MsgEphemerisSbasDepB {
 }
 
 impl MsgEphemerisSbasDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbasDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbasDepB, crate::Error> {
         Ok(MsgEphemerisSbasDepB {
             sender_id: None,
             common: EphemerisCommonContentDepB::parse(_buf)?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_double_array_limit(_buf, 3)?,
             a_gf0: _buf.read_f64::<LittleEndian>()?,
             a_gf1: _buf.read_f64::<LittleEndian>()?,
         })
@@ -2091,6 +2140,7 @@ impl super::SBPMessage for MsgEphemerisSbasDepB {
 /// Characteristics of words of immediate information (ephemeris parameters)"
 /// for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGloDepB {
@@ -2110,15 +2160,15 @@ pub struct MsgEphemerisGloDepB {
 }
 
 impl MsgEphemerisGloDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepB, crate::Error> {
         Ok(MsgEphemerisGloDepB {
             sender_id: None,
             common: EphemerisCommonContentDepB::parse(_buf)?,
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_double_array_limit(_buf, 3)?,
         })
     }
 }
@@ -2139,6 +2189,7 @@ impl super::SBPMessage for MsgEphemerisGloDepB {
 /// This observation message has been deprecated in favor of
 /// ephemeris message using floats for size reduction.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGPSDepF {
@@ -2196,7 +2247,7 @@ pub struct MsgEphemerisGPSDepF {
 }
 
 impl MsgEphemerisGPSDepF {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPSDepF, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPSDepF, crate::Error> {
         Ok(MsgEphemerisGPSDepF {
             sender_id: None,
             common: EphemerisCommonContentDepB::parse(_buf)?,
@@ -2245,6 +2296,7 @@ impl super::SBPMessage for MsgEphemerisGPSDepF {
 /// Characteristics of words of immediate information (ephemeris parameters)"
 /// for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGloDepC {
@@ -2268,16 +2320,16 @@ pub struct MsgEphemerisGloDepC {
 }
 
 impl MsgEphemerisGloDepC {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepC, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepC, crate::Error> {
         Ok(MsgEphemerisGloDepC {
             sender_id: None,
             common: EphemerisCommonContentDepB::parse(_buf)?,
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
             d_tau: _buf.read_f64::<LittleEndian>()?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_double_array_limit(_buf, 3)?,
             fcn: _buf.read_u8()?,
         })
     }
@@ -2299,6 +2351,7 @@ impl super::SBPMessage for MsgEphemerisGloDepC {
 /// This observation message has been deprecated in favor of
 /// ephemeris message using floats for size reduction.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGloDepD {
@@ -2324,16 +2377,16 @@ pub struct MsgEphemerisGloDepD {
 }
 
 impl MsgEphemerisGloDepD {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepD, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepD, crate::Error> {
         Ok(MsgEphemerisGloDepD {
             sender_id: None,
             common: EphemerisCommonContentDepB::parse(_buf)?,
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
             d_tau: _buf.read_f64::<LittleEndian>()?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_double_array_limit(_buf, 3)?,
             fcn: _buf.read_u8()?,
             iod: _buf.read_u8()?,
         })
@@ -2358,6 +2411,7 @@ impl super::SBPMessage for MsgEphemerisGloDepD {
 /// velocity, and clock offset. Please see the BeiDou Navigation
 /// Satellite System SIS-ICD Version 2.1, Table 5-9 for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisBds {
@@ -2417,7 +2471,7 @@ pub struct MsgEphemerisBds {
 }
 
 impl MsgEphemerisBds {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisBds, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisBds, crate::Error> {
         Ok(MsgEphemerisBds {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
@@ -2467,6 +2521,7 @@ impl super::SBPMessage for MsgEphemerisBds {
 /// Space Segment/Navigation user interfaces (ICD-GPS-200, Table
 /// 20-III) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGPS {
@@ -2524,7 +2579,7 @@ pub struct MsgEphemerisGPS {
 }
 
 impl MsgEphemerisGPS {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPS, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPS, crate::Error> {
         Ok(MsgEphemerisGPS {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
@@ -2573,6 +2628,7 @@ impl super::SBPMessage for MsgEphemerisGPS {
 /// Characteristics of words of immediate information (ephemeris parameters)"
 /// for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGlo {
@@ -2598,16 +2654,16 @@ pub struct MsgEphemerisGlo {
 }
 
 impl MsgEphemerisGlo {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGlo, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGlo, crate::Error> {
         Ok(MsgEphemerisGlo {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
             gamma: _buf.read_f32::<LittleEndian>()?,
             tau: _buf.read_f32::<LittleEndian>()?,
             d_tau: _buf.read_f32::<LittleEndian>()?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_double_array_limit(_buf, 3)?,
-            acc: ::parser::read_float_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_double_array_limit(_buf, 3)?,
+            acc: crate::parser::read_float_array_limit(_buf, 3)?,
             fcn: _buf.read_u8()?,
             iod: _buf.read_u8()?,
         })
@@ -2625,6 +2681,7 @@ impl super::SBPMessage for MsgEphemerisGlo {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisSbas {
@@ -2644,13 +2701,13 @@ pub struct MsgEphemerisSbas {
 }
 
 impl MsgEphemerisSbas {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbas, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbas, crate::Error> {
         Ok(MsgEphemerisSbas {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
-            pos: ::parser::read_double_array_limit(_buf, 3)?,
-            vel: ::parser::read_float_array_limit(_buf, 3)?,
-            acc: ::parser::read_float_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_limit(_buf, 3)?,
+            vel: crate::parser::read_float_array_limit(_buf, 3)?,
+            acc: crate::parser::read_float_array_limit(_buf, 3)?,
             a_gf0: _buf.read_f32::<LittleEndian>()?,
             a_gf1: _buf.read_f32::<LittleEndian>()?,
         })
@@ -2675,6 +2732,7 @@ impl super::SBPMessage for MsgEphemerisSbas {
 /// velocity, and clock offset. Please see the Signal In Space ICD
 /// OS SIS ICD, Issue 1.3, December 2016 for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGal {
@@ -2736,7 +2794,7 @@ pub struct MsgEphemerisGal {
 }
 
 impl MsgEphemerisGal {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGal, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGal, crate::Error> {
         Ok(MsgEphemerisGal {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
@@ -2785,6 +2843,7 @@ impl super::SBPMessage for MsgEphemerisGal {
 /// parameters that is used to calculate QZSS satellite position,
 /// velocity, and clock offset.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisQzss {
@@ -2842,7 +2901,7 @@ pub struct MsgEphemerisQzss {
 }
 
 impl MsgEphemerisQzss {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisQzss, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisQzss, crate::Error> {
         Ok(MsgEphemerisQzss {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
@@ -2889,6 +2948,7 @@ impl super::SBPMessage for MsgEphemerisQzss {
 /// utilize the ionospheric model for computation of the ionospheric delay.
 /// Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgIono {
@@ -2906,7 +2966,7 @@ pub struct MsgIono {
 }
 
 impl MsgIono {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgIono, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgIono, crate::Error> {
         Ok(MsgIono {
             sender_id: None,
             t_nmct: GPSTimeSec::parse(_buf)?,
@@ -2937,6 +2997,7 @@ impl super::SBPMessage for MsgIono {
 ///
 /// Please see ICD-GPS-200 (Chapter 20.3.3.5.1.4) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSvConfigurationGPSDep {
@@ -2948,7 +3009,7 @@ pub struct MsgSvConfigurationGPSDep {
 }
 
 impl MsgSvConfigurationGPSDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSvConfigurationGPSDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSvConfigurationGPSDep, crate::Error> {
         Ok(MsgSvConfigurationGPSDep {
             sender_id: None,
             t_nmct: GPSTimeSec::parse(_buf)?,
@@ -2972,6 +3033,7 @@ impl super::SBPMessage for MsgSvConfigurationGPSDep {
 ///
 /// Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGroupDelayDepA {
@@ -2989,7 +3051,7 @@ pub struct MsgGroupDelayDepA {
 }
 
 impl MsgGroupDelayDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelayDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelayDepA, crate::Error> {
         Ok(MsgGroupDelayDepA {
             sender_id: None,
             t_op: GPSTimeDep::parse(_buf)?,
@@ -3017,6 +3079,7 @@ impl super::SBPMessage for MsgGroupDelayDepA {
 ///
 /// Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGroupDelayDepB {
@@ -3034,7 +3097,7 @@ pub struct MsgGroupDelayDepB {
 }
 
 impl MsgGroupDelayDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelayDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelayDepB, crate::Error> {
         Ok(MsgGroupDelayDepB {
             sender_id: None,
             t_op: GPSTimeSec::parse(_buf)?,
@@ -3062,6 +3125,7 @@ impl super::SBPMessage for MsgGroupDelayDepB {
 ///
 /// Please see ICD-GPS-200 (30.3.3.3.1.1) for more details.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGroupDelay {
@@ -3079,7 +3143,7 @@ pub struct MsgGroupDelay {
 }
 
 impl MsgGroupDelay {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelay, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelay, crate::Error> {
         Ok(MsgGroupDelay {
             sender_id: None,
             t_op: GPSTimeSec::parse(_buf)?,
@@ -3108,6 +3172,7 @@ impl super::SBPMessage for MsgGroupDelay {
 /// This observation message has been deprecated in favor of
 /// an ephemeris message with explicit source of NAV data.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgEphemerisGalDepA {
@@ -3167,7 +3232,7 @@ pub struct MsgEphemerisGalDepA {
 }
 
 impl MsgEphemerisGalDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGalDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGalDepA, crate::Error> {
         Ok(MsgEphemerisGalDepA {
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
@@ -3209,6 +3274,7 @@ impl super::SBPMessage for MsgEphemerisGalDepA {
     }
 }
 
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgGnssCapb {
@@ -3220,7 +3286,7 @@ pub struct MsgGnssCapb {
 }
 
 impl MsgGnssCapb {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGnssCapb, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGnssCapb, crate::Error> {
         Ok(MsgGnssCapb {
             sender_id: None,
             t_nmct: GPSTimeSec::parse(_buf)?,
@@ -3245,6 +3311,7 @@ impl super::SBPMessage for MsgGnssCapb {
 /// Azimuth and elevation angles of all the visible satellites
 /// that the device does have ephemeris or almanac for.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSvAzEl {
@@ -3254,7 +3321,7 @@ pub struct MsgSvAzEl {
 }
 
 impl MsgSvAzEl {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSvAzEl, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSvAzEl, crate::Error> {
         Ok(MsgSvAzEl {
             sender_id: None,
             azel: SvAzEl::parse_array(_buf)?,
@@ -3277,6 +3344,7 @@ impl super::SBPMessage for MsgSvAzEl {
 ///
 /// The OSR message contains network corrections in an observation-like format
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgOsr {
@@ -3288,7 +3356,7 @@ pub struct MsgOsr {
 }
 
 impl MsgOsr {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOsr, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOsr, crate::Error> {
         Ok(MsgOsr {
             sender_id: None,
             header: ObservationHeader::parse(_buf)?,

--- a/rust/sbp/src/messages/orientation.rs
+++ b/rust/sbp/src/messages/orientation.rs
@@ -17,6 +17,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Heading relative to True North
 ///
@@ -25,6 +27,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// preceding MSG_GPS_TIME with the matching time-of-week (tow). It is intended
 /// that time-matched RTK mode is used when the base station is moving.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgBaselineHeading {
@@ -40,7 +43,7 @@ pub struct MsgBaselineHeading {
 }
 
 impl MsgBaselineHeading {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineHeading, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineHeading, crate::Error> {
         Ok(MsgBaselineHeading {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -70,6 +73,7 @@ impl super::SBPMessage for MsgBaselineHeading {
 /// be available in future INS versions of Swift Products and is not produced by Piksi Multi
 /// or Duro.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgOrientQuat {
@@ -97,7 +101,7 @@ pub struct MsgOrientQuat {
 }
 
 impl MsgOrientQuat {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOrientQuat, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOrientQuat, crate::Error> {
         Ok(MsgOrientQuat {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -133,6 +137,7 @@ impl super::SBPMessage for MsgOrientQuat {
 /// to the vehicle body frame.  This message will only be available in future
 /// INS versions of Swift Products and is not produced by Piksi Multi or Duro.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgOrientEuler {
@@ -156,7 +161,7 @@ pub struct MsgOrientEuler {
 }
 
 impl MsgOrientEuler {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOrientEuler, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOrientEuler, crate::Error> {
         Ok(MsgOrientEuler {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,
@@ -194,6 +199,7 @@ impl super::SBPMessage for MsgOrientEuler {
 /// This message will only be available in future INS versions of Swift Products
 /// and is not produced by Piksi Multi or Duro.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAngularRate {
@@ -211,7 +217,7 @@ pub struct MsgAngularRate {
 }
 
 impl MsgAngularRate {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAngularRate, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAngularRate, crate::Error> {
         Ok(MsgAngularRate {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,

--- a/rust/sbp/src/messages/piksi.rs
+++ b/rust/sbp/src/messages/piksi.rs
@@ -21,6 +21,8 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// State of the UART channel
 ///
@@ -28,6 +30,7 @@ use super::gnss::*;
 /// of this UART channel. The reported percentage values must
 /// be normalized.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct UARTChannel {
@@ -46,7 +49,7 @@ pub struct UARTChannel {
 }
 
 impl UARTChannel {
-    pub fn parse(_buf: &mut &[u8]) -> Result<UARTChannel, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<UARTChannel, crate::Error> {
         Ok(UARTChannel {
             tx_throughput: _buf.read_f32::<LittleEndian>()?,
             rx_throughput: _buf.read_f32::<LittleEndian>()?,
@@ -56,7 +59,7 @@ impl UARTChannel {
             rx_buffer_level: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<UARTChannel>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<UARTChannel>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(UARTChannel::parse(buf)?);
@@ -64,7 +67,7 @@ impl UARTChannel {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<UARTChannel>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<UARTChannel>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(UARTChannel::parse(buf)?);
@@ -82,6 +85,7 @@ impl UARTChannel {
 /// or missing sets will increase the period.  Long periods
 /// can cause momentary RTK solution outages.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct Period {
@@ -96,7 +100,7 @@ pub struct Period {
 }
 
 impl Period {
-    pub fn parse(_buf: &mut &[u8]) -> Result<Period, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<Period, crate::Error> {
         Ok(Period {
             avg: _buf.read_i32::<LittleEndian>()?,
             pmin: _buf.read_i32::<LittleEndian>()?,
@@ -104,7 +108,7 @@ impl Period {
             current: _buf.read_i32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Period>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Period>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(Period::parse(buf)?);
@@ -112,7 +116,7 @@ impl Period {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Period>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Period>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(Period::parse(buf)?);
@@ -129,6 +133,7 @@ impl Period {
 /// receiver to give a precise measurement of the end-to-end
 /// communication latency in the system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct Latency {
@@ -143,7 +148,7 @@ pub struct Latency {
 }
 
 impl Latency {
-    pub fn parse(_buf: &mut &[u8]) -> Result<Latency, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<Latency, crate::Error> {
         Ok(Latency {
             avg: _buf.read_i32::<LittleEndian>()?,
             lmin: _buf.read_i32::<LittleEndian>()?,
@@ -151,7 +156,7 @@ impl Latency {
             current: _buf.read_i32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Latency>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Latency>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(Latency::parse(buf)?);
@@ -159,7 +164,7 @@ impl Latency {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Latency>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Latency>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(Latency::parse(buf)?);
@@ -177,6 +182,7 @@ impl Latency {
 /// may vary, both a timestamp and period field is provided,
 /// though may not necessarily be populated with a value.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct NetworkUsage {
@@ -193,16 +199,16 @@ pub struct NetworkUsage {
 }
 
 impl NetworkUsage {
-    pub fn parse(_buf: &mut &[u8]) -> Result<NetworkUsage, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<NetworkUsage, crate::Error> {
         Ok(NetworkUsage {
             duration: _buf.read_u64::<LittleEndian>()?,
             total_bytes: _buf.read_u64::<LittleEndian>()?,
             rx_bytes: _buf.read_u32::<LittleEndian>()?,
             tx_bytes: _buf.read_u32::<LittleEndian>()?,
-            interface_name: ::parser::read_string_limit(_buf, 16)?,
+            interface_name: crate::parser::read_string_limit(_buf, 16)?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<NetworkUsage>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<NetworkUsage>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(NetworkUsage::parse(buf)?);
@@ -210,7 +216,7 @@ impl NetworkUsage {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<NetworkUsage>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<NetworkUsage>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(NetworkUsage::parse(buf)?);
@@ -225,6 +231,7 @@ impl NetworkUsage {
 /// operating system (RTOS) thread usage statistics for the named
 /// thread. The reported percentage values must be normalized.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgThreadState {
@@ -239,10 +246,10 @@ pub struct MsgThreadState {
 }
 
 impl MsgThreadState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgThreadState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgThreadState, crate::Error> {
         Ok(MsgThreadState {
             sender_id: None,
-            name: ::parser::read_string_limit(_buf, 20)?,
+            name: crate::parser::read_string_limit(_buf, 20)?,
             cpu: _buf.read_u16::<LittleEndian>()?,
             stack_free: _buf.read_u32::<LittleEndian>()?,
         })
@@ -264,6 +271,7 @@ impl super::SBPMessage for MsgThreadState {
 ///
 /// Deprecated
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgUartStateDepa {
@@ -279,7 +287,7 @@ pub struct MsgUartStateDepa {
 }
 
 impl MsgUartStateDepa {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUartStateDepa, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUartStateDepa, crate::Error> {
         Ok(MsgUartStateDepa {
             sender_id: None,
             uart_a: UARTChannel::parse(_buf)?,
@@ -308,6 +316,7 @@ impl super::SBPMessage for MsgUartStateDepa {
 /// ambiguities from double-differenced carrier-phase measurements
 /// from satellite observations.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgIarState {
@@ -317,7 +326,7 @@ pub struct MsgIarState {
 }
 
 impl MsgIarState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgIarState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgIarState, crate::Error> {
         Ok(MsgIarState {
             sender_id: None,
             num_hyps: _buf.read_u32::<LittleEndian>()?,
@@ -340,6 +349,7 @@ impl super::SBPMessage for MsgIarState {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgMaskSatelliteDep {
@@ -351,7 +361,7 @@ pub struct MsgMaskSatelliteDep {
 }
 
 impl MsgMaskSatelliteDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMaskSatelliteDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMaskSatelliteDep, crate::Error> {
         Ok(MsgMaskSatelliteDep {
             sender_id: None,
             mask: _buf.read_u8()?,
@@ -383,6 +393,7 @@ impl super::SBPMessage for MsgMaskSatelliteDep {
 /// the timeliness of received base observations while the
 /// period indicates their likelihood of transmission.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgUartState {
@@ -400,7 +411,7 @@ pub struct MsgUartState {
 }
 
 impl MsgUartState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUartState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUartState, crate::Error> {
         Ok(MsgUartState {
             sender_id: None,
             uart_a: UARTChannel::parse(_buf)?,
@@ -428,6 +439,7 @@ impl super::SBPMessage for MsgUartState {
 /// This message resets either the DGNSS Kalman filters or Integer
 /// Ambiguity Resolution (IAR) process.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgResetFilters {
@@ -437,7 +449,7 @@ pub struct MsgResetFilters {
 }
 
 impl MsgResetFilters {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgResetFilters, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgResetFilters, crate::Error> {
         Ok(MsgResetFilters {
             sender_id: None,
             filter: _buf.read_u8()?,
@@ -460,6 +472,7 @@ impl super::SBPMessage for MsgResetFilters {
 ///
 /// Deprecated
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgInitBaseDep {
@@ -467,7 +480,7 @@ pub struct MsgInitBaseDep {
 }
 
 impl MsgInitBaseDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInitBaseDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInitBaseDep, crate::Error> {
         Ok(MsgInitBaseDep { sender_id: None })
     }
 }
@@ -488,6 +501,7 @@ impl super::SBPMessage for MsgInitBaseDep {
 /// This message allows setting a mask to prevent a particular satellite
 /// from being used in various Piksi subsystems.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgMaskSatellite {
@@ -499,7 +513,7 @@ pub struct MsgMaskSatellite {
 }
 
 impl MsgMaskSatellite {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMaskSatellite, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMaskSatellite, crate::Error> {
         Ok(MsgMaskSatellite {
             sender_id: None,
             mask: _buf.read_u8()?,
@@ -523,6 +537,7 @@ impl super::SBPMessage for MsgMaskSatellite {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSpecanDep {
@@ -544,7 +559,7 @@ pub struct MsgSpecanDep {
 }
 
 impl MsgSpecanDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSpecanDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSpecanDep, crate::Error> {
         Ok(MsgSpecanDep {
             sender_id: None,
             channel_tag: _buf.read_u16::<LittleEndian>()?,
@@ -553,7 +568,7 @@ impl MsgSpecanDep {
             freq_step: _buf.read_f32::<LittleEndian>()?,
             amplitude_ref: _buf.read_f32::<LittleEndian>()?,
             amplitude_unit: _buf.read_f32::<LittleEndian>()?,
-            amplitude_value: ::parser::read_u8_array(_buf)?,
+            amplitude_value: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -573,6 +588,7 @@ impl super::SBPMessage for MsgSpecanDep {
 ///
 /// Spectrum analyzer packet.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSpecan {
@@ -594,7 +610,7 @@ pub struct MsgSpecan {
 }
 
 impl MsgSpecan {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSpecan, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSpecan, crate::Error> {
         Ok(MsgSpecan {
             sender_id: None,
             channel_tag: _buf.read_u16::<LittleEndian>()?,
@@ -603,7 +619,7 @@ impl MsgSpecan {
             freq_step: _buf.read_f32::<LittleEndian>()?,
             amplitude_ref: _buf.read_f32::<LittleEndian>()?,
             amplitude_unit: _buf.read_f32::<LittleEndian>()?,
-            amplitude_value: ::parser::read_u8_array(_buf)?,
+            amplitude_value: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -624,6 +640,7 @@ impl super::SBPMessage for MsgSpecan {
 /// This message sets up timing functionality using a coarse GPS
 /// time estimate sent by the host.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSetTime {
@@ -631,7 +648,7 @@ pub struct MsgSetTime {
 }
 
 impl MsgSetTime {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSetTime, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSetTime, crate::Error> {
         Ok(MsgSetTime { sender_id: None })
     }
 }
@@ -652,6 +669,7 @@ impl super::SBPMessage for MsgSetTime {
 /// This is a legacy message for sending and loading a satellite
 /// alamanac onto the Piksi's flash memory from the host.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgAlmanac {
@@ -659,7 +677,7 @@ pub struct MsgAlmanac {
 }
 
 impl MsgAlmanac {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanac, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanac, crate::Error> {
         Ok(MsgAlmanac { sender_id: None })
     }
 }
@@ -680,6 +698,7 @@ impl super::SBPMessage for MsgAlmanac {
 /// This message from the host resets the Piksi back into the
 /// bootloader.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgResetDep {
@@ -687,7 +706,7 @@ pub struct MsgResetDep {
 }
 
 impl MsgResetDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgResetDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgResetDep, crate::Error> {
         Ok(MsgResetDep { sender_id: None })
     }
 }
@@ -709,6 +728,7 @@ impl super::SBPMessage for MsgResetDep {
 /// processor's monitoring system and the RF frontend die temperature if
 /// available.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgDeviceMonitor {
@@ -726,7 +746,7 @@ pub struct MsgDeviceMonitor {
 }
 
 impl MsgDeviceMonitor {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDeviceMonitor, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDeviceMonitor, crate::Error> {
         Ok(MsgDeviceMonitor {
             sender_id: None,
             dev_vin: _buf.read_i16::<LittleEndian>()?,
@@ -754,6 +774,7 @@ impl super::SBPMessage for MsgDeviceMonitor {
 /// This message from the host resets the Piksi back into the
 /// bootloader.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgReset {
@@ -763,7 +784,7 @@ pub struct MsgReset {
 }
 
 impl MsgReset {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgReset, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgReset, crate::Error> {
         Ok(MsgReset {
             sender_id: None,
             flags: _buf.read_u32::<LittleEndian>()?,
@@ -788,6 +809,7 @@ impl super::SBPMessage for MsgReset {
 /// Output will be sent in MSG_LOG messages, and the exit
 /// code will be returned with MSG_COMMAND_RESP.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCommandReq {
@@ -799,11 +821,11 @@ pub struct MsgCommandReq {
 }
 
 impl MsgCommandReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandReq, crate::Error> {
         Ok(MsgCommandReq {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
-            command: ::parser::read_string(_buf)?,
+            command: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -824,6 +846,7 @@ impl super::SBPMessage for MsgCommandReq {
 /// The response to MSG_COMMAND_REQ with the return code of
 /// the command.  A return code of zero indicates success.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCommandResp {
@@ -835,7 +858,7 @@ pub struct MsgCommandResp {
 }
 
 impl MsgCommandResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandResp, crate::Error> {
         Ok(MsgCommandResp {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
@@ -860,6 +883,7 @@ impl super::SBPMessage for MsgCommandResp {
 /// Request state of Piksi network interfaces.
 /// Output will be sent in MSG_NETWORK_STATE_RESP messages
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgNetworkStateReq {
@@ -867,7 +891,7 @@ pub struct MsgNetworkStateReq {
 }
 
 impl MsgNetworkStateReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateReq, crate::Error> {
         Ok(MsgNetworkStateReq { sender_id: None })
     }
 }
@@ -889,6 +913,7 @@ impl super::SBPMessage for MsgNetworkStateReq {
 /// Data is made to reflect output of ifaddrs struct returned by getifaddrs
 /// in c.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgNetworkStateResp {
@@ -912,16 +937,16 @@ pub struct MsgNetworkStateResp {
 }
 
 impl MsgNetworkStateResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateResp, crate::Error> {
         Ok(MsgNetworkStateResp {
             sender_id: None,
-            ipv4_address: ::parser::read_u8_array_limit(_buf, 4)?,
+            ipv4_address: crate::parser::read_u8_array_limit(_buf, 4)?,
             ipv4_mask_size: _buf.read_u8()?,
-            ipv6_address: ::parser::read_u8_array_limit(_buf, 16)?,
+            ipv6_address: crate::parser::read_u8_array_limit(_buf, 16)?,
             ipv6_mask_size: _buf.read_u8()?,
             rx_bytes: _buf.read_u32::<LittleEndian>()?,
             tx_bytes: _buf.read_u32::<LittleEndian>()?,
-            interface_name: ::parser::read_string_limit(_buf, 16)?,
+            interface_name: crate::parser::read_string_limit(_buf, 16)?,
             flags: _buf.read_u32::<LittleEndian>()?,
         })
     }
@@ -945,6 +970,7 @@ impl super::SBPMessage for MsgNetworkStateResp {
 /// The sequence number can be used to filter for filtering
 /// the correct command.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCommandOutput {
@@ -956,11 +982,11 @@ pub struct MsgCommandOutput {
 }
 
 impl MsgCommandOutput {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandOutput, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandOutput, crate::Error> {
         Ok(MsgCommandOutput {
             sender_id: None,
             sequence: _buf.read_u32::<LittleEndian>()?,
-            line: ::parser::read_string(_buf)?,
+            line: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -980,6 +1006,7 @@ impl super::SBPMessage for MsgCommandOutput {
 ///
 /// The bandwidth usage, a list of usage by interface.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgNetworkBandwidthUsage {
@@ -989,7 +1016,7 @@ pub struct MsgNetworkBandwidthUsage {
 }
 
 impl MsgNetworkBandwidthUsage {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkBandwidthUsage, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkBandwidthUsage, crate::Error> {
         Ok(MsgNetworkBandwidthUsage {
             sender_id: None,
             interfaces: NetworkUsage::parse_array(_buf)?,
@@ -1014,6 +1041,7 @@ impl super::SBPMessage for MsgNetworkBandwidthUsage {
 /// will be send periodically to update the host on the status
 /// of the modem and its various parameters.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCellModemStatus {
@@ -1027,12 +1055,12 @@ pub struct MsgCellModemStatus {
 }
 
 impl MsgCellModemStatus {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCellModemStatus, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCellModemStatus, crate::Error> {
         Ok(MsgCellModemStatus {
             sender_id: None,
             signal_strength: _buf.read_i8()?,
             signal_error_rate: _buf.read_f32::<LittleEndian>()?,
-            reserved: ::parser::read_u8_array(_buf)?,
+            reserved: crate::parser::read_u8_array(_buf)?,
         })
     }
 }
@@ -1057,6 +1085,7 @@ impl super::SBPMessage for MsgCellModemStatus {
 /// in the frontend. A gain of 127 percent encodes that rf channel is not present in the hardware.
 /// A negative value implies an error for the particular gain stage as reported by the frontend.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgFrontEndGain {
@@ -1068,11 +1097,11 @@ pub struct MsgFrontEndGain {
 }
 
 impl MsgFrontEndGain {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFrontEndGain, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFrontEndGain, crate::Error> {
         Ok(MsgFrontEndGain {
             sender_id: None,
-            rf_gain: ::parser::read_s8_array_limit(_buf, 8)?,
-            if_gain: ::parser::read_s8_array_limit(_buf, 8)?,
+            rf_gain: crate::parser::read_s8_array_limit(_buf, 8)?,
+            if_gain: crate::parser::read_s8_array_limit(_buf, 8)?,
         })
     }
 }
@@ -1094,6 +1123,7 @@ impl super::SBPMessage for MsgFrontEndGain {
 /// CW interference channel on the SwiftNAP. This message will be
 /// removed in a future release.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCwResults {
@@ -1101,7 +1131,7 @@ pub struct MsgCwResults {
 }
 
 impl MsgCwResults {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCwResults, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCwResults, crate::Error> {
         Ok(MsgCwResults { sender_id: None })
     }
 }
@@ -1123,6 +1153,7 @@ impl super::SBPMessage for MsgCwResults {
 /// the CW interference channel on the SwiftNAP. This message will
 /// be removed in a future release.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCwStart {
@@ -1130,7 +1161,7 @@ pub struct MsgCwStart {
 }
 
 impl MsgCwStart {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCwStart, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCwStart, crate::Error> {
         Ok(MsgCwStart { sender_id: None })
     }
 }

--- a/rust/sbp/src/messages/sbas.rs
+++ b/rust/sbp/src/messages/sbas.rs
@@ -18,12 +18,15 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Raw SBAS data
 ///
 /// This message is sent once per second per SBAS satellite. ME checks the
 /// parity of the data block and sends only blocks that pass the check.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSbasRaw {
@@ -39,13 +42,13 @@ pub struct MsgSbasRaw {
 }
 
 impl MsgSbasRaw {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSbasRaw, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSbasRaw, crate::Error> {
         Ok(MsgSbasRaw {
             sender_id: None,
             sid: GnssSignal::parse(_buf)?,
             tow: _buf.read_u32::<LittleEndian>()?,
             message_type: _buf.read_u8()?,
-            data: ::parser::read_u8_array_limit(_buf, 27)?,
+            data: crate::parser::read_u8_array_limit(_buf, 27)?,
         })
     }
 }

--- a/rust/sbp/src/messages/settings.rs
+++ b/rust/sbp/src/messages/settings.rs
@@ -43,6 +43,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Write device configuration settings (host => device)
 ///
@@ -54,6 +56,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// An example string that could be sent to a device is
 /// "solution\0soln_freq\010\0".
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsWrite {
@@ -64,10 +67,10 @@ pub struct MsgSettingsWrite {
 }
 
 impl MsgSettingsWrite {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsWrite, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsWrite, crate::Error> {
         Ok(MsgSettingsWrite {
             sender_id: None,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -88,6 +91,7 @@ impl super::SBPMessage for MsgSettingsWrite {
 /// The save settings message persists the device's current settings
 /// configuration to its onboard flash memory file system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsSave {
@@ -95,7 +99,7 @@ pub struct MsgSettingsSave {
 }
 
 impl MsgSettingsSave {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsSave, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsSave, crate::Error> {
         Ok(MsgSettingsSave { sender_id: None })
     }
 }
@@ -117,6 +121,7 @@ impl super::SBPMessage for MsgSettingsSave {
 /// values. A device will respond to this message with a
 /// "MSG_SETTINGS_READ_BY_INDEX_RESP".
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsReadByIndexReq {
@@ -127,7 +132,7 @@ pub struct MsgSettingsReadByIndexReq {
 }
 
 impl MsgSettingsReadByIndexReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexReq, crate::Error> {
         Ok(MsgSettingsReadByIndexReq {
             sender_id: None,
             index: _buf.read_u16::<LittleEndian>()?,
@@ -157,6 +162,7 @@ impl super::SBPMessage for MsgSettingsReadByIndexReq {
 /// sender ID 0x42. A device should respond with a MSG_SETTINGS_READ_RESP
 /// message (msg_id 0x00A5).
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsReadReq {
@@ -167,10 +173,10 @@ pub struct MsgSettingsReadReq {
 }
 
 impl MsgSettingsReadReq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadReq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadReq, crate::Error> {
         Ok(MsgSettingsReadReq {
             sender_id: None,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -196,6 +202,7 @@ impl super::SBPMessage for MsgSettingsReadReq {
 /// example string that could be sent from device is
 /// "solution\0soln_freq\010\0".
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsReadResp {
@@ -206,10 +213,10 @@ pub struct MsgSettingsReadResp {
 }
 
 impl MsgSettingsReadResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadResp, crate::Error> {
         Ok(MsgSettingsReadResp {
             sender_id: None,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -229,6 +236,7 @@ impl super::SBPMessage for MsgSettingsReadResp {
 ///
 /// The settings message for indicating end of the settings values.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsReadByIndexDone {
@@ -236,7 +244,7 @@ pub struct MsgSettingsReadByIndexDone {
 }
 
 impl MsgSettingsReadByIndexDone {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexDone, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexDone, crate::Error> {
         Ok(MsgSettingsReadByIndexDone { sender_id: None })
     }
 }
@@ -265,6 +273,7 @@ impl super::SBPMessage for MsgSettingsReadByIndexDone {
 /// "enum:value1,value2,value3". An example string that could be sent from
 /// the device is "simulator\0enabled\0True\0enum:True,False\0"
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsReadByIndexResp {
@@ -278,11 +287,11 @@ pub struct MsgSettingsReadByIndexResp {
 }
 
 impl MsgSettingsReadByIndexResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexResp, crate::Error> {
         Ok(MsgSettingsReadByIndexResp {
             sender_id: None,
             index: _buf.read_u16::<LittleEndian>()?,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -304,6 +313,7 @@ impl super::SBPMessage for MsgSettingsReadByIndexResp {
 /// with a settings daemon.  The host should reply with MSG_SETTINGS_WRITE
 /// for this setting to set the initial value.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsRegister {
@@ -314,10 +324,10 @@ pub struct MsgSettingsRegister {
 }
 
 impl MsgSettingsRegister {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsRegister, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsRegister, crate::Error> {
         Ok(MsgSettingsRegister {
             sender_id: None,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -343,6 +353,7 @@ impl super::SBPMessage for MsgSettingsRegister {
 /// are omitted. An example string that could be sent from device is
 /// "solution\0soln_freq\010\0".
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsWriteResp {
@@ -355,11 +366,11 @@ pub struct MsgSettingsWriteResp {
 }
 
 impl MsgSettingsWriteResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsWriteResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsWriteResp, crate::Error> {
         Ok(MsgSettingsWriteResp {
             sender_id: None,
             status: _buf.read_u8()?,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -382,6 +393,7 @@ impl super::SBPMessage for MsgSettingsWriteResp {
 /// was already registered or is available in the permanent setting storage
 /// and had a different value.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSettingsRegisterResp {
@@ -395,11 +407,11 @@ pub struct MsgSettingsRegisterResp {
 }
 
 impl MsgSettingsRegisterResp {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsRegisterResp, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsRegisterResp, crate::Error> {
         Ok(MsgSettingsRegisterResp {
             sender_id: None,
             status: _buf.read_u8()?,
-            setting: ::parser::read_string(_buf)?,
+            setting: crate::parser::read_string(_buf)?,
         })
     }
 }

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -18,12 +18,15 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// SSR code biases corrections for a particular satellite.
 ///
 /// Code biases are to be added to pseudorange.
 /// The corrections conform with typical RTCMv3 MT1059 and 1065.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct CodeBiasesContent {
@@ -34,13 +37,13 @@ pub struct CodeBiasesContent {
 }
 
 impl CodeBiasesContent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<CodeBiasesContent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<CodeBiasesContent, crate::Error> {
         Ok(CodeBiasesContent {
             code: _buf.read_u8()?,
             value: _buf.read_i16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CodeBiasesContent>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CodeBiasesContent>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(CodeBiasesContent::parse(buf)?);
@@ -48,7 +51,10 @@ impl CodeBiasesContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<CodeBiasesContent>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<CodeBiasesContent>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(CodeBiasesContent::parse(buf)?);
@@ -62,6 +68,7 @@ impl CodeBiasesContent {
 /// Phase biases are to be added to carrier phase measurements.
 /// The corrections conform with typical RTCMv3 MT1059 and 1065.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct PhaseBiasesContent {
@@ -79,7 +86,7 @@ pub struct PhaseBiasesContent {
 }
 
 impl PhaseBiasesContent {
-    pub fn parse(_buf: &mut &[u8]) -> Result<PhaseBiasesContent, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<PhaseBiasesContent, crate::Error> {
         Ok(PhaseBiasesContent {
             code: _buf.read_u8()?,
             integer_indicator: _buf.read_u8()?,
@@ -88,7 +95,7 @@ impl PhaseBiasesContent {
             bias: _buf.read_i32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PhaseBiasesContent>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PhaseBiasesContent>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(PhaseBiasesContent::parse(buf)?);
@@ -99,7 +106,7 @@ impl PhaseBiasesContent {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<PhaseBiasesContent>, ::Error> {
+    ) -> Result<Vec<PhaseBiasesContent>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(PhaseBiasesContent::parse(buf)?);
@@ -114,6 +121,7 @@ impl PhaseBiasesContent {
 /// messages, since SBP message a limited to 255 bytes.  The header
 /// is used to tie multiple SBP messages into a sequence.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct STECHeader {
@@ -131,7 +139,7 @@ pub struct STECHeader {
 }
 
 impl STECHeader {
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECHeader, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<STECHeader, crate::Error> {
         Ok(STECHeader {
             time: GPSTimeSec::parse(_buf)?,
             num_msgs: _buf.read_u8()?,
@@ -140,7 +148,7 @@ impl STECHeader {
             iod_atmo: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECHeader>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECHeader>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(STECHeader::parse(buf)?);
@@ -148,7 +156,7 @@ impl STECHeader {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECHeader>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECHeader>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(STECHeader::parse(buf)?);
@@ -163,6 +171,7 @@ impl STECHeader {
 /// which are not suppported in SBP, so each grid point will
 /// be identified by the index.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GriddedCorrectionHeader {
@@ -183,7 +192,7 @@ pub struct GriddedCorrectionHeader {
 }
 
 impl GriddedCorrectionHeader {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GriddedCorrectionHeader, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GriddedCorrectionHeader, crate::Error> {
         Ok(GriddedCorrectionHeader {
             time: GPSTimeSec::parse(_buf)?,
             num_msgs: _buf.read_u16::<LittleEndian>()?,
@@ -193,7 +202,7 @@ impl GriddedCorrectionHeader {
             tropo_quality_indicator: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GriddedCorrectionHeader>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GriddedCorrectionHeader>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GriddedCorrectionHeader::parse(buf)?);
@@ -204,7 +213,7 @@ impl GriddedCorrectionHeader {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<GriddedCorrectionHeader>, ::Error> {
+    ) -> Result<Vec<GriddedCorrectionHeader>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GriddedCorrectionHeader::parse(buf)?);
@@ -217,6 +226,7 @@ impl GriddedCorrectionHeader {
 ///
 /// STEC polynomial for the given satellite.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct STECSatElement {
@@ -230,14 +240,14 @@ pub struct STECSatElement {
 }
 
 impl STECSatElement {
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECSatElement, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<STECSatElement, crate::Error> {
         Ok(STECSatElement {
             sv_id: SvId::parse(_buf)?,
             stec_quality_indicator: _buf.read_u8()?,
-            stec_coeff: ::parser::read_s16_array_limit(_buf, 4)?,
+            stec_coeff: crate::parser::read_s16_array_limit(_buf, 4)?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECSatElement>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECSatElement>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(STECSatElement::parse(buf)?);
@@ -245,7 +255,10 @@ impl STECSatElement {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECSatElement>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<STECSatElement>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(STECSatElement::parse(buf)?);
@@ -258,6 +271,7 @@ impl STECSatElement {
 ///
 /// Troposphere vertical delays at the grid point.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct TroposphericDelayCorrection {
@@ -268,13 +282,13 @@ pub struct TroposphericDelayCorrection {
 }
 
 impl TroposphericDelayCorrection {
-    pub fn parse(_buf: &mut &[u8]) -> Result<TroposphericDelayCorrection, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<TroposphericDelayCorrection, crate::Error> {
         Ok(TroposphericDelayCorrection {
             hydro: _buf.read_i16::<LittleEndian>()?,
             wet: _buf.read_i8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TroposphericDelayCorrection>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TroposphericDelayCorrection>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(TroposphericDelayCorrection::parse(buf)?);
@@ -285,7 +299,7 @@ impl TroposphericDelayCorrection {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<TroposphericDelayCorrection>, ::Error> {
+    ) -> Result<Vec<TroposphericDelayCorrection>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(TroposphericDelayCorrection::parse(buf)?);
@@ -298,6 +312,7 @@ impl TroposphericDelayCorrection {
 ///
 /// STEC residual for the given satellite at the grid point.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct STECResidual {
@@ -308,13 +323,13 @@ pub struct STECResidual {
 }
 
 impl STECResidual {
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECResidual, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<STECResidual, crate::Error> {
         Ok(STECResidual {
             sv_id: SvId::parse(_buf)?,
             residual: _buf.read_i16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECResidual>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECResidual>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(STECResidual::parse(buf)?);
@@ -322,7 +337,7 @@ impl STECResidual {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECResidual>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECResidual>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(STECResidual::parse(buf)?);
@@ -336,6 +351,7 @@ impl STECResidual {
 /// Contains one tropo delay, plus STEC residuals for each satellite at the
 /// grid point.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GridElement {
@@ -348,14 +364,14 @@ pub struct GridElement {
 }
 
 impl GridElement {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GridElement, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GridElement, crate::Error> {
         Ok(GridElement {
             index: _buf.read_u16::<LittleEndian>()?,
             tropo_delay_correction: TroposphericDelayCorrection::parse(_buf)?,
             stec_residuals: STECResidual::parse_array(_buf)?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridElement>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridElement>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GridElement::parse(buf)?);
@@ -363,7 +379,7 @@ impl GridElement {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GridElement>, ::Error> {
+    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GridElement>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GridElement::parse(buf)?);
@@ -377,6 +393,7 @@ impl GridElement {
 /// Defines the grid for MSG_SSR_GRIDDED_CORRECTION messages.
 /// Also includes an RLE encoded validity list.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct GridDefinitionHeader {
@@ -397,7 +414,7 @@ pub struct GridDefinitionHeader {
 }
 
 impl GridDefinitionHeader {
-    pub fn parse(_buf: &mut &[u8]) -> Result<GridDefinitionHeader, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<GridDefinitionHeader, crate::Error> {
         Ok(GridDefinitionHeader {
             region_size_inverse: _buf.read_u8()?,
             area_width: _buf.read_u16::<LittleEndian>()?,
@@ -407,7 +424,7 @@ impl GridDefinitionHeader {
             seq_num: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridDefinitionHeader>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridDefinitionHeader>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(GridDefinitionHeader::parse(buf)?);
@@ -418,7 +435,7 @@ impl GridDefinitionHeader {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<GridDefinitionHeader>, ::Error> {
+    ) -> Result<Vec<GridDefinitionHeader>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(GridDefinitionHeader::parse(buf)?);
@@ -434,6 +451,7 @@ impl GridDefinitionHeader {
 /// ephemeris and is typically an equivalent to the 1060
 /// and 1066 RTCM message types
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrOrbitClockDepA {
@@ -471,7 +489,7 @@ pub struct MsgSsrOrbitClockDepA {
 }
 
 impl MsgSsrOrbitClockDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrOrbitClockDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrOrbitClockDepA, crate::Error> {
         Ok(MsgSsrOrbitClockDepA {
             sender_id: None,
             time: GPSTimeSec::parse(_buf)?,
@@ -510,6 +528,7 @@ impl super::SBPMessage for MsgSsrOrbitClockDepA {
 /// ephemeris and is typically an equivalent to the 1060
 /// and 1066 RTCM message types
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrOrbitClock {
@@ -547,7 +566,7 @@ pub struct MsgSsrOrbitClock {
 }
 
 impl MsgSsrOrbitClock {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrOrbitClock, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrOrbitClock, crate::Error> {
         Ok(MsgSsrOrbitClock {
             sender_id: None,
             time: GPSTimeSec::parse(_buf)?,
@@ -586,6 +605,7 @@ impl super::SBPMessage for MsgSsrOrbitClock {
 /// to get corrected pseudorange. It is typically
 /// an equivalent to the 1059 and 1065 RTCM message types
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrCodeBiases {
@@ -605,7 +625,7 @@ pub struct MsgSsrCodeBiases {
 }
 
 impl MsgSsrCodeBiases {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrCodeBiases, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrCodeBiases, crate::Error> {
         Ok(MsgSsrCodeBiases {
             sender_id: None,
             time: GPSTimeSec::parse(_buf)?,
@@ -637,6 +657,7 @@ impl super::SBPMessage for MsgSsrCodeBiases {
 /// the phase wind-up correction.
 /// It is typically an equivalent to the 1265 RTCM message types
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrPhaseBiases {
@@ -664,7 +685,7 @@ pub struct MsgSsrPhaseBiases {
 }
 
 impl MsgSsrPhaseBiases {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrPhaseBiases, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrPhaseBiases, crate::Error> {
         Ok(MsgSsrPhaseBiases {
             sender_id: None,
             time: GPSTimeSec::parse(_buf)?,
@@ -698,6 +719,7 @@ impl super::SBPMessage for MsgSsrPhaseBiases {
 /// message to get the state space representation of the atmospheric
 /// delay. It is typically equivalent to the QZSS CLAS Sub Type 8 messages
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrStecCorrection {
@@ -709,7 +731,7 @@ pub struct MsgSsrStecCorrection {
 }
 
 impl MsgSsrStecCorrection {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrStecCorrection, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrStecCorrection, crate::Error> {
         Ok(MsgSsrStecCorrection {
             sender_id: None,
             header: STECHeader::parse(_buf)?,
@@ -734,6 +756,7 @@ impl super::SBPMessage for MsgSsrStecCorrection {
 /// STEC residuals are per space vehicle, tropo is not.
 /// It is typically equivalent to the QZSS CLAS Sub Type 9 messages
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrGriddedCorrection {
@@ -745,7 +768,7 @@ pub struct MsgSsrGriddedCorrection {
 }
 
 impl MsgSsrGriddedCorrection {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGriddedCorrection, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGriddedCorrection, crate::Error> {
         Ok(MsgSsrGriddedCorrection {
             sender_id: None,
             header: GriddedCorrectionHeader::parse(_buf)?,
@@ -770,6 +793,7 @@ impl super::SBPMessage for MsgSsrGriddedCorrection {
 /// Based on the 3GPP proposal R2-1906781 which is in turn based on
 /// OMA-LPPe-ValidityArea from OMA-TS-LPPe-V2_0-20141202-C
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgSsrGridDefinition {
@@ -784,11 +808,11 @@ pub struct MsgSsrGridDefinition {
 }
 
 impl MsgSsrGridDefinition {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGridDefinition, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGridDefinition, crate::Error> {
         Ok(MsgSsrGridDefinition {
             sender_id: None,
             header: GridDefinitionHeader::parse(_buf)?,
-            rle_list: ::parser::read_u8_array(_buf)?,
+            rle_list: crate::parser::read_u8_array(_buf)?,
         })
     }
 }

--- a/rust/sbp/src/messages/system.rs
+++ b/rust/sbp/src/messages/system.rs
@@ -17,6 +17,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// System start-up message
 ///
@@ -25,6 +27,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// the system has started and is now ready to respond to commands
 /// or configuration requests.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgStartup {
@@ -38,7 +41,7 @@ pub struct MsgStartup {
 }
 
 impl MsgStartup {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStartup, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStartup, crate::Error> {
         Ok(MsgStartup {
             sender_id: None,
             cause: _buf.read_u8()?,
@@ -65,6 +68,7 @@ impl super::SBPMessage for MsgStartup {
 /// corrections.  It is expected to be sent with each receipt of a complete
 /// corrections packet.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgDgnssStatus {
@@ -80,13 +84,13 @@ pub struct MsgDgnssStatus {
 }
 
 impl MsgDgnssStatus {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDgnssStatus, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDgnssStatus, crate::Error> {
         Ok(MsgDgnssStatus {
             sender_id: None,
             flags: _buf.read_u8()?,
             latency: _buf.read_u16::<LittleEndian>()?,
             num_signals: _buf.read_u8()?,
-            source: ::parser::read_string(_buf)?,
+            source: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -107,6 +111,7 @@ impl super::SBPMessage for MsgDgnssStatus {
 /// The INS status message describes the state of the operation
 /// and initialization of the inertial navigation system.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgInsStatus {
@@ -116,7 +121,7 @@ pub struct MsgInsStatus {
 }
 
 impl MsgInsStatus {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInsStatus, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInsStatus, crate::Error> {
         Ok(MsgInsStatus {
             sender_id: None,
             flags: _buf.read_u32::<LittleEndian>()?,
@@ -141,6 +146,7 @@ impl super::SBPMessage for MsgInsStatus {
 /// from a device. It is not produced or available on general Swift Products.
 /// It is intended to be a low rate message for status purposes.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCsacTelemetry {
@@ -153,11 +159,11 @@ pub struct MsgCsacTelemetry {
 }
 
 impl MsgCsacTelemetry {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCsacTelemetry, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCsacTelemetry, crate::Error> {
         Ok(MsgCsacTelemetry {
             sender_id: None,
             id: _buf.read_u8()?,
-            telemetry: ::parser::read_string(_buf)?,
+            telemetry: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -179,6 +185,7 @@ impl super::SBPMessage for MsgCsacTelemetry {
 /// produced by MSG_CSAC_TELEMETRY. It should be provided by a device at a lower
 /// rate than the MSG_CSAC_TELEMETRY.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgCsacTelemetryLabels {
@@ -191,11 +198,11 @@ pub struct MsgCsacTelemetryLabels {
 }
 
 impl MsgCsacTelemetryLabels {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCsacTelemetryLabels, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCsacTelemetryLabels, crate::Error> {
         Ok(MsgCsacTelemetryLabels {
             sender_id: None,
             id: _buf.read_u8()?,
-            telemetry_labels: ::parser::read_string(_buf)?,
+            telemetry_labels: crate::parser::read_string(_buf)?,
         })
     }
 }
@@ -224,6 +231,7 @@ impl super::SBPMessage for MsgCsacTelemetryLabels {
 /// occurred in the system. To determine the source of the error,
 /// the remaining error flags should be inspected.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgHeartbeat {
@@ -233,7 +241,7 @@ pub struct MsgHeartbeat {
 }
 
 impl MsgHeartbeat {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgHeartbeat, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgHeartbeat, crate::Error> {
         Ok(MsgHeartbeat {
             sender_id: None,
             flags: _buf.read_u32::<LittleEndian>()?,

--- a/rust/sbp/src/messages/tracking.rs
+++ b/rust/sbp/src/messages/tracking.rs
@@ -19,12 +19,15 @@ extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
 use super::gnss::*;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Signal tracking channel state
 ///
 /// Tracking channel state for a specific satellite signal and
 /// measured signal power.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct TrackingChannelState {
@@ -37,14 +40,14 @@ pub struct TrackingChannelState {
 }
 
 impl TrackingChannelState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelState, crate::Error> {
         Ok(TrackingChannelState {
             sid: GnssSignal::parse(_buf)?,
             fcn: _buf.read_u8()?,
             cn0: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelState>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelState>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(TrackingChannelState::parse(buf)?);
@@ -55,7 +58,7 @@ impl TrackingChannelState {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<TrackingChannelState>, ::Error> {
+    ) -> Result<Vec<TrackingChannelState>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(TrackingChannelState::parse(buf)?);
@@ -72,6 +75,7 @@ impl TrackingChannelState {
 /// carry the FCN as 100 + FCN where FCN is in [-7, +6] or
 /// the Slot ID (from 1 to 28)
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MeasurementState {
@@ -83,13 +87,13 @@ pub struct MeasurementState {
 }
 
 impl MeasurementState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MeasurementState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MeasurementState, crate::Error> {
         Ok(MeasurementState {
             mesid: GnssSignal::parse(_buf)?,
             cn0: _buf.read_u8()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<MeasurementState>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<MeasurementState>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(MeasurementState::parse(buf)?);
@@ -97,7 +101,10 @@ impl MeasurementState {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<MeasurementState>, ::Error> {
+    pub fn parse_array_limit(
+        buf: &mut &[u8],
+        n: usize,
+    ) -> Result<Vec<MeasurementState>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(MeasurementState::parse(buf)?);
@@ -110,6 +117,7 @@ impl MeasurementState {
 ///
 /// Structure containing in-phase and quadrature correlation components.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct TrackingChannelCorrelation {
@@ -120,13 +128,13 @@ pub struct TrackingChannelCorrelation {
 }
 
 impl TrackingChannelCorrelation {
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelCorrelation, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelCorrelation, crate::Error> {
         Ok(TrackingChannelCorrelation {
             I: _buf.read_i16::<LittleEndian>()?,
             Q: _buf.read_i16::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelCorrelation>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelCorrelation>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(TrackingChannelCorrelation::parse(buf)?);
@@ -137,7 +145,7 @@ impl TrackingChannelCorrelation {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<TrackingChannelCorrelation>, ::Error> {
+    ) -> Result<Vec<TrackingChannelCorrelation>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(TrackingChannelCorrelation::parse(buf)?);
@@ -150,6 +158,7 @@ impl TrackingChannelCorrelation {
 ///
 /// Structure containing in-phase and quadrature correlation components.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct TrackingChannelCorrelationDep {
@@ -160,13 +169,15 @@ pub struct TrackingChannelCorrelationDep {
 }
 
 impl TrackingChannelCorrelationDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelCorrelationDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelCorrelationDep, crate::Error> {
         Ok(TrackingChannelCorrelationDep {
             I: _buf.read_i32::<LittleEndian>()?,
             Q: _buf.read_i32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelCorrelationDep>, ::Error> {
+    pub fn parse_array(
+        buf: &mut &[u8],
+    ) -> Result<Vec<TrackingChannelCorrelationDep>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(TrackingChannelCorrelationDep::parse(buf)?);
@@ -177,7 +188,7 @@ impl TrackingChannelCorrelationDep {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<TrackingChannelCorrelationDep>, ::Error> {
+    ) -> Result<Vec<TrackingChannelCorrelationDep>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(TrackingChannelCorrelationDep::parse(buf)?);
@@ -190,6 +201,7 @@ impl TrackingChannelCorrelationDep {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct TrackingChannelStateDepA {
@@ -202,14 +214,14 @@ pub struct TrackingChannelStateDepA {
 }
 
 impl TrackingChannelStateDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelStateDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelStateDepA, crate::Error> {
         Ok(TrackingChannelStateDepA {
             state: _buf.read_u8()?,
             prn: _buf.read_u8()?,
             cn0: _buf.read_f32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelStateDepA>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelStateDepA>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(TrackingChannelStateDepA::parse(buf)?);
@@ -220,7 +232,7 @@ impl TrackingChannelStateDepA {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<TrackingChannelStateDepA>, ::Error> {
+    ) -> Result<Vec<TrackingChannelStateDepA>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(TrackingChannelStateDepA::parse(buf)?);
@@ -233,6 +245,7 @@ impl TrackingChannelStateDepA {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct TrackingChannelStateDepB {
@@ -245,14 +258,14 @@ pub struct TrackingChannelStateDepB {
 }
 
 impl TrackingChannelStateDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelStateDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelStateDepB, crate::Error> {
         Ok(TrackingChannelStateDepB {
             state: _buf.read_u8()?,
             sid: GnssSignalDep::parse(_buf)?,
             cn0: _buf.read_f32::<LittleEndian>()?,
         })
     }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelStateDepB>, ::Error> {
+    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelStateDepB>, crate::Error> {
         let mut v = Vec::new();
         while buf.len() > 0 {
             v.push(TrackingChannelStateDepB::parse(buf)?);
@@ -263,7 +276,7 @@ impl TrackingChannelStateDepB {
     pub fn parse_array_limit(
         buf: &mut &[u8],
         n: usize,
-    ) -> Result<Vec<TrackingChannelStateDepB>, ::Error> {
+    ) -> Result<Vec<TrackingChannelStateDepB>, crate::Error> {
         let mut v = Vec::new();
         for _ in 0..n {
             v.push(TrackingChannelStateDepB::parse(buf)?);
@@ -276,6 +289,7 @@ impl TrackingChannelStateDepB {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingStateDetailedDep {
@@ -331,7 +345,7 @@ pub struct MsgTrackingStateDetailedDep {
 }
 
 impl MsgTrackingStateDetailedDep {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDetailedDep, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDetailedDep, crate::Error> {
         Ok(MsgTrackingStateDetailedDep {
             sender_id: None,
             recv_time: _buf.read_u64::<LittleEndian>()?,
@@ -374,6 +388,7 @@ impl super::SBPMessage for MsgTrackingStateDetailedDep {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingStateDepB {
@@ -383,7 +398,7 @@ pub struct MsgTrackingStateDepB {
 }
 
 impl MsgTrackingStateDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDepB, crate::Error> {
         Ok(MsgTrackingStateDepB {
             sender_id: None,
             states: TrackingChannelStateDepB::parse_array(_buf)?,
@@ -406,6 +421,7 @@ impl super::SBPMessage for MsgTrackingStateDepB {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingStateDepA {
@@ -415,7 +431,7 @@ pub struct MsgTrackingStateDepA {
 }
 
 impl MsgTrackingStateDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDepA, crate::Error> {
         Ok(MsgTrackingStateDepA {
             sender_id: None,
             states: TrackingChannelStateDepA::parse_array(_buf)?,
@@ -438,6 +454,7 @@ impl super::SBPMessage for MsgTrackingStateDepA {
 ///
 /// Deprecated.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingIqDepA {
@@ -451,7 +468,7 @@ pub struct MsgTrackingIqDepA {
 }
 
 impl MsgTrackingIqDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIqDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIqDepA, crate::Error> {
         Ok(MsgTrackingIqDepA {
             sender_id: None,
             channel: _buf.read_u8()?,
@@ -477,6 +494,7 @@ impl super::SBPMessage for MsgTrackingIqDepA {
 /// The tracking message returns a set tracking channel parameters for a
 /// single tracking channel useful for debugging issues.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingStateDetailedDepA {
@@ -532,7 +550,7 @@ pub struct MsgTrackingStateDetailedDepA {
 }
 
 impl MsgTrackingStateDetailedDepA {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDetailedDepA, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDetailedDepA, crate::Error> {
         Ok(MsgTrackingStateDetailedDepA {
             sender_id: None,
             recv_time: _buf.read_u64::<LittleEndian>()?,
@@ -576,6 +594,7 @@ impl super::SBPMessage for MsgTrackingStateDetailedDepA {
 /// When enabled, a tracking channel can output the correlations at each
 /// update interval.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingIqDepB {
@@ -589,7 +608,7 @@ pub struct MsgTrackingIqDepB {
 }
 
 impl MsgTrackingIqDepB {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIqDepB, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIqDepB, crate::Error> {
         Ok(MsgTrackingIqDepB {
             sender_id: None,
             channel: _buf.read_u8()?,
@@ -615,6 +634,7 @@ impl super::SBPMessage for MsgTrackingIqDepB {
 /// When enabled, a tracking channel can output the correlations at each
 /// update interval.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingIq {
@@ -628,7 +648,7 @@ pub struct MsgTrackingIq {
 }
 
 impl MsgTrackingIq {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIq, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIq, crate::Error> {
         Ok(MsgTrackingIq {
             sender_id: None,
             channel: _buf.read_u8()?,
@@ -655,6 +675,7 @@ impl super::SBPMessage for MsgTrackingIq {
 /// channel states. It reports status and carrier-to-noise density
 /// measurements for all tracked satellites.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgTrackingState {
@@ -664,7 +685,7 @@ pub struct MsgTrackingState {
 }
 
 impl MsgTrackingState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingState, crate::Error> {
         Ok(MsgTrackingState {
             sender_id: None,
             states: TrackingChannelState::parse_array(_buf)?,
@@ -689,6 +710,7 @@ impl super::SBPMessage for MsgTrackingState {
 /// channel states. It reports status and carrier-to-noise density
 /// measurements for all tracked satellites.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgMeasurementState {
@@ -698,7 +720,7 @@ pub struct MsgMeasurementState {
 }
 
 impl MsgMeasurementState {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMeasurementState, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMeasurementState, crate::Error> {
         Ok(MsgMeasurementState {
             sender_id: None,
             states: MeasurementState::parse_array(_buf)?,

--- a/rust/sbp/src/messages/user.rs
+++ b/rust/sbp/src/messages/user.rs
@@ -18,12 +18,15 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// User data
 ///
 /// This message can contain any application specific user data up to a
 /// maximum length of 255 bytes per message.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgUserData {
@@ -33,10 +36,10 @@ pub struct MsgUserData {
 }
 
 impl MsgUserData {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUserData, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUserData, crate::Error> {
         Ok(MsgUserData {
             sender_id: None,
-            contents: ::parser::read_u8_array(_buf)?,
+            contents: crate::parser::read_u8_array(_buf)?,
         })
     }
 }

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -17,6 +17,8 @@
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Vehicle forward (x-axis) velocity
 ///
@@ -26,6 +28,7 @@ use self::byteorder::{LittleEndian, ReadBytesExt};
 /// There are 4 possible user-defined sources of this message  which are labeled arbitrarily
 /// source 0 through 3.
 ///
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct MsgOdometry {
@@ -41,7 +44,7 @@ pub struct MsgOdometry {
 }
 
 impl MsgOdometry {
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOdometry, ::Error> {
+    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOdometry, crate::Error> {
         Ok(MsgOdometry {
             sender_id: None,
             tow: _buf.read_u32::<LittleEndian>()?,

--- a/rust/sbp/src/parser/mod.rs
+++ b/rust/sbp/src/parser/mod.rs
@@ -8,7 +8,7 @@ use self::nom::bytes::complete::is_a;
 use self::nom::multi::length_data;
 use self::nom::number::complete::{le_u16, le_u8};
 use self::nom::sequence::tuple;
-use messages::SBP;
+use crate::messages::SBP;
 use std::io::{self, Read};
 
 /// Attempts to extract a single SBP message from a data
@@ -21,7 +21,7 @@ use std::io::{self, Read};
 /// removed from the slice before calling `frame()` again.
 /// If the result is a
 /// success then the SBP message has been fully validated.
-pub fn frame(input: &[u8]) -> (Result<SBP, ::Error>, usize) {
+pub fn frame(input: &[u8]) -> (Result<SBP, crate::Error>, usize) {
     let original_size = input.len();
     let preamble = is_a("\x55");
     let payload = length_data(le_u8);
@@ -42,15 +42,15 @@ pub fn frame(input: &[u8]) -> (Result<SBP, ::Error>, usize) {
                     bytes_read,
                 )
             } else {
-                (Err(::Error::ParseError), 1)
+                (Err(crate::Error::ParseError), 1)
             }
         }
         // Act like we didn't read anything
-        Err(self::nom::Err::Incomplete(_)) => (Err(::Error::NotEnoughData), 0),
+        Err(self::nom::Err::Incomplete(_)) => (Err(crate::Error::NotEnoughData), 0),
         // Act like we only read a single byte
-        Err(self::nom::Err::Error((_, _))) => (Err(::Error::ParseError), 1),
+        Err(self::nom::Err::Error((_, _))) => (Err(crate::Error::ParseError), 1),
         // Act like we didn't read anything
-        Err(self::nom::Err::Failure((_, _))) => (Err(::Error::UnrecoverableFailure), 0),
+        Err(self::nom::Err::Failure((_, _))) => (Err(crate::Error::UnrecoverableFailure), 0),
     }
 }
 
@@ -80,7 +80,7 @@ impl Parser {
     /// as needed
     /// until either a message is successfully parsed or an
     /// error occurs
-    pub fn parse<R: Read>(&mut self, input: &mut R) -> Result<SBP, ::Error> {
+    pub fn parse<R: Read>(&mut self, input: &mut R) -> Result<SBP, crate::Error> {
         if self.buffer.len() == 0 {
             self.read_more(input)?;
         }
@@ -88,9 +88,9 @@ impl Parser {
         let result = loop {
             match self.parse_remaining() {
                 Ok(msg) => break Ok(msg),
-                Err(::Error::NotEnoughData) => {
+                Err(crate::Error::NotEnoughData) => {
                     if let Err(e) = self.read_more(input) {
-                        break Err(::Error::IoError(e));
+                        break Err(crate::Error::IoError(e));
                     }
                 }
                 Err(e) => break Err(e),
@@ -107,7 +107,7 @@ impl Parser {
         Ok(read_bytes)
     }
 
-    fn parse_remaining(&mut self) -> Result<SBP, ::Error> {
+    fn parse_remaining(&mut self) -> Result<SBP, crate::Error> {
         loop {
             let result = frame(&self.buffer);
 
@@ -116,7 +116,7 @@ impl Parser {
                     self.buffer = self.buffer[bytes_read..].to_vec();
                     break Ok(msg);
                 }
-                (Err(::Error::ParseError), bytes_read) => {
+                (Err(crate::Error::ParseError), bytes_read) => {
                     self.buffer = self.buffer[bytes_read..].to_vec();
                 }
                 (Err(e), _bytes_read) => break Err(e),
@@ -125,27 +125,27 @@ impl Parser {
     }
 }
 
-impl From<io::Error> for ::Error {
+impl From<io::Error> for crate::Error {
     fn from(error: io::Error) -> Self {
-        ::Error::IoError(error)
+        crate::Error::IoError(error)
     }
 }
 
-pub fn read_string(buf: &mut Read) -> Result<String, ::Error> {
+pub fn read_string(buf: &mut dyn Read) -> Result<String, crate::Error> {
     let mut s = String::new();
     buf.read_to_string(&mut s)?;
     Ok(s)
 }
 
-pub fn read_string_limit(buf: &mut Read, n: u64) -> Result<String, ::Error> {
+pub fn read_string_limit(buf: &mut dyn Read, n: u64) -> Result<String, crate::Error> {
     read_string(&mut buf.take(n))
 }
 
-pub fn read_u8_array(buf: &mut &[u8]) -> Result<Vec<u8>, ::Error> {
+pub fn read_u8_array(buf: &mut &[u8]) -> Result<Vec<u8>, crate::Error> {
     Ok(buf.to_vec())
 }
 
-pub fn read_u8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u8>, ::Error> {
+pub fn read_u8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u8>, crate::Error> {
     let mut v = Vec::new();
     for _ in 0..n {
         v.push(buf.read_u8()?);
@@ -153,7 +153,7 @@ pub fn read_u8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u8>, ::Error
     Ok(v)
 }
 
-pub fn read_s8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i8>, ::Error> {
+pub fn read_s8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i8>, crate::Error> {
     let mut v = Vec::new();
     for _ in 0..n {
         v.push(buf.read_i8()?);
@@ -161,7 +161,7 @@ pub fn read_s8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i8>, ::Error
     Ok(v)
 }
 
-pub fn read_s16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i16>, ::Error> {
+pub fn read_s16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i16>, crate::Error> {
     let mut v = Vec::new();
     for _ in 0..n {
         v.push(buf.read_i16::<LittleEndian>()?);
@@ -169,7 +169,7 @@ pub fn read_s16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i16>, ::Err
     Ok(v)
 }
 
-pub fn read_u16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u16>, ::Error> {
+pub fn read_u16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u16>, crate::Error> {
     let mut v = Vec::new();
     for _ in 0..n {
         v.push(buf.read_u16::<LittleEndian>()?);
@@ -177,7 +177,7 @@ pub fn read_u16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u16>, ::Err
     Ok(v)
 }
 
-pub fn read_float_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f32>, ::Error> {
+pub fn read_float_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f32>, crate::Error> {
     let mut v = Vec::new();
     for _ in 0..n {
         v.push(buf.read_f32::<LittleEndian>()?);
@@ -185,7 +185,7 @@ pub fn read_float_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f32>, ::E
     Ok(v)
 }
 
-pub fn read_double_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f64>, ::Error> {
+pub fn read_double_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f64>, crate::Error> {
     let mut v = Vec::new();
     for _ in 0..n {
         v.push(buf.read_f64::<LittleEndian>()?);


### PR DESCRIPTION
Added a compile time feature, called `serialize`, which pulls in the base serde crate and derives all message types from the serde serialize and deserialize traits. In addition I updated the sbp crate to use the 2018 edition and fixed a few minor issues in the rust file templates.