### PR TITLE
Public receive method in SBPFramer Java class

### DIFF
--- a/java/src/com/swiftnav/sbp/client/SBPCallback.java
+++ b/java/src/com/swiftnav/sbp/client/SBPCallback.java
@@ -16,5 +16,5 @@ import com.swiftnav.sbp.SBPMessage;
 /** Interface for SBP message handlers. */
 public interface SBPCallback {
     void receiveCallback(SBPMessage msg);
-    void allCallbacksDone();
+    void callbacksDone();
 }

--- a/java/src/com/swiftnav/sbp/client/SBPCallback.java
+++ b/java/src/com/swiftnav/sbp/client/SBPCallback.java
@@ -16,4 +16,5 @@ import com.swiftnav.sbp.SBPMessage;
 /** Interface for SBP message handlers. */
 public interface SBPCallback {
     void receiveCallback(SBPMessage msg);
+    void allCallbacksDone();
 }

--- a/java/src/com/swiftnav/sbp/client/SBPFramer.java
+++ b/java/src/com/swiftnav/sbp/client/SBPFramer.java
@@ -33,7 +33,7 @@ public class SBPFramer extends SBPIterable implements SBPSender {
         }
     }
 
-    private SBPMessage receive() throws IOException {
+    public SBPMessage receive() throws IOException {
         /* Wait for a preamble to be received */
         byte[] preamble;
         do {

--- a/java/src/com/swiftnav/sbp/client/SBPFramer.java
+++ b/java/src/com/swiftnav/sbp/client/SBPFramer.java
@@ -33,7 +33,7 @@ public class SBPFramer extends SBPIterable implements SBPSender {
         }
     }
 
-    public SBPMessage receive() throws IOException {
+    private SBPMessage receive() throws IOException {
         /* Wait for a preamble to be received */
         byte[] preamble;
         do {

--- a/java/src/com/swiftnav/sbp/client/SBPHandler.java
+++ b/java/src/com/swiftnav/sbp/client/SBPHandler.java
@@ -156,7 +156,7 @@ public class SBPHandler implements Iterable<SBPMessage> {
                 for (Reference<SBPCallback> wr : cb_list) {
                     SBPCallback cb = wr.get();
                     if (cb != null) {
-                        cb.allCallbacksDone();
+                        cb.callbacksDone();
                     }
                 }
             }
@@ -199,7 +199,7 @@ public class SBPHandler implements Iterable<SBPMessage> {
         }
 
         @Override
-        public void allCallbacksDone() {
+        public void callbacksDone() {
             finished.set(true);
         }
 


### PR DESCRIPTION
Need this method as `public` to be able to see if the connection is broken or not. Access outside package was only available through an iterator in `SBPHandler` which swallows the exception.