### PR TITLE
Improve how the rust parser handles errors

### DIFF
--- a/rust/sbp/src/parser/mod.rs
+++ b/rust/sbp/src/parser/mod.rs
@@ -131,14 +131,19 @@ impl Parser {
                     self.buffer = self.buffer[bytes_read..].to_vec();
                     break Ok(msg);
                 }
-                (Err(crate::Error::ParseError), bytes_read) => {
+                (Err(e), bytes_read) => {
                     if bytes_read >= self.buffer.len() {
                         self.buffer.clear()
                     } else {
                         self.buffer = self.buffer[bytes_read..].to_vec();
                     }
+
+                    if let crate::Error::ParseError = e {
+                        // Continue parsing
+                    } else {
+                        break Err(e)
+                    }
                 }
-                (Err(e), _bytes_read) => break Err(e),
             }
 
             if self.buffer.is_empty() {


### PR DESCRIPTION
This changes the Rust parser to advance its internal buffer by the number of processed bytes in the case of any error. Includes a new test of the CRC failure handling, making sure that we continue to parse subsequent messages after such an error.

This should fix issue https://github.com/swift-nav/libsbp/issues/793.