### PR TITLE
Changed the CMake to install all headers

### DIFF
--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -1,32 +1,3 @@
-set(libsbp_HEADERS
-  "${PROJECT_SOURCE_DIR}/include/libsbp/acquisition.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/bootload.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/common.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/edc.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/ext_events.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/file_io.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/flash.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/gnss.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/imu.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/linux.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/logging.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/mag.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/navigation.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/ndb.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/observation.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/orientation.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/piksi.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/sbas.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/sbp.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/settings.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/ssr.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/system.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/tracking.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/user.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/vehicle.h"
-  "${PROJECT_SOURCE_DIR}/include/libsbp/version.h"
-  )
-
 set(libsbp_SRCS
   edc.c
   sbp.c
@@ -52,7 +23,7 @@ target_code_coverage(sbp AUTO ALL)
 install(TARGETS sbp
         EXPORT sbp-export
         DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
-install(FILES ${libsbp_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/libsbp)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/libsbp/" DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/libsbp")
 
 export(EXPORT sbp-export
         NAMESPACE LibSbp::


### PR DESCRIPTION
@lkloh noticed that we don't install the C++ libsbp headers, this PR is meant to fix that. I tried simply adding the headers to the existing list but the install command didn't put them in a `cpp/` subdirectory. This approach seemed cleaner than making a second variable and second install command.