### PR TITLE
Changes needed to libsbp for road runner [INFRA-35]

### DIFF
--- a/haskell/main/SBP2JSON.hs
+++ b/haskell/main/SBP2JSON.hs
@@ -28,7 +28,9 @@ encodeLine :: SBPMsg -> ByteString
 encodeLine v = toStrict $ encode v <> "\n"
 
 main :: IO ()
-main =
+main = do
+  hSetBuffering stdin NoBuffering
+  hSetBuffering stdout NoBuffering
   runResourceT $
     sourceHandle stdin
       =$= conduitDecode

--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -49,7 +49,7 @@ class TCPDriver(BaseDriver):
                  reconnect=False,
                  max_reconnect=MAX_RECONNECT_RETRIES):
         self._address = (host, port)
-        print((host, port))
+        # print((host, port))
         self._create_connection = partial(socket.create_connection,
                                           (host, port),
                                           timeout=timeout

--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -49,7 +49,6 @@ class TCPDriver(BaseDriver):
                  reconnect=False,
                  max_reconnect=MAX_RECONNECT_RETRIES):
         self._address = (host, port)
-        # print((host, port))
         self._create_connection = partial(socket.create_connection,
                                           (host, port),
                                           timeout=timeout


### PR DESCRIPTION
+ sbp2json: tools like ubx2sbp produce small amount of output (because of the small amount of data processed), in order for sbp2json to be responsive we need to disable buffering of stdin and stdout

+  In the handler code, since we spawn a thread, there's currently no way to "percolate" an exception that happens in the handler thread back to caller... the prevents code from doing things like reconnecting when a tcp connect dies... for example:
    - https://github.com/swift-nav/swiftcar/pull/42/files#diff-60beabf3ee14b8a53421a34aa6f05cdbR238 
    - or: https://github.com/swift-nav/swiftcar/pull/42/files#diff-60beabf3ee14b8a53421a34aa6f05cdbR678
   .
   These functions handle exceptions in order to know that a device is not responding and retry the connection as needed.