### PR TITLE
Fix bugs in Java array decoding

### DIFF
--- a/java/src/com/swiftnav/sbp/SBPMessage.java
+++ b/java/src/com/swiftnav/sbp/SBPMessage.java
@@ -167,7 +167,7 @@ public class SBPMessage {
         }
 
         public int[] getArrayofS16() {
-            return getArrayofS16(buf.remaining());
+            return getArrayofS16(buf.remaining() / 2);
         }
         public int[] getArrayofS16(int n) {
             int[] ret = new int[n];
@@ -177,7 +177,7 @@ public class SBPMessage {
         }
 
         public int[] getArrayofU16() {
-            return getArrayofU16(buf.remaining());
+            return getArrayofU16(buf.remaining() / 2);
         }
         public int[] getArrayofU16(int n) {
             int[] ret = new int[n];
@@ -187,7 +187,7 @@ public class SBPMessage {
         }
 
         public float[] getArrayofFloat() {
-            return getArrayofFloat(buf.remaining());
+            return getArrayofFloat(buf.remaining() / Float.BYTES);
         }
         public float[] getArrayofFloat(int n) {
             float [] ret = new float[n];
@@ -197,7 +197,7 @@ public class SBPMessage {
         }
 
         public double[] getArrayofDouble() {
-            return getArrayofDouble(buf.remaining());
+            return getArrayofDouble(buf.remaining() / Double.BYTES);
         }
         public double[] getArrayofDouble(int n) {
             double [] ret = new double[n];


### PR DESCRIPTION
Found a bug when decoding array of U16 in Java. It would try to decode as many U16s as there were bytes left in the buffer, causing the buffer to run out halfway there.
I believe the same logic goes for the `float` and `double` versions, but I have not tested these myself.
This was triggered by the `MSG_GROUP_META`, not sure if these functions are used from somewhere else.