### PR TITLE
Disallow copying of State

### DIFF
--- a/c/include/libsbp/cpp/state.h
+++ b/c/include/libsbp/cpp/state.h
@@ -37,6 +37,10 @@ class State {
   IReader *reader_;
   IWriter *writer_;
 
+  State(const State&);
+  
+  State& operator=(const State&);
+
   static s32 read_func(u8 *buff, u32 n, void *ctx) {
     State *instance = static_cast<State *>(ctx);
     return instance->reader_->read(buff, n);

--- a/c/include/libsbp/cpp/state.h
+++ b/c/include/libsbp/cpp/state.h
@@ -37,9 +37,9 @@ class State {
   IReader *reader_;
   IWriter *writer_;
 
-  State(const State&);
+  State(const State&) = delete;
   
-  State& operator=(const State&);
+  State& operator=(const State&) = delete;
 
   static s32 read_func(u8 *buff, u32 n, void *ctx) {
     State *instance = static_cast<State *>(ctx);


### PR DESCRIPTION
To support the coding guidelines that ban copying into functions.

RE: https://github.com/swift-nav/interleaver/pull/2/files#r366537476