### PR TITLE
[SEN-138] Add message for accumulated wheeltick count

### DIFF
--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -44,7 +44,7 @@ def test_table_count():
   Test number of available messages to deserialize.
 
   """
-  number_of_messages = 183
+  number_of_messages = 184
   assert len(_SBP_TABLE) == number_of_messages
 
 def test_table_unqiue_count():

--- a/spec/yaml/swiftnav/sbp/vehicle.yaml
+++ b/spec/yaml/swiftnav/sbp/vehicle.yaml
@@ -55,3 +55,47 @@ definitions:
                           - 0: None (invalid)
                           - 1: GPS Solution (ms in week)
                           - 2: Processor Time
+
+ - MSG_WHEELTICK:
+    id: 0x0904
+    short_desc: Accumulated wheeltick count message
+    desc: |
+      Message containing the accumulated distance travelled by a wheel located at an odometry
+      reference point defined by the user. The offset for the odometry reference point and the
+      definition and origin of the user frame are defined through the device settings interface.
+      The source of this message is identified by the source field, which is an integer ranging
+      from 0 to 255.
+      The timestamp associated with this message should represent the time when the accumulated
+      tick count reached the value given by the contents of this message as accurately as possible.
+    fields:
+        - time:
+            type: u64
+            units: us
+            desc: |
+             Time field representing either microseconds since the last PPS, microseconds in the GPS
+             Week or local CPU time from the producing system in microseconds. See the synch_type
+             field for the exact meaning of this timestamp.
+        - flags:
+            type: u8
+            desc: |
+              Field indicating the type of timestamp contained in the time field.
+            fields:
+                  - 2-7:
+                      desc: Reserved
+                  - 0-1:
+                      desc: Synchronization type
+                      values:
+                          - 0: microseconds since last PPS
+                          - 1: microseconds ing GPS week
+                          - 2: local CPU time in nominal microseconds
+        - source:
+            type: u8
+            desc: |
+              ID of the sensor producing this message
+        - ticks:
+            type: s32
+            units: arbitrary distance units
+            desc: |
+              Free-running counter of the accumulated distance for this sensor. The counter should be
+              incrementing if travelling into one direction and decrementing when travelling in the
+              opposite direction.


### PR DESCRIPTION
I'm still trying to generate the bindings but here's my proposal for a wheel tick message. While trying to implement the message that we had agreed upon, I noticed it has a fatal flaw: we really need timestamps for the latest tick count for every single wheel, especially if we don't have many ticks per revolution.

There are still some reserved bits in the `flags` field which could be used to communicate additional information, but IMHO the producing side should handle a lot of what was in our initial proposal, e.g. it should provide the logic to reverse the counting direction if the direction signal changes polarity.