### PR TITLE
tcp_example error fix (signed /unsigned mismatch)

### DIFF
--- a/c/example/tcp_example/tcp_example.c
+++ b/c/example/tcp_example/tcp_example.c
@@ -48,10 +48,10 @@ void heartbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context)
   fprintf(stdout, "%s\n", __FUNCTION__);
 }
 
-u32 socket_read(u8 *buff, u32 n, void *context)
+s32 socket_read(u8 *buff, u32 n, void *context)
 {
   (void)context;
-  u32 result;
+  s32 result;
 
   result = read(socket_desc, buff, n);
   return result;


### PR DESCRIPTION
fixing a small forgetfulness in the TCP example, the return of `socket_read` should be `s32` instead of `u32`