### PR TITLE
Changed C++ wrapper to not require non-const access to the buffer when sending

### DIFF
--- a/c/include/libsbp/cpp/state.h
+++ b/c/include/libsbp/cpp/state.h
@@ -68,12 +68,12 @@ class State {
     return sbp_process(&state_, &read_func);
   }
 
-  s8 send_message(u16 msg_type, u16 sender_id, u8 length, u8 payload[]) {
-    return sbp_send_message(&state_, msg_type, sender_id, length, payload, &write_func);
+  s8 send_message(u16 msg_type, u16 sender_id, u8 length, const u8 payload[]) {
+    return sbp_send_message(&state_, msg_type, sender_id, length, const_cast<u8 *>(payload), &write_func);
   }
 
-  s8 process_payload(u16 sender_id, u16 msg_type, u8 msg_length, u8 payload[]) {
-    return sbp_process_payload(&state_, sender_id, msg_type, msg_length, payload);
+  s8 process_payload(u16 sender_id, u16 msg_type, u8 msg_length, const u8 payload[]) {
+    return sbp_process_payload(&state_, sender_id, msg_type, msg_length, const_cast<u8 *>(payload));
   }
 };
 


### PR DESCRIPTION
This is an attempt to fix the poor const choices made in the C API. The write function in the C API takes the output buffer as a non-const pointer, but the writer should not be modifying the buffer (see `fwrite` for an example).

The C++ API now accepts a `const` qualified buffer, casts away the `const`ness of that buffer when calling the C `sbp_send_message` function, but inside of the `sbp::State::write_func` function the buffer's `const`ness is added when forwarding o the `sbp::IWriter::write` function. This should be safe since the C library doesn't do any modifications of the buffer, so the actual `const`ness is never violated in reality.