### PR TITLE
Add a new SBP IMU type

### DIFF
--- a/spec/yaml/swiftnav/sbp/imu.yaml
+++ b/spec/yaml/swiftnav/sbp/imu.yaml
@@ -80,6 +80,7 @@ definitions:
                   values:
                       - 0: Bosch BMI160
                       - 1: ST Microelectronics ASM330LLH
+                      - 2: Android smartphone
         - temp:
             type: s16
             desc: Raw IMU temperature


### PR DESCRIPTION
This PR extends the list of supported IMU types in the SBP IMU_AUX message