### PR TITLE
Update BDS eph to include AODE/AODC parameters.

### DIFF
--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -340,6 +340,40 @@ typedef struct SBP_ATTR_PACKED {
 } msg_ephemeris_qzss_t;
 
 
+/** Deprecated
+ *
+ * This observation message has been deprecated in favor of
+ * an ephemeris message with AODE/AODC.
+ */
+#define SBP_MSG_EPHEMERIS_BDS_DEP_A            0x0089
+typedef struct SBP_ATTR_PACKED {
+    ephemeris_common_content_t common;      /**< Values common for all ephemeris types */
+    float tgd1;        /**< Group delay differential for B1 [s] */
+    float tgd2;        /**< Group delay differential for B2 [s] */
+    float c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
+    float c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
+    float c_uc;        /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
+    float c_us;        /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
+    float c_ic;        /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
+    float c_is;        /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
+    double dn;          /**< Mean motion difference [rad/s] */
+    double m0;          /**< Mean anomaly at reference time [rad] */
+    double ecc;         /**< Eccentricity of satellite orbit */
+    double sqrta;       /**< Square root of the semi-major axis of orbit [m^(1/2)] */
+    double omega0;      /**< Longitude of ascending node of orbit plane at weekly epoch [rad] */
+    double omegadot;    /**< Rate of right ascension [rad/s] */
+    double w;           /**< Argument of perigee [rad] */
+    double inc;         /**< Inclination [rad] */
+    double inc_dot;     /**< Inclination first derivative [rad/s] */
+    double af0;         /**< Polynomial clock correction coefficient (clock bias) [s] */
+    float af1;         /**< Polynomial clock correction coefficient (clock drift) [s/s] */
+    float af2;         /**< Polynomial clock correction coefficient (rate of clock drift) [s/s^2] */
+    gps_time_sec_t toc;         /**< Clock reference */
+    u8 iode;        /**< Issue of ephemeris data */
+    u16 iodc;        /**< Issue of clock data */
+} msg_ephemeris_bds_t;
+
+
 /** Satellite broadcast ephemeris for BDS
  *
  * The ephemeris message returns a set of satellite orbit
@@ -347,32 +381,34 @@ typedef struct SBP_ATTR_PACKED {
  * velocity, and clock offset. Please see the BeiDou Navigation
  * Satellite System SIS-ICD Version 2.1, Table 5-9 for more details.
  */
-#define SBP_MSG_EPHEMERIS_BDS            0x0089
+#define SBP_MSG_EPHEMERIS_BDS            0x0091
 typedef struct SBP_ATTR_PACKED {
-  ephemeris_common_content_t common;      /**< Values common for all ephemeris types */
-  float tgd1;        /**< Group delay differential for B1 [s] */
-  float tgd2;        /**< Group delay differential for B2 [s] */
-  float c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
-  float c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
-  float c_uc;        /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
-  float c_us;        /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
-  float c_ic;        /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
-  float c_is;        /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
-  double dn;          /**< Mean motion difference [rad/s] */
-  double m0;          /**< Mean anomaly at reference time [rad] */
-  double ecc;         /**< Eccentricity of satellite orbit */
-  double sqrta;       /**< Square root of the semi-major axis of orbit [m^(1/2)] */
-  double omega0;      /**< Longitude of ascending node of orbit plane at weekly epoch [rad] */
-  double omegadot;    /**< Rate of right ascension [rad/s] */
-  double w;           /**< Argument of perigee [rad] */
-  double inc;         /**< Inclination [rad] */
-  double inc_dot;     /**< Inclination first derivative [rad/s] */
-  double af0;         /**< Polynomial clock correction coefficient (clock bias) [s] */
-  float af1;         /**< Polynomial clock correction coefficient (clock drift) [s/s] */
-  float af2;         /**< Polynomial clock correction coefficient (rate of clock drift) [s/s^2] */
-  gps_time_sec_t toc;         /**< Clock reference */
-  u8 iode;        /**< Issue of ephemeris data */
-  u16 iodc;        /**< Issue of clock data */
+    ephemeris_common_content_t common;      /**< Values common for all ephemeris types */
+    float tgd1;        /**< Group delay differential for B1 [s] */
+    float tgd2;        /**< Group delay differential for B2 [s] */
+    float c_rs;        /**< Amplitude of the sine harmonic correction term to the orbit radius [m] */
+    float c_rc;        /**< Amplitude of the cosine harmonic correction term to the orbit radius [m] */
+    float c_uc;        /**< Amplitude of the cosine harmonic correction term to the argument of latitude [rad] */
+    float c_us;        /**< Amplitude of the sine harmonic correction term to the argument of latitude [rad] */
+    float c_ic;        /**< Amplitude of the cosine harmonic correction term to the angle of inclination [rad] */
+    float c_is;        /**< Amplitude of the sine harmonic correction term to the angle of inclination [rad] */
+    double dn;          /**< Mean motion difference [rad/s] */
+    double m0;          /**< Mean anomaly at reference time [rad] */
+    double ecc;         /**< Eccentricity of satellite orbit */
+    double sqrta;       /**< Square root of the semi-major axis of orbit [m^(1/2)] */
+    double omega0;      /**< Longitude of ascending node of orbit plane at weekly epoch [rad] */
+    double omegadot;    /**< Rate of right ascension [rad/s] */
+    double w;           /**< Argument of perigee [rad] */
+    double inc;         /**< Inclination [rad] */
+    double inc_dot;     /**< Inclination first derivative [rad/s] */
+    double af0;         /**< Polynomial clock correction coefficient (clock bias) [s] */
+    float af1;         /**< Polynomial clock correction coefficient (clock drift) [s/s] */
+    float af2;         /**< Polynomial clock correction coefficient (rate of clock drift) [s/s^2] */
+    gps_time_sec_t toc;         /**< Clock reference */
+    u8 iode;        /**< Issue of ephemeris data */
+    u16 iodc;        /**< Issue of clock data */
+    u8 aodc;        /**< Age of data clock */
+    u8 aode;        /**< Age of data ephemeris */
 } msg_ephemeris_bds_t;
 
 


### PR DESCRIPTION
One part of a change that will involve adding a new SBP message for BDS ephs. The problem is that the current one round trips by storing the AODE/AODC in the IODE/IODC parameters. This is confusing and we also want to use the IODE/IODC as a unique key (in a later PR).