### PR TITLE
python: remove generation of the sbp.jit _payload_size method

### DIFF
--- a/generator/sbpg/targets/pythonNG.py
+++ b/generator/sbpg/targets/pythonNG.py
@@ -87,31 +87,6 @@ def numba_type(f):
     return '__' + f.identifier
 
 
-def numba_size(f):
-  # the worst case 255 - 6 (header) - 2 (crc)
-  UNKNOWN_LEN = 255 - 6 - 2
-
-  if f.type_id in NUMBA_TY_BYTES:
-    return NUMBA_TY_BYTES[f.type_id]
-  elif f.type_id == 'string':
-    if f.options.get('size', None) is not None:
-      return f.options.get('size', None).value
-    return UNKNOWN_LEN
-  elif f.type_id == 'array':
-    # NOTE: arrays of arrays are not supported
-    t = f.options['fill'].value
-    count = f.options.get('size', None)
-    if count:
-      if t in NUMBA_TY_BYTES:
-        return "%d * %d" % (NUMBA_TY_BYTES[t], count.value)
-      else:
-        return t + "._payload_size() * %d" % (count.value)
-    else:
-      return UNKNOWN_LEN
-  else:
-    return f.type_id + '._payload_size()'
-
-
 def numba_format(f):
   if NUMBA_GET_FN.get(f.type_id, None):
     return NUMBA_GET_FN.get(f.type_id)
@@ -164,7 +139,6 @@ def classnameify(s):
 
 JENV.filters['numba_py'] = numba_format
 JENV.filters['numba_type'] = numba_type
-JENV.filters['numba_size'] = numba_size
 JENV.filters['classnameify'] = classnameify
 JENV.filters['pydoc'] = pydoc_format
 JENV.filters['comment_links'] = comment_links
@@ -174,7 +148,7 @@ def render_source(output_dir, package_spec, jenv=JENV):
   """
   Render and output
   """
-  path, name = package_spec.filepath
+  _path, name = package_spec.filepath
   directory = output_dir
   destination_filename = "%s/%s.py" % (directory, name)
   py_template = jenv.get_template(TEMPLATE_NAME)

--- a/generator/sbpg/targets/resources/sbp_numba.py.j2
+++ b/generator/sbpg/targets/resources/sbp_numba.py.j2
@@ -82,20 +82,9 @@ class ((( m.identifier )))(object):
     ((*- endfor *))
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    ((*- for f in m.fields *))
-    # (((f.identifier))): (((f.type_id))) ((*- if f.options['fill'] *)) of (((f.options['fill'].value))) ((*- endif *))
-    ret += (((f | numba_size)))
-    ((*- endfor *))
-    return ret
   ((* else *))
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   ((* endif *))
 ((*- endif *))
 ((*- endfor *))

--- a/python/sbp/jit/acquisition.py
+++ b/python/sbp/jit/acquisition.py
@@ -73,18 +73,6 @@ ratio.
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # cn0: float
-    ret += 4
-    # cp: float
-    ret += 4
-    # cf: float
-    ret += 4
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    return ret
   
 SBP_MSG_ACQ_RESULT_DEP_C = 0x001F
 class MsgAcqResultDepC(SBP):
@@ -126,18 +114,6 @@ class MsgAcqResultDepC(SBP):
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # cn0: float
-    ret += 4
-    # cp: float
-    ret += 4
-    # cf: float
-    ret += 4
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    return ret
   
 SBP_MSG_ACQ_RESULT_DEP_B = 0x0014
 class MsgAcqResultDepB(SBP):
@@ -179,18 +155,6 @@ class MsgAcqResultDepB(SBP):
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # snr: float
-    ret += 4
-    # cp: float
-    ret += 4
-    # cf: float
-    ret += 4
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    return ret
   
 SBP_MSG_ACQ_RESULT_DEP_A = 0x0015
 class MsgAcqResultDepA(SBP):
@@ -232,18 +196,6 @@ class MsgAcqResultDepA(SBP):
     self.prn = res['prn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # snr: float
-    ret += 4
-    # cp: float
-    ret += 4
-    # cf: float
-    ret += 4
-    # prn: u8
-    ret += 1
-    return ret
   
 class AcqSvProfile(object):
   """SBP class for message AcqSvProfile
@@ -319,34 +271,6 @@ The message is used to debug and measure the performance.
     self.cp = res['cp']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # job_type: u8
-    ret += 1
-    # status: u8
-    ret += 1
-    # cn0: u16
-    ret += 2
-    # int_time: u8
-    ret += 1
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # bin_width: u16
-    ret += 2
-    # timestamp: u32
-    ret += 4
-    # time_spent: u32
-    ret += 4
-    # cf_min: s32
-    ret += 4
-    # cf_max: s32
-    ret += 4
-    # cf: s32
-    ret += 4
-    # cp: u32
-    ret += 4
-    return ret
   
 class AcqSvProfileDep(object):
   """SBP class for message AcqSvProfileDep
@@ -419,34 +343,6 @@ class AcqSvProfileDep(object):
     self.cp = res['cp']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # job_type: u8
-    ret += 1
-    # status: u8
-    ret += 1
-    # cn0: u16
-    ret += 2
-    # int_time: u8
-    ret += 1
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # bin_width: u16
-    ret += 2
-    # timestamp: u32
-    ret += 4
-    # time_spent: u32
-    ret += 4
-    # cf_min: s32
-    ret += 4
-    # cf_max: s32
-    ret += 4
-    # cf: s32
-    ret += 4
-    # cp: u32
-    ret += 4
-    return ret
   
 SBP_MSG_ACQ_SV_PROFILE = 0x002E
 class MsgAcqSvProfile(SBP):
@@ -478,12 +374,6 @@ The message is used to debug and measure the performance.
     self.acq_sv_profile = res['acq_sv_profile']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # acq_sv_profile: array of AcqSvProfile
-    ret += 247
-    return ret
   
 SBP_MSG_ACQ_SV_PROFILE_DEP = 0x001E
 class MsgAcqSvProfileDep(SBP):
@@ -513,12 +403,6 @@ class MsgAcqSvProfileDep(SBP):
     self.acq_sv_profile = res['acq_sv_profile']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # acq_sv_profile: array of AcqSvProfileDep
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/bootload.py
+++ b/python/sbp/jit/bootload.py
@@ -50,9 +50,6 @@ response from the device is MSG_BOOTLOADER_HANDSHAKE_RESP.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_BOOTLOADER_HANDSHAKE_RESP = 0x00B4
 class MsgBootloaderHandshakeResp(SBP):
@@ -91,14 +88,6 @@ protocol version number.
     self.version = res['version']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # flags: u32
-    ret += 4
-    # version: string
-    ret += 247
-    return ret
   
 SBP_MSG_BOOTLOADER_JUMP_TO_APP = 0x00B1
 class MsgBootloaderJumpToApp(SBP):
@@ -129,12 +118,6 @@ class MsgBootloaderJumpToApp(SBP):
     self.jump = res['jump']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # jump: u8
-    ret += 1
-    return ret
   
 SBP_MSG_NAP_DEVICE_DNA_REQ = 0x00DE
 class MsgNapDeviceDnaReq(SBP):
@@ -157,9 +140,6 @@ and not related to the Piksi's serial number.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_NAP_DEVICE_DNA_RESP = 0x00DD
 class MsgNapDeviceDnaResp(SBP):
@@ -195,12 +175,6 @@ and not related to the Piksi's serial number.
     self.dna = res['dna']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # dna: array of u8
-    ret += 1 * 8
-    return ret
   
 SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A = 0x00B0
 class MsgBootloaderHandshakeDepA(SBP):
@@ -230,12 +204,6 @@ class MsgBootloaderHandshakeDepA(SBP):
     self.handshake = res['handshake']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # handshake: array of u8
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/ext_events.py
+++ b/python/sbp/jit/ext_events.py
@@ -75,20 +75,6 @@ which pin it was and whether it was rising or falling.
     self.pin = res['pin']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # wn: u16
-    ret += 2
-    # tow: u32
-    ret += 4
-    # ns_residual: s32
-    ret += 4
-    # flags: u8
-    ret += 1
-    # pin: u8
-    ret += 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/file_io.py
+++ b/python/sbp/jit/file_io.py
@@ -83,18 +83,6 @@ to this message when it is received from sender ID 0x42.
     self.filename = res['filename']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # offset: u32
-    ret += 4
-    # chunk_size: u8
-    ret += 1
-    # filename: string
-    ret += 247
-    return ret
   
 SBP_MSG_FILEIO_READ_RESP = 0x00A3
 class MsgFileioReadResp(SBP):
@@ -133,14 +121,6 @@ preserved from the request.
     self.contents = res['contents']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # contents: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_FILEIO_READ_DIR_REQ = 0x00A9
 class MsgFileioReadDirReq(SBP):
@@ -188,16 +168,6 @@ from sender ID 0x42.
     self.dirname = res['dirname']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # offset: u32
-    ret += 4
-    # dirname: string
-    ret += 247
-    return ret
   
 SBP_MSG_FILEIO_READ_DIR_RESP = 0x00AA
 class MsgFileioReadDirResp(SBP):
@@ -237,14 +207,6 @@ the response is preserved from the request.
     self.contents = res['contents']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # contents: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_FILEIO_REMOVE = 0x00AC
 class MsgFileioRemove(SBP):
@@ -278,12 +240,6 @@ process this message when it is received from sender ID 0x42.
     self.filename = res['filename']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # filename: string
-    ret += 247
-    return ret
   
 SBP_MSG_FILEIO_WRITE_REQ = 0x00AD
 class MsgFileioWriteReq(SBP):
@@ -333,18 +289,6 @@ only  process this message when it is received from sender ID
     self.data = res['data']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # offset: u32
-    ret += 4
-    # filename: string
-    ret += 247
-    # data: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_FILEIO_WRITE_RESP = 0x00AB
 class MsgFileioWriteResp(SBP):
@@ -379,12 +323,6 @@ request.
     self.sequence = res['sequence']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    return ret
   
 SBP_MSG_FILEIO_CONFIG_REQ = 0x1001
 class MsgFileioConfigReq(SBP):
@@ -418,12 +356,6 @@ that can be in-flight during read or write operations.
     self.sequence = res['sequence']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    return ret
   
 SBP_MSG_FILEIO_CONFIG_RESP = 0x1002
 class MsgFileioConfigResp(SBP):
@@ -469,18 +401,6 @@ that can be in-flight during read or write operations.
     self.fileio_version = res['fileio_version']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # window_size: u32
-    ret += 4
-    # batch_size: u32
-    ret += 4
-    # fileio_version: u32
-    ret += 4
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/flash.py
+++ b/python/sbp/jit/flash.py
@@ -78,18 +78,6 @@ erased before addresses can be programmed.
     self.data = res['data']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # target: u8
-    ret += 1
-    # addr_start: array of u8
-    ret += 1 * 3
-    # addr_len: u8
-    ret += 1
-    # data: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_FLASH_DONE = 0x00E0
 class MsgFlashDone(SBP):
@@ -123,12 +111,6 @@ MSG_FLASH_PROGRAM, may return this message on failure.
     self.response = res['response']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # response: u8
-    ret += 1
-    return ret
   
 SBP_MSG_FLASH_READ_REQ = 0x00E7
 class MsgFlashReadReq(SBP):
@@ -173,16 +155,6 @@ range.
     self.addr_len = res['addr_len']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # target: u8
-    ret += 1
-    # addr_start: array of u8
-    ret += 1 * 3
-    # addr_len: u8
-    ret += 1
-    return ret
   
 SBP_MSG_FLASH_READ_RESP = 0x00E1
 class MsgFlashReadResp(SBP):
@@ -227,16 +199,6 @@ range.
     self.addr_len = res['addr_len']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # target: u8
-    ret += 1
-    # addr_start: array of u8
-    ret += 1 * 3
-    # addr_len: u8
-    ret += 1
-    return ret
   
 SBP_MSG_FLASH_ERASE = 0x00E2
 class MsgFlashErase(SBP):
@@ -275,14 +237,6 @@ invalid.
     self.sector_num = res['sector_num']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # target: u8
-    ret += 1
-    # sector_num: u32
-    ret += 4
-    return ret
   
 SBP_MSG_STM_FLASH_LOCK_SECTOR = 0x00E3
 class MsgStmFlashLockSector(SBP):
@@ -314,12 +268,6 @@ memory. The device replies with a MSG_FLASH_DONE message.
     self.sector = res['sector']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sector: u32
-    ret += 4
-    return ret
   
 SBP_MSG_STM_FLASH_UNLOCK_SECTOR = 0x00E4
 class MsgStmFlashUnlockSector(SBP):
@@ -351,12 +299,6 @@ memory. The device replies with a MSG_FLASH_DONE message.
     self.sector = res['sector']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sector: u32
-    ret += 4
-    return ret
   
 SBP_MSG_STM_UNIQUE_ID_REQ = 0x00E8
 class MsgStmUniqueIdReq(SBP):
@@ -377,9 +319,6 @@ ID in the payload.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_STM_UNIQUE_ID_RESP = 0x00E5
 class MsgStmUniqueIdResp(SBP):
@@ -413,12 +352,6 @@ ID in the payload..
     self.stm_id = res['stm_id']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # stm_id: array of u8
-    ret += 1 * 12
-    return ret
   
 SBP_MSG_M25_FLASH_WRITE_STATUS = 0x00F3
 class MsgM25FlashWriteStatus(SBP):
@@ -450,12 +383,6 @@ register. The device replies with a MSG_FLASH_DONE message.
     self.status = res['status']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # status: array of u8
-    ret += 1 * 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/gnss.py
+++ b/python/sbp/jit/gnss.py
@@ -59,14 +59,6 @@ class GnssSignal(object):
     self.code = res['code']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sat: u8
-    ret += 1
-    # code: u8
-    ret += 1
-    return ret
   
 class SvId(object):
   """SBP class for message SvId
@@ -101,14 +93,6 @@ a space vehicle
     self.constellation = res['constellation']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # satId: u8
-    ret += 1
-    # constellation: u8
-    ret += 1
-    return ret
   
 class GnssSignalDep(object):
   """SBP class for message GnssSignalDep
@@ -145,16 +129,6 @@ class GnssSignalDep(object):
     self.reserved = res['reserved']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sat: u16
-    ret += 2
-    # code: u8
-    ret += 1
-    # reserved: u8
-    ret += 1
-    return ret
   
 class GPSTimeDep(object):
   """SBP class for message GPSTimeDep
@@ -190,14 +164,6 @@ transition.
     self.wn = res['wn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # wn: u16
-    ret += 2
-    return ret
   
 class GPSTimeSec(object):
   """SBP class for message GPSTimeSec
@@ -233,14 +199,6 @@ transition.
     self.wn = res['wn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # wn: u16
-    ret += 2
-    return ret
   
 class GPSTime(object):
   """SBP class for message GPSTime
@@ -281,16 +239,6 @@ so ns field will be 0.
     self.wn = res['wn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # ns_residual: s32
-    ret += 4
-    # wn: u16
-    ret += 2
-    return ret
   
 class CarrierPhase(object):
   """SBP class for message CarrierPhase
@@ -327,14 +275,6 @@ same sign as the pseudorange.
     self.f = res['f']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # i: s32
-    ret += 4
-    # f: u8
-    ret += 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/imu.py
+++ b/python/sbp/jit/imu.py
@@ -87,26 +87,6 @@ device hardware and settings, are communicated via the MSG_IMU_AUX message.
     self.gyr_z = res['gyr_z']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # tow_f: u8
-    ret += 1
-    # acc_x: s16
-    ret += 2
-    # acc_y: s16
-    ret += 2
-    # acc_z: s16
-    ret += 2
-    # gyr_x: s16
-    ret += 2
-    # gyr_y: s16
-    ret += 2
-    # gyr_z: s16
-    ret += 2
-    return ret
   
 SBP_MSG_IMU_AUX = 0x0901
 class MsgImuAux(SBP):
@@ -147,16 +127,6 @@ depends on the value of `imu_type`.
     self.imu_conf = res['imu_conf']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # imu_type: u8
-    ret += 1
-    # temp: s16
-    ret += 2
-    # imu_conf: u8
-    ret += 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/linux.py
+++ b/python/sbp/jit/linux.py
@@ -74,20 +74,6 @@ consumers of CPU on the system.
     self.cmdline = res['cmdline']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u8
-    ret += 1
-    # pid: u16
-    ret += 2
-    # pcpu: u8
-    ret += 1
-    # tname: string
-    ret += 15
-    # cmdline: string
-    ret += 247
-    return ret
   
 SBP_MSG_LINUX_MEM_STATE = 0x7F01
 class MsgLinuxMemState(SBP):
@@ -135,20 +121,6 @@ consumers of memory on the system.
     self.cmdline = res['cmdline']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u8
-    ret += 1
-    # pid: u16
-    ret += 2
-    # pmem: u8
-    ret += 1
-    # tname: string
-    ret += 15
-    # cmdline: string
-    ret += 247
-    return ret
   
 SBP_MSG_LINUX_SYS_STATE = 0x7F02
 class MsgLinuxSysState(SBP):
@@ -199,22 +171,6 @@ class MsgLinuxSysState(SBP):
     self.pid_count = res['pid_count']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # mem_total: u16
-    ret += 2
-    # pcpu: u8
-    ret += 1
-    # pmem: u8
-    ret += 1
-    # procs_starting: u16
-    ret += 2
-    # procs_stopping: u16
-    ret += 2
-    # pid_count: u16
-    ret += 2
-    return ret
   
 SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS = 0x7F03
 class MsgLinuxProcessSocketCounts(SBP):
@@ -265,22 +221,6 @@ class MsgLinuxProcessSocketCounts(SBP):
     self.cmdline = res['cmdline']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u8
-    ret += 1
-    # pid: u16
-    ret += 2
-    # socket_count: u16
-    ret += 2
-    # socket_types: u16
-    ret += 2
-    # socket_states: u16
-    ret += 2
-    # cmdline: string
-    ret += 247
-    return ret
   
 SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES = 0x7F04
 class MsgLinuxProcessSocketQueues(SBP):
@@ -339,26 +279,6 @@ class MsgLinuxProcessSocketQueues(SBP):
     self.cmdline = res['cmdline']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u8
-    ret += 1
-    # pid: u16
-    ret += 2
-    # recv_queued: u16
-    ret += 2
-    # send_queued: u16
-    ret += 2
-    # socket_types: u16
-    ret += 2
-    # socket_states: u16
-    ret += 2
-    # address_of_largest: string
-    ret += 64
-    # cmdline: string
-    ret += 247
-    return ret
   
 SBP_MSG_LINUX_SOCKET_USAGE = 0x7F05
 class MsgLinuxSocketUsage(SBP):
@@ -401,18 +321,6 @@ class MsgLinuxSocketUsage(SBP):
     self.socket_type_counts = res['socket_type_counts']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # avg_queue_depth: u32
-    ret += 4
-    # max_queue_depth: u32
-    ret += 4
-    # socket_state_counts: array of u16
-    ret += 2 * 16
-    # socket_type_counts: array of u16
-    ret += 2 * 16
-    return ret
   
 SBP_MSG_LINUX_PROCESS_FD_COUNT = 0x7F06
 class MsgLinuxProcessFdCount(SBP):
@@ -455,18 +363,6 @@ class MsgLinuxProcessFdCount(SBP):
     self.cmdline = res['cmdline']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u8
-    ret += 1
-    # pid: u16
-    ret += 2
-    # fd_count: u16
-    ret += 2
-    # cmdline: string
-    ret += 247
-    return ret
   
 SBP_MSG_LINUX_PROCESS_FD_SUMMARY = 0x7F07
 class MsgLinuxProcessFdSummary(SBP):
@@ -501,14 +397,6 @@ class MsgLinuxProcessFdSummary(SBP):
     self.most_opened = res['most_opened']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sys_fd_count: u32
-    ret += 4
-    # most_opened: string
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/logging.py
+++ b/python/sbp/jit/logging.py
@@ -63,14 +63,6 @@ ERROR, WARNING, DEBUG, INFO logging levels.
     self.text = res['text']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # level: u8
-    ret += 1
-    # text: string
-    ret += 247
-    return ret
   
 SBP_MSG_FWD = 0x0402
 class MsgFwd(SBP):
@@ -115,16 +107,6 @@ Protocol 0 represents SBP and the remaining values are implementation defined.
     self.fwd_payload = res['fwd_payload']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # source: u8
-    ret += 1
-    # protocol: u8
-    ret += 1
-    # fwd_payload: string
-    ret += 247
-    return ret
   
 SBP_MSG_PRINT_DEP = 0x0010
 class MsgPrintDep(SBP):
@@ -154,12 +136,6 @@ class MsgPrintDep(SBP):
     self.text = res['text']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # text: string
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/mag.py
+++ b/python/sbp/jit/mag.py
@@ -72,20 +72,6 @@ class MsgMagRaw(SBP):
     self.mag_z = res['mag_z']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # tow_f: u8
-    ret += 1
-    # mag_x: s16
-    ret += 2
-    # mag_y: s16
-    ret += 2
-    # mag_z: s16
-    ret += 2
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/navigation.py
+++ b/python/sbp/jit/navigation.py
@@ -98,18 +98,6 @@ these messages.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # wn: u16
-    ret += 2
-    # tow: u32
-    ret += 4
-    # ns_residual: s32
-    ret += 4
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_UTC_TIME = 0x0103
 class MsgUtcTime(SBP):
@@ -173,28 +161,6 @@ which indicate the source of the UTC offset value and source of the time fix.
     self.ns = res['ns']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # flags: u8
-    ret += 1
-    # tow: u32
-    ret += 4
-    # year: u16
-    ret += 2
-    # month: u8
-    ret += 1
-    # day: u8
-    ret += 1
-    # hours: u8
-    ret += 1
-    # minutes: u8
-    ret += 1
-    # seconds: u8
-    ret += 1
-    # ns: u32
-    ret += 4
-    return ret
   
 SBP_MSG_DOPS = 0x0208
 class MsgDops(SBP):
@@ -252,24 +218,6 @@ corresponds to differential or SPP solution.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # gdop: u16
-    ret += 2
-    # pdop: u16
-    ret += 2
-    # tdop: u16
-    ret += 2
-    # hdop: u16
-    ret += 2
-    # vdop: u16
-    ret += 2
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_ECEF = 0x0209
 class MsgPosECEF(SBP):
@@ -331,24 +279,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: double
-    ret += 8
-    # y: double
-    ret += 8
-    # z: double
-    ret += 8
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_ECEF_COV = 0x0214
 class MsgPosECEFCov(SBP):
@@ -431,34 +361,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: double
-    ret += 8
-    # y: double
-    ret += 8
-    # z: double
-    ret += 8
-    # cov_x_x: float
-    ret += 4
-    # cov_x_y: float
-    ret += 4
-    # cov_x_z: float
-    ret += 4
-    # cov_y_y: float
-    ret += 4
-    # cov_y_z: float
-    ret += 4
-    # cov_z_z: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_LLH = 0x020A
 class MsgPosLLH(SBP):
@@ -524,26 +426,6 @@ matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_LLH_COV = 0x0211
 class MsgPosLLHCov(SBP):
@@ -625,34 +507,6 @@ measurement and care should be taken with the sign convention.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    # cov_n_n: float
-    ret += 4
-    # cov_n_e: float
-    ret += 4
-    # cov_n_d: float
-    ret += 4
-    # cov_e_e: float
-    ret += 4
-    # cov_e_d: float
-    ret += 4
-    # cov_d_d: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_BASELINE_ECEF = 0x020B
 class MsgBaselineECEF(SBP):
@@ -711,24 +565,6 @@ matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_BASELINE_NED = 0x020C
 class MsgBaselineNED(SBP):
@@ -792,26 +628,6 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_ECEF = 0x020D
 class MsgVelECEF(SBP):
@@ -868,24 +684,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_ECEF_COV = 0x0215
 class MsgVelECEFCov(SBP):
@@ -962,34 +760,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # cov_x_x: float
-    ret += 4
-    # cov_x_y: float
-    ret += 4
-    # cov_x_z: float
-    ret += 4
-    # cov_y_y: float
-    ret += 4
-    # cov_y_z: float
-    ret += 4
-    # cov_z_z: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_NED = 0x020E
 class MsgVelNED(SBP):
@@ -1051,26 +821,6 @@ given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_NED_COV = 0x0212
 class MsgVelNEDCov(SBP):
@@ -1150,34 +900,6 @@ portion of the 3x3 covariance matrix.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # cov_n_n: float
-    ret += 4
-    # cov_n_e: float
-    ret += 4
-    # cov_n_d: float
-    ret += 4
-    # cov_e_e: float
-    ret += 4
-    # cov_e_d: float
-    ret += 4
-    # cov_d_d: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_ECEF_GNSS = 0x0229
 class MsgPosECEFGnss(SBP):
@@ -1239,24 +961,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: double
-    ret += 8
-    # y: double
-    ret += 8
-    # z: double
-    ret += 8
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_ECEF_COV_GNSS = 0x0234
 class MsgPosECEFCovGnss(SBP):
@@ -1339,34 +1043,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: double
-    ret += 8
-    # y: double
-    ret += 8
-    # z: double
-    ret += 8
-    # cov_x_x: float
-    ret += 4
-    # cov_x_y: float
-    ret += 4
-    # cov_x_z: float
-    ret += 4
-    # cov_y_y: float
-    ret += 4
-    # cov_y_z: float
-    ret += 4
-    # cov_z_z: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_LLH_GNSS = 0x022A
 class MsgPosLLHGnss(SBP):
@@ -1432,26 +1108,6 @@ matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_LLH_COV_GNSS = 0x0231
 class MsgPosLLHCovGnss(SBP):
@@ -1533,34 +1189,6 @@ measurement and care should be taken with the sign convention.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    # cov_n_n: float
-    ret += 4
-    # cov_n_e: float
-    ret += 4
-    # cov_n_d: float
-    ret += 4
-    # cov_e_e: float
-    ret += 4
-    # cov_e_d: float
-    ret += 4
-    # cov_d_d: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_ECEF_GNSS = 0x022D
 class MsgVelECEFGnss(SBP):
@@ -1617,24 +1245,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_ECEF_COV_GNSS = 0x0235
 class MsgVelECEFCovGnss(SBP):
@@ -1711,34 +1321,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # cov_x_x: float
-    ret += 4
-    # cov_x_y: float
-    ret += 4
-    # cov_x_z: float
-    ret += 4
-    # cov_y_y: float
-    ret += 4
-    # cov_y_z: float
-    ret += 4
-    # cov_z_z: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_NED_GNSS = 0x022E
 class MsgVelNEDGnss(SBP):
@@ -1800,26 +1382,6 @@ given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_NED_COV_GNSS = 0x0232
 class MsgVelNEDCovGnss(SBP):
@@ -1899,34 +1461,6 @@ portion of the 3x3 covariance matrix.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # cov_n_n: float
-    ret += 4
-    # cov_n_e: float
-    ret += 4
-    # cov_n_d: float
-    ret += 4
-    # cov_e_e: float
-    ret += 4
-    # cov_e_d: float
-    ret += 4
-    # cov_d_d: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_BODY = 0x0213
 class MsgVelBody(SBP):
@@ -2008,34 +1542,6 @@ products and is not available from Piksi Multi or Duro.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # cov_x_x: float
-    ret += 4
-    # cov_x_y: float
-    ret += 4
-    # cov_x_z: float
-    ret += 4
-    # cov_y_y: float
-    ret += 4
-    # cov_y_z: float
-    ret += 4
-    # cov_z_z: float
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_AGE_CORRECTIONS = 0x0210
 class MsgAgeCorrections(SBP):
@@ -2071,14 +1577,6 @@ Differential solution
     self.age = res['age']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # age: u16
-    ret += 2
-    return ret
   
 SBP_MSG_GPS_TIME_DEP_A = 0x0100
 class MsgGPSTimeDepA(SBP):
@@ -2133,18 +1631,6 @@ these messages.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # wn: u16
-    ret += 2
-    # tow: u32
-    ret += 4
-    # ns_residual: s32
-    ret += 4
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_DOPS_DEP_A = 0x0206
 class MsgDopsDepA(SBP):
@@ -2197,22 +1683,6 @@ precision.
     self.vdop = res['vdop']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # gdop: u16
-    ret += 2
-    # pdop: u16
-    ret += 2
-    # tdop: u16
-    ret += 2
-    # hdop: u16
-    ret += 2
-    # vdop: u16
-    ret += 2
-    return ret
   
 SBP_MSG_POS_ECEF_DEP_A = 0x0200
 class MsgPosECEFDepA(SBP):
@@ -2274,24 +1744,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: double
-    ret += 8
-    # y: double
-    ret += 8
-    # z: double
-    ret += 8
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_POS_LLH_DEP_A = 0x0201
 class MsgPosLLHDepA(SBP):
@@ -2357,26 +1809,6 @@ matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_BASELINE_ECEF_DEP_A = 0x0202
 class MsgBaselineECEFDepA(SBP):
@@ -2435,24 +1867,6 @@ matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_BASELINE_NED_DEP_A = 0x0203
 class MsgBaselineNEDDepA(SBP):
@@ -2516,26 +1930,6 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_ECEF_DEP_A = 0x0204
 class MsgVelECEFDepA(SBP):
@@ -2592,24 +1986,6 @@ MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_VEL_NED_DEP_A = 0x0205
 class MsgVelNEDDepA(SBP):
@@ -2671,26 +2047,6 @@ given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # n: s32
-    ret += 4
-    # e: s32
-    ret += 4
-    # d: s32
-    ret += 4
-    # h_accuracy: u16
-    ret += 2
-    # v_accuracy: u16
-    ret += 2
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_BASELINE_HEADING_DEP_A = 0x0207
 class MsgBaselineHeadingDepA(SBP):
@@ -2735,18 +2091,6 @@ preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # heading: u32
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_PROTECTION_LEVEL = 0x0216
 class MsgProtectionLevel(SBP):
@@ -2803,24 +2147,6 @@ by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # vpl: u16
-    ret += 2
-    # hpl: u16
-    ret += 2
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    # flags: u8
-    ret += 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/ndb.py
+++ b/python/sbp/jit/ndb.py
@@ -87,26 +87,6 @@ message could also be sent out when fetching an object from NDB.
     self.original_sender = res['original_sender']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # recv_time: u64
-    ret += 8
-    # event: u8
-    ret += 1
-    # object_type: u8
-    ret += 1
-    # result: u8
-    ret += 1
-    # data_source: u8
-    ret += 1
-    # object_sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # src_sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # original_sender: u16
-    ret += 2
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/observation.py
+++ b/python/sbp/jit/observation.py
@@ -59,14 +59,6 @@ class ObservationHeader(object):
     self.n_obs = res['n_obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t: GPSTime
-    ret += GPSTime._payload_size()
-    # n_obs: u8
-    ret += 1
-    return ret
   
 class Doppler(object):
   """SBP class for message Doppler
@@ -103,14 +95,6 @@ as positive for approaching satellites.
     self.f = res['f']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # i: s16
-    ret += 2
-    # f: u8
-    ret += 1
-    return ret
   
 class PackedObsContent(object):
   """SBP class for message PackedObsContent
@@ -170,24 +154,6 @@ peformed.
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # P: u32
-    ret += 4
-    # L: CarrierPhase
-    ret += CarrierPhase._payload_size()
-    # D: Doppler
-    ret += Doppler._payload_size()
-    # cn0: u8
-    ret += 1
-    # lock: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    return ret
   
 class PackedOsrContent(object):
   """SBP class for message PackedOsrContent
@@ -245,26 +211,6 @@ class PackedOsrContent(object):
     self.range_std = res['range_std']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # P: u32
-    ret += 4
-    # L: CarrierPhase
-    ret += CarrierPhase._payload_size()
-    # lock: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # iono_std: u16
-    ret += 2
-    # tropo_std: u16
-    ret += 2
-    # range_std: u16
-    ret += 2
-    return ret
   
 SBP_MSG_OBS = 0x004A
 class MsgObs(SBP):
@@ -305,14 +251,6 @@ with typical RTCMv3 GNSS observations.
     self.obs = res['obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: ObservationHeader
-    ret += ObservationHeader._payload_size()
-    # obs: array of PackedObsContent
-    ret += 247
-    return ret
   
 SBP_MSG_BASE_POS_LLH = 0x0044
 class MsgBasePosLLH(SBP):
@@ -355,16 +293,6 @@ error in the pseudo-absolute position output.
     self.height = res['height']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # lat: double
-    ret += 8
-    # lon: double
-    ret += 8
-    # height: double
-    ret += 8
-    return ret
   
 SBP_MSG_BASE_POS_ECEF = 0x0048
 class MsgBasePosECEF(SBP):
@@ -408,16 +336,6 @@ pseudo-absolute position output.
     self.z = res['z']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # x: double
-    ret += 8
-    # y: double
-    ret += 8
-    # z: double
-    ret += 8
-    return ret
   
 class EphemerisCommonContent(object):
   """SBP class for message EphemerisCommonContent
@@ -465,22 +383,6 @@ class EphemerisCommonContent(object):
     self.health_bits = res['health_bits']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # toe: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # ura: float
-    ret += 4
-    # fit_interval: u32
-    ret += 4
-    # valid: u8
-    ret += 1
-    # health_bits: u8
-    ret += 1
-    return ret
   
 class EphemerisCommonContentDepB(object):
   """SBP class for message EphemerisCommonContentDepB
@@ -528,22 +430,6 @@ class EphemerisCommonContentDepB(object):
     self.health_bits = res['health_bits']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # toe: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # ura: double
-    ret += 8
-    # fit_interval: u32
-    ret += 4
-    # valid: u8
-    ret += 1
-    # health_bits: u8
-    ret += 1
-    return ret
   
 class EphemerisCommonContentDepA(object):
   """SBP class for message EphemerisCommonContentDepA
@@ -591,22 +477,6 @@ class EphemerisCommonContentDepA(object):
     self.health_bits = res['health_bits']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # toe: GPSTimeDep
-    ret += GPSTimeDep._payload_size()
-    # ura: double
-    ret += 8
-    # fit_interval: u32
-    ret += 4
-    # valid: u8
-    ret += 1
-    # health_bits: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_GPS_DEP_E = 0x0081
 class MsgEphemerisGPSDepE(SBP):
@@ -729,56 +599,6 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     self.iodc = res['iodc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepA
-    ret += EphemerisCommonContentDepA._payload_size()
-    # tgd: double
-    ret += 8
-    # c_rs: double
-    ret += 8
-    # c_rc: double
-    ret += 8
-    # c_uc: double
-    ret += 8
-    # c_us: double
-    ret += 8
-    # c_ic: double
-    ret += 8
-    # c_is: double
-    ret += 8
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: double
-    ret += 8
-    # toc: GPSTimeDep
-    ret += GPSTimeDep._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    return ret
   
 SBP_MSG_EPHEMERIS_GPS_DEP_F = 0x0086
 class MsgEphemerisGPSDepF(SBP):
@@ -898,56 +718,6 @@ ephemeris message using floats for size reduction.
     self.iodc = res['iodc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepB
-    ret += EphemerisCommonContentDepB._payload_size()
-    # tgd: double
-    ret += 8
-    # c_rs: double
-    ret += 8
-    # c_rc: double
-    ret += 8
-    # c_uc: double
-    ret += 8
-    # c_us: double
-    ret += 8
-    # c_ic: double
-    ret += 8
-    # c_is: double
-    ret += 8
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: double
-    ret += 8
-    # toc: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    return ret
   
 SBP_MSG_EPHEMERIS_GPS = 0x008A
 class MsgEphemerisGPS(SBP):
@@ -1070,56 +840,6 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     self.iodc = res['iodc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # tgd: float
-    ret += 4
-    # c_rs: float
-    ret += 4
-    # c_rc: float
-    ret += 4
-    # c_uc: float
-    ret += 4
-    # c_us: float
-    ret += 4
-    # c_ic: float
-    ret += 4
-    # c_is: float
-    ret += 4
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: float
-    ret += 4
-    # af1: float
-    ret += 4
-    # af2: float
-    ret += 4
-    # toc: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    return ret
   
 SBP_MSG_EPHEMERIS_QZSS = 0x008E
 class MsgEphemerisQzss(SBP):
@@ -1240,56 +960,6 @@ velocity, and clock offset.
     self.iodc = res['iodc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # tgd: float
-    ret += 4
-    # c_rs: float
-    ret += 4
-    # c_rc: float
-    ret += 4
-    # c_uc: float
-    ret += 4
-    # c_us: float
-    ret += 4
-    # c_ic: float
-    ret += 4
-    # c_is: float
-    ret += 4
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: float
-    ret += 4
-    # af1: float
-    ret += 4
-    # af2: float
-    ret += 4
-    # toc: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    return ret
   
 SBP_MSG_EPHEMERIS_BDS = 0x0089
 class MsgEphemerisBds(SBP):
@@ -1415,58 +1085,6 @@ Satellite System SIS-ICD Version 2.1, Table 5-9 for more details.
     self.iodc = res['iodc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # tgd1: float
-    ret += 4
-    # tgd2: float
-    ret += 4
-    # c_rs: float
-    ret += 4
-    # c_rc: float
-    ret += 4
-    # c_uc: float
-    ret += 4
-    # c_us: float
-    ret += 4
-    # c_ic: float
-    ret += 4
-    # c_is: float
-    ret += 4
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: float
-    ret += 4
-    # af2: float
-    ret += 4
-    # toc: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    return ret
   
 SBP_MSG_EPHEMERIS_GAL_DEP_A = 0x0095
 class MsgEphemerisGalDepA(SBP):
@@ -1590,58 +1208,6 @@ an ephemeris message with explicit source of NAV data.
     self.iodc = res['iodc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # bgd_e1e5a: float
-    ret += 4
-    # bgd_e1e5b: float
-    ret += 4
-    # c_rs: float
-    ret += 4
-    # c_rc: float
-    ret += 4
-    # c_uc: float
-    ret += 4
-    # c_us: float
-    ret += 4
-    # c_ic: float
-    ret += 4
-    # c_is: float
-    ret += 4
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: float
-    ret += 4
-    # toc: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # iode: u16
-    ret += 2
-    # iodc: u16
-    ret += 2
-    return ret
   
 SBP_MSG_EPHEMERIS_GAL = 0x008D
 class MsgEphemerisGal(SBP):
@@ -1771,60 +1337,6 @@ OS SIS ICD, Issue 1.3, December 2016 for more details.
     self.source = res['source']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # bgd_e1e5a: float
-    ret += 4
-    # bgd_e1e5b: float
-    ret += 4
-    # c_rs: float
-    ret += 4
-    # c_rc: float
-    ret += 4
-    # c_uc: float
-    ret += 4
-    # c_us: float
-    ret += 4
-    # c_ic: float
-    ret += 4
-    # c_is: float
-    ret += 4
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: float
-    ret += 4
-    # toc: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # iode: u16
-    ret += 2
-    # iodc: u16
-    ret += 2
-    # source: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_SBAS_DEP_A = 0x0082
 class MsgEphemerisSbasDepA(SBP):
@@ -1873,22 +1385,6 @@ class MsgEphemerisSbasDepA(SBP):
     self.a_gf1 = res['a_gf1']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepA
-    ret += EphemerisCommonContentDepA._payload_size()
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of double
-    ret += 8 * 3
-    # a_gf0: double
-    ret += 8
-    # a_gf1: double
-    ret += 8
-    return ret
   
 SBP_MSG_EPHEMERIS_GLO_DEP_A = 0x0083
 class MsgEphemerisGloDepA(SBP):
@@ -1943,22 +1439,6 @@ for more details.
     self.acc = res['acc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepA
-    ret += EphemerisCommonContentDepA._payload_size()
-    # gamma: double
-    ret += 8
-    # tau: double
-    ret += 8
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of double
-    ret += 8 * 3
-    return ret
   
 SBP_MSG_EPHEMERIS_SBAS_DEP_B = 0x0084
 class MsgEphemerisSbasDepB(SBP):
@@ -2010,22 +1490,6 @@ ephemeris message using floats for size reduction.
     self.a_gf1 = res['a_gf1']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepB
-    ret += EphemerisCommonContentDepB._payload_size()
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of double
-    ret += 8 * 3
-    # a_gf0: double
-    ret += 8
-    # a_gf1: double
-    ret += 8
-    return ret
   
 SBP_MSG_EPHEMERIS_SBAS = 0x008C
 class MsgEphemerisSbas(SBP):
@@ -2074,22 +1538,6 @@ class MsgEphemerisSbas(SBP):
     self.a_gf1 = res['a_gf1']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of float
-    ret += 4 * 3
-    # acc: array of float
-    ret += 4 * 3
-    # a_gf0: float
-    ret += 4
-    # a_gf1: float
-    ret += 4
-    return ret
   
 SBP_MSG_EPHEMERIS_GLO_DEP_B = 0x0085
 class MsgEphemerisGloDepB(SBP):
@@ -2144,22 +1592,6 @@ for more details.
     self.acc = res['acc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepB
-    ret += EphemerisCommonContentDepB._payload_size()
-    # gamma: double
-    ret += 8
-    # tau: double
-    ret += 8
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of double
-    ret += 8 * 3
-    return ret
   
 SBP_MSG_EPHEMERIS_GLO_DEP_C = 0x0087
 class MsgEphemerisGloDepC(SBP):
@@ -2222,26 +1654,6 @@ for more details.
     self.fcn = res['fcn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepB
-    ret += EphemerisCommonContentDepB._payload_size()
-    # gamma: double
-    ret += 8
-    # tau: double
-    ret += 8
-    # d_tau: double
-    ret += 8
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of double
-    ret += 8 * 3
-    # fcn: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_GLO_DEP_D = 0x0088
 class MsgEphemerisGloDepD(SBP):
@@ -2305,28 +1717,6 @@ ephemeris message using floats for size reduction.
     self.iod = res['iod']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContentDepB
-    ret += EphemerisCommonContentDepB._payload_size()
-    # gamma: double
-    ret += 8
-    # tau: double
-    ret += 8
-    # d_tau: double
-    ret += 8
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of double
-    ret += 8 * 3
-    # fcn: u8
-    ret += 1
-    # iod: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_GLO = 0x008B
 class MsgEphemerisGlo(SBP):
@@ -2393,28 +1783,6 @@ for more details.
     self.iod = res['iod']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: EphemerisCommonContent
-    ret += EphemerisCommonContent._payload_size()
-    # gamma: float
-    ret += 4
-    # tau: float
-    ret += 4
-    # d_tau: float
-    ret += 4
-    # pos: array of double
-    ret += 8 * 3
-    # vel: array of double
-    ret += 8 * 3
-    # acc: array of float
-    ret += 4 * 3
-    # fcn: u8
-    ret += 1
-    # iod: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_DEP_D = 0x0080
 class MsgEphemerisDepD(SBP):
@@ -2561,68 +1929,6 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     self.reserved = res['reserved']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tgd: double
-    ret += 8
-    # c_rs: double
-    ret += 8
-    # c_rc: double
-    ret += 8
-    # c_uc: double
-    ret += 8
-    # c_us: double
-    ret += 8
-    # c_ic: double
-    ret += 8
-    # c_is: double
-    ret += 8
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: double
-    ret += 8
-    # toe_tow: double
-    ret += 8
-    # toe_wn: u16
-    ret += 2
-    # toc_tow: double
-    ret += 8
-    # toc_wn: u16
-    ret += 2
-    # valid: u8
-    ret += 1
-    # healthy: u8
-    ret += 1
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    # reserved: u32
-    ret += 4
-    return ret
   
 SBP_MSG_EPHEMERIS_DEP_A = 0x001A
 class MsgEphemerisDepA(SBP):
@@ -2752,62 +2058,6 @@ class MsgEphemerisDepA(SBP):
     self.prn = res['prn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tgd: double
-    ret += 8
-    # c_rs: double
-    ret += 8
-    # c_rc: double
-    ret += 8
-    # c_uc: double
-    ret += 8
-    # c_us: double
-    ret += 8
-    # c_ic: double
-    ret += 8
-    # c_is: double
-    ret += 8
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: double
-    ret += 8
-    # toe_tow: double
-    ret += 8
-    # toe_wn: u16
-    ret += 2
-    # toc_tow: double
-    ret += 8
-    # toc_wn: u16
-    ret += 2
-    # valid: u8
-    ret += 1
-    # healthy: u8
-    ret += 1
-    # prn: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_DEP_B = 0x0046
 class MsgEphemerisDepB(SBP):
@@ -2941,64 +2191,6 @@ class MsgEphemerisDepB(SBP):
     self.iode = res['iode']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tgd: double
-    ret += 8
-    # c_rs: double
-    ret += 8
-    # c_rc: double
-    ret += 8
-    # c_uc: double
-    ret += 8
-    # c_us: double
-    ret += 8
-    # c_ic: double
-    ret += 8
-    # c_is: double
-    ret += 8
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: double
-    ret += 8
-    # toe_tow: double
-    ret += 8
-    # toe_wn: u16
-    ret += 2
-    # toc_tow: double
-    ret += 8
-    # toc_wn: u16
-    ret += 2
-    # valid: u8
-    ret += 1
-    # healthy: u8
-    ret += 1
-    # prn: u8
-    ret += 1
-    # iode: u8
-    ret += 1
-    return ret
   
 SBP_MSG_EPHEMERIS_DEP_C = 0x0047
 class MsgEphemerisDepC(SBP):
@@ -3145,68 +2337,6 @@ Space Segment/Navigation user interfaces (ICD-GPS-200, Table
     self.reserved = res['reserved']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tgd: double
-    ret += 8
-    # c_rs: double
-    ret += 8
-    # c_rc: double
-    ret += 8
-    # c_uc: double
-    ret += 8
-    # c_us: double
-    ret += 8
-    # c_ic: double
-    ret += 8
-    # c_is: double
-    ret += 8
-    # dn: double
-    ret += 8
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # inc_dot: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    # af2: double
-    ret += 8
-    # toe_tow: double
-    ret += 8
-    # toe_wn: u16
-    ret += 2
-    # toc_tow: double
-    ret += 8
-    # toc_wn: u16
-    ret += 2
-    # valid: u8
-    ret += 1
-    # healthy: u8
-    ret += 1
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # iode: u8
-    ret += 1
-    # iodc: u16
-    ret += 2
-    # reserved: u32
-    ret += 4
-    return ret
   
 class ObservationHeaderDep(object):
   """SBP class for message ObservationHeaderDep
@@ -3239,14 +2369,6 @@ class ObservationHeaderDep(object):
     self.n_obs = res['n_obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t: GPSTimeDep
-    ret += GPSTimeDep._payload_size()
-    # n_obs: u8
-    ret += 1
-    return ret
   
 class CarrierPhaseDepA(object):
   """SBP class for message CarrierPhaseDepA
@@ -3284,14 +2406,6 @@ the opposite sign as the pseudorange.
     self.f = res['f']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # i: s32
-    ret += 4
-    # f: u8
-    ret += 1
-    return ret
   
 class PackedObsContentDepA(object):
   """SBP class for message PackedObsContentDepA
@@ -3336,20 +2450,6 @@ class PackedObsContentDepA(object):
     self.prn = res['prn']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # P: u32
-    ret += 4
-    # L: CarrierPhaseDepA
-    ret += CarrierPhaseDepA._payload_size()
-    # cn0: u8
-    ret += 1
-    # lock: u16
-    ret += 2
-    # prn: u8
-    ret += 1
-    return ret
   
 class PackedObsContentDepB(object):
   """SBP class for message PackedObsContentDepB
@@ -3396,20 +2496,6 @@ tracked.  Pseudoranges are referenced to a nominal pseudorange.
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # P: u32
-    ret += 4
-    # L: CarrierPhaseDepA
-    ret += CarrierPhaseDepA._payload_size()
-    # cn0: u8
-    ret += 1
-    # lock: u16
-    ret += 2
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    return ret
   
 class PackedObsContentDepC(object):
   """SBP class for message PackedObsContentDepC
@@ -3457,20 +2543,6 @@ receivers and conform with typical RTCMv3 GNSS observations.
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # P: u32
-    ret += 4
-    # L: CarrierPhase
-    ret += CarrierPhase._payload_size()
-    # cn0: u8
-    ret += 1
-    # lock: u16
-    ret += 2
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    return ret
   
 SBP_MSG_OBS_DEP_A = 0x0045
 class MsgObsDepA(SBP):
@@ -3504,14 +2576,6 @@ class MsgObsDepA(SBP):
     self.obs = res['obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: ObservationHeaderDep
-    ret += ObservationHeaderDep._payload_size()
-    # obs: array of PackedObsContentDepA
-    ret += 247
-    return ret
   
 SBP_MSG_OBS_DEP_B = 0x0043
 class MsgObsDepB(SBP):
@@ -3551,14 +2615,6 @@ observations.
     self.obs = res['obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: ObservationHeaderDep
-    ret += ObservationHeaderDep._payload_size()
-    # obs: array of PackedObsContentDepB
-    ret += 247
-    return ret
   
 SBP_MSG_OBS_DEP_C = 0x0049
 class MsgObsDepC(SBP):
@@ -3599,14 +2655,6 @@ with typical RTCMv3 GNSS observations.
     self.obs = res['obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: ObservationHeaderDep
-    ret += ObservationHeaderDep._payload_size()
-    # obs: array of PackedObsContentDepC
-    ret += 247
-    return ret
   
 SBP_MSG_IONO = 0x0090
 class MsgIono(SBP):
@@ -3671,28 +2719,6 @@ Please see ICD-GPS-200 (Chapter 20.3.3.5.1.7) for more details.
     self.b3 = res['b3']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t_nmct: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # a0: double
-    ret += 8
-    # a1: double
-    ret += 8
-    # a2: double
-    ret += 8
-    # a3: double
-    ret += 8
-    # b0: double
-    ret += 8
-    # b1: double
-    ret += 8
-    # b2: double
-    ret += 8
-    # b3: double
-    ret += 8
-    return ret
   
 SBP_MSG_SV_CONFIGURATION_GPS_DEP = 0x0091
 class MsgSvConfigurationGPSDep(SBP):
@@ -3727,14 +2753,6 @@ class MsgSvConfigurationGPSDep(SBP):
     self.l2c_mask = res['l2c_mask']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t_nmct: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # l2c_mask: u32
-    ret += 4
-    return ret
   
 class GnssCapb(object):
   """SBP class for message GnssCapb
@@ -3818,40 +2836,6 @@ class GnssCapb(object):
     self.gal_e5 = res['gal_e5']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # gps_active: u64
-    ret += 8
-    # gps_l2c: u64
-    ret += 8
-    # gps_l5: u64
-    ret += 8
-    # glo_active: u32
-    ret += 4
-    # glo_l2of: u32
-    ret += 4
-    # glo_l3: u32
-    ret += 4
-    # sbas_active: u64
-    ret += 8
-    # sbas_l5: u64
-    ret += 8
-    # bds_active: u64
-    ret += 8
-    # bds_d2nav: u64
-    ret += 8
-    # bds_b2: u64
-    ret += 8
-    # bds_b2a: u64
-    ret += 8
-    # qzss_active: u32
-    ret += 4
-    # gal_active: u64
-    ret += 8
-    # gal_e5: u64
-    ret += 8
-    return ret
   
 SBP_MSG_GNSS_CAPB = 0x0096
 class MsgGnssCapb(SBP):
@@ -3884,14 +2868,6 @@ class MsgGnssCapb(SBP):
     self.gc = res['gc']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t_nmct: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # gc: GnssCapb
-    ret += GnssCapb._payload_size()
-    return ret
   
 SBP_MSG_GROUP_DELAY_DEP_A = 0x0092
 class MsgGroupDelayDepA(SBP):
@@ -3941,22 +2917,6 @@ class MsgGroupDelayDepA(SBP):
     self.isc_l2c = res['isc_l2c']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t_op: GPSTimeDep
-    ret += GPSTimeDep._payload_size()
-    # prn: u8
-    ret += 1
-    # valid: u8
-    ret += 1
-    # tgd: s16
-    ret += 2
-    # isc_l1ca: s16
-    ret += 2
-    # isc_l2c: s16
-    ret += 2
-    return ret
   
 SBP_MSG_GROUP_DELAY_DEP_B = 0x0093
 class MsgGroupDelayDepB(SBP):
@@ -4006,22 +2966,6 @@ class MsgGroupDelayDepB(SBP):
     self.isc_l2c = res['isc_l2c']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t_op: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # valid: u8
-    ret += 1
-    # tgd: s16
-    ret += 2
-    # isc_l1ca: s16
-    ret += 2
-    # isc_l2c: s16
-    ret += 2
-    return ret
   
 SBP_MSG_GROUP_DELAY = 0x0094
 class MsgGroupDelay(SBP):
@@ -4071,22 +3015,6 @@ class MsgGroupDelay(SBP):
     self.isc_l2c = res['isc_l2c']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # t_op: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # valid: u8
-    ret += 1
-    # tgd: s16
-    ret += 2
-    # isc_l1ca: s16
-    ret += 2
-    # isc_l2c: s16
-    ret += 2
-    return ret
   
 class AlmanacCommonContent(object):
   """SBP class for message AlmanacCommonContent
@@ -4134,22 +3062,6 @@ class AlmanacCommonContent(object):
     self.health_bits = res['health_bits']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # toa: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # ura: double
-    ret += 8
-    # fit_interval: u32
-    ret += 4
-    # valid: u8
-    ret += 1
-    # health_bits: u8
-    ret += 1
-    return ret
   
 class AlmanacCommonContentDep(object):
   """SBP class for message AlmanacCommonContentDep
@@ -4197,22 +3109,6 @@ class AlmanacCommonContentDep(object):
     self.health_bits = res['health_bits']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # toa: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # ura: double
-    ret += 8
-    # fit_interval: u32
-    ret += 4
-    # valid: u8
-    ret += 1
-    # health_bits: u8
-    ret += 1
-    return ret
   
 SBP_MSG_ALMANAC_GPS_DEP = 0x0070
 class MsgAlmanacGPSDep(SBP):
@@ -4282,30 +3178,6 @@ Please see the Navstar GPS Space Segment/Navigation user interfaces
     self.af1 = res['af1']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: AlmanacCommonContentDep
-    ret += AlmanacCommonContentDep._payload_size()
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    return ret
   
 SBP_MSG_ALMANAC_GPS = 0x0072
 class MsgAlmanacGPS(SBP):
@@ -4375,30 +3247,6 @@ Please see the Navstar GPS Space Segment/Navigation user interfaces
     self.af1 = res['af1']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: AlmanacCommonContent
-    ret += AlmanacCommonContent._payload_size()
-    # m0: double
-    ret += 8
-    # ecc: double
-    ret += 8
-    # sqrta: double
-    ret += 8
-    # omega0: double
-    ret += 8
-    # omegadot: double
-    ret += 8
-    # w: double
-    ret += 8
-    # inc: double
-    ret += 8
-    # af0: double
-    ret += 8
-    # af1: double
-    ret += 8
-    return ret
   
 SBP_MSG_ALMANAC_GLO_DEP = 0x0071
 class MsgAlmanacGloDep(SBP):
@@ -4460,26 +3308,6 @@ almanac" for details.
     self.omega = res['omega']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: AlmanacCommonContentDep
-    ret += AlmanacCommonContentDep._payload_size()
-    # lambda_na: double
-    ret += 8
-    # t_lambda_na: double
-    ret += 8
-    # i: double
-    ret += 8
-    # t: double
-    ret += 8
-    # t_dot: double
-    ret += 8
-    # epsilon: double
-    ret += 8
-    # omega: double
-    ret += 8
-    return ret
   
 SBP_MSG_ALMANAC_GLO = 0x0073
 class MsgAlmanacGlo(SBP):
@@ -4541,26 +3369,6 @@ almanac" for details.
     self.omega = res['omega']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # common: AlmanacCommonContent
-    ret += AlmanacCommonContent._payload_size()
-    # lambda_na: double
-    ret += 8
-    # t_lambda_na: double
-    ret += 8
-    # i: double
-    ret += 8
-    # t: double
-    ret += 8
-    # t_dot: double
-    ret += 8
-    # epsilon: double
-    ret += 8
-    # omega: double
-    ret += 8
-    return ret
   
 SBP_MSG_GLO_BIASES = 0x0075
 class MsgGloBiases(SBP):
@@ -4610,20 +3418,6 @@ manufacturers)
     self.l2p_bias = res['l2p_bias']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # mask: u8
-    ret += 1
-    # l1ca_bias: s16
-    ret += 2
-    # l1p_bias: s16
-    ret += 2
-    # l2ca_bias: s16
-    ret += 2
-    # l2p_bias: s16
-    ret += 2
-    return ret
   
 class SvAzEl(object):
   """SBP class for message SvAzEl
@@ -4660,16 +3454,6 @@ class SvAzEl(object):
     self.el = res['el']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # az: u8
-    ret += 1
-    # el: s8
-    ret += 1
-    return ret
   
 SBP_MSG_SV_AZ_EL = 0x0097
 class MsgSvAzEl(SBP):
@@ -4701,12 +3485,6 @@ that the device does have ephemeris or almanac for.
     self.azel = res['azel']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # azel: array of SvAzEl
-    ret += 247
-    return ret
   
 SBP_MSG_OSR = 0x0640
 class MsgOsr(SBP):
@@ -4741,14 +3519,6 @@ class MsgOsr(SBP):
     self.obs = res['obs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: ObservationHeader
-    ret += ObservationHeader._payload_size()
-    # obs: array of PackedOsrContent
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/orientation.py
+++ b/python/sbp/jit/orientation.py
@@ -71,18 +71,6 @@ that time-matched RTK mode is used when the base station is moving.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # heading: u32
-    ret += 4
-    # n_sats: u8
-    ret += 1
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_ORIENT_QUAT = 0x0220
 class MsgOrientQuat(SBP):
@@ -153,30 +141,6 @@ or Duro.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # w: s32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # w_accuracy: float
-    ret += 4
-    # x_accuracy: float
-    ret += 4
-    # y_accuracy: float
-    ret += 4
-    # z_accuracy: float
-    ret += 4
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_ORIENT_EULER = 0x0221
 class MsgOrientEuler(SBP):
@@ -239,26 +203,6 @@ INS versions of Swift Products and is not produced by Piksi Multi or Duro.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # roll: s32
-    ret += 4
-    # pitch: s32
-    ret += 4
-    # yaw: s32
-    ret += 4
-    # roll_accuracy: float
-    ret += 4
-    # pitch_accuracy: float
-    ret += 4
-    # yaw_accuracy: float
-    ret += 4
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_ANGULAR_RATE = 0x0222
 class MsgAngularRate(SBP):
@@ -313,20 +257,6 @@ and is not produced by Piksi Multi or Duro.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # x: s32
-    ret += 4
-    # y: s32
-    ret += 4
-    # z: s32
-    ret += 4
-    # flags: u8
-    ret += 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/piksi.py
+++ b/python/sbp/jit/piksi.py
@@ -48,9 +48,6 @@ alamanac onto the Piksi's flash memory from the host.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_SET_TIME = 0x0068
 class MsgSetTime(SBP):
@@ -69,9 +66,6 @@ time estimate sent by the host.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_RESET = 0x00B6
 class MsgReset(SBP):
@@ -103,12 +97,6 @@ bootloader.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # flags: u32
-    ret += 4
-    return ret
   
 SBP_MSG_RESET_DEP = 0x00B2
 class MsgResetDep(SBP):
@@ -127,9 +115,6 @@ bootloader.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_CW_RESULTS = 0x00C0
 class MsgCwResults(SBP):
@@ -149,9 +134,6 @@ removed in a future release.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_CW_START = 0x00C1
 class MsgCwStart(SBP):
@@ -171,9 +153,6 @@ be removed in a future release.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_RESET_FILTERS = 0x0022
 class MsgResetFilters(SBP):
@@ -205,12 +184,6 @@ Ambiguity Resolution (IAR) process.
     self.filter = res['filter']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # filter: u8
-    ret += 1
-    return ret
   
 SBP_MSG_INIT_BASE_DEP = 0x0023
 class MsgInitBaseDep(SBP):
@@ -227,9 +200,6 @@ class MsgInitBaseDep(SBP):
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_THREAD_STATE = 0x0017
 class MsgThreadState(SBP):
@@ -270,16 +240,6 @@ thread. The reported percentage values must be normalized.
     self.stack_free = res['stack_free']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # name: string
-    ret += 20
-    # cpu: u16
-    ret += 2
-    # stack_free: u32
-    ret += 4
-    return ret
   
 class UARTChannel(object):
   """SBP class for message UARTChannel
@@ -331,22 +291,6 @@ be normalized.
     self.rx_buffer_level = res['rx_buffer_level']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tx_throughput: float
-    ret += 4
-    # rx_throughput: float
-    ret += 4
-    # crc_error_count: u16
-    ret += 2
-    # io_error_count: u16
-    ret += 2
-    # tx_buffer_level: u8
-    ret += 1
-    # rx_buffer_level: u8
-    ret += 1
-    return ret
   
 class Period(object):
   """SBP class for message Period
@@ -393,18 +337,6 @@ can cause momentary RTK solution outages.
     self.current = res['current']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # avg: s32
-    ret += 4
-    # pmin: s32
-    ret += 4
-    # pmax: s32
-    ret += 4
-    # current: s32
-    ret += 4
-    return ret
   
 class Latency(object):
   """SBP class for message Latency
@@ -450,18 +382,6 @@ communication latency in the system.
     self.current = res['current']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # avg: s32
-    ret += 4
-    # lmin: s32
-    ret += 4
-    # lmax: s32
-    ret += 4
-    # current: s32
-    ret += 4
-    return ret
   
 SBP_MSG_UART_STATE = 0x001D
 class MsgUartState(SBP):
@@ -516,20 +436,6 @@ period indicates their likelihood of transmission.
     self.obs_period = res['obs_period']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # uart_a: UARTChannel
-    ret += UARTChannel._payload_size()
-    # uart_b: UARTChannel
-    ret += UARTChannel._payload_size()
-    # uart_ftdi: UARTChannel
-    ret += UARTChannel._payload_size()
-    # latency: Latency
-    ret += Latency._payload_size()
-    # obs_period: Period
-    ret += Period._payload_size()
-    return ret
   
 SBP_MSG_UART_STATE_DEPA = 0x0018
 class MsgUartStateDepa(SBP):
@@ -571,18 +477,6 @@ class MsgUartStateDepa(SBP):
     self.latency = res['latency']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # uart_a: UARTChannel
-    ret += UARTChannel._payload_size()
-    # uart_b: UARTChannel
-    ret += UARTChannel._payload_size()
-    # uart_ftdi: UARTChannel
-    ret += UARTChannel._payload_size()
-    # latency: Latency
-    ret += Latency._payload_size()
-    return ret
   
 SBP_MSG_IAR_STATE = 0x0019
 class MsgIarState(SBP):
@@ -616,12 +510,6 @@ from satellite observations.
     self.num_hyps = res['num_hyps']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # num_hyps: u32
-    ret += 4
-    return ret
   
 SBP_MSG_MASK_SATELLITE = 0x002B
 class MsgMaskSatellite(SBP):
@@ -657,14 +545,6 @@ from being used in various Piksi subsystems.
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # mask: u8
-    ret += 1
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    return ret
   
 SBP_MSG_MASK_SATELLITE_DEP = 0x001B
 class MsgMaskSatelliteDep(SBP):
@@ -698,14 +578,6 @@ class MsgMaskSatelliteDep(SBP):
     self.sid = res['sid']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # mask: u8
-    ret += 1
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    return ret
   
 SBP_MSG_DEVICE_MONITOR = 0x00B5
 class MsgDeviceMonitor(SBP):
@@ -754,20 +626,6 @@ available.
     self.fe_temperature = res['fe_temperature']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # dev_vin: s16
-    ret += 2
-    # cpu_vint: s16
-    ret += 2
-    # cpu_vaux: s16
-    ret += 2
-    # cpu_temperature: s16
-    ret += 2
-    # fe_temperature: s16
-    ret += 2
-    return ret
   
 SBP_MSG_COMMAND_REQ = 0x00B8
 class MsgCommandReq(SBP):
@@ -804,14 +662,6 @@ code will be returned with MSG_COMMAND_RESP.
     self.command = res['command']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # command: string
-    ret += 247
-    return ret
   
 SBP_MSG_COMMAND_RESP = 0x00B9
 class MsgCommandResp(SBP):
@@ -847,14 +697,6 @@ the command.  A return code of zero indicates success.
     self.code = res['code']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # code: s32
-    ret += 4
-    return ret
   
 SBP_MSG_COMMAND_OUTPUT = 0x00BC
 class MsgCommandOutput(SBP):
@@ -892,14 +734,6 @@ the correct command.
     self.line = res['line']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sequence: u32
-    ret += 4
-    # line: string
-    ret += 247
-    return ret
   
 SBP_MSG_NETWORK_STATE_REQ = 0x00BA
 class MsgNetworkStateReq(SBP):
@@ -918,9 +752,6 @@ Output will be sent in MSG_NETWORK_STATE_RESP messages
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_NETWORK_STATE_RESP = 0x00BB
 class MsgNetworkStateResp(SBP):
@@ -981,26 +812,6 @@ in c.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # ipv4_address: array of u8
-    ret += 1 * 4
-    # ipv4_mask_size: u8
-    ret += 1
-    # ipv6_address: array of u8
-    ret += 1 * 16
-    # ipv6_mask_size: u8
-    ret += 1
-    # rx_bytes: u32
-    ret += 4
-    # tx_bytes: u32
-    ret += 4
-    # interface_name: string
-    ret += 16
-    # flags: u32
-    ret += 4
-    return ret
   
 class NetworkUsage(object):
   """SBP class for message NetworkUsage
@@ -1051,20 +862,6 @@ though may not necessarily be populated with a value.
     self.interface_name = res['interface_name']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # duration: u64
-    ret += 8
-    # total_bytes: u64
-    ret += 8
-    # rx_bytes: u32
-    ret += 4
-    # tx_bytes: u32
-    ret += 4
-    # interface_name: string
-    ret += 16
-    return ret
   
 SBP_MSG_NETWORK_BANDWIDTH_USAGE = 0x00BD
 class MsgNetworkBandwidthUsage(SBP):
@@ -1095,12 +892,6 @@ class MsgNetworkBandwidthUsage(SBP):
     self.interfaces = res['interfaces']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # interfaces: array of NetworkUsage
-    ret += 247
-    return ret
   
 SBP_MSG_CELL_MODEM_STATUS = 0x00BE
 class MsgCellModemStatus(SBP):
@@ -1141,16 +932,6 @@ of the modem and its various parameters.
     self.reserved = res['reserved']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # signal_strength: s8
-    ret += 1
-    # signal_error_rate: float
-    ret += 4
-    # reserved: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_SPECAN_DEP = 0x0050
 class MsgSpecanDep(SBP):
@@ -1204,24 +985,6 @@ class MsgSpecanDep(SBP):
     self.amplitude_value = res['amplitude_value']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # channel_tag: u16
-    ret += 2
-    # t: GPSTimeDep
-    ret += GPSTimeDep._payload_size()
-    # freq_ref: float
-    ret += 4
-    # freq_step: float
-    ret += 4
-    # amplitude_ref: float
-    ret += 4
-    # amplitude_unit: float
-    ret += 4
-    # amplitude_value: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_SPECAN = 0x0051
 class MsgSpecan(SBP):
@@ -1276,24 +1039,6 @@ class MsgSpecan(SBP):
     self.amplitude_value = res['amplitude_value']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # channel_tag: u16
-    ret += 2
-    # t: GPSTime
-    ret += GPSTime._payload_size()
-    # freq_ref: float
-    ret += 4
-    # freq_step: float
-    ret += 4
-    # amplitude_ref: float
-    ret += 4
-    # amplitude_unit: float
-    ret += 4
-    # amplitude_value: array of u8
-    ret += 247
-    return ret
   
 SBP_MSG_FRONT_END_GAIN = 0x00BF
 class MsgFrontEndGain(SBP):
@@ -1333,14 +1078,6 @@ A negative value implies an error for the particular gain stage as reported by t
     self.if_gain = res['if_gain']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # rf_gain: array of s8
-    ret += 1 * 8
-    # if_gain: array of s8
-    ret += 1 * 8
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/sbas.py
+++ b/python/sbp/jit/sbas.py
@@ -70,18 +70,6 @@ parity of the data block and sends only blocks that pass the check.
     self.data = res['data']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # tow: u32
-    ret += 4
-    # message_type: u8
-    ret += 1
-    # data: array of u8
-    ret += 1 * 27
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/settings.py
+++ b/python/sbp/jit/settings.py
@@ -70,9 +70,6 @@ configuration to its onboard flash memory file system.
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_SETTINGS_WRITE = 0x00A0
 class MsgSettingsWrite(SBP):
@@ -109,12 +106,6 @@ An example string that could be sent to a device is
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # setting: string
-    ret += 247
-    return ret
   
 SBP_MSG_SETTINGS_WRITE_RESP = 0x00AF
 class MsgSettingsWriteResp(SBP):
@@ -155,14 +146,6 @@ are omitted. An example string that could be sent from device is
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # status: u8
-    ret += 1
-    # setting: string
-    ret += 247
-    return ret
   
 SBP_MSG_SETTINGS_READ_REQ = 0x00A4
 class MsgSettingsReadReq(SBP):
@@ -200,12 +183,6 @@ message (msg_id 0x00A5).
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # setting: string
-    ret += 247
-    return ret
   
 SBP_MSG_SETTINGS_READ_RESP = 0x00A5
 class MsgSettingsReadResp(SBP):
@@ -242,12 +219,6 @@ example string that could be sent from device is
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # setting: string
-    ret += 247
-    return ret
   
 SBP_MSG_SETTINGS_READ_BY_INDEX_REQ = 0x00A2
 class MsgSettingsReadByIndexReq(SBP):
@@ -280,12 +251,6 @@ values. A device will respond to this message with a
     self.index = res['index']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u16
-    ret += 2
-    return ret
   
 SBP_MSG_SETTINGS_READ_BY_INDEX_RESP = 0x00A7
 class MsgSettingsReadByIndexResp(SBP):
@@ -329,14 +294,6 @@ the device is "simulator\0enabled\0True\0enum:True,False\0"
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u16
-    ret += 2
-    # setting: string
-    ret += 247
-    return ret
   
 SBP_MSG_SETTINGS_READ_BY_INDEX_DONE = 0x00A6
 class MsgSettingsReadByIndexDone(SBP):
@@ -354,9 +311,6 @@ class MsgSettingsReadByIndexDone(SBP):
   __slots__ = []
   def _unpack_members(self, buf, offset, length):
     return {}, offset, length
-
-  def _payload_size(self):
-    return 0
   
 SBP_MSG_SETTINGS_REGISTER = 0x00AE
 class MsgSettingsRegister(SBP):
@@ -389,12 +343,6 @@ for this setting to set the initial value.
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # setting: string
-    ret += 247
-    return ret
   
 SBP_MSG_SETTINGS_REGISTER_RESP = 0x01AF
 class MsgSettingsRegisterResp(SBP):
@@ -432,14 +380,6 @@ and had a different value.
     self.setting = res['setting']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # status: u8
-    ret += 1
-    # setting: string
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/ssr.py
+++ b/python/sbp/jit/ssr.py
@@ -61,14 +61,6 @@ The corrections conform with typical RTCMv3 MT1059 and 1065.
     self.value = res['value']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # code: u8
-    ret += 1
-    # value: s16
-    ret += 2
-    return ret
   
 class PhaseBiasesContent(object):
   """SBP class for message PhaseBiasesContent
@@ -115,20 +107,6 @@ The corrections conform with typical RTCMv3 MT1059 and 1065.
     self.bias = res['bias']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # code: u8
-    ret += 1
-    # integer_indicator: u8
-    ret += 1
-    # widelane_integer_indicator: u8
-    ret += 1
-    # discontinuity_counter: u8
-    ret += 1
-    # bias: s32
-    ret += 4
-    return ret
   
 class STECHeader(object):
   """SBP class for message STECHeader
@@ -176,20 +154,6 @@ is used to tie multiple SBP messages into a sequence.
     self.iod_atmo = res['iod_atmo']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # num_msgs: u8
-    ret += 1
-    # seq_num: u8
-    ret += 1
-    # update_interval: u8
-    ret += 1
-    # iod_atmo: u8
-    ret += 1
-    return ret
   
 class GriddedCorrectionHeader(object):
   """SBP class for message GriddedCorrectionHeader
@@ -241,22 +205,6 @@ be identified by the index.
     self.tropo_quality_indicator = res['tropo_quality_indicator']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # num_msgs: u16
-    ret += 2
-    # seq_num: u16
-    ret += 2
-    # update_interval: u8
-    ret += 1
-    # iod_atmo: u8
-    ret += 1
-    # tropo_quality_indicator: u8
-    ret += 1
-    return ret
   
 class STECSatElement(object):
   """SBP class for message STECSatElement
@@ -293,16 +241,6 @@ class STECSatElement(object):
     self.stec_coeff = res['stec_coeff']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sv_id: SvId
-    ret += SvId._payload_size()
-    # stec_quality_indicator: u8
-    ret += 1
-    # stec_coeff: array of s16
-    ret += 2 * 4
-    return ret
   
 class TroposphericDelayCorrectionNoStd(object):
   """SBP class for message TroposphericDelayCorrectionNoStd
@@ -336,14 +274,6 @@ class TroposphericDelayCorrectionNoStd(object):
     self.wet = res['wet']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # hydro: s16
-    ret += 2
-    # wet: s8
-    ret += 1
-    return ret
   
 class TroposphericDelayCorrection(object):
   """SBP class for message TroposphericDelayCorrection
@@ -382,16 +312,6 @@ point.
     self.stddev = res['stddev']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # hydro: s16
-    ret += 2
-    # wet: s8
-    ret += 1
-    # stddev: u8
-    ret += 1
-    return ret
   
 class STECResidualNoStd(object):
   """SBP class for message STECResidualNoStd
@@ -424,14 +344,6 @@ class STECResidualNoStd(object):
     self.residual = res['residual']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sv_id: SvId
-    ret += SvId._payload_size()
-    # residual: s16
-    ret += 2
-    return ret
   
 class STECResidual(object):
   """SBP class for message STECResidual
@@ -470,16 +382,6 @@ at the grid point,
     self.stddev = res['stddev']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sv_id: SvId
-    ret += SvId._payload_size()
-    # residual: s16
-    ret += 2
-    # stddev: u8
-    ret += 1
-    return ret
   
 class GridElementNoStd(object):
   """SBP class for message GridElementNoStd
@@ -518,16 +420,6 @@ grid point.
     self.stec_residuals = res['stec_residuals']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u16
-    ret += 2
-    # tropo_delay_correction: TroposphericDelayCorrectionNoStd
-    ret += TroposphericDelayCorrectionNoStd._payload_size()
-    # stec_residuals: array of STECResidualNoStd
-    ret += 247
-    return ret
   
 class GridElement(object):
   """SBP class for message GridElement
@@ -566,16 +458,6 @@ stddev) for each satellite at the grid point.
     self.stec_residuals = res['stec_residuals']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # index: u16
-    ret += 2
-    # tropo_delay_correction: TroposphericDelayCorrection
-    ret += TroposphericDelayCorrection._payload_size()
-    # stec_residuals: array of STECResidual
-    ret += 247
-    return ret
   
 class GridDefinitionHeader(object):
   """SBP class for message GridDefinitionHeader
@@ -626,22 +508,6 @@ Also includes an RLE encoded validity list.
     self.seq_num = res['seq_num']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # region_size_inverse: u8
-    ret += 1
-    # area_width: u16
-    ret += 2
-    # lat_nw_corner_enc: u16
-    ret += 2
-    # lon_nw_corner_enc: u16
-    ret += 2
-    # num_msgs: u8
-    ret += 1
-    # seq_num: u8
-    ret += 1
-    return ret
   
 SBP_MSG_SSR_ORBIT_CLOCK = 0x05DD
 class MsgSsrOrbitClock(SBP):
@@ -727,38 +593,6 @@ and 1066 RTCM message types
     self.c2 = res['c2']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # update_interval: u8
-    ret += 1
-    # iod_ssr: u8
-    ret += 1
-    # iod: u32
-    ret += 4
-    # radial: s32
-    ret += 4
-    # along: s32
-    ret += 4
-    # cross: s32
-    ret += 4
-    # dot_radial: s32
-    ret += 4
-    # dot_along: s32
-    ret += 4
-    # dot_cross: s32
-    ret += 4
-    # c0: s32
-    ret += 4
-    # c1: s32
-    ret += 4
-    # c2: s32
-    ret += 4
-    return ret
   
 SBP_MSG_SSR_ORBIT_CLOCK_DEP_A = 0x05DC
 class MsgSsrOrbitClockDepA(SBP):
@@ -844,38 +678,6 @@ and 1066 RTCM message types
     self.c2 = res['c2']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # update_interval: u8
-    ret += 1
-    # iod_ssr: u8
-    ret += 1
-    # iod: u8
-    ret += 1
-    # radial: s32
-    ret += 4
-    # along: s32
-    ret += 4
-    # cross: s32
-    ret += 4
-    # dot_radial: s32
-    ret += 4
-    # dot_along: s32
-    ret += 4
-    # dot_cross: s32
-    ret += 4
-    # c0: s32
-    ret += 4
-    # c1: s32
-    ret += 4
-    # c2: s32
-    ret += 4
-    return ret
   
 SBP_MSG_SSR_CODE_BIASES = 0x05E1
 class MsgSsrCodeBiases(SBP):
@@ -925,20 +727,6 @@ an equivalent to the 1059 and 1065 RTCM message types
     self.biases = res['biases']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # update_interval: u8
-    ret += 1
-    # iod_ssr: u8
-    ret += 1
-    # biases: array of CodeBiasesContent
-    ret += 247
-    return ret
   
 SBP_MSG_SSR_PHASE_BIASES = 0x05E6
 class MsgSsrPhaseBiases(SBP):
@@ -1006,28 +794,6 @@ It is typically an equivalent to the 1265 RTCM message types
     self.biases = res['biases']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: GPSTimeSec
-    ret += GPSTimeSec._payload_size()
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # update_interval: u8
-    ret += 1
-    # iod_ssr: u8
-    ret += 1
-    # dispersive_bias: u8
-    ret += 1
-    # mw_consistency: u8
-    ret += 1
-    # yaw: u16
-    ret += 2
-    # yaw_rate: s8
-    ret += 1
-    # biases: array of PhaseBiasesContent
-    ret += 247
-    return ret
   
 SBP_MSG_SSR_STEC_CORRECTION = 0x05EB
 class MsgSsrStecCorrection(SBP):
@@ -1065,14 +831,6 @@ delay. It is typically equivalent to the QZSS CLAS Sub Type 8 messages
     self.stec_sat_list = res['stec_sat_list']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: STECHeader
-    ret += STECHeader._payload_size()
-    # stec_sat_list: array of STECSatElement
-    ret += 247
-    return ret
   
 SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD = 0x05F0
 class MsgSsrGriddedCorrectionNoStd(SBP):
@@ -1108,14 +866,6 @@ were added.
     self.element = res['element']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: GriddedCorrectionHeader
-    ret += GriddedCorrectionHeader._payload_size()
-    # element: GridElementNoStd
-    ret += GridElementNoStd._payload_size()
-    return ret
   
 SBP_MSG_SSR_GRIDDED_CORRECTION = 0x05FA
 class MsgSsrGriddedCorrection(SBP):
@@ -1151,14 +901,6 @@ It is typically equivalent to the QZSS CLAS Sub Type 9 messages
     self.element = res['element']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: GriddedCorrectionHeader
-    ret += GriddedCorrectionHeader._payload_size()
-    # element: GridElement
-    ret += GridElement._payload_size()
-    return ret
   
 SBP_MSG_SSR_GRID_DEFINITION = 0x05F5
 class MsgSsrGridDefinition(SBP):
@@ -1194,14 +936,6 @@ OMA-LPPe-ValidityArea from OMA-TS-LPPe-V2_0-20141202-C
     self.rle_list = res['rle_list']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # header: GridDefinitionHeader
-    ret += GridDefinitionHeader._payload_size()
-    # rle_list: array of u8
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/system.py
+++ b/python/sbp/jit/system.py
@@ -67,16 +67,6 @@ or configuration requests.
     self.reserved = res['reserved']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # cause: u8
-    ret += 1
-    # startup_type: u8
-    ret += 1
-    # reserved: u16
-    ret += 2
-    return ret
   
 SBP_MSG_DGNSS_STATUS = 0xFF02
 class MsgDgnssStatus(SBP):
@@ -121,18 +111,6 @@ corrections packet.
     self.source = res['source']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # flags: u8
-    ret += 1
-    # latency: u16
-    ret += 2
-    # num_signals: u8
-    ret += 1
-    # source: string
-    ret += 247
-    return ret
   
 SBP_MSG_HEARTBEAT = 0xFFFF
 class MsgHeartbeat(SBP):
@@ -172,12 +150,6 @@ the remaining error flags should be inspected.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # flags: u32
-    ret += 4
-    return ret
   
 SBP_MSG_INS_STATUS = 0xFF03
 class MsgInsStatus(SBP):
@@ -209,12 +181,6 @@ and initialization of the inertial navigation system.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # flags: u32
-    ret += 4
-    return ret
   
 SBP_MSG_CSAC_TELEMETRY = 0xFF04
 class MsgCsacTelemetry(SBP):
@@ -251,14 +217,6 @@ It is intended to be a low rate message for status purposes.
     self.telemetry = res['telemetry']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # id: u8
-    ret += 1
-    # telemetry: string
-    ret += 247
-    return ret
   
 SBP_MSG_CSAC_TELEMETRY_LABELS = 0xFF05
 class MsgCsacTelemetryLabels(SBP):
@@ -295,14 +253,6 @@ rate than the MSG_CSAC_TELEMETRY.
     self.telemetry_labels = res['telemetry_labels']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # id: u8
-    ret += 1
-    # telemetry_labels: string
-    ret += 247
-    return ret
   
 SBP_MSG_INS_UPDATES = 0xFF06
 class MsgInsUpdates(SBP):
@@ -358,24 +308,6 @@ This message is expected to be extended in the future as new types of measuremen
     self.zerovel = res['zerovel']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # gnsspos: u8
-    ret += 1
-    # gnssvel: u8
-    ret += 1
-    # wheelticks: u8
-    ret += 1
-    # speed: u8
-    ret += 1
-    # nhc: u8
-    ret += 1
-    # zerovel: u8
-    ret += 1
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/tracking.py
+++ b/python/sbp/jit/tracking.py
@@ -139,52 +139,6 @@ single tracking channel useful for debugging issues.
     self.misc_flags = res['misc_flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # recv_time: u64
-    ret += 8
-    # tot: GPSTime
-    ret += GPSTime._payload_size()
-    # P: u32
-    ret += 4
-    # P_std: u16
-    ret += 2
-    # L: CarrierPhase
-    ret += CarrierPhase._payload_size()
-    # cn0: u8
-    ret += 1
-    # lock: u16
-    ret += 2
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # doppler: s32
-    ret += 4
-    # doppler_std: u16
-    ret += 2
-    # uptime: u32
-    ret += 4
-    # clock_offset: s16
-    ret += 2
-    # clock_drift: s16
-    ret += 2
-    # corr_spacing: u16
-    ret += 2
-    # acceleration: s8
-    ret += 1
-    # sync_flags: u8
-    ret += 1
-    # tow_flags: u8
-    ret += 1
-    # track_flags: u8
-    ret += 1
-    # nav_flags: u8
-    ret += 1
-    # pset_flags: u8
-    ret += 1
-    # misc_flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_TRACKING_STATE_DETAILED_DEP = 0x0011
 class MsgTrackingStateDetailedDep(SBP):
@@ -294,52 +248,6 @@ class MsgTrackingStateDetailedDep(SBP):
     self.misc_flags = res['misc_flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # recv_time: u64
-    ret += 8
-    # tot: GPSTimeDep
-    ret += GPSTimeDep._payload_size()
-    # P: u32
-    ret += 4
-    # P_std: u16
-    ret += 2
-    # L: CarrierPhase
-    ret += CarrierPhase._payload_size()
-    # cn0: u8
-    ret += 1
-    # lock: u16
-    ret += 2
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # doppler: s32
-    ret += 4
-    # doppler_std: u16
-    ret += 2
-    # uptime: u32
-    ret += 4
-    # clock_offset: s16
-    ret += 2
-    # clock_drift: s16
-    ret += 2
-    # corr_spacing: u16
-    ret += 2
-    # acceleration: s8
-    ret += 1
-    # sync_flags: u8
-    ret += 1
-    # tow_flags: u8
-    ret += 1
-    # track_flags: u8
-    ret += 1
-    # nav_flags: u8
-    ret += 1
-    # pset_flags: u8
-    ret += 1
-    # misc_flags: u8
-    ret += 1
-    return ret
   
 class TrackingChannelState(object):
   """SBP class for message TrackingChannelState
@@ -378,16 +286,6 @@ measured signal power.
     self.cn0 = res['cn0']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # fcn: u8
-    ret += 1
-    # cn0: u8
-    ret += 1
-    return ret
   
 SBP_MSG_TRACKING_STATE = 0x0041
 class MsgTrackingState(SBP):
@@ -420,12 +318,6 @@ measurements for all tracked satellites.
     self.states = res['states']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # states: array of TrackingChannelState
-    ret += 247
-    return ret
   
 class MeasurementState(object):
   """SBP class for message MeasurementState
@@ -463,14 +355,6 @@ the Slot ID (from 1 to 28)
     self.cn0 = res['cn0']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # mesid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # cn0: u8
-    ret += 1
-    return ret
   
 SBP_MSG_MEASUREMENT_STATE = 0x0061
 class MsgMeasurementState(SBP):
@@ -503,12 +387,6 @@ measurements for all tracked satellites.
     self.states = res['states']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # states: array of MeasurementState
-    ret += 247
-    return ret
   
 class TrackingChannelCorrelation(object):
   """SBP class for message TrackingChannelCorrelation
@@ -542,14 +420,6 @@ class TrackingChannelCorrelation(object):
     self.Q = res['Q']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # I: s16
-    ret += 2
-    # Q: s16
-    ret += 2
-    return ret
   
 SBP_MSG_TRACKING_IQ = 0x002D
 class MsgTrackingIq(SBP):
@@ -589,16 +459,6 @@ update interval.
     self.corrs = res['corrs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # channel: u8
-    ret += 1
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # corrs: array of TrackingChannelCorrelation
-    ret += TrackingChannelCorrelation._payload_size() * 3
-    return ret
   
 class TrackingChannelCorrelationDep(object):
   """SBP class for message TrackingChannelCorrelationDep
@@ -632,14 +492,6 @@ class TrackingChannelCorrelationDep(object):
     self.Q = res['Q']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # I: s32
-    ret += 4
-    # Q: s32
-    ret += 4
-    return ret
   
 SBP_MSG_TRACKING_IQ_DEP_B = 0x002C
 class MsgTrackingIqDepB(SBP):
@@ -679,16 +531,6 @@ update interval.
     self.corrs = res['corrs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # channel: u8
-    ret += 1
-    # sid: GnssSignal
-    ret += GnssSignal._payload_size()
-    # corrs: array of TrackingChannelCorrelationDep
-    ret += TrackingChannelCorrelationDep._payload_size() * 3
-    return ret
   
 SBP_MSG_TRACKING_IQ_DEP_A = 0x001C
 class MsgTrackingIqDepA(SBP):
@@ -726,16 +568,6 @@ class MsgTrackingIqDepA(SBP):
     self.corrs = res['corrs']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # channel: u8
-    ret += 1
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # corrs: array of TrackingChannelCorrelationDep
-    ret += TrackingChannelCorrelationDep._payload_size() * 3
-    return ret
   
 class TrackingChannelStateDepA(object):
   """SBP class for message TrackingChannelStateDepA
@@ -772,16 +604,6 @@ class TrackingChannelStateDepA(object):
     self.cn0 = res['cn0']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # state: u8
-    ret += 1
-    # prn: u8
-    ret += 1
-    # cn0: float
-    ret += 4
-    return ret
   
 SBP_MSG_TRACKING_STATE_DEP_A = 0x0016
 class MsgTrackingStateDepA(SBP):
@@ -811,12 +633,6 @@ class MsgTrackingStateDepA(SBP):
     self.states = res['states']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # states: array of TrackingChannelStateDepA
-    ret += 247
-    return ret
   
 class TrackingChannelStateDepB(object):
   """SBP class for message TrackingChannelStateDepB
@@ -853,16 +669,6 @@ class TrackingChannelStateDepB(object):
     self.cn0 = res['cn0']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # state: u8
-    ret += 1
-    # sid: GnssSignalDep
-    ret += GnssSignalDep._payload_size()
-    # cn0: float
-    ret += 4
-    return ret
   
 SBP_MSG_TRACKING_STATE_DEP_B = 0x0013
 class MsgTrackingStateDepB(SBP):
@@ -892,12 +698,6 @@ class MsgTrackingStateDepB(SBP):
     self.states = res['states']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # states: array of TrackingChannelStateDepB
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/user.py
+++ b/python/sbp/jit/user.py
@@ -58,12 +58,6 @@ maximum length of 255 bytes per message.
     self.contents = res['contents']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # contents: array of u8
-    ret += 247
-    return ret
   
 
 msg_classes = {

--- a/python/sbp/jit/vehicle.py
+++ b/python/sbp/jit/vehicle.py
@@ -68,16 +68,6 @@ source 0 through 3.
     self.flags = res['flags']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # tow: u32
-    ret += 4
-    # velocity: s32
-    ret += 4
-    # flags: u8
-    ret += 1
-    return ret
   
 SBP_MSG_WHEELTICK = 0x0904
 class MsgWheeltick(SBP):
@@ -126,18 +116,6 @@ tick count reached the value given by the contents of this message as accurately
     self.ticks = res['ticks']
     return res, off, length
 
-  @classmethod
-  def _payload_size(self):
-    ret = 0
-    # time: u64
-    ret += 8
-    # flags: u8
-    ret += 1
-    # source: u8
-    ret += 1
-    # ticks: s32
-    ret += 4
-    return ret
   
 
 msg_classes = {


### PR DESCRIPTION
This method was not used, and the genreated code wasn't correct when the
message included an unsized member like a string or a variable sized
array.