### PR TITLE
fix tox tests for Python 3.5

### DIFF
--- a/generator/setup.py
+++ b/generator/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(name='sbp_gen',
       description='Generator for Swift Binary Protocol',
-      long_description=open('README.md').read(),
+      long_description=open('README.md', 'rb').read().decode('utf8'),
       version='0.10',
       author='Swift Navigation',
       author_email='mookerji@swiftnav.com',

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -134,6 +134,7 @@ class JSONLogIterator(LogIterator):
         if self._broken:
             raise StopIteration
 
+        line = ''
         try:
             line = self.handle.readline()
 
@@ -148,12 +149,17 @@ class JSONLogIterator(LogIterator):
             return self._next_conventional()
 
     def _next_legacy(self):
-        for line in self.handle:
-            try:
-                yield self._extract_data(line)
-            except (ValueError, UnicodeDecodeError):
-                warn = "Bad JSON decoding for line %s" % line
-                warnings.warn(warn, RuntimeWarning)
+        line = ''
+        try:
+            for line in self.handle:
+                try:
+                    yield self._extract_data(line)
+                except (ValueError, UnicodeDecodeError):
+                    warn = "Bad JSON decoding for line %s" % (line,)
+                    warnings.warn(warn, RuntimeWarning)
+        except (ValueError, UnicodeDecodeError):
+            warn = "Bad JSON decoding"
+            warnings.warn(warn, RuntimeWarning)
         self.handle.seek(0, 0)
 
     def __next__(self):

--- a/python/setup.py
+++ b/python/setup.py
@@ -163,8 +163,8 @@ def exclude_jit_libs(lib):
 
 if __name__ == "__main__":
 
-    with open(os.path.join(setup_py_dir, 'README.rst')) as f:
-        readme = f.read()
+    with open(os.path.join(setup_py_dir, 'README.rst'), 'rb') as f:
+        readme = f.read().decode('utf8')
 
     write_version_py()
 


### PR DESCRIPTION
We support Python 3.5 (this is what the console uses) but our tests don't currently succeed on 3.5, fix this...