### PR TITLE
updated swift libraries with namespace

### DIFF
--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(libsbp_SRCS
   )
 
 add_library(sbp ${libsbp_SRCS})
+add_library(swiftnav::sbp ALIAS sbp)
 
 if(MSVC)
     separate_arguments(LIBSBP_COMPILER_OPTIONS WINDOWS_COMMAND ${LIBSBP_CFLAGS})


### PR DESCRIPTION
Added a namespace to the sbp library as per the discussion in the "cmake" slack channel.

**NOTE**: I'm not sure why the `CMakeLists.txt` file has the below code:

```
export(EXPORT sbp-export
        NAMESPACE LibSbp::
        FILE ${PROJECT_BINARY_DIR}/LibSbpImport.cmake)
```

I'm not sure what this is trying to achieve since it installs the `LibSbpImport.cmake` file onto the build directory. If the main intension was suppose to be something that gets installed, it would need to be `install(EXPORT sbp-export ...)`. The reason I bring this up is because the namespace specified there `LibSbp::` conflicts with the `swiftnav::`. Anyone using this library publicly probably won't use the exported `LibSbpImport.cmake` anyways. Anyone have any issues with just leaving the `LibSbp` namespace on the `export` command as it is for now?