### PR TITLE
Added virtual destructor to sbp::State

### DIFF
--- a/c/include/libsbp/cpp/state.h
+++ b/c/include/libsbp/cpp/state.h
@@ -58,6 +58,8 @@ class State {
     writer_ = writer;
   }
 
+  virtual ~State() = default;
+
   sbp_state_t *get_state() { return &state_; }
 
   void set_reader(IReader *reader) { reader_ = reader; }


### PR DESCRIPTION
Without a virtual destructor the `sbp::State` class isn't really safe to inherit from, as per good C++ practise. I've added that in as its currently blocking developers from creating the following class:

```
class SbpProcessor : public sbp::State, private sbp::MessageHandler<msg_pos_llh_t> {
public:
  SbpProcessor() : : sbp::State(), sbp::MessageHandler<msg_pos_llh_t>(this) {
    // fill this in
  }

  void handle_sbp_msg(uint16_t sender_id, uint8_t message_length, const msg_pos_llh_t &msg) override {
    // fill this in
  }
};

SbpProcessor sbp_processor;
sbp_processor.set_reader(&file_reader);  // lets assume he have an sbp::IReader that reads files
while(sbp_processor.process() >= 0) {}
```