### PR TITLE
Dzollo/pyserial timeout remove

### DIFF
--- a/python/sbp/client/drivers/cdc_driver.py
+++ b/python/sbp/client/drivers/cdc_driver.py
@@ -39,12 +39,14 @@ class CdcDriver(BaseDriver):
                 print()
                 print("Piksi disconnected")
                 print()
+                self.close()
                 raise IOError
             return return_val
         except OSError:
             print()
             print("Piksi disconnected")
             print()
+            self.close()
             raise IOError
 
     def _write(self, s):
@@ -62,6 +64,7 @@ class CdcDriver(BaseDriver):
             print()
             print("Piksi disconnected")
             print()
+            self.close()
             raise IOError
 
     def close(self):

--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -81,7 +81,7 @@ class PySerialDriver(BaseDriver):
             print()
             print("Piksi disconnected")
             print()
-            self.handle.close()
+            self.close()
             raise IOError
 
     def _write(self, s):
@@ -104,7 +104,7 @@ class PySerialDriver(BaseDriver):
                 print()
                 print("Piksi disconnected")
                 print()
-                self.handle.close()
+                self.close()
                 raise IOError
 
     def __enter__(self):

--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -46,7 +46,7 @@ class PySerialDriver(BaseDriver):
         try:
             handle = serial.serial_for_url(port)
             handle.baudrate = baud
-            handle.timeout = 1
+            handle.timeout = None
             handle.rtscts = rtscts
             super(PySerialDriver, self).__init__(handle)
         except (OSError, serial.SerialException) as e:


### PR DESCRIPTION
This change is to address bug report below:

```
The recent console does not receive Piksi data if I power down Piksi for a some time.
Windows PC
Piksi over serial port

Procedure:
Start Piksi
connect console
power off Piksi
wait a minute
power up Piksi -> there will be no any data on console
````

After painful investigation, the bug was traced down to this change in the framer behavior when encountering a zero length byte array from the driver and on Windows only.  https://github.com/swift-nav/libsbp/commit/2d2d1f475ab7132cce1ce2da99848913ad65bd92#diff-f7e7ceb9c48458bb44be66283049a27bL106 

Basically, since there was a 1 second timeout on the pyserial driver if it didn't get data in one second it could cause the framer to start iterating nothing to the handler which caused the handler to yield none.  

As a side note, I sort of think we might need to throw an exception here: https://github.com/swift-nav/libsbp/blob/master/python/sbp/client/handler.py#L72 , so that at least the handler communicates that it is no longer iterating correctly.  But I'm not sure what to do there so I left as is.