### PR TITLE
Dzollo/test new msgs

### DIFF
--- a/generator/sbpg/build_test_data.py
+++ b/generator/sbpg/build_test_data.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+# Copyright (C) 2015-2020 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""
+Command line utility for reading an SBP log and generating
+YAML-formatted unit test data. This largely samples a set messages
+from a existing log, gathers them by module, formats them to YAML, and
+writes them out to files.
+
+Running this command from the top level,
+
+  python tests/sbp/build_test_data.py <log_file>,
+
+produces <module_name>/test_<message_name>.yaml files in directory the command is
+written. The produced file looks like:
+
+description: Unit tests for swiftnav.sbp.acquisition v0.23.
+generated_on: 2015-03-22 17:40:06.567183
+package: sbp.acquisition
+tests:
+- msg:
+    fields:
+      cf: 8241.943359375
+      cp: 727.0
+      prn: 8
+      snr: 14.5
+    module: sbp.acquisition
+    name: MsgAcqResult
+  msg_type: '0x15'
+  raw_json: '{"sender": 1219, "msg_type": 21, "prn": 8, "cf": 8241.943359375, "crc":
+    17410, "length": 13, "snr": 14.5, "cp": 727.0, "preamble": 85, "payload": "AABoQQDANUTGxwBGCA=="}'
+  raw_packet: VRUAwwQNAABoQQDANUTGxwBGCAJE
+  sbp:
+    crc: '0x4402'
+    length: 13
+    msg_type: '0x15'
+    payload: AABoQQDANUTGxwBGCA==
+    preamble: '0x55'
+    sender: '0x4c3'
+
+For the sake of readability, some of the fields that are typically
+displayed as hex, such as SBP message type, crc, and preamble are cast
+into hex strings.
+
+"""
+
+import sbp
+from sbp.table import _SBP_TABLE
+from sbp.version import VERSION
+from sbp.utils import walk_json_dict
+from sbp.client.loggers.json_logger import JSONLogIterator 
+import base64
+import datetime
+import warnings
+import yaml
+import os
+
+print("SBP Version {}".format(VERSION))
+
+
+def encode_for_jinja(bin_field):
+    return base64.b64encode(bin_field).decode('UTF-8')
+
+
+def _to_readable_dict(msg):
+  """
+  Format an SBP message's attributes for a preferred YAML output.
+
+  Parameters
+  ----------
+  msg : :class: `SBP`
+    A parsed SBP message.
+
+  Returns
+  ----------
+  dict
+
+  """
+  return {'preamble': hex(msg.preamble),
+          'msg_type': hex(msg.msg_type),
+          'sender': hex(msg.sender),
+          'length': msg.length,
+          'payload': encode_for_jinja(msg.payload),
+          'crc': hex(msg.crc)}
+
+def dump_modules_to_yaml(test_map, version, output_path):
+  """
+  Take unit test data data from test, format as YAML, and write to
+  local files. Each file is stored in a directory structure consisting
+  of components of its package name, 
+  e.g. sbp/acquisition/test_MsgAcqResult.yaml
+
+  Parameters
+  ----------
+  test_map : dict
+    Dictionary mapping SBP message name to instances of SBP object to be used
+    for making unit test cases.
+
+  """
+  for (k, v) in list(test_map.items()):
+    if not v:
+      continue
+    package = v[0]['msg']['module']
+    item = {'package': package,
+            'description': "Unit tests for swiftnav.%s %s v%s." % (package, k, version),
+            'generated_on': datetime.datetime.now(),
+            'version': version,
+            'tests': v}
+    d = yaml.dump(item, explicit_start=True,
+                  default_flow_style=False,
+                  explicit_end=True)
+
+    path = output_path
+    components = package.split(".")
+    for component in components:
+      path = os.path.join(path, component)
+      if not os.path.isdir(path):
+        os.makedirs(path)
+
+
+    filename = "test_"+k+".yaml"
+    filepath = os.path.join(path, filename)
+    with open(filepath, 'w') as f:
+      f.write(d.replace('\n- ', '\n\n- '))
+
+def mk_readable_msg(msg):
+  """
+  Produces a unit test case from a parsed SBP message. The case
+  includes the raw output, the SBP message with unparsed payload, and
+  the parsed SBP message
+
+  Parameters
+  ----------
+  msg : Subclass of :class: `SBP`.
+    Parsed SBP message.
+  keys : list
+    List of keys to remove from the rendered
+
+  Returns
+  ----------
+  A dict formatted for a unit test case.
+
+  """
+  f = walk_json_dict(dict([(k, getattr(msg, k)) for k in msg.__slots__]))
+  # Message includes fields from the SBP message it inherits from, so
+  # remove those.
+  msg.pack()
+  i = {'raw_packet' : encode_for_jinja(msg.to_binary()),
+       'raw_json'   : msg.to_json(),
+       'msg_type'   : hex(msg.msg_type),
+       'sbp'        : _to_readable_dict(msg),
+       'msg'        : { 'module' : msg.__class__.__module__,
+                        'name' : msg.__class__.__name__,
+                        'fields' : f if f else None}}
+  return i
+
+def get_args():
+  """
+  Get and parse command line arguments.
+  """
+  import argparse
+  parser = argparse.ArgumentParser(description="Swift Navigation SBP Client.")
+  parser.add_argument("log_file",
+                     help="use input file to read SBP messages from.")
+  parser.add_argument("-s", "--version",
+                      default=VERSION,
+                      help="SBP version number (e.g. 0.29).")
+  parser.add_argument("-o", "--output_path",
+                      default="spec/tests/yaml/swiftnav/",
+                      help="Place to put test yaml specifications")
+  parser.add_argument("-v", "--verbose",
+                      action="store_true",
+                      help="print extra debugging information.")
+  return parser.parse_args()
+
+def main():
+  """
+  Get command line configuration, read log data, and write out
+  YAML-formatted unit test data.
+
+  """
+  args = get_args()
+  log_datafile = args.log_file
+  version = args.version
+  verbose = args.verbose
+  if verbose:
+    assert False, "Verbose output not implemented yet."
+  # Build
+  num_test_cases = 5
+  message_table = _SBP_TABLE
+  test_table = dict((k, []) for (k, v) in message_table.copy().items())
+  with open(log_datafile, 'r') as datafile:
+      with JSONLogIterator(datafile) as log:
+        for msg, metadata in next(log):
+          try:
+            i = mk_readable_msg(msg)
+          except TypeError as ex_info:
+            # Note data errors as they come up, but don't crash the test
+            # generation.
+            out = "Warning! %s for message 0x00%x." \
+                  % (ex_info.message, msg.msg_type)
+            warnings.warn(out, RuntimeWarning)
+            continue
+          except StopIteration:
+              break
+          # For a given SBP message type, sample only num_test_cases
+          # hopefully unique cases. Assume that messages that are likely
+          # to be identical are consecutive, so coompare any new message
+          # with the most recent one.
+          name = i['msg']['name']
+          if not name in test_table:
+            test_table[name] = [i];      
+          elif len(test_table[name]) < num_test_cases and test_table[name][-1] != i:
+            test_table[name].append(i)
+      print("completed parsing datafile {}".format(log_datafile))
+      print("dumping test yaml files to path {}".format(args.output_path))
+      dump_modules_to_yaml(test_table, version, args.output_path)
+
+if __name__ == "__main__":
+  main()

--- a/generator/sbpg/specs/yaml_test_schema.py
+++ b/generator/sbpg/specs/yaml_test_schema.py
@@ -27,7 +27,7 @@ test = Schema({
   'msg': msg,
   'msg_type': Schema(str),
   'raw_json': Schema(str),
-  'raw_packet': Coerce(str),
+  'raw_packet': Coerce(bytes),
   'sbp': Schema({ Coerce(str): Coerce(str) }),
 })
 

--- a/javascript/sbp/msg.js
+++ b/javascript/sbp/msg.js
@@ -106,6 +106,7 @@ var sbpImports = {
   settings: require('./settings.js'),
   signal: require('./signal.js'),
   ssr: require('./ssr.js'),
+  solution_meta: require('./solution_meta.js'),
   system: require('./system.js'),
   tracking: require('./tracking.js'),
   user: require('./user.js'),

--- a/javascript/tests/test_dispatch_decoder.js
+++ b/javascript/tests/test_dispatch_decoder.js
@@ -90,7 +90,7 @@ describe('test packages based on YAML descriptors, through the dispatcher', func
             var packetBuf = new Buffer(testSpec['raw_packet'], 'base64');
             rs.push(packetBuf.slice(0,packetBuf.length-5));
 
-            var requiredCalls = 1;
+            var requiredCalls = 2;
 
             // `length` is longer than one full buffer for these corrupted messages
             // similar issue to the above tests

--- a/spec/tests/yaml/swiftnav/sbp/imu/test_MsgImuAux.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/imu/test_MsgImuAux.yaml
@@ -1,0 +1,102 @@
+---
+description: Unit tests for swiftnav.sbp.imu MsgImuAux v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.692712
+package: sbp.imu
+tests:
+
+- msg:
+    fields:
+      imu_conf: 66
+      imu_type: 1
+      temp: 5340
+    module: sbp.imu
+    name: MsgImuAux
+  msg_type: '0x901'
+  raw_json: '{"preamble": 85, "msg_type": 2305, "sender": 51228, "length": 4, "payload":
+    "AdwUQg==", "crc": 11326, "imu_type": 1, "temp": 5340, "imu_conf": 66}'
+  raw_packet: VQEJHMgEAdwUQj4s
+  sbp:
+    crc: '0x2c3e'
+    length: 4
+    msg_type: '0x901'
+    payload: AdwUQg==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      imu_conf: 66
+      imu_type: 1
+      temp: 5400
+    module: sbp.imu
+    name: MsgImuAux
+  msg_type: '0x901'
+  raw_json: '{"preamble": 85, "msg_type": 2305, "sender": 51228, "length": 4, "payload":
+    "ARgVQg==", "crc": 58680, "imu_type": 1, "temp": 5400, "imu_conf": 66}'
+  raw_packet: VQEJHMgEARgVQjjl
+  sbp:
+    crc: '0xe538'
+    length: 4
+    msg_type: '0x901'
+    payload: ARgVQg==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      imu_conf: 66
+      imu_type: 1
+      temp: 5417
+    module: sbp.imu
+    name: MsgImuAux
+  msg_type: '0x901'
+  raw_json: '{"preamble": 85, "msg_type": 2305, "sender": 51228, "length": 4, "payload":
+    "ASkVQg==", "crc": 6061, "imu_type": 1, "temp": 5417, "imu_conf": 66}'
+  raw_packet: VQEJHMgEASkVQq0X
+  sbp:
+    crc: '0x17ad'
+    length: 4
+    msg_type: '0x901'
+    payload: ASkVQg==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      imu_conf: 66
+      imu_type: 1
+      temp: 5447
+    module: sbp.imu
+    name: MsgImuAux
+  msg_type: '0x901'
+  raw_json: '{"preamble": 85, "msg_type": 2305, "sender": 51228, "length": 4, "payload":
+    "AUcVQg==", "crc": 38855, "imu_type": 1, "temp": 5447, "imu_conf": 66}'
+  raw_packet: VQEJHMgEAUcVQseX
+  sbp:
+    crc: '0x97c7'
+    length: 4
+    msg_type: '0x901'
+    payload: AUcVQg==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      imu_conf: 66
+      imu_type: 1
+      temp: 5480
+    module: sbp.imu
+    name: MsgImuAux
+  msg_type: '0x901'
+  raw_json: '{"preamble": 85, "msg_type": 2305, "sender": 51228, "length": 4, "payload":
+    "AWgVQg==", "crc": 15664, "imu_type": 1, "temp": 5480, "imu_conf": 66}'
+  raw_packet: VQEJHMgEAWgVQjA9
+  sbp:
+    crc: '0x3d30'
+    length: 4
+    msg_type: '0x901'
+    payload: AWgVQg==
+    preamble: '0x55'
+    sender: '0xc81c'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/imu/test_MsgImuRaw.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/imu/test_MsgImuRaw.yaml
@@ -1,0 +1,132 @@
+---
+description: Unit tests for swiftnav.sbp.imu MsgImuRaw v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.644708
+package: sbp.imu
+tests:
+
+- msg:
+    fields:
+      acc_x: 39
+      acc_y: 41
+      acc_z: 4206
+      gyr_x: 187
+      gyr_y: -268
+      gyr_z: -120
+      tow: 3221226012
+      tow_f: 0
+    module: sbp.imu
+    name: MsgImuRaw
+  msg_type: '0x900'
+  raw_json: '{"preamble": 85, "msg_type": 2304, "sender": 51228, "length": 17, "payload":
+    "HAIAwAAnACkAbhC7APT+iP8=", "crc": 31424, "tow": 3221226012, "tow_f": 0, "acc_x":
+    39, "acc_y": 41, "acc_z": 4206, "gyr_x": 187, "gyr_y": -268, "gyr_z": -120}'
+  raw_packet: VQAJHMgRHAIAwAAnACkAbhC7APT+iP/Aeg==
+  sbp:
+    crc: '0x7ac0'
+    length: 17
+    msg_type: '0x900'
+    payload: HAIAwAAnACkAbhC7APT+iP8=
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      acc_x: 43
+      acc_y: 42
+      acc_z: 4204
+      gyr_x: 166
+      gyr_y: -281
+      gyr_z: -127
+      tow: 3221226022
+      tow_f: 0
+    module: sbp.imu
+    name: MsgImuRaw
+  msg_type: '0x900'
+  raw_json: '{"preamble": 85, "msg_type": 2304, "sender": 51228, "length": 17, "payload":
+    "JgIAwAArACoAbBCmAOf+gf8=", "crc": 47142, "tow": 3221226022, "tow_f": 0, "acc_x":
+    43, "acc_y": 42, "acc_z": 4204, "gyr_x": 166, "gyr_y": -281, "gyr_z": -127}'
+  raw_packet: VQAJHMgRJgIAwAArACoAbBCmAOf+gf8muA==
+  sbp:
+    crc: '0xb826'
+    length: 17
+    msg_type: '0x900'
+    payload: JgIAwAArACoAbBCmAOf+gf8=
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      acc_x: 39
+      acc_y: 41
+      acc_z: 4204
+      gyr_x: 184
+      gyr_y: -297
+      gyr_z: -109
+      tow: 3221226032
+      tow_f: 0
+    module: sbp.imu
+    name: MsgImuRaw
+  msg_type: '0x900'
+  raw_json: '{"preamble": 85, "msg_type": 2304, "sender": 51228, "length": 17, "payload":
+    "MAIAwAAnACkAbBC4ANf+k/8=", "crc": 45063, "tow": 3221226032, "tow_f": 0, "acc_x":
+    39, "acc_y": 41, "acc_z": 4204, "gyr_x": 184, "gyr_y": -297, "gyr_z": -109}'
+  raw_packet: VQAJHMgRMAIAwAAnACkAbBC4ANf+k/8HsA==
+  sbp:
+    crc: '0xb007'
+    length: 17
+    msg_type: '0x900'
+    payload: MAIAwAAnACkAbBC4ANf+k/8=
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      acc_x: 37
+      acc_y: 41
+      acc_z: 4206
+      gyr_x: 182
+      gyr_y: -280
+      gyr_z: -111
+      tow: 3221226042
+      tow_f: 0
+    module: sbp.imu
+    name: MsgImuRaw
+  msg_type: '0x900'
+  raw_json: '{"preamble": 85, "msg_type": 2304, "sender": 51228, "length": 17, "payload":
+    "OgIAwAAlACkAbhC2AOj+kf8=", "crc": 33113, "tow": 3221226042, "tow_f": 0, "acc_x":
+    37, "acc_y": 41, "acc_z": 4206, "gyr_x": 182, "gyr_y": -280, "gyr_z": -111}'
+  raw_packet: VQAJHMgROgIAwAAlACkAbhC2AOj+kf9ZgQ==
+  sbp:
+    crc: '0x8159'
+    length: 17
+    msg_type: '0x900'
+    payload: OgIAwAAlACkAbhC2AOj+kf8=
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      acc_x: 38
+      acc_y: 45
+      acc_z: 4209
+      gyr_x: 190
+      gyr_y: -277
+      gyr_z: -130
+      tow: 3221226052
+      tow_f: 0
+    module: sbp.imu
+    name: MsgImuRaw
+  msg_type: '0x900'
+  raw_json: '{"preamble": 85, "msg_type": 2304, "sender": 51228, "length": 17, "payload":
+    "RAIAwAAmAC0AcRC+AOv+fv8=", "crc": 58572, "tow": 3221226052, "tow_f": 0, "acc_x":
+    38, "acc_y": 45, "acc_z": 4209, "gyr_x": 190, "gyr_y": -277, "gyr_z": -130}'
+  raw_packet: VQAJHMgRRAIAwAAmAC0AcRC+AOv+fv/M5A==
+  sbp:
+    crc: '0xe4cc'
+    length: 17
+    msg_type: '0x900'
+    payload: RAIAwAAmAC0AcRC+AOv+fv8=
+    preamble: '0x55'
+    sender: '0xc81c'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/logging/test_MsgLog.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/logging/test_MsgLog.yaml
@@ -1,0 +1,83 @@
+---
+description: Unit tests for swiftnav.sbp.logging MsgLog v3.4.1.dev12+g7ff5295c-dirty.
+generated_on: 2020-09-18 18:32:15.365082
+package: sbp.logging
+tests:
+
+- msg:
+    fields:
+      level: 5
+      text: "MCU FW version: v1.0.2-3-gc9285c5-dirty\0"
+    module: sbp.logging
+    name: MsgLog
+  msg_type: '0x401'
+  raw_json: '{"preamble": 85, "msg_type": 1025, "sender": 170, "length": 41, "payload":
+    "BU1DVSBGVyB2ZXJzaW9uOiB2MS4wLjItMy1nYzkyODVjNS1kaXJ0eQA=", "crc": 61647, "level":
+    5, "text": "MCU FW version: v1.0.2-3-gc9285c5-dirty\u0000"}'
+  raw_packet: VQEEqgApBU1DVSBGVyB2ZXJzaW9uOiB2MS4wLjItMy1nYzkyODVjNS1kaXJ0eQDP8A==
+  sbp:
+    crc: '0xf0cf'
+    length: 41
+    msg_type: '0x401'
+    payload: BU1DVSBGVyB2ZXJzaW9uOiB2MS4wLjItMy1nYzkyODVjNS1kaXJ0eQA=
+    preamble: '0x55'
+    sender: '0xaa'
+
+- msg:
+    fields:
+      level: 5
+      text: "MCU Unique ID: 0042001A-31395119-35333634\0"
+    module: sbp.logging
+    name: MsgLog
+  msg_type: '0x401'
+  raw_json: '{"preamble": 85, "msg_type": 1025, "sender": 170, "length": 43, "payload":
+    "BU1DVSBVbmlxdWUgSUQ6IDAwNDIwMDFBLTMxMzk1MTE5LTM1MzMzNjM0AA==", "crc": 2463, "level":
+    5, "text": "MCU Unique ID: 0042001A-31395119-35333634\u0000"}'
+  raw_packet: VQEEqgArBU1DVSBVbmlxdWUgSUQ6IDAwNDIwMDFBLTMxMzk1MTE5LTM1MzMzNjM0AJ8J
+  sbp:
+    crc: '0x99f'
+    length: 43
+    msg_type: '0x401'
+    payload: BU1DVSBVbmlxdWUgSUQ6IDAwNDIwMDFBLTMxMzk1MTE5LTM1MzMzNjM0AA==
+    preamble: '0x55'
+    sender: '0xaa'
+
+- msg:
+    fields:
+      level: 5
+      text: "PGM HW version: 01097-01 Rev 03\0"
+    module: sbp.logging
+    name: MsgLog
+  msg_type: '0x401'
+  raw_json: '{"preamble": 85, "msg_type": 1025, "sender": 170, "length": 33, "payload":
+    "BVBHTSBIVyB2ZXJzaW9uOiAwMTA5Ny0wMSBSZXYgMDMA", "crc": 28656, "level": 5, "text":
+    "PGM HW version: 01097-01 Rev 03\u0000"}'
+  raw_packet: VQEEqgAhBVBHTSBIVyB2ZXJzaW9uOiAwMTA5Ny0wMSBSZXYgMDMA8G8=
+  sbp:
+    crc: '0x6ff0'
+    length: 33
+    msg_type: '0x401'
+    payload: BVBHTSBIVyB2ZXJzaW9uOiAwMTA5Ny0wMSBSZXYgMDMA
+    preamble: '0x55'
+    sender: '0xaa'
+
+- msg:
+    fields:
+      level: 5
+      text: "PGM process version: 01109-01 Rev 02\0"
+    module: sbp.logging
+    name: MsgLog
+  msg_type: '0x401'
+  raw_json: '{"preamble": 85, "msg_type": 1025, "sender": 170, "length": 38, "payload":
+    "BVBHTSBwcm9jZXNzIHZlcnNpb246IDAxMTA5LTAxIFJldiAwMgA=", "crc": 64908, "level":
+    5, "text": "PGM process version: 01109-01 Rev 02\u0000"}'
+  raw_packet: VQEEqgAmBVBHTSBwcm9jZXNzIHZlcnNpb246IDAxMTA5LTAxIFJldiAwMgCM/Q==
+  sbp:
+    crc: '0xfd8c'
+    length: 38
+    msg_type: '0x401'
+    payload: BVBHTSBwcm9jZXNzIHZlcnNpb246IDAxMTA5LTAxIFJldiAwMgA=
+    preamble: '0x55'
+    sender: '0xaa'
+version: 3.4.1.dev12+g7ff5295c-dirty
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgGPSTimeGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgGPSTimeGnss.yaml
@@ -1,0 +1,112 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgGPSTimeGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.774682
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      flags: 1
+      ns_residual: 25
+      tow: 500066600
+      wn: 2122
+    module: sbp.navigation
+    name: MsgGPSTimeGnss
+  msg_type: '0x104'
+  raw_json: '{"preamble": 85, "msg_type": 260, "sender": 4096, "length": 11, "payload":
+    "Sggoac4dGQAAAAE=", "crc": 56545, "wn": 2122, "tow": 500066600, "ns_residual":
+    25, "flags": 1}'
+  raw_packet: VQQBABALSggoac4dGQAAAAHh3A==
+  sbp:
+    crc: '0xdce1'
+    length: 11
+    msg_type: '0x104'
+    payload: Sggoac4dGQAAAAE=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 1
+      ns_residual: 25
+      tow: 500066700
+      wn: 2122
+    module: sbp.navigation
+    name: MsgGPSTimeGnss
+  msg_type: '0x104'
+  raw_json: '{"preamble": 85, "msg_type": 260, "sender": 4096, "length": 11, "payload":
+    "SgiMac4dGQAAAAE=", "crc": 22592, "wn": 2122, "tow": 500066700, "ns_residual":
+    25, "flags": 1}'
+  raw_packet: VQQBABALSgiMac4dGQAAAAFAWA==
+  sbp:
+    crc: '0x5840'
+    length: 11
+    msg_type: '0x104'
+    payload: SgiMac4dGQAAAAE=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 1
+      ns_residual: 25
+      tow: 500066800
+      wn: 2122
+    module: sbp.navigation
+    name: MsgGPSTimeGnss
+  msg_type: '0x104'
+  raw_json: '{"preamble": 85, "msg_type": 260, "sender": 4096, "length": 11, "payload":
+    "Sgjwac4dGQAAAAE=", "crc": 18059, "wn": 2122, "tow": 500066800, "ns_residual":
+    25, "flags": 1}'
+  raw_packet: VQQBABALSgjwac4dGQAAAAGLRg==
+  sbp:
+    crc: '0x468b'
+    length: 11
+    msg_type: '0x104'
+    payload: Sgjwac4dGQAAAAE=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 1
+      ns_residual: 25
+      tow: 500066900
+      wn: 2122
+    module: sbp.navigation
+    name: MsgGPSTimeGnss
+  msg_type: '0x104'
+  raw_json: '{"preamble": 85, "msg_type": 260, "sender": 4096, "length": 11, "payload":
+    "SghUas4dGQAAAAE=", "crc": 2655, "wn": 2122, "tow": 500066900, "ns_residual":
+    25, "flags": 1}'
+  raw_packet: VQQBABALSghUas4dGQAAAAFfCg==
+  sbp:
+    crc: '0xa5f'
+    length: 11
+    msg_type: '0x104'
+    payload: SghUas4dGQAAAAE=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 1
+      ns_residual: 25
+      tow: 500067000
+      wn: 2122
+    module: sbp.navigation
+    name: MsgGPSTimeGnss
+  msg_type: '0x104'
+  raw_json: '{"preamble": 85, "msg_type": 260, "sender": 4096, "length": 11, "payload":
+    "Sgi4as4dGQAAAAE=", "crc": 63704, "wn": 2122, "tow": 500067000, "ns_residual":
+    25, "flags": 1}'
+  raw_packet: VQQBABALSgi4as4dGQAAAAHY+A==
+  sbp:
+    crc: '0xf8d8'
+    length: 11
+    msg_type: '0x104'
+    payload: Sgi4as4dGQAAAAE=
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosECEFCovGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosECEFCovGnss.yaml
@@ -1,0 +1,167 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgPosECEFCovGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.878670
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      cov_x_x: 0.3960290849208832
+      cov_x_y: 0.49448975920677185
+      cov_x_z: -0.1946154534816742
+      cov_y_y: 0.8988719582557678
+      cov_y_z: -0.30093663930892944
+      cov_z_z: 0.1911001354455948
+      flags: 3
+      n_sats: 11
+      tow: 500066600
+      x: -2684190.415671157
+      y: -4320608.999748357
+      z: 3835346.74454021
+    module: sbp.navigation
+    name: MsgPosECEFCovGnss
+  msg_type: '0x234'
+  raw_json: '{"preamble": 85, "msg_type": 564, "sender": 4096, "length": 54, "payload":
+    "KGnOHWW2NDWPekTBiOD7P1h7UMH2F01f6UJNQVPEyj7DLf0+RklHvnkcZj9eFJq+wa9DPgsD", "crc":
+    58969, "tow": 500066600, "x": -2684190.415671157, "y": -4320608.999748357, "z":
+    3835346.74454021, "cov_x_x": 0.3960290849208832, "cov_x_y": 0.49448975920677185,
+    "cov_x_z": -0.1946154534816742, "cov_y_y": 0.8988719582557678, "cov_y_z": -0.30093663930892944,
+    "cov_z_z": 0.1911001354455948, "n_sats": 11, "flags": 3}'
+  raw_packet: VTQCABA2KGnOHWW2NDWPekTBiOD7P1h7UMH2F01f6UJNQVPEyj7DLf0+RklHvnkcZj9eFJq+wa9DPgsDWeY=
+  sbp:
+    crc: '0xe659'
+    length: 54
+    msg_type: '0x234'
+    payload: KGnOHWW2NDWPekTBiOD7P1h7UMH2F01f6UJNQVPEyj7DLf0+RklHvnkcZj9eFJq+wa9DPgsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.39464035630226135
+      cov_x_y: 0.49261459708213806
+      cov_x_z: -0.1939391791820526
+      cov_y_y: 0.8953226804733276
+      cov_y_z: -0.2998029291629791
+      cov_z_z: 0.19050642848014832
+      flags: 3
+      n_sats: 11
+      tow: 500066700
+      x: -2684190.4111688524
+      y: -4320608.994067186
+      z: 3835346.7470143503
+    module: sbp.navigation
+    name: MsgPosECEFCovGnss
+  msg_type: '0x234'
+  raw_json: '{"preamble": 85, "msg_type": 564, "sender": 4096, "length": 54, "payload":
+    "jGnOHVMuoTSPekTB+cueP1h7UMGOKp5f6UJNQU0Oyj77N/w+/pdGvt4zZT/Ff5m+HhRDPgsD", "crc":
+    30751, "tow": 500066700, "x": -2684190.4111688524, "y": -4320608.994067186, "z":
+    3835346.7470143503, "cov_x_x": 0.39464035630226135, "cov_x_y": 0.49261459708213806,
+    "cov_x_z": -0.1939391791820526, "cov_y_y": 0.8953226804733276, "cov_y_z": -0.2998029291629791,
+    "cov_z_z": 0.19050642848014832, "n_sats": 11, "flags": 3}'
+  raw_packet: VTQCABA2jGnOHVMuoTSPekTB+cueP1h7UMGOKp5f6UJNQU0Oyj77N/w+/pdGvt4zZT/Ff5m+HhRDPgsDH3g=
+  sbp:
+    crc: '0x781f'
+    length: 54
+    msg_type: '0x234'
+    payload: jGnOHVMuoTSPekTB+cueP1h7UMGOKp5f6UJNQU0Oyj77N/w+/pdGvt4zZT/Ff5m+HhRDPgsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.39325010776519775
+      cov_x_y: 0.49073871970176697
+      cov_x_z: -0.19326351583003998
+      cov_y_y: 0.8917729258537292
+      cov_y_z: -0.2986699044704437
+      cov_z_z: 0.18991482257843018
+      flags: 3
+      n_sats: 11
+      tow: 500066800
+      x: -2684190.40859952
+      y: -4320608.9926557485
+      z: 3835346.746767551
+    module: sbp.navigation
+    name: MsgPosECEFCovGnss
+  msg_type: '0x234'
+  raw_json: '{"preamble": 85, "msg_type": 564, "sender": 4096, "length": 54, "payload":
+    "8GnOHTT9TDSPekTB+quHP1h7UMFBFJZf6UJNQRRYyT4bQvs+3+ZFvjtLZD9D65i+CHlCPgsD", "crc":
+    31590, "tow": 500066800, "x": -2684190.40859952, "y": -4320608.9926557485, "z":
+    3835346.746767551, "cov_x_x": 0.39325010776519775, "cov_x_y": 0.49073871970176697,
+    "cov_x_z": -0.19326351583003998, "cov_y_y": 0.8917729258537292, "cov_y_z": -0.2986699044704437,
+    "cov_z_z": 0.18991482257843018, "n_sats": 11, "flags": 3}'
+  raw_packet: VTQCABA28GnOHTT9TDSPekTB+quHP1h7UMFBFJZf6UJNQRRYyT4bQvs+3+ZFvjtLZD9D65i+CHlCPgsDZns=
+  sbp:
+    crc: '0x7b66'
+    length: 54
+    msg_type: '0x234'
+    payload: 8GnOHTT9TDSPekTB+quHP1h7UMFBFJZf6UJNQRRYyT4bQvs+3+ZFvjtLZD9D65i+CHlCPgsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.3955013155937195
+      cov_x_y: 0.4934066832065582
+      cov_x_z: -0.1943788081407547
+      cov_y_y: 0.8964797258377075
+      cov_y_z: -0.30030348896980286
+      cov_z_z: 0.19108527898788452
+      flags: 3
+      n_sats: 11
+      tow: 500066900
+      x: -2684190.403587801
+      y: -4320608.986333581
+      z: 3835346.748566272
+    module: sbp.navigation
+    name: MsgPosECEFCovGnss
+  msg_type: '0x234'
+  raw_json: '{"preamble": 85, "msg_type": 564, "sender": 4096, "length": 54, "payload":
+    "VGrOHdvDqDOPekTB4hYgP1h7UMEFBdFf6UJNQSZ/yj7Nn/w+PQtHvrJ/ZT9hwZm+3KtDPgsD", "crc":
+    65078, "tow": 500066900, "x": -2684190.403587801, "y": -4320608.986333581, "z":
+    3835346.748566272, "cov_x_x": 0.3955013155937195, "cov_x_y": 0.4934066832065582,
+    "cov_x_z": -0.1943788081407547, "cov_y_y": 0.8964797258377075, "cov_y_z": -0.30030348896980286,
+    "cov_z_z": 0.19108527898788452, "n_sats": 11, "flags": 3}'
+  raw_packet: VTQCABA2VGrOHdvDqDOPekTB4hYgP1h7UMEFBdFf6UJNQSZ/yj7Nn/w+PQtHvrJ/ZT9hwZm+3KtDPgsDNv4=
+  sbp:
+    crc: '0xfe36'
+    length: 54
+    msg_type: '0x234'
+    payload: VGrOHdvDqDOPekTB4hYgP1h7UMEFBdFf6UJNQSZ/yj7Nn/w+PQtHvrJ/ZT9hwZm+3KtDPgsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.4281696677207947
+      cov_x_y: 0.5340088605880737
+      cov_x_z: -0.2104455530643463
+      cov_y_y: 0.9700968265533447
+      cov_y_z: -0.32502713799476624
+      cov_z_z: 0.20696251094341278
+      flags: 3
+      n_sats: 11
+      tow: 500067000
+      x: -2684190.4020042913
+      y: -4320608.984031659
+      z: 3835346.7527100914
+    module: sbp.navigation
+    name: MsgPosECEFCovGnss
+  msg_type: '0x234'
+  raw_json: '{"preamble": 85, "msg_type": 564, "sender": 4096, "length": 54, "payload":
+    "uGrOHWrgdDOPekTB7F/6Plh7UMHlzVhg6UJNQQ452z7OtAg/Cn9XvkRYeD/1aaa+++1TPgsD", "crc":
+    58964, "tow": 500067000, "x": -2684190.4020042913, "y": -4320608.984031659, "z":
+    3835346.7527100914, "cov_x_x": 0.4281696677207947, "cov_x_y": 0.5340088605880737,
+    "cov_x_z": -0.2104455530643463, "cov_y_y": 0.9700968265533447, "cov_y_z": -0.32502713799476624,
+    "cov_z_z": 0.20696251094341278, "n_sats": 11, "flags": 3}'
+  raw_packet: VTQCABA2uGrOHWrgdDOPekTB7F/6Plh7UMHlzVhg6UJNQQ452z7OtAg/Cn9XvkRYeD/1aaa+++1TPgsDVOY=
+  sbp:
+    crc: '0xe654'
+    length: 54
+    msg_type: '0x234'
+    payload: uGrOHWrgdDOPekTB7F/6Plh7UMHlzVhg6UJNQQ452z7OtAg/Cn9XvkRYeD/1aaa+++1TPgsD
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosECEFGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosECEFGnss.yaml
@@ -1,0 +1,132 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgPosECEFGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.824753
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      accuracy: 1147
+      flags: 3
+      n_sats: 11
+      tow: 500066600
+      x: -2684190.415671157
+      y: -4320608.999748357
+      z: 3835346.74454021
+    module: sbp.navigation
+    name: MsgPosECEFGnss
+  msg_type: '0x229'
+  raw_json: '{"preamble": 85, "msg_type": 553, "sender": 4096, "length": 32, "payload":
+    "KGnOHWW2NDWPekTBiOD7P1h7UMH2F01f6UJNQXsECwM=", "crc": 1798, "tow": 500066600,
+    "x": -2684190.415671157, "y": -4320608.999748357, "z": 3835346.74454021, "accuracy":
+    1147, "n_sats": 11, "flags": 3}'
+  raw_packet: VSkCABAgKGnOHWW2NDWPekTBiOD7P1h7UMH2F01f6UJNQXsECwMGBw==
+  sbp:
+    crc: '0x706'
+    length: 32
+    msg_type: '0x229'
+    payload: KGnOHWW2NDWPekTBiOD7P1h7UMH2F01f6UJNQXsECwM=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 1145
+      flags: 3
+      n_sats: 11
+      tow: 500066700
+      x: -2684190.4111688524
+      y: -4320608.994067186
+      z: 3835346.7470143503
+    module: sbp.navigation
+    name: MsgPosECEFGnss
+  msg_type: '0x229'
+  raw_json: '{"preamble": 85, "msg_type": 553, "sender": 4096, "length": 32, "payload":
+    "jGnOHVMuoTSPekTB+cueP1h7UMGOKp5f6UJNQXkECwM=", "crc": 35708, "tow": 500066700,
+    "x": -2684190.4111688524, "y": -4320608.994067186, "z": 3835346.7470143503, "accuracy":
+    1145, "n_sats": 11, "flags": 3}'
+  raw_packet: VSkCABAgjGnOHVMuoTSPekTB+cueP1h7UMGOKp5f6UJNQXkECwN8iw==
+  sbp:
+    crc: '0x8b7c'
+    length: 32
+    msg_type: '0x229'
+    payload: jGnOHVMuoTSPekTB+cueP1h7UMGOKp5f6UJNQXkECwM=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 1143
+      flags: 3
+      n_sats: 11
+      tow: 500066800
+      x: -2684190.40859952
+      y: -4320608.9926557485
+      z: 3835346.746767551
+    module: sbp.navigation
+    name: MsgPosECEFGnss
+  msg_type: '0x229'
+  raw_json: '{"preamble": 85, "msg_type": 553, "sender": 4096, "length": 32, "payload":
+    "8GnOHTT9TDSPekTB+quHP1h7UMFBFJZf6UJNQXcECwM=", "crc": 64187, "tow": 500066800,
+    "x": -2684190.40859952, "y": -4320608.9926557485, "z": 3835346.746767551, "accuracy":
+    1143, "n_sats": 11, "flags": 3}'
+  raw_packet: VSkCABAg8GnOHTT9TDSPekTB+quHP1h7UMFBFJZf6UJNQXcECwO7+g==
+  sbp:
+    crc: '0xfabb'
+    length: 32
+    msg_type: '0x229'
+    payload: 8GnOHTT9TDSPekTB+quHP1h7UMFBFJZf6UJNQXcECwM=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 1146
+      flags: 3
+      n_sats: 11
+      tow: 500066900
+      x: -2684190.403587801
+      y: -4320608.986333581
+      z: 3835346.748566272
+    module: sbp.navigation
+    name: MsgPosECEFGnss
+  msg_type: '0x229'
+  raw_json: '{"preamble": 85, "msg_type": 553, "sender": 4096, "length": 32, "payload":
+    "VGrOHdvDqDOPekTB4hYgP1h7UMEFBdFf6UJNQXoECwM=", "crc": 62405, "tow": 500066900,
+    "x": -2684190.403587801, "y": -4320608.986333581, "z": 3835346.748566272, "accuracy":
+    1146, "n_sats": 11, "flags": 3}'
+  raw_packet: VSkCABAgVGrOHdvDqDOPekTB4hYgP1h7UMEFBdFf6UJNQXoECwPF8w==
+  sbp:
+    crc: '0xf3c5'
+    length: 32
+    msg_type: '0x229'
+    payload: VGrOHdvDqDOPekTB4hYgP1h7UMEFBdFf6UJNQXoECwM=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 1192
+      flags: 3
+      n_sats: 11
+      tow: 500067000
+      x: -2684190.4020042913
+      y: -4320608.984031659
+      z: 3835346.7527100914
+    module: sbp.navigation
+    name: MsgPosECEFGnss
+  msg_type: '0x229'
+  raw_json: '{"preamble": 85, "msg_type": 553, "sender": 4096, "length": 32, "payload":
+    "uGrOHWrgdDOPekTB7F/6Plh7UMHlzVhg6UJNQagECwM=", "crc": 26878, "tow": 500067000,
+    "x": -2684190.4020042913, "y": -4320608.984031659, "z": 3835346.7527100914, "accuracy":
+    1192, "n_sats": 11, "flags": 3}'
+  raw_packet: VSkCABAguGrOHWrgdDOPekTB7F/6Plh7UMHlzVhg6UJNQagECwP+aA==
+  sbp:
+    crc: '0x68fe'
+    length: 32
+    msg_type: '0x229'
+    payload: uGrOHWrgdDOPekTB7F/6Plh7UMHlzVhg6UJNQagECwM=
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosLLHCovGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosLLHCovGnss.yaml
@@ -1,0 +1,167 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgPosLLHCovGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.940673
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      cov_d_d: 1.1896724700927734
+      cov_e_d: -0.001238731318153441
+      cov_e_e: 0.09274973720312119
+      cov_n_d: 0.3753088116645813
+      cov_n_e: -0.008981493301689625
+      cov_n_n: 0.203578919172287
+      flags: 3
+      height: 72.86228782601304
+      lat: 37.20233535830912
+      lon: -121.85073280120506
+      n_sats: 11
+      tow: 500066600
+    module: sbp.navigation
+    name: MsgPosLLHCovGnss
+  msg_type: '0x231'
+  raw_json: '{"preamble": 85, "msg_type": 561, "sender": 4096, "length": 54, "payload":
+    "KGnOHY1hASDmmUJA2rP9Z3J2XsDCHUe5LzdSQP52UD4dJxO8eijAPpPzvT3tXKK6MEeYPwsD", "crc":
+    2001, "tow": 500066600, "lat": 37.20233535830912, "lon": -121.85073280120506,
+    "height": 72.86228782601304, "cov_n_n": 0.203578919172287, "cov_n_e": -0.008981493301689625,
+    "cov_n_d": 0.3753088116645813, "cov_e_e": 0.09274973720312119, "cov_e_d": -0.001238731318153441,
+    "cov_d_d": 1.1896724700927734, "n_sats": 11, "flags": 3}'
+  raw_packet: VTECABA2KGnOHY1hASDmmUJA2rP9Z3J2XsDCHUe5LzdSQP52UD4dJxO8eijAPpPzvT3tXKK6MEeYPwsD0Qc=
+  sbp:
+    crc: '0x7d1'
+    length: 54
+    msg_type: '0x231'
+    payload: KGnOHY1hASDmmUJA2rP9Z3J2XsDCHUe5LzdSQP52UD4dJxO8eijAPpPzvT3tXKK6MEeYPwsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 1.1851987838745117
+      cov_e_d: -0.0011136713437736034
+      cov_e_e: 0.0924404114484787
+      cov_n_d: 0.3737780749797821
+      cov_n_e: -0.008919186890125275
+      cov_n_n: 0.20283031463623047
+      flags: 3
+      height: 72.85804762706461
+      lat: 37.20233541529999
+      lon: -121.85073279189656
+      n_sats: 11
+      tow: 500066700
+    module: sbp.navigation
+    name: MsgPosLLHCovGnss
+  msg_type: '0x231'
+  raw_json: '{"preamble": 85, "msg_type": 561, "sender": 4096, "length": 54, "payload":
+    "jGnOHZ3EeyDmmUJAJ7XzZ3J2XsDJKZhA6jZSQMCyTz7IIRK811+/PmZRvT2c+JG6mLSXPwsD", "crc":
+    50175, "tow": 500066700, "lat": 37.20233541529999, "lon": -121.85073279189656,
+    "height": 72.85804762706461, "cov_n_n": 0.20283031463623047, "cov_n_e": -0.008919186890125275,
+    "cov_n_d": 0.3737780749797821, "cov_e_e": 0.0924404114484787, "cov_e_d": -0.0011136713437736034,
+    "cov_d_d": 1.1851987838745117, "n_sats": 11, "flags": 3}'
+  raw_packet: VTECABA2jGnOHZ3EeyDmmUJAJ7XzZ3J2XsDJKZhA6jZSQMCyTz7IIRK811+/PmZRvT2c+JG6mLSXPwsD/8M=
+  sbp:
+    crc: '0xc3ff'
+    length: 54
+    msg_type: '0x231'
+    payload: jGnOHZ3EeyDmmUJAJ7XzZ3J2XsDJKZhA6jZSQMCyTz7IIRK811+/PmZRvT2c+JG6mLSXPwsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 1.1807255744934082
+      cov_e_d: -0.000989166321232915
+      cov_e_e: 0.09213053435087204
+      cov_n_d: 0.3722454011440277
+      cov_n_e: -0.00885747466236353
+      cov_n_n: 0.20208171010017395
+      flags: 3
+      height: 72.85586351953172
+      lat: 37.20233542744708
+      lon: -121.85073277570271
+      n_sats: 11
+      tow: 500066800
+    module: sbp.navigation
+    name: MsgPosLLHCovGnss
+  msg_type: '0x231'
+  raw_json: '{"preamble": 85, "msg_type": 561, "sender": 4096, "length": 54, "payload":
+    "8GnOHYzalSDmmUJA0lHiZ3J2XsCbjsh3xjZSQILuTj7xHhG885a+Pu+uvD3qpoG6BCKXPwsD", "crc":
+    10909, "tow": 500066800, "lat": 37.20233542744708, "lon": -121.85073277570271,
+    "height": 72.85586351953172, "cov_n_n": 0.20208171010017395, "cov_n_e": -0.00885747466236353,
+    "cov_n_d": 0.3722454011440277, "cov_e_e": 0.09213053435087204, "cov_e_d": -0.000989166321232915,
+    "cov_d_d": 1.1807255744934082, "n_sats": 11, "flags": 3}'
+  raw_packet: VTECABA28GnOHYzalSDmmUJA0lHiZ3J2XsCbjsh3xjZSQILuTj7xHhG885a+Pu+uvD3qpoG6BCKXPwsDnSo=
+  sbp:
+    crc: '0x2a9d'
+    length: 54
+    msg_type: '0x231'
+    payload: 8GnOHYzalSDmmUJA0lHiZ3J2XsCbjsh3xjZSQILuTj7xHhG885a+Pu+uvD3qpoG6BCKXPwsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 1.187187910079956
+      cov_e_d: -0.0008731157868169248
+      cov_e_e: 0.09267372637987137
+      cov_n_d: 0.37415701150894165
+      cov_n_e: -0.008878067135810852
+      cov_n_n: 0.20320473611354828
+      flags: 3
+      height: 72.85056714382918
+      lat: 37.20233548402143
+      lon: -121.85073276533028
+      n_sats: 11
+      tow: 500066900
+    module: sbp.navigation
+    name: MsgPosLLHCovGnss
+  msg_type: '0x231'
+  raw_json: '{"preamble": 85, "msg_type": 561, "sender": 4096, "length": 54, "payload":
+    "VGrOHaBYDyHmmUJAqy7XZ3J2XsAacyyxbzZSQOcUUD5QdRG8gpG/PrnLvT3P4WS6xvWXPwsD", "crc":
+    45286, "tow": 500066900, "lat": 37.20233548402143, "lon": -121.85073276533028,
+    "height": 72.85056714382918, "cov_n_n": 0.20320473611354828, "cov_n_e": -0.008878067135810852,
+    "cov_n_d": 0.37415701150894165, "cov_e_e": 0.09267372637987137, "cov_e_d": -0.0008731157868169248,
+    "cov_d_d": 1.187187910079956, "n_sats": 11, "flags": 3}'
+  raw_packet: VTECABA2VGrOHaBYDyHmmUJAqy7XZ3J2XsAacyyxbzZSQOcUUD5QdRG8gpG/PrnLvT3P4WS6xvWXPwsD5rA=
+  sbp:
+    crc: '0xb0e6'
+    length: 54
+    msg_type: '0x231'
+    payload: VGrOHaBYDyHmmUJAqy7XZ3J2XsAacyyxbzZSQOcUUD5QdRG8gpG/PrnLvT3P4WS6xvWXPwsD
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 1.2849302291870117
+      cov_e_d: -0.0008128563640639186
+      cov_e_e: 0.10034556686878204
+      cov_n_d: 0.40482231974601746
+      cov_n_e: -0.009579113684594631
+      cov_n_n: 0.21995319426059723
+      flags: 3
+      height: 72.85084962586637
+      lat: 37.202335528965975
+      lon: -121.85073276386221
+      n_sats: 11
+      tow: 500067000
+    module: sbp.navigation
+    name: MsgPosLLHCovGnss
+  msg_type: '0x231'
+  raw_json: '{"preamble": 85, "msg_type": 561, "sender": 4096, "length": 54, "payload":
+    "uGrOHSbdbyHmmUJAIZvVZ3J2XsA8Ov1RdDZSQGk7YT638Ry830TPPvqBzT3eFVW6mHikPwsD", "crc":
+    31490, "tow": 500067000, "lat": 37.202335528965975, "lon": -121.85073276386221,
+    "height": 72.85084962586637, "cov_n_n": 0.21995319426059723, "cov_n_e": -0.009579113684594631,
+    "cov_n_d": 0.40482231974601746, "cov_e_e": 0.10034556686878204, "cov_e_d": -0.0008128563640639186,
+    "cov_d_d": 1.2849302291870117, "n_sats": 11, "flags": 3}'
+  raw_packet: VTECABA2uGrOHSbdbyHmmUJAIZvVZ3J2XsA8Ov1RdDZSQGk7YT638Ry830TPPvqBzT3eFVW6mHikPwsDAns=
+  sbp:
+    crc: '0x7b02'
+    length: 54
+    msg_type: '0x231'
+    payload: uGrOHSbdbyHmmUJAIZvVZ3J2XsA8Ov1RdDZSQGk7YT638Ry830TPPvqBzT3eFVW6mHikPwsD
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosLLHGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgPosLLHGnss.yaml
@@ -1,0 +1,137 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgPosLLHGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.808561
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      flags: 3
+      h_accuracy: 452
+      height: 72.86228782601304
+      lat: 37.20233535830912
+      lon: -121.85073280120506
+      n_sats: 11
+      tow: 500066600
+      v_accuracy: 1091
+    module: sbp.navigation
+    name: MsgPosLLHGnss
+  msg_type: '0x22a'
+  raw_json: '{"preamble": 85, "msg_type": 554, "sender": 4096, "length": 34, "payload":
+    "KGnOHY1hASDmmUJA2rP9Z3J2XsDCHUe5LzdSQMQBQwQLAw==", "crc": 34346, "tow": 500066600,
+    "lat": 37.20233535830912, "lon": -121.85073280120506, "height": 72.86228782601304,
+    "h_accuracy": 452, "v_accuracy": 1091, "n_sats": 11, "flags": 3}'
+  raw_packet: VSoCABAiKGnOHY1hASDmmUJA2rP9Z3J2XsDCHUe5LzdSQMQBQwQLAyqG
+  sbp:
+    crc: '0x862a'
+    length: 34
+    msg_type: '0x22a'
+    payload: KGnOHY1hASDmmUJA2rP9Z3J2XsDCHUe5LzdSQMQBQwQLAw==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 3
+      h_accuracy: 451
+      height: 72.85804762706461
+      lat: 37.20233541529999
+      lon: -121.85073279189656
+      n_sats: 11
+      tow: 500066700
+      v_accuracy: 1089
+    module: sbp.navigation
+    name: MsgPosLLHGnss
+  msg_type: '0x22a'
+  raw_json: '{"preamble": 85, "msg_type": 554, "sender": 4096, "length": 34, "payload":
+    "jGnOHZ3EeyDmmUJAJ7XzZ3J2XsDJKZhA6jZSQMMBQQQLAw==", "crc": 24948, "tow": 500066700,
+    "lat": 37.20233541529999, "lon": -121.85073279189656, "height": 72.85804762706461,
+    "h_accuracy": 451, "v_accuracy": 1089, "n_sats": 11, "flags": 3}'
+  raw_packet: VSoCABAijGnOHZ3EeyDmmUJAJ7XzZ3J2XsDJKZhA6jZSQMMBQQQLA3Rh
+  sbp:
+    crc: '0x6174'
+    length: 34
+    msg_type: '0x22a'
+    payload: jGnOHZ3EeyDmmUJAJ7XzZ3J2XsDJKZhA6jZSQMMBQQQLAw==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 3
+      h_accuracy: 450
+      height: 72.85586351953172
+      lat: 37.20233542744708
+      lon: -121.85073277570271
+      n_sats: 11
+      tow: 500066800
+      v_accuracy: 1087
+    module: sbp.navigation
+    name: MsgPosLLHGnss
+  msg_type: '0x22a'
+  raw_json: '{"preamble": 85, "msg_type": 554, "sender": 4096, "length": 34, "payload":
+    "8GnOHYzalSDmmUJA0lHiZ3J2XsCbjsh3xjZSQMIBPwQLAw==", "crc": 16093, "tow": 500066800,
+    "lat": 37.20233542744708, "lon": -121.85073277570271, "height": 72.85586351953172,
+    "h_accuracy": 450, "v_accuracy": 1087, "n_sats": 11, "flags": 3}'
+  raw_packet: VSoCABAi8GnOHYzalSDmmUJA0lHiZ3J2XsCbjsh3xjZSQMIBPwQLA90+
+  sbp:
+    crc: '0x3edd'
+    length: 34
+    msg_type: '0x22a'
+    payload: 8GnOHYzalSDmmUJA0lHiZ3J2XsCbjsh3xjZSQMIBPwQLAw==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 3
+      h_accuracy: 452
+      height: 72.85056714382918
+      lat: 37.20233548402143
+      lon: -121.85073276533028
+      n_sats: 11
+      tow: 500066900
+      v_accuracy: 1090
+    module: sbp.navigation
+    name: MsgPosLLHGnss
+  msg_type: '0x22a'
+  raw_json: '{"preamble": 85, "msg_type": 554, "sender": 4096, "length": 34, "payload":
+    "VGrOHaBYDyHmmUJAqy7XZ3J2XsAacyyxbzZSQMQBQgQLAw==", "crc": 2581, "tow": 500066900,
+    "lat": 37.20233548402143, "lon": -121.85073276533028, "height": 72.85056714382918,
+    "h_accuracy": 452, "v_accuracy": 1090, "n_sats": 11, "flags": 3}'
+  raw_packet: VSoCABAiVGrOHaBYDyHmmUJAqy7XZ3J2XsAacyyxbzZSQMQBQgQLAxUK
+  sbp:
+    crc: '0xa15'
+    length: 34
+    msg_type: '0x22a'
+    payload: VGrOHaBYDyHmmUJAqy7XZ3J2XsAacyyxbzZSQMQBQgQLAw==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 3
+      h_accuracy: 470
+      height: 72.85084962586637
+      lat: 37.202335528965975
+      lon: -121.85073276386221
+      n_sats: 11
+      tow: 500067000
+      v_accuracy: 1134
+    module: sbp.navigation
+    name: MsgPosLLHGnss
+  msg_type: '0x22a'
+  raw_json: '{"preamble": 85, "msg_type": 554, "sender": 4096, "length": 34, "payload":
+    "uGrOHSbdbyHmmUJAIZvVZ3J2XsA8Ov1RdDZSQNYBbgQLAw==", "crc": 55334, "tow": 500067000,
+    "lat": 37.202335528965975, "lon": -121.85073276386221, "height": 72.85084962586637,
+    "h_accuracy": 470, "v_accuracy": 1134, "n_sats": 11, "flags": 3}'
+  raw_packet: VSoCABAiuGrOHSbdbyHmmUJAIZvVZ3J2XsA8Ov1RdDZSQNYBbgQLAybY
+  sbp:
+    crc: '0xd826'
+    length: 34
+    msg_type: '0x22a'
+    payload: uGrOHSbdbyHmmUJAIZvVZ3J2XsA8Ov1RdDZSQNYBbgQLAw==
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgProtectionLevel.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgProtectionLevel.yaml
@@ -1,0 +1,127 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgProtectionLevel v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.020327
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      flags: 0
+      height: 0.0
+      hpl: 0
+      lat: 0.0
+      lon: 0.0
+      tow: 500066600
+      vpl: 0
+    module: sbp.navigation
+    name: MsgProtectionLevel
+  msg_type: '0x216'
+  raw_json: '{"preamble": 85, "msg_type": 534, "sender": 4096, "length": 33, "payload":
+    "KGnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "crc": 65372, "tow": 500066600,
+    "vpl": 0, "hpl": 0, "lat": 0.0, "lon": 0.0, "height": 0.0, "flags": 0}'
+  raw_packet: VRYCABAhKGnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXP8=
+  sbp:
+    crc: '0xff5c'
+    length: 33
+    msg_type: '0x216'
+    payload: KGnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 0
+      height: 0.0
+      hpl: 0
+      lat: 0.0
+      lon: 0.0
+      tow: 500066700
+      vpl: 0
+    module: sbp.navigation
+    name: MsgProtectionLevel
+  msg_type: '0x216'
+  raw_json: '{"preamble": 85, "msg_type": 534, "sender": 4096, "length": 33, "payload":
+    "jGnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "crc": 38908, "tow": 500066700,
+    "vpl": 0, "hpl": 0, "lat": 0.0, "lon": 0.0, "height": 0.0, "flags": 0}'
+  raw_packet: VRYCABAhjGnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/Jc=
+  sbp:
+    crc: '0x97fc'
+    length: 33
+    msg_type: '0x216'
+    payload: jGnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 0
+      height: 0.0
+      hpl: 0
+      lat: 0.0
+      lon: 0.0
+      tow: 500066800
+      vpl: 0
+    module: sbp.navigation
+    name: MsgProtectionLevel
+  msg_type: '0x216'
+  raw_json: '{"preamble": 85, "msg_type": 534, "sender": 4096, "length": 33, "payload":
+    "8GnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "crc": 10483, "tow": 500066800,
+    "vpl": 0, "hpl": 0, "lat": 0.0, "lon": 0.0, "height": 0.0, "flags": 0}'
+  raw_packet: VRYCABAh8GnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8yg=
+  sbp:
+    crc: '0x28f3'
+    length: 33
+    msg_type: '0x216'
+    payload: 8GnOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 0
+      height: 0.0
+      hpl: 0
+      lat: 0.0
+      lon: 0.0
+      tow: 500066900
+      vpl: 0
+    module: sbp.navigation
+    name: MsgProtectionLevel
+  msg_type: '0x216'
+  raw_json: '{"preamble": 85, "msg_type": 534, "sender": 4096, "length": 33, "payload":
+    "VGrOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "crc": 43929, "tow": 500066900,
+    "vpl": 0, "hpl": 0, "lat": 0.0, "lon": 0.0, "height": 0.0, "flags": 0}'
+  raw_packet: VRYCABAhVGrOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmas=
+  sbp:
+    crc: '0xab99'
+    length: 33
+    msg_type: '0x216'
+    payload: VGrOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      flags: 0
+      height: 0.0
+      hpl: 0
+      lat: 0.0
+      lon: 0.0
+      tow: 500067000
+      vpl: 0
+    module: sbp.navigation
+    name: MsgProtectionLevel
+  msg_type: '0x216'
+  raw_json: '{"preamble": 85, "msg_type": 534, "sender": 4096, "length": 33, "payload":
+    "uGrOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "crc": 36444, "tow": 500067000,
+    "vpl": 0, "hpl": 0, "lat": 0.0, "lon": 0.0, "height": 0.0, "flags": 0}'
+  raw_packet: VRYCABAhuGrOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI4=
+  sbp:
+    crc: '0x8e5c'
+    length: 33
+    msg_type: '0x216'
+    payload: uGrOHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgUtcTime.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgUtcTime.yaml
@@ -1,0 +1,137 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgUtcTime v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.156159
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 600000025
+      seconds: 8
+      tow: 500066600
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTime
+  msg_type: '0x103'
+  raw_json: '{"preamble": 85, "msg_type": 259, "sender": 789, "length": 16, "payload":
+    "AShpzh3kBwkLEjYIGUbDIw==", "crc": 18297, "flags": 1, "tow": 500066600, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 600000025}'
+  raw_packet: VQMBFQMQAShpzh3kBwkLEjYIGUbDI3lH
+  sbp:
+    crc: '0x4779'
+    length: 16
+    msg_type: '0x103'
+    payload: AShpzh3kBwkLEjYIGUbDIw==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 700000025
+      seconds: 8
+      tow: 500066700
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTime
+  msg_type: '0x103'
+  raw_json: '{"preamble": 85, "msg_type": 259, "sender": 789, "length": 16, "payload":
+    "AYxpzh3kBwkLEjYIGSe5KQ==", "crc": 65358, "flags": 1, "tow": 500066700, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 700000025}'
+  raw_packet: VQMBFQMQAYxpzh3kBwkLEjYIGSe5KU7/
+  sbp:
+    crc: '0xff4e'
+    length: 16
+    msg_type: '0x103'
+    payload: AYxpzh3kBwkLEjYIGSe5KQ==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 800000025
+      seconds: 8
+      tow: 500066800
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTime
+  msg_type: '0x103'
+  raw_json: '{"preamble": 85, "msg_type": 259, "sender": 789, "length": 16, "payload":
+    "AfBpzh3kBwkLEjYIGQivLw==", "crc": 55754, "flags": 1, "tow": 500066800, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 800000025}'
+  raw_packet: VQMBFQMQAfBpzh3kBwkLEjYIGQivL8rZ
+  sbp:
+    crc: '0xd9ca'
+    length: 16
+    msg_type: '0x103'
+    payload: AfBpzh3kBwkLEjYIGQivLw==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 900000025
+      seconds: 8
+      tow: 500066900
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTime
+  msg_type: '0x103'
+  raw_json: '{"preamble": 85, "msg_type": 259, "sender": 789, "length": 16, "payload":
+    "AVRqzh3kBwkLEjYIGemkNQ==", "crc": 65117, "flags": 1, "tow": 500066900, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 900000025}'
+  raw_packet: VQMBFQMQAVRqzh3kBwkLEjYIGemkNV3+
+  sbp:
+    crc: '0xfe5d'
+    length: 16
+    msg_type: '0x103'
+    payload: AVRqzh3kBwkLEjYIGemkNQ==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 25
+      seconds: 9
+      tow: 500067000
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTime
+  msg_type: '0x103'
+  raw_json: '{"preamble": 85, "msg_type": 259, "sender": 789, "length": 16, "payload":
+    "Abhqzh3kBwkLEjYJGQAAAA==", "crc": 33304, "flags": 1, "tow": 500067000, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 9, "ns": 25}'
+  raw_packet: VQMBFQMQAbhqzh3kBwkLEjYJGQAAABiC
+  sbp:
+    crc: '0x8218'
+    length: 16
+    msg_type: '0x103'
+    payload: Abhqzh3kBwkLEjYJGQAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgUtcTimeGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgUtcTimeGnss.yaml
@@ -1,0 +1,137 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgUtcTimeGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.790494
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 600000025
+      seconds: 8
+      tow: 500066600
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTimeGnss
+  msg_type: '0x105'
+  raw_json: '{"preamble": 85, "msg_type": 261, "sender": 4096, "length": 16, "payload":
+    "AShpzh3kBwkLEjYIGUbDIw==", "crc": 53215, "flags": 1, "tow": 500066600, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 600000025}'
+  raw_packet: VQUBABAQAShpzh3kBwkLEjYIGUbDI9/P
+  sbp:
+    crc: '0xcfdf'
+    length: 16
+    msg_type: '0x105'
+    payload: AShpzh3kBwkLEjYIGUbDIw==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 700000025
+      seconds: 8
+      tow: 500066700
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTimeGnss
+  msg_type: '0x105'
+  raw_json: '{"preamble": 85, "msg_type": 261, "sender": 4096, "length": 16, "payload":
+    "AYxpzh3kBwkLEjYIGSe5KQ==", "crc": 30696, "flags": 1, "tow": 500066700, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 700000025}'
+  raw_packet: VQUBABAQAYxpzh3kBwkLEjYIGSe5Keh3
+  sbp:
+    crc: '0x77e8'
+    length: 16
+    msg_type: '0x105'
+    payload: AYxpzh3kBwkLEjYIGSe5KQ==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 800000025
+      seconds: 8
+      tow: 500066800
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTimeGnss
+  msg_type: '0x105'
+  raw_json: '{"preamble": 85, "msg_type": 261, "sender": 4096, "length": 16, "payload":
+    "AfBpzh3kBwkLEjYIGQivLw==", "crc": 20844, "flags": 1, "tow": 500066800, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 800000025}'
+  raw_packet: VQUBABAQAfBpzh3kBwkLEjYIGQivL2xR
+  sbp:
+    crc: '0x516c'
+    length: 16
+    msg_type: '0x105'
+    payload: AfBpzh3kBwkLEjYIGQivLw==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 900000025
+      seconds: 8
+      tow: 500066900
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTimeGnss
+  msg_type: '0x105'
+  raw_json: '{"preamble": 85, "msg_type": 261, "sender": 4096, "length": 16, "payload":
+    "AVRqzh3kBwkLEjYIGemkNQ==", "crc": 30459, "flags": 1, "tow": 500066900, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 8, "ns": 900000025}'
+  raw_packet: VQUBABAQAVRqzh3kBwkLEjYIGemkNft2
+  sbp:
+    crc: '0x76fb'
+    length: 16
+    msg_type: '0x105'
+    payload: AVRqzh3kBwkLEjYIGemkNQ==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      day: 11
+      flags: 1
+      hours: 18
+      minutes: 54
+      month: 9
+      ns: 25
+      seconds: 9
+      tow: 500067000
+      year: 2020
+    module: sbp.navigation
+    name: MsgUtcTimeGnss
+  msg_type: '0x105'
+  raw_json: '{"preamble": 85, "msg_type": 261, "sender": 4096, "length": 16, "payload":
+    "Abhqzh3kBwkLEjYJGQAAAA==", "crc": 2750, "flags": 1, "tow": 500067000, "year":
+    2020, "month": 9, "day": 11, "hours": 18, "minutes": 54, "seconds": 9, "ns": 25}'
+  raw_packet: VQUBABAQAbhqzh3kBwkLEjYJGQAAAL4K
+  sbp:
+    crc: '0xabe'
+    length: 16
+    msg_type: '0x105'
+    payload: Abhqzh3kBwkLEjYJGQAAAA==
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelECEFCovGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelECEFCovGnss.yaml
@@ -1,0 +1,167 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgVelECEFCovGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.908295
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      cov_x_x: 0.030367126688361168
+      cov_x_y: 0.0289162565022707
+      cov_x_z: -0.017464784905314445
+      cov_y_y: 0.050206590443849564
+      cov_y_z: -0.022163640707731247
+      cov_z_z: 0.02751787379384041
+      flags: 2
+      n_sats: 16
+      tow: 500066600
+      x: 2
+      y: 10
+      z: -26
+    module: sbp.navigation
+    name: MsgVelECEFCovGnss
+  msg_type: '0x235'
+  raw_json: '{"preamble": 85, "msg_type": 565, "sender": 4096, "length": 42, "payload":
+    "KGnOHQIAAAAKAAAA5v///3vE+DzJ4ew8TxKPvG2lTT2GkLW8Km3hPBAC", "crc": 14564, "tow":
+    500066600, "x": 2, "y": 10, "z": -26, "cov_x_x": 0.030367126688361168, "cov_x_y":
+    0.0289162565022707, "cov_x_z": -0.017464784905314445, "cov_y_y": 0.050206590443849564,
+    "cov_y_z": -0.022163640707731247, "cov_z_z": 0.02751787379384041, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTUCABAqKGnOHQIAAAAKAAAA5v///3vE+DzJ4ew8TxKPvG2lTT2GkLW8Km3hPBAC5Dg=
+  sbp:
+    crc: '0x38e4'
+    length: 42
+    msg_type: '0x235'
+    payload: KGnOHQIAAAAKAAAA5v///3vE+DzJ4ew8TxKPvG2lTT2GkLW8Km3hPBAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.03036646917462349
+      cov_x_y: 0.028915580362081528
+      cov_x_z: -0.017464376986026764
+      cov_y_y: 0.050206154584884644
+      cov_y_z: -0.022163329645991325
+      cov_z_z: 0.027517609298229218
+      flags: 2
+      n_sats: 16
+      tow: 500066700
+      x: 12
+      y: 10
+      z: 10
+    module: sbp.navigation
+    name: MsgVelECEFCovGnss
+  msg_type: '0x235'
+  raw_json: '{"preamble": 85, "msg_type": 565, "sender": 4096, "length": 42, "payload":
+    "jGnOHQwAAAAKAAAACgAAABrD+Dxe4Ow8dBGPvPikTT3fj7W8nGzhPBAC", "crc": 59719, "tow":
+    500066700, "x": 12, "y": 10, "z": 10, "cov_x_x": 0.03036646917462349, "cov_x_y":
+    0.028915580362081528, "cov_x_z": -0.017464376986026764, "cov_y_y": 0.050206154584884644,
+    "cov_y_z": -0.022163329645991325, "cov_z_z": 0.027517609298229218, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTUCABAqjGnOHQwAAAAKAAAACgAAABrD+Dxe4Ow8dBGPvPikTT3fj7W8nGzhPBACR+k=
+  sbp:
+    crc: '0xe947'
+    length: 42
+    msg_type: '0x235'
+    payload: jGnOHQwAAAAKAAAACgAAABrD+Dxe4Ow8dBGPvPikTT3fj7W8nGzhPBAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.03036581352353096
+      cov_x_y: 0.028914904221892357
+      cov_x_z: -0.017463969066739082
+      cov_y_y: 0.050205715000629425
+      cov_y_z: -0.022163018584251404
+      cov_z_z: 0.027517344802618027
+      flags: 2
+      n_sats: 16
+      tow: 500066800
+      x: 13
+      y: -5
+      z: -15
+    module: sbp.navigation
+    name: MsgVelECEFCovGnss
+  msg_type: '0x235'
+  raw_json: '{"preamble": 85, "msg_type": 565, "sender": 4096, "length": 42, "payload":
+    "8GnOHQ0AAAD7////8f///7rB+Dzz3uw8mRCPvIKkTT04j7W8DmzhPBAC", "crc": 11509, "tow":
+    500066800, "x": 13, "y": -5, "z": -15, "cov_x_x": 0.03036581352353096, "cov_x_y":
+    0.028914904221892357, "cov_x_z": -0.017463969066739082, "cov_y_y": 0.050205715000629425,
+    "cov_y_z": -0.022163018584251404, "cov_z_z": 0.027517344802618027, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTUCABAq8GnOHQ0AAAD7////8f///7rB+Dzz3uw8mRCPvIKkTT04j7W8DmzhPBAC9Sw=
+  sbp:
+    crc: '0x2cf5'
+    length: 42
+    msg_type: '0x235'
+    payload: 8GnOHQ0AAAD7////8f///7rB+Dzz3uw8mRCPvIKkTT04j7W8DmzhPBAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.03036515600979328
+      cov_x_y: 0.028914228081703186
+      cov_x_z: -0.01746355928480625
+      cov_y_y: 0.05020527541637421
+      cov_y_z: -0.022162707522511482
+      cov_z_z: 0.027517080307006836
+      flags: 2
+      n_sats: 16
+      tow: 500066900
+      x: 14
+      y: 22
+      z: -6
+    module: sbp.navigation
+    name: MsgVelECEFCovGnss
+  msg_type: '0x235'
+  raw_json: '{"preamble": 85, "msg_type": 565, "sender": 4096, "length": 42, "payload":
+    "VGrOHQ4AAAAWAAAA+v///1nA+DyI3ew8vQ+PvAykTT2RjrW8gGvhPBAC", "crc": 64187, "tow":
+    500066900, "x": 14, "y": 22, "z": -6, "cov_x_x": 0.03036515600979328, "cov_x_y":
+    0.028914228081703186, "cov_x_z": -0.01746355928480625, "cov_y_y": 0.05020527541637421,
+    "cov_y_z": -0.022162707522511482, "cov_z_z": 0.027517080307006836, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTUCABAqVGrOHQ4AAAAWAAAA+v///1nA+DyI3ew8vQ+PvAykTT2RjrW8gGvhPBACu/o=
+  sbp:
+    crc: '0xfabb'
+    length: 42
+    msg_type: '0x235'
+    payload: VGrOHQ4AAAAWAAAA+v///1nA+DyI3ew8vQ+PvAykTT2RjrW8gGvhPBAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_x_x: 0.030364498496055603
+      cov_x_y: 0.028913551941514015
+      cov_x_z: -0.01746315136551857
+      cov_y_y: 0.05020483210682869
+      cov_y_z: -0.02216239646077156
+      cov_z_z: 0.027516815811395645
+      flags: 2
+      n_sats: 16
+      tow: 500067000
+      x: -16
+      y: -27
+      z: 28
+    module: sbp.navigation
+    name: MsgVelECEFCovGnss
+  msg_type: '0x235'
+  raw_json: '{"preamble": 85, "msg_type": 565, "sender": 4096, "length": 42, "payload":
+    "uGrOHfD////l////HAAAAPi++Dwd3Ow84g6PvJWjTT3qjbW88mrhPBAC", "crc": 45140, "tow":
+    500067000, "x": -16, "y": -27, "z": 28, "cov_x_x": 0.030364498496055603, "cov_x_y":
+    0.028913551941514015, "cov_x_z": -0.01746315136551857, "cov_y_y": 0.05020483210682869,
+    "cov_y_z": -0.02216239646077156, "cov_z_z": 0.027516815811395645, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTUCABAquGrOHfD////l////HAAAAPi++Dwd3Ow84g6PvJWjTT3qjbW88mrhPBACVLA=
+  sbp:
+    crc: '0xb054'
+    length: 42
+    msg_type: '0x235'
+    payload: uGrOHfD////l////HAAAAPi++Dwd3Ow84g6PvJWjTT3qjbW88mrhPBAC
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelECEFGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelECEFGnss.yaml
@@ -1,0 +1,127 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgVelECEFGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.851958
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      accuracy: 291
+      flags: 2
+      n_sats: 16
+      tow: 500066600
+      x: 2
+      y: 10
+      z: -26
+    module: sbp.navigation
+    name: MsgVelECEFGnss
+  msg_type: '0x22d'
+  raw_json: '{"preamble": 85, "msg_type": 557, "sender": 4096, "length": 20, "payload":
+    "KGnOHQIAAAAKAAAA5v///yMBEAI=", "crc": 24242, "tow": 500066600, "x": 2, "y": 10,
+    "z": -26, "accuracy": 291, "n_sats": 16, "flags": 2}'
+  raw_packet: VS0CABAUKGnOHQIAAAAKAAAA5v///yMBEAKyXg==
+  sbp:
+    crc: '0x5eb2'
+    length: 20
+    msg_type: '0x22d'
+    payload: KGnOHQIAAAAKAAAA5v///yMBEAI=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 291
+      flags: 2
+      n_sats: 16
+      tow: 500066700
+      x: 12
+      y: 10
+      z: 10
+    module: sbp.navigation
+    name: MsgVelECEFGnss
+  msg_type: '0x22d'
+  raw_json: '{"preamble": 85, "msg_type": 557, "sender": 4096, "length": 20, "payload":
+    "jGnOHQwAAAAKAAAACgAAACMBEAI=", "crc": 12274, "tow": 500066700, "x": 12, "y":
+    10, "z": 10, "accuracy": 291, "n_sats": 16, "flags": 2}'
+  raw_packet: VS0CABAUjGnOHQwAAAAKAAAACgAAACMBEALyLw==
+  sbp:
+    crc: '0x2ff2'
+    length: 20
+    msg_type: '0x22d'
+    payload: jGnOHQwAAAAKAAAACgAAACMBEAI=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 291
+      flags: 2
+      n_sats: 16
+      tow: 500066800
+      x: 13
+      y: -5
+      z: -15
+    module: sbp.navigation
+    name: MsgVelECEFGnss
+  msg_type: '0x22d'
+  raw_json: '{"preamble": 85, "msg_type": 557, "sender": 4096, "length": 20, "payload":
+    "8GnOHQ0AAAD7////8f///yMBEAI=", "crc": 43310, "tow": 500066800, "x": 13, "y":
+    -5, "z": -15, "accuracy": 291, "n_sats": 16, "flags": 2}'
+  raw_packet: VS0CABAU8GnOHQ0AAAD7////8f///yMBEAIuqQ==
+  sbp:
+    crc: '0xa92e'
+    length: 20
+    msg_type: '0x22d'
+    payload: 8GnOHQ0AAAD7////8f///yMBEAI=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 291
+      flags: 2
+      n_sats: 16
+      tow: 500066900
+      x: 14
+      y: 22
+      z: -6
+    module: sbp.navigation
+    name: MsgVelECEFGnss
+  msg_type: '0x22d'
+  raw_json: '{"preamble": 85, "msg_type": 557, "sender": 4096, "length": 20, "payload":
+    "VGrOHQ4AAAAWAAAA+v///yMBEAI=", "crc": 56103, "tow": 500066900, "x": 14, "y":
+    22, "z": -6, "accuracy": 291, "n_sats": 16, "flags": 2}'
+  raw_packet: VS0CABAUVGrOHQ4AAAAWAAAA+v///yMBEAIn2w==
+  sbp:
+    crc: '0xdb27'
+    length: 20
+    msg_type: '0x22d'
+    payload: VGrOHQ4AAAAWAAAA+v///yMBEAI=
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      accuracy: 291
+      flags: 2
+      n_sats: 16
+      tow: 500067000
+      x: -16
+      y: -27
+      z: 28
+    module: sbp.navigation
+    name: MsgVelECEFGnss
+  msg_type: '0x22d'
+  raw_json: '{"preamble": 85, "msg_type": 557, "sender": 4096, "length": 20, "payload":
+    "uGrOHfD////l////HAAAACMBEAI=", "crc": 61961, "tow": 500067000, "x": -16, "y":
+    -27, "z": 28, "accuracy": 291, "n_sats": 16, "flags": 2}'
+  raw_packet: VS0CABAUuGrOHfD////l////HAAAACMBEAIJ8g==
+  sbp:
+    crc: '0xf209'
+    length: 20
+    msg_type: '0x22d'
+    payload: uGrOHfD////l////HAAAACMBEAI=
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelNEDCovGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelNEDCovGnss.yaml
@@ -1,0 +1,167 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgVelNEDCovGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.977227
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      cov_d_d: 0.08186359703540802
+      cov_e_d: 0.0050189308822155
+      cov_e_e: 0.00996857974678278
+      cov_n_d: 0.013211467303335667
+      cov_n_e: -0.00013119776849634945
+      cov_n_n: 0.016259418800473213
+      d: 24
+      e: -4
+      flags: 2
+      n: -15
+      n_sats: 16
+      tow: 500066600
+    module: sbp.navigation
+    name: MsgVelNEDCovGnss
+  msg_type: '0x232'
+  raw_json: '{"preamble": 85, "msg_type": 562, "sender": 4096, "length": 42, "payload":
+    "KGnOHfH////8////GAAAAHkyhTwikgm56XRYPEFTIzzYdaQ7GqinPRAC", "crc": 65456, "tow":
+    500066600, "n": -15, "e": -4, "d": 24, "cov_n_n": 0.016259418800473213, "cov_n_e":
+    -0.00013119776849634945, "cov_n_d": 0.013211467303335667, "cov_e_e": 0.00996857974678278,
+    "cov_e_d": 0.0050189308822155, "cov_d_d": 0.08186359703540802, "n_sats": 16, "flags":
+    2}'
+  raw_packet: VTICABAqKGnOHfH////8////GAAAAHkyhTwikgm56XRYPEFTIzzYdaQ7GqinPRACsP8=
+  sbp:
+    crc: '0xffb0'
+    length: 42
+    msg_type: '0x232'
+    payload: KGnOHfH////8////GAAAAHkyhTwikgm56XRYPEFTIzzYdaQ7GqinPRAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 0.08186233043670654
+      cov_e_d: 0.005018504802137613
+      cov_e_e: 0.0099685899913311
+      cov_n_d: 0.01321119163185358
+      cov_n_e: -0.00013129241415299475
+      cov_n_n: 0.01625930890440941
+      d: 5
+      e: 5
+      flags: 2
+      n: 17
+      n_sats: 16
+      tow: 500066700
+    module: sbp.navigation
+    name: MsgVelNEDCovGnss
+  msg_type: '0x232'
+  raw_json: '{"preamble": 85, "msg_type": 562, "sender": 4096, "length": 42, "payload":
+    "jGnOHREAAAAFAAAABQAAAD4yhTyKqwm5wXNYPExTIzxFcqQ7cKenPRAC", "crc": 53513, "tow":
+    500066700, "n": 17, "e": 5, "d": 5, "cov_n_n": 0.01625930890440941, "cov_n_e":
+    -0.00013129241415299475, "cov_n_d": 0.01321119163185358, "cov_e_e": 0.0099685899913311,
+    "cov_e_d": 0.005018504802137613, "cov_d_d": 0.08186233043670654, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTICABAqjGnOHREAAAAFAAAABQAAAD4yhTyKqwm5wXNYPExTIzxFcqQ7cKenPRACCdE=
+  sbp:
+    crc: '0xd109'
+    length: 42
+    msg_type: '0x232'
+    payload: jGnOHREAAAAFAAAABQAAAD4yhTyKqwm5wXNYPExTIzxFcqQ7cKenPRAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 0.08186107128858566
+      cov_e_d: 0.005018078256398439
+      cov_e_e: 0.009968599304556847
+      cov_n_d: 0.01321091502904892
+      cov_n_e: -0.00013138705980964005
+      cov_n_n: 0.016259199008345604
+      d: 11
+      e: 14
+      flags: 2
+      n: -10
+      n_sats: 16
+      tow: 500066800
+    module: sbp.navigation
+    name: MsgVelNEDCovGnss
+  msg_type: '0x232'
+  raw_json: '{"preamble": 85, "msg_type": 562, "sender": 4096, "length": 42, "payload":
+    "8GnOHfb///8OAAAACwAAAAMyhTzyxAm5mHJYPFZTIzyxbqQ7x6anPRAC", "crc": 33473, "tow":
+    500066800, "n": -10, "e": 14, "d": 11, "cov_n_n": 0.016259199008345604, "cov_n_e":
+    -0.00013138705980964005, "cov_n_d": 0.01321091502904892, "cov_e_e": 0.009968599304556847,
+    "cov_e_d": 0.005018078256398439, "cov_d_d": 0.08186107128858566, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTICABAq8GnOHfb///8OAAAACwAAAAMyhTzyxAm5mHJYPFZTIzyxbqQ7x6anPRACwYI=
+  sbp:
+    crc: '0x82c1'
+    length: 42
+    msg_type: '0x232'
+    payload: 8GnOHfb///8OAAAACwAAAAMyhTzyxAm5mHJYPFZTIzyxbqQ7x6anPRAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 0.08185981214046478
+      cov_e_d: 0.0050176517106592655
+      cov_e_e: 0.009968608617782593
+      cov_n_d: 0.013210639357566833
+      cov_n_e: -0.00013148169091437012
+      cov_n_n: 0.0162590891122818
+      d: 24
+      e: 0
+      flags: 2
+      n: 12
+      n_sats: 16
+      tow: 500066900
+    module: sbp.navigation
+    name: MsgVelNEDCovGnss
+  msg_type: '0x232'
+  raw_json: '{"preamble": 85, "msg_type": 562, "sender": 4096, "length": 42, "payload":
+    "VGrOHQwAAAAAAAAAGAAAAMgxhTxZ3gm5cHFYPGBTIzwda6Q7HqanPRAC", "crc": 21205, "tow":
+    500066900, "n": 12, "e": 0, "d": 24, "cov_n_n": 0.0162590891122818, "cov_n_e":
+    -0.00013148169091437012, "cov_n_d": 0.013210639357566833, "cov_e_e": 0.009968608617782593,
+    "cov_e_d": 0.0050176517106592655, "cov_d_d": 0.08185981214046478, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTICABAqVGrOHQwAAAAAAAAAGAAAAMgxhTxZ3gm5cHFYPGBTIzwda6Q7HqanPRAC1VI=
+  sbp:
+    crc: '0x52d5'
+    length: 42
+    msg_type: '0x232'
+    payload: VGrOHQwAAAAAAAAAGAAAAMgxhTxZ3gm5cHFYPGBTIzwda6Q7HqanPRAC
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      cov_d_d: 0.0818585529923439
+      cov_e_d: 0.005017225164920092
+      cov_e_e: 0.009968618862330914
+      cov_n_d: 0.013210362754762173
+      cov_n_e: -0.0001315763220191002
+      cov_n_n: 0.016258979216217995
+      d: -41
+      e: 1
+      flags: 2
+      n: 3
+      n_sats: 16
+      tow: 500067000
+    module: sbp.navigation
+    name: MsgVelNEDCovGnss
+  msg_type: '0x232'
+  raw_json: '{"preamble": 85, "msg_type": 562, "sender": 4096, "length": 42, "payload":
+    "uGrOHQMAAAABAAAA1////40xhTzA9wm5R3BYPGtTIzyJZ6Q7daWnPRAC", "crc": 47669, "tow":
+    500067000, "n": 3, "e": 1, "d": -41, "cov_n_n": 0.016258979216217995, "cov_n_e":
+    -0.0001315763220191002, "cov_n_d": 0.013210362754762173, "cov_e_e": 0.009968618862330914,
+    "cov_e_d": 0.005017225164920092, "cov_d_d": 0.0818585529923439, "n_sats": 16,
+    "flags": 2}'
+  raw_packet: VTICABAquGrOHQMAAAABAAAA1////40xhTzA9wm5R3BYPGtTIzyJZ6Q7daWnPRACNbo=
+  sbp:
+    crc: '0xba35'
+    length: 42
+    msg_type: '0x232'
+    payload: uGrOHQMAAAABAAAA1////40xhTzA9wm5R3BYPGtTIzyJZ6Q7daWnPRAC
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelNEDGnss.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/navigation/test_MsgVelNEDGnss.yaml
@@ -1,0 +1,134 @@
+---
+description: Unit tests for swiftnav.sbp.navigation MsgVelNEDGnss v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.837687
+package: sbp.navigation
+tests:
+
+- msg:
+    fields:
+      d: 24
+      e: -4
+      flags: 2
+      h_accuracy: 128
+      n: -15
+      n_sats: 16
+      tow: 500066600
+      v_accuracy: 286
+    module: sbp.navigation
+    name: MsgVelNEDGnss
+  msg_type: '0x22e'
+  raw_json: '{"preamble": 85, "msg_type": 558, "sender": 4096, "length": 22, "payload":
+    "KGnOHfH////8////GAAAAIAAHgEQAg==", "crc": 11909, "tow": 500066600, "n": -15,
+    "e": -4, "d": 24, "h_accuracy": 128, "v_accuracy": 286, "n_sats": 16, "flags":
+    2}'
+  raw_packet: VS4CABAWKGnOHfH////8////GAAAAIAAHgEQAoUu
+  sbp:
+    crc: '0x2e85'
+    length: 22
+    msg_type: '0x22e'
+    payload: KGnOHfH////8////GAAAAIAAHgEQAg==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      d: 5
+      e: 5
+      flags: 2
+      h_accuracy: 128
+      n: 17
+      n_sats: 16
+      tow: 500066700
+      v_accuracy: 286
+    module: sbp.navigation
+    name: MsgVelNEDGnss
+  msg_type: '0x22e'
+  raw_json: '{"preamble": 85, "msg_type": 558, "sender": 4096, "length": 22, "payload":
+    "jGnOHREAAAAFAAAABQAAAIAAHgEQAg==", "crc": 48961, "tow": 500066700, "n": 17, "e":
+    5, "d": 5, "h_accuracy": 128, "v_accuracy": 286, "n_sats": 16, "flags": 2}'
+  raw_packet: VS4CABAWjGnOHREAAAAFAAAABQAAAIAAHgEQAkG/
+  sbp:
+    crc: '0xbf41'
+    length: 22
+    msg_type: '0x22e'
+    payload: jGnOHREAAAAFAAAABQAAAIAAHgEQAg==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      d: 11
+      e: 14
+      flags: 2
+      h_accuracy: 128
+      n: -10
+      n_sats: 16
+      tow: 500066800
+      v_accuracy: 286
+    module: sbp.navigation
+    name: MsgVelNEDGnss
+  msg_type: '0x22e'
+  raw_json: '{"preamble": 85, "msg_type": 558, "sender": 4096, "length": 22, "payload":
+    "8GnOHfb///8OAAAACwAAAIAAHgEQAg==", "crc": 14111, "tow": 500066800, "n": -10,
+    "e": 14, "d": 11, "h_accuracy": 128, "v_accuracy": 286, "n_sats": 16, "flags":
+    2}'
+  raw_packet: VS4CABAW8GnOHfb///8OAAAACwAAAIAAHgEQAh83
+  sbp:
+    crc: '0x371f'
+    length: 22
+    msg_type: '0x22e'
+    payload: 8GnOHfb///8OAAAACwAAAIAAHgEQAg==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      d: 24
+      e: 0
+      flags: 2
+      h_accuracy: 128
+      n: 12
+      n_sats: 16
+      tow: 500066900
+      v_accuracy: 286
+    module: sbp.navigation
+    name: MsgVelNEDGnss
+  msg_type: '0x22e'
+  raw_json: '{"preamble": 85, "msg_type": 558, "sender": 4096, "length": 22, "payload":
+    "VGrOHQwAAAAAAAAAGAAAAIAAHgEQAg==", "crc": 50239, "tow": 500066900, "n": 12, "e":
+    0, "d": 24, "h_accuracy": 128, "v_accuracy": 286, "n_sats": 16, "flags": 2}'
+  raw_packet: VS4CABAWVGrOHQwAAAAAAAAAGAAAAIAAHgEQAj/E
+  sbp:
+    crc: '0xc43f'
+    length: 22
+    msg_type: '0x22e'
+    payload: VGrOHQwAAAAAAAAAGAAAAIAAHgEQAg==
+    preamble: '0x55'
+    sender: '0x1000'
+
+- msg:
+    fields:
+      d: -41
+      e: 1
+      flags: 2
+      h_accuracy: 128
+      n: 3
+      n_sats: 16
+      tow: 500067000
+      v_accuracy: 286
+    module: sbp.navigation
+    name: MsgVelNEDGnss
+  msg_type: '0x22e'
+  raw_json: '{"preamble": 85, "msg_type": 558, "sender": 4096, "length": 22, "payload":
+    "uGrOHQMAAAABAAAA1////4AAHgEQAg==", "crc": 16376, "tow": 500067000, "n": 3, "e":
+    1, "d": -41, "h_accuracy": 128, "v_accuracy": 286, "n_sats": 16, "flags": 2}'
+  raw_packet: VS4CABAWuGrOHQMAAAABAAAA1////4AAHgEQAvg/
+  sbp:
+    crc: '0x3ff8'
+    length: 22
+    msg_type: '0x22e'
+    payload: uGrOHQMAAAABAAAA1////4AAHgEQAg==
+    preamble: '0x55'
+    sender: '0x1000'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgBasePosECEF.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgBasePosECEF.yaml
@@ -1,0 +1,107 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgBasePosECEF v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.718658
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      x: -2715668.8018
+      y: -4371277.9681
+      z: 3755474.6092
+    module: sbp.observation
+    name: MsgBasePosECEF
+  msg_type: '0x48'
+  raw_json: '{"preamble": 85, "msg_type": 72, "sender": 0, "length": 24, "payload":
+    "5WGhZgq4RMG0WfV906xQwf5D+k3ppkxB", "crc": 47527, "x": -2715668.8018, "y": -4371277.9681,
+    "z": 3755474.6092}'
+  raw_packet: VUgAAAAY5WGhZgq4RMG0WfV906xQwf5D+k3ppkxBp7k=
+  sbp:
+    crc: '0xb9a7'
+    length: 24
+    msg_type: '0x48'
+    payload: 5WGhZgq4RMG0WfV906xQwf5D+k3ppkxB
+    preamble: '0x55'
+    sender: '0x0'
+
+- msg:
+    fields:
+      x: -2684185.4532
+      y: -4320601.5743
+      z: 3835340.2343
+    module: sbp.observation
+    name: MsgBasePosECEF
+  msg_type: '0x48'
+  raw_json: '{"preamble": 85, "msg_type": 72, "sender": 51228, "length": 24, "payload":
+    "JXUCuox6RMHKVMFkVntQwduK/R3mQk1B", "crc": 40530, "x": -2684185.4532, "y": -4320601.5743,
+    "z": 3835340.2343}'
+  raw_packet: VUgAHMgYJXUCuox6RMHKVMFkVntQwduK/R3mQk1BUp4=
+  sbp:
+    crc: '0x9e52'
+    length: 24
+    msg_type: '0x48'
+    payload: JXUCuox6RMHKVMFkVntQwduK/R3mQk1B
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      x: -2715668.8018
+      y: -4371277.9681
+      z: 3755474.6092
+    module: sbp.observation
+    name: MsgBasePosECEF
+  msg_type: '0x48'
+  raw_json: '{"preamble": 85, "msg_type": 72, "sender": 0, "length": 24, "payload":
+    "5WGhZgq4RMG0WfV906xQwf5D+k3ppkxB", "crc": 47527, "x": -2715668.8018, "y": -4371277.9681,
+    "z": 3755474.6092}'
+  raw_packet: VUgAAAAY5WGhZgq4RMG0WfV906xQwf5D+k3ppkxBp7k=
+  sbp:
+    crc: '0xb9a7'
+    length: 24
+    msg_type: '0x48'
+    payload: 5WGhZgq4RMG0WfV906xQwf5D+k3ppkxB
+    preamble: '0x55'
+    sender: '0x0'
+
+- msg:
+    fields:
+      x: -2684186.25
+      y: -4320602.1485
+      z: 3835340.2265
+    module: sbp.observation
+    name: MsgBasePosECEF
+  msg_type: '0x48'
+  raw_json: '{"preamble": 85, "msg_type": 72, "sender": 51228, "length": 24, "payload":
+    "AAAAII16RMElBoGJVntQwbbz/RzmQk1B", "crc": 18744, "x": -2684186.25, "y": -4320602.1485,
+    "z": 3835340.2265}'
+  raw_packet: VUgAHMgYAAAAII16RMElBoGJVntQwbbz/RzmQk1BOEk=
+  sbp:
+    crc: '0x4938'
+    length: 24
+    msg_type: '0x48'
+    payload: AAAAII16RMElBoGJVntQwbbz/RzmQk1B
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      x: -2715668.8018
+      y: -4371277.9681
+      z: 3755474.6092
+    module: sbp.observation
+    name: MsgBasePosECEF
+  msg_type: '0x48'
+  raw_json: '{"preamble": 85, "msg_type": 72, "sender": 0, "length": 24, "payload":
+    "5WGhZgq4RMG0WfV906xQwf5D+k3ppkxB", "crc": 47527, "x": -2715668.8018, "y": -4371277.9681,
+    "z": 3755474.6092}'
+  raw_packet: VUgAAAAY5WGhZgq4RMG0WfV906xQwf5D+k3ppkxBp7k=
+  sbp:
+    crc: '0xb9a7'
+    length: 24
+    msg_type: '0x48'
+    payload: 5WGhZgq4RMG0WfV906xQwf5D+k3ppkxB
+    preamble: '0x55'
+    sender: '0x0'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgEphemerisBds.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgEphemerisBds.yaml
@@ -1,0 +1,317 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgEphemerisBds v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.893464
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      af0: -0.0008420408703386784
+      af1: -4.177103107849689e-12
+      af2: 0.0
+      c_ic: -7.450580596923828e-09
+      c_is: 3.259629011154175e-08
+      c_rc: 169.390625
+      c_rs: -39.9375
+      c_uc: -1.9385479390621185e-06
+      c_us: 9.563285857439041e-06
+      common:
+        fit_interval: 10800
+        health_bits: 0
+        sid:
+          code: 12
+          sat: 20
+        toe:
+          tow: 496814
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 3.840159958076294e-09
+      ecc: 0.0006740774260833859
+      inc: 0.9644173827350714
+      inc_dot: 3.125130174215734e-10
+      iodc: 1
+      iode: 1
+      m0: 0.38394770532877115
+      omega0: 2.579890563505979
+      omegadot: -6.61670418371665e-09
+      sqrta: 5282.623254776001
+      tgd1: 2.310000013494573e-08
+      tgd2: 2.310000013494573e-08
+      toc:
+        tow: 496814
+        wn: 2122
+      w: -0.4218735420063852
+    module: sbp.observation
+    name: MsgEphemerisBds
+  msg_type: '0x89'
+  raw_json: '{"preamble": 85, "msg_type": 137, "sender": 51228, "length": 147, "payload":
+    "FAyulAcASggAAABAMCoAAAEAcG3GMnBtxjIAwB/CAGQpQwAYArYAciA3AAAAsgAADDOYvUzvTH4wPmu5cGWZktg/AAAAQJIWRj8AAKCNn6K0QDUj7KmdowRA3XbwpyRrPL5PxH3i+f/av0FQ0deB3O4/iEFBgsl59T0AAAAAjZdLvwD4kqwAAAAArpQHAEoIAQEA",
+    "crc": 12627, "common": {"sid": {"sat": 20, "code": 12}, "toe": {"tow": 496814,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 10800, "valid": 1, "health_bits": 0},
+    "tgd1": 2.310000013494573e-08, "tgd2": 2.310000013494573e-08, "c_rs": -39.9375,
+    "c_rc": 169.390625, "c_uc": -1.9385479390621185e-06, "c_us": 9.563285857439041e-06,
+    "c_ic": -7.450580596923828e-09, "c_is": 3.259629011154175e-08, "dn": 3.840159958076294e-09,
+    "m0": 0.38394770532877115, "ecc": 0.0006740774260833859, "sqrta": 5282.623254776001,
+    "omega0": 2.579890563505979, "omegadot": -6.61670418371665e-09, "w": -0.4218735420063852,
+    "inc": 0.9644173827350714, "inc_dot": 3.125130174215734e-10, "af0": -0.0008420408703386784,
+    "af1": -4.177103107849689e-12, "af2": 0.0, "toc": {"tow": 496814, "wn": 2122},
+    "iode": 1, "iodc": 1}'
+  raw_packet: VYkAHMiTFAyulAcASggAAABAMCoAAAEAcG3GMnBtxjIAwB/CAGQpQwAYArYAciA3AAAAsgAADDOYvUzvTH4wPmu5cGWZktg/AAAAQJIWRj8AAKCNn6K0QDUj7KmdowRA3XbwpyRrPL5PxH3i+f/av0FQ0deB3O4/iEFBgsl59T0AAAAAjZdLvwD4kqwAAAAArpQHAEoIAQEAUzE=
+  sbp:
+    crc: '0x3153'
+    length: 147
+    msg_type: '0x89'
+    payload: FAyulAcASggAAABAMCoAAAEAcG3GMnBtxjIAwB/CAGQpQwAYArYAciA3AAAAsgAADDOYvUzvTH4wPmu5cGWZktg/AAAAQJIWRj8AAKCNn6K0QDUj7KmdowRA3XbwpyRrPL5PxH3i+f/av0FQ0deB3O4/iEFBgsl59T0AAAAAjZdLvwD4kqwAAAAArpQHAEoIAQEA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 0.0002824777038767934
+      af1: 5.200284647344233e-12
+      af2: 0.0
+      c_ic: -3.3993273973464966e-08
+      c_is: 1.30385160446167e-08
+      c_rc: 320.75
+      c_rs: 3.0625
+      c_uc: -7.497146725654602e-08
+      c_us: 2.1774321794509888e-06
+      common:
+        fit_interval: 10800
+        health_bits: 0
+        sid:
+          code: 12
+          sat: 29
+        toe:
+          tow: 496814
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 3.859446475722883e-09
+      ecc: 0.00023170793429017067
+      inc: 0.965584374430674
+      inc_dot: 1.353627812603158e-10
+      iodc: 1
+      iode: 1
+      m0: -0.7149194472874559
+      omega0: 0.46967236264198176
+      omegadot: -7.108867541438854e-09
+      sqrta: 5282.617807388306
+      tgd1: 1.000000013351432e-10
+      tgd2: 1.000000013351432e-10
+      toc:
+        tow: 496814
+        wn: 2122
+      w: 2.003312796784809
+    module: sbp.observation
+    name: MsgEphemerisBds
+  msg_type: '0x89'
+  raw_json: '{"preamble": 85, "msg_type": 137, "sender": 51228, "length": 147, "payload":
+    "HQyulAcASggAAABAMCoAAAEA/+bbLv/m2y4AAERAAGCgQwAAobMAIBI2AAASswAAYDIe11ubgZMwPvf3q7+e4Oa/AAAAANReLj8AAKAonqK0QKZ4WKscD94/yNJeU0iIPr7ayg7cyAYAQOqqtjMR5u4/YXfgiqea4j0AAACAMIMyPwD4tiwAAAAArpQHAEoIAQEA",
+    "crc": 50594, "common": {"sid": {"sat": 29, "code": 12}, "toe": {"tow": 496814,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 10800, "valid": 1, "health_bits": 0},
+    "tgd1": 1.000000013351432e-10, "tgd2": 1.000000013351432e-10, "c_rs": 3.0625,
+    "c_rc": 320.75, "c_uc": -7.497146725654602e-08, "c_us": 2.1774321794509888e-06,
+    "c_ic": -3.3993273973464966e-08, "c_is": 1.30385160446167e-08, "dn": 3.859446475722883e-09,
+    "m0": -0.7149194472874559, "ecc": 0.00023170793429017067, "sqrta": 5282.617807388306,
+    "omega0": 0.46967236264198176, "omegadot": -7.108867541438854e-09, "w": 2.003312796784809,
+    "inc": 0.965584374430674, "inc_dot": 1.353627812603158e-10, "af0": 0.0002824777038767934,
+    "af1": 5.200284647344233e-12, "af2": 0.0, "toc": {"tow": 496814, "wn": 2122},
+    "iode": 1, "iodc": 1}'
+  raw_packet: VYkAHMiTHQyulAcASggAAABAMCoAAAEA/+bbLv/m2y4AAERAAGCgQwAAobMAIBI2AAASswAAYDIe11ubgZMwPvf3q7+e4Oa/AAAAANReLj8AAKAonqK0QKZ4WKscD94/yNJeU0iIPr7ayg7cyAYAQOqqtjMR5u4/YXfgiqea4j0AAACAMIMyPwD4tiwAAAAArpQHAEoIAQEAosU=
+  sbp:
+    crc: '0xc5a2'
+    length: 147
+    msg_type: '0x89'
+    payload: HQyulAcASggAAABAMCoAAAEA/+bbLv/m2y4AAERAAGCgQwAAobMAIBI2AAASswAAYDIe11ubgZMwPvf3q7+e4Oa/AAAAANReLj8AAKAonqK0QKZ4WKscD94/yNJeU0iIPr7ayg7cyAYAQOqqtjMR5u4/YXfgiqea4j0AAACAMIMyPwD4tiwAAAAArpQHAEoIAQEA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 0.0003742704866454005
+      af1: 5.4649618164148706e-12
+      af2: 0.0
+      c_ic: -2.7474015951156616e-08
+      c_is: 1.4435499906539917e-08
+      c_rc: 313.265625
+      c_rs: -4.140625
+      c_uc: -2.505257725715637e-07
+      c_us: 2.3087486624717712e-06
+      common:
+        fit_interval: 10800
+        health_bits: 0
+        sid:
+          code: 12
+          sat: 30
+        toe:
+          tow: 496814
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 3.793015137162411e-09
+      ecc: 0.0002919562393799424
+      inc: 0.9655234643735257
+      inc_dot: 1.2536236470282545e-10
+      iodc: 1
+      iode: 1
+      m0: 1.7273354969710963
+      omega0: 0.47022036443988485
+      omegadot: -7.108153225970462e-09
+      sqrta: 5282.616565704346
+      tgd1: -9.599999906129142e-09
+      tgd2: -9.599999906129142e-09
+      toc:
+        tow: 496814
+        wn: 2122
+      w: 0.36283014638339145
+    module: sbp.observation
+    name: MsgEphemerisBds
+  msg_type: '0x89'
+  raw_json: '{"preamble": 85, "msg_type": 137, "sender": 51228, "length": 147, "payload":
+    "HgyulAcASggAAABAMCoAAAEAP+0ksj/tJLIAgITAAKKcQwCAhrQA8Bo2AADssgAAeDL78O7YdkowPkxfy4sqo/s/AAAAgDYiMz8AAEDXnaK0QDGuyycXGN4/pzCEQ3+HPr5BDS7vmzjXP0Eo4HaR5e4/6rxEzMs64T0AAACAN4c4PwBIwCwAAAAArpQHAEoIAQEA",
+    "crc": 58565, "common": {"sid": {"sat": 30, "code": 12}, "toe": {"tow": 496814,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 10800, "valid": 1, "health_bits": 0},
+    "tgd1": -9.599999906129142e-09, "tgd2": -9.599999906129142e-09, "c_rs": -4.140625,
+    "c_rc": 313.265625, "c_uc": -2.505257725715637e-07, "c_us": 2.3087486624717712e-06,
+    "c_ic": -2.7474015951156616e-08, "c_is": 1.4435499906539917e-08, "dn": 3.793015137162411e-09,
+    "m0": 1.7273354969710963, "ecc": 0.0002919562393799424, "sqrta": 5282.616565704346,
+    "omega0": 0.47022036443988485, "omegadot": -7.108153225970462e-09, "w": 0.36283014638339145,
+    "inc": 0.9655234643735257, "inc_dot": 1.2536236470282545e-10, "af0": 0.0003742704866454005,
+    "af1": 5.4649618164148706e-12, "af2": 0.0, "toc": {"tow": 496814, "wn": 2122},
+    "iode": 1, "iodc": 1}'
+  raw_packet: VYkAHMiTHgyulAcASggAAABAMCoAAAEAP+0ksj/tJLIAgITAAKKcQwCAhrQA8Bo2AADssgAAeDL78O7YdkowPkxfy4sqo/s/AAAAgDYiMz8AAEDXnaK0QDGuyycXGN4/pzCEQ3+HPr5BDS7vmzjXP0Eo4HaR5e4/6rxEzMs64T0AAACAN4c4PwBIwCwAAAAArpQHAEoIAQEAxeQ=
+  sbp:
+    crc: '0xe4c5'
+    length: 147
+    msg_type: '0x89'
+    payload: HgyulAcASggAAABAMCoAAAEAP+0ksj/tJLIAgITAAKKcQwCAhrQA8Bo2AADssgAAeDL78O7YdkowPkxfy4sqo/s/AAAAgDYiMz8AAEDXnaK0QDGuyycXGN4/pzCEQ3+HPr5BDS7vmzjXP0Eo4HaR5e4/6rxEzMs64T0AAACAN4c4PwBIwCwAAAAArpQHAEoIAQEA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: -0.0008420408703386784
+      af1: -4.177103107849689e-12
+      af2: 0.0
+      c_ic: -7.450580596923828e-09
+      c_is: 3.259629011154175e-08
+      c_rc: 169.390625
+      c_rs: -39.9375
+      c_uc: -1.9385479390621185e-06
+      c_us: 9.563285857439041e-06
+      common:
+        fit_interval: 10800
+        health_bits: 0
+        sid:
+          code: 12
+          sat: 20
+        toe:
+          tow: 496814
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 3.840159958076294e-09
+      ecc: 0.0006740774260833859
+      inc: 0.9644173827350714
+      inc_dot: 3.125130174215734e-10
+      iodc: 1
+      iode: 1
+      m0: 0.38394770532877115
+      omega0: 2.579890563505979
+      omegadot: -6.61670418371665e-09
+      sqrta: 5282.623254776001
+      tgd1: 2.310000013494573e-08
+      tgd2: 2.310000013494573e-08
+      toc:
+        tow: 496814
+        wn: 2122
+      w: -0.4218735420063852
+    module: sbp.observation
+    name: MsgEphemerisBds
+  msg_type: '0x89'
+  raw_json: '{"preamble": 85, "msg_type": 137, "sender": 51228, "length": 147, "payload":
+    "FAyulAcASggAAABAMCoAAAEAcG3GMnBtxjIAwB/CAGQpQwAYArYAciA3AAAAsgAADDOYvUzvTH4wPmu5cGWZktg/AAAAQJIWRj8AAKCNn6K0QDUj7KmdowRA3XbwpyRrPL5PxH3i+f/av0FQ0deB3O4/iEFBgsl59T0AAAAAjZdLvwD4kqwAAAAArpQHAEoIAQEA",
+    "crc": 12627, "common": {"sid": {"sat": 20, "code": 12}, "toe": {"tow": 496814,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 10800, "valid": 1, "health_bits": 0},
+    "tgd1": 2.310000013494573e-08, "tgd2": 2.310000013494573e-08, "c_rs": -39.9375,
+    "c_rc": 169.390625, "c_uc": -1.9385479390621185e-06, "c_us": 9.563285857439041e-06,
+    "c_ic": -7.450580596923828e-09, "c_is": 3.259629011154175e-08, "dn": 3.840159958076294e-09,
+    "m0": 0.38394770532877115, "ecc": 0.0006740774260833859, "sqrta": 5282.623254776001,
+    "omega0": 2.579890563505979, "omegadot": -6.61670418371665e-09, "w": -0.4218735420063852,
+    "inc": 0.9644173827350714, "inc_dot": 3.125130174215734e-10, "af0": -0.0008420408703386784,
+    "af1": -4.177103107849689e-12, "af2": 0.0, "toc": {"tow": 496814, "wn": 2122},
+    "iode": 1, "iodc": 1}'
+  raw_packet: VYkAHMiTFAyulAcASggAAABAMCoAAAEAcG3GMnBtxjIAwB/CAGQpQwAYArYAciA3AAAAsgAADDOYvUzvTH4wPmu5cGWZktg/AAAAQJIWRj8AAKCNn6K0QDUj7KmdowRA3XbwpyRrPL5PxH3i+f/av0FQ0deB3O4/iEFBgsl59T0AAAAAjZdLvwD4kqwAAAAArpQHAEoIAQEAUzE=
+  sbp:
+    crc: '0x3153'
+    length: 147
+    msg_type: '0x89'
+    payload: FAyulAcASggAAABAMCoAAAEAcG3GMnBtxjIAwB/CAGQpQwAYArYAciA3AAAAsgAADDOYvUzvTH4wPmu5cGWZktg/AAAAQJIWRj8AAKCNn6K0QDUj7KmdowRA3XbwpyRrPL5PxH3i+f/av0FQ0deB3O4/iEFBgsl59T0AAAAAjZdLvwD4kqwAAAAArpQHAEoIAQEA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 0.0002824777038767934
+      af1: 5.200284647344233e-12
+      af2: 0.0
+      c_ic: -3.3993273973464966e-08
+      c_is: 1.30385160446167e-08
+      c_rc: 320.75
+      c_rs: 3.0625
+      c_uc: -7.497146725654602e-08
+      c_us: 2.1774321794509888e-06
+      common:
+        fit_interval: 10800
+        health_bits: 0
+        sid:
+          code: 12
+          sat: 29
+        toe:
+          tow: 496814
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 3.859446475722883e-09
+      ecc: 0.00023170793429017067
+      inc: 0.965584374430674
+      inc_dot: 1.353627812603158e-10
+      iodc: 1
+      iode: 1
+      m0: -0.7149194472874559
+      omega0: 0.46967236264198176
+      omegadot: -7.108867541438854e-09
+      sqrta: 5282.617807388306
+      tgd1: 1.000000013351432e-10
+      tgd2: 1.000000013351432e-10
+      toc:
+        tow: 496814
+        wn: 2122
+      w: 2.003312796784809
+    module: sbp.observation
+    name: MsgEphemerisBds
+  msg_type: '0x89'
+  raw_json: '{"preamble": 85, "msg_type": 137, "sender": 51228, "length": 147, "payload":
+    "HQyulAcASggAAABAMCoAAAEA/+bbLv/m2y4AAERAAGCgQwAAobMAIBI2AAASswAAYDIe11ubgZMwPvf3q7+e4Oa/AAAAANReLj8AAKAonqK0QKZ4WKscD94/yNJeU0iIPr7ayg7cyAYAQOqqtjMR5u4/YXfgiqea4j0AAACAMIMyPwD4tiwAAAAArpQHAEoIAQEA",
+    "crc": 50594, "common": {"sid": {"sat": 29, "code": 12}, "toe": {"tow": 496814,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 10800, "valid": 1, "health_bits": 0},
+    "tgd1": 1.000000013351432e-10, "tgd2": 1.000000013351432e-10, "c_rs": 3.0625,
+    "c_rc": 320.75, "c_uc": -7.497146725654602e-08, "c_us": 2.1774321794509888e-06,
+    "c_ic": -3.3993273973464966e-08, "c_is": 1.30385160446167e-08, "dn": 3.859446475722883e-09,
+    "m0": -0.7149194472874559, "ecc": 0.00023170793429017067, "sqrta": 5282.617807388306,
+    "omega0": 0.46967236264198176, "omegadot": -7.108867541438854e-09, "w": 2.003312796784809,
+    "inc": 0.965584374430674, "inc_dot": 1.353627812603158e-10, "af0": 0.0002824777038767934,
+    "af1": 5.200284647344233e-12, "af2": 0.0, "toc": {"tow": 496814, "wn": 2122},
+    "iode": 1, "iodc": 1}'
+  raw_packet: VYkAHMiTHQyulAcASggAAABAMCoAAAEA/+bbLv/m2y4AAERAAGCgQwAAobMAIBI2AAASswAAYDIe11ubgZMwPvf3q7+e4Oa/AAAAANReLj8AAKAonqK0QKZ4WKscD94/yNJeU0iIPr7ayg7cyAYAQOqqtjMR5u4/YXfgiqea4j0AAACAMIMyPwD4tiwAAAAArpQHAEoIAQEAosU=
+  sbp:
+    crc: '0xc5a2'
+    length: 147
+    msg_type: '0x89'
+    payload: HQyulAcASggAAABAMCoAAAEA/+bbLv/m2y4AAERAAGCgQwAAobMAIBI2AAASswAAYDIe11ubgZMwPvf3q7+e4Oa/AAAAANReLj8AAKAonqK0QKZ4WKscD94/yNJeU0iIPr7ayg7cyAYAQOqqtjMR5u4/YXfgiqea4j0AAACAMIMyPwD4tiwAAAAArpQHAEoIAQEA
+    preamble: '0x55'
+    sender: '0xc81c'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgEphemerisGPS.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgEphemerisGPS.yaml
@@ -1,0 +1,307 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgEphemerisGPS v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.836242
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      af0: -0.0004520649090409279
+      af1: -9.890754881780595e-12
+      af2: 0.0
+      c_ic: -6.705522537231445e-08
+      c_is: -8.568167686462402e-08
+      c_rc: 195.40625
+      c_rs: -61.3125
+      c_uc: -3.1907111406326294e-06
+      c_us: 9.823590517044067e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 0
+          sat: 10
+        toe:
+          tow: 504000
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 4.338752155014027e-09
+      ecc: 0.0058618332259356976
+      inc: 0.9665848041254436
+      inc_dot: 3.017982853956909e-10
+      iodc: 57
+      iode: 57
+      m0: -2.796409538778957
+      omega0: 2.230825267878158
+      omegadot: -7.757823144473138e-09
+      sqrta: 5153.670713424683
+      tgd: 2.3283064365386963e-09
+      toc:
+        tow: 504000
+        wn: 2122
+      w: -2.6611224911418225
+    module: sbp.observation
+    name: MsgEphemerisGPS
+  msg_type: '0x8a'
+  raw_json: '{"preamble": 85, "msg_type": 138, "sender": 51228, "length": 139, "payload":
+    "CgDAsAcASggAAABAQDgAAAEAAAAgMQBAdcIAaENDACBWtgDQJDcAAJCzAAC4s6/MaimCojI+ejna9gtfBsAAAADgkwJ4PwAA4LOrIbRAXAQF67rYAUAsmWGL6KhAvlvVsJb6SQXAZ/BQQUPu7j82QkmlSr30PSAD7bkAAC6tAAAAAMCwBwBKCDk5AA==",
+    "crc": 38731, "common": {"sid": {"sat": 10, "code": 0}, "toe": {"tow": 504000,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 14400, "valid": 1, "health_bits": 0},
+    "tgd": 2.3283064365386963e-09, "c_rs": -61.3125, "c_rc": 195.40625, "c_uc": -3.1907111406326294e-06,
+    "c_us": 9.823590517044067e-06, "c_ic": -6.705522537231445e-08, "c_is": -8.568167686462402e-08,
+    "dn": 4.338752155014027e-09, "m0": -2.796409538778957, "ecc": 0.0058618332259356976,
+    "sqrta": 5153.670713424683, "omega0": 2.230825267878158, "omegadot": -7.757823144473138e-09,
+    "w": -2.6611224911418225, "inc": 0.9665848041254436, "inc_dot": 3.017982853956909e-10,
+    "af0": -0.0004520649090409279, "af1": -9.890754881780595e-12, "af2": 0.0, "toc":
+    {"tow": 504000, "wn": 2122}, "iode": 57, "iodc": 57}'
+  raw_packet: VYoAHMiLCgDAsAcASggAAABAQDgAAAEAAAAgMQBAdcIAaENDACBWtgDQJDcAAJCzAAC4s6/MaimCojI+ejna9gtfBsAAAADgkwJ4PwAA4LOrIbRAXAQF67rYAUAsmWGL6KhAvlvVsJb6SQXAZ/BQQUPu7j82QkmlSr30PSAD7bkAAC6tAAAAAMCwBwBKCDk5AEuX
+  sbp:
+    crc: '0x974b'
+    length: 139
+    msg_type: '0x8a'
+    payload: CgDAsAcASggAAABAQDgAAAEAAAAgMQBAdcIAaENDACBWtgDQJDcAAJCzAAC4s6/MaimCojI+ejna9gtfBsAAAADgkwJ4PwAA4LOrIbRAXAQF67rYAUAsmWGL6KhAvlvVsJb6SQXAZ/BQQUPu7j82QkmlSr30PSAD7bkAAC6tAAAAAMCwBwBKCDk5AA==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: -0.00020434334874153137
+      af1: 2.6147972675971687e-12
+      af2: 0.0
+      c_ic: -6.891787052154541e-08
+      c_is: 1.1548399925231934e-07
+      c_rc: 216.09375
+      c_rs: 9.8125
+      c_uc: 8.046627044677734e-07
+      c_us: 7.597729563713074e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 0
+          sat: 15
+        toe:
+          tow: 504000
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 5.651306828184636e-09
+      ecc: 0.012736670556478202
+      inc: 0.9288395412780257
+      inc_dot: 8.143196339670712e-11
+      iodc: 59
+      iode: 59
+      m0: 0.5057736098552638
+      omega0: -3.1111814218570664
+      omegadot: -8.680004414167427e-09
+      sqrta: 5153.741733551025
+      tgd: -1.0710209608078003e-08
+      toc:
+        tow: 504000
+        wn: 2122
+      w: 0.9155426370543066
+    module: sbp.observation
+    name: MsgEphemerisGPS
+  msg_type: '0x8a'
+  raw_json: '{"preamble": 85, "msg_type": 138, "sender": 51228, "length": 139, "payload":
+    "DwDAsAcASggAAABAQDgAAAEAAAA4sgAAHUEAGFhDAABYNQDw/jYAAJSzAAD4M32HNXWtRTg+WUMwI0wv4D8AAAD8rhWKPwAAQOK9IbRAG2TWFbPjCMBqaCkF4qNCvjG9hxIgTO0/Fqqgsw257T8puAzXQ2LWPQBFVrkAADgsAAAAAMCwBwBKCDs7AA==",
+    "crc": 46257, "common": {"sid": {"sat": 15, "code": 0}, "toe": {"tow": 504000,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 14400, "valid": 1, "health_bits": 0},
+    "tgd": -1.0710209608078003e-08, "c_rs": 9.8125, "c_rc": 216.09375, "c_uc": 8.046627044677734e-07,
+    "c_us": 7.597729563713074e-06, "c_ic": -6.891787052154541e-08, "c_is": 1.1548399925231934e-07,
+    "dn": 5.651306828184636e-09, "m0": 0.5057736098552638, "ecc": 0.012736670556478202,
+    "sqrta": 5153.741733551025, "omega0": -3.1111814218570664, "omegadot": -8.680004414167427e-09,
+    "w": 0.9155426370543066, "inc": 0.9288395412780257, "inc_dot": 8.143196339670712e-11,
+    "af0": -0.00020434334874153137, "af1": 2.6147972675971687e-12, "af2": 0.0, "toc":
+    {"tow": 504000, "wn": 2122}, "iode": 59, "iodc": 59}'
+  raw_packet: VYoAHMiLDwDAsAcASggAAABAQDgAAAEAAAA4sgAAHUEAGFhDAABYNQDw/jYAAJSzAAD4M32HNXWtRTg+WUMwI0wv4D8AAAD8rhWKPwAAQOK9IbRAG2TWFbPjCMBqaCkF4qNCvjG9hxIgTO0/Fqqgsw257T8puAzXQ2LWPQBFVrkAADgsAAAAAMCwBwBKCDs7ALG0
+  sbp:
+    crc: '0xb4b1'
+    length: 139
+    msg_type: '0x8a'
+    payload: DwDAsAcASggAAABAQDgAAAEAAAA4sgAAHUEAGFhDAABYNQDw/jYAAJSzAAD4M32HNXWtRTg+WUMwI0wv4D8AAAD8rhWKPwAAQOK9IbRAG2TWFbPjCMBqaCkF4qNCvjG9hxIgTO0/Fqqgsw257T8puAzXQ2LWPQBFVrkAADgsAAAAAMCwBwBKCDs7AA==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 0.00028834957629442215
+      af1: 7.16227077646181e-12
+      af2: 0.0
+      c_ic: -1.862645149230957e-09
+      c_is: 1.6763806343078613e-08
+      c_rc: 281.09375
+      c_rs: -71.03125
+      c_uc: -3.7476420402526855e-06
+      c_us: 5.066394805908203e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 0
+          sat: 18
+        toe:
+          tow: 504000
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 4.450899683551598e-09
+      ecc: 0.0010028165997937322
+      inc: 0.9648295291826252
+      inc_dot: 5.285934466102042e-11
+      iodc: 452
+      iode: 196
+      m0: -0.3447632982837923
+      omega0: 1.2093173710483045
+      omegadot: -8.164268645988282e-09
+      sqrta: 5153.712779998779
+      tgd: -8.381903171539307e-09
+      toc:
+        tow: 504000
+        wn: 2122
+      w: 2.7279719942290965
+    module: sbp.observation
+    name: MsgEphemerisGPS
+  msg_type: '0x8a'
+  raw_json: '{"preamble": 85, "msg_type": 138, "sender": 51228, "length": 139, "payload":
+    "EgDAsAcASggAAABAQDgAAAEAAAAQsgAQjsIAjIxDAIB7tgAAqjYAAACxAACQMi07gOLQHTM+2Vu/FJoQ1r8AAAAgHm5QPwAAwHi2IbRA1DHyK11Z8z9Nx9qpWohBvmbxHPvi0gVAFL5BLeLf7j8k1G6ZSg/NPaAtlzkAAPwsAAAAAMCwBwBKCMTEAQ==",
+    "crc": 44108, "common": {"sid": {"sat": 18, "code": 0}, "toe": {"tow": 504000,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 14400, "valid": 1, "health_bits": 0},
+    "tgd": -8.381903171539307e-09, "c_rs": -71.03125, "c_rc": 281.09375, "c_uc": -3.7476420402526855e-06,
+    "c_us": 5.066394805908203e-06, "c_ic": -1.862645149230957e-09, "c_is": 1.6763806343078613e-08,
+    "dn": 4.450899683551598e-09, "m0": -0.3447632982837923, "ecc": 0.0010028165997937322,
+    "sqrta": 5153.712779998779, "omega0": 1.2093173710483045, "omegadot": -8.164268645988282e-09,
+    "w": 2.7279719942290965, "inc": 0.9648295291826252, "inc_dot": 5.285934466102042e-11,
+    "af0": 0.00028834957629442215, "af1": 7.16227077646181e-12, "af2": 0.0, "toc":
+    {"tow": 504000, "wn": 2122}, "iode": 196, "iodc": 452}'
+  raw_packet: VYoAHMiLEgDAsAcASggAAABAQDgAAAEAAAAQsgAQjsIAjIxDAIB7tgAAqjYAAACxAACQMi07gOLQHTM+2Vu/FJoQ1r8AAAAgHm5QPwAAwHi2IbRA1DHyK11Z8z9Nx9qpWohBvmbxHPvi0gVAFL5BLeLf7j8k1G6ZSg/NPaAtlzkAAPwsAAAAAMCwBwBKCMTEAUys
+  sbp:
+    crc: '0xac4c'
+    length: 139
+    msg_type: '0x8a'
+    payload: EgDAsAcASggAAABAQDgAAAEAAAAQsgAQjsIAjIxDAIB7tgAAqjYAAACxAACQMi07gOLQHTM+2Vu/FJoQ1r8AAAAgHm5QPwAAwHi2IbRA1DHyK11Z8z9Nx9qpWohBvmbxHPvi0gVAFL5BLeLf7j8k1G6ZSg/NPaAtlzkAAPwsAAAAAMCwBwBKCMTEAQ==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 0.0005267667584121227
+      af1: -1.1368683772161603e-13
+      af2: 0.0
+      c_ic: -7.078051567077637e-08
+      c_is: -6.51925802230835e-08
+      c_rc: 187.46875
+      c_rs: -66.34375
+      c_uc: -3.5725533962249756e-06
+      c_us: 9.300187230110168e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 0
+          sat: 20
+        toe:
+          tow: 504000
+          wn: 2122
+        ura: 2.0
+        valid: 1
+      dn: 5.045210153253881e-09
+      ecc: 0.005587180843576789
+      inc: 0.9350518887329473
+      inc_dot: 3.042983895350635e-10
+      iodc: 54
+      iode: 54
+      m0: -1.2937952725205584
+      omega0: 2.0964129457739955
+      omegadot: -8.260344076487028e-09
+      sqrta: 5153.664438247681
+      tgd: -8.847564458847046e-09
+      toc:
+        tow: 504000
+        wn: 2122
+      w: 2.70250264752286
+    module: sbp.observation
+    name: MsgEphemerisGPS
+  msg_type: '0x8a'
+  raw_json: '{"preamble": 85, "msg_type": 138, "sender": 51228, "length": 139, "payload":
+    "FADAsAcASggAAABAQDgAAAEAAAAYsgCwhMIAeDtDAMBvtgAIHDcAAJizAACMs8EnD2lEqzU+kB/zq2Kz9L8AAABwleJ2PwAAoBiqIbRAKRWIJnTFAECU3gkULL1Bvnq2Q7W5ngVAKHlF8PHr7T+FuRwdRun0PbgWCjoAAACqAAAAAMCwBwBKCDY2AA==",
+    "crc": 49375, "common": {"sid": {"sat": 20, "code": 0}, "toe": {"tow": 504000,
+    "wn": 2122}, "ura": 2.0, "fit_interval": 14400, "valid": 1, "health_bits": 0},
+    "tgd": -8.847564458847046e-09, "c_rs": -66.34375, "c_rc": 187.46875, "c_uc": -3.5725533962249756e-06,
+    "c_us": 9.300187230110168e-06, "c_ic": -7.078051567077637e-08, "c_is": -6.51925802230835e-08,
+    "dn": 5.045210153253881e-09, "m0": -1.2937952725205584, "ecc": 0.005587180843576789,
+    "sqrta": 5153.664438247681, "omega0": 2.0964129457739955, "omegadot": -8.260344076487028e-09,
+    "w": 2.70250264752286, "inc": 0.9350518887329473, "inc_dot": 3.042983895350635e-10,
+    "af0": 0.0005267667584121227, "af1": -1.1368683772161603e-13, "af2": 0.0, "toc":
+    {"tow": 504000, "wn": 2122}, "iode": 54, "iodc": 54}'
+  raw_packet: VYoAHMiLFADAsAcASggAAABAQDgAAAEAAAAYsgCwhMIAeDtDAMBvtgAIHDcAAJizAACMs8EnD2lEqzU+kB/zq2Kz9L8AAABwleJ2PwAAoBiqIbRAKRWIJnTFAECU3gkULL1Bvnq2Q7W5ngVAKHlF8PHr7T+FuRwdRun0PbgWCjoAAACqAAAAAMCwBwBKCDY2AN/A
+  sbp:
+    crc: '0xc0df'
+    length: 139
+    msg_type: '0x8a'
+    payload: FADAsAcASggAAABAQDgAAAEAAAAYsgCwhMIAeDtDAMBvtgAIHDcAAJizAACMs8EnD2lEqzU+kB/zq2Kz9L8AAABwleJ2PwAAoBiqIbRAKRWIJnTFAECU3gkULL1Bvnq2Q7W5ngVAKHlF8PHr7T+FuRwdRun0PbgWCjoAAACqAAAAAMCwBwBKCDY2AA==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 5.916692316532135e-05
+      af1: 5.5706550483591855e-12
+      af2: 0.0
+      c_ic: -4.6566128730773926e-08
+      c_is: 9.313225746154785e-09
+      c_rc: 195.78125
+      c_rs: -57.96875
+      c_uc: -3.0472874641418457e-06
+      c_us: 9.605661034584045e-06
+      common:
+        fit_interval: 14400
+        health_bits: 1
+        sid:
+          code: 0
+          sat: 23
+        toe:
+          tow: 504000
+          wn: 2122
+        ura: 4096.0
+        valid: 1
+      dn: 4.459828626906499e-09
+      ecc: 0.001012304681353271
+      inc: 0.9614967370098824
+      inc_dot: 2.6286809236831773e-10
+      iodc: 770
+      iode: 2
+      m0: -0.5588799382441478
+      omega0: 2.2087226837653837
+      omegadot: -7.918901282595572e-09
+      sqrta: 5153.641044616699
+      tgd: -8.381903171539307e-09
+      toc:
+        tow: 504000
+        wn: 2122
+      w: 1.828394362112756
+    module: sbp.observation
+    name: MsgEphemerisGPS
+  msg_type: '0x8a'
+  raw_json: '{"preamble": 85, "msg_type": 138, "sender": 51228, "length": 139, "payload":
+    "FwDAsAcASggAAIBFQDgAAAEBAAAQsgDgZ8IAyENDAIBMtgAoITcAAEizAAAgMs4lrSiiJzM+jMUkLlji4b8AAADg6ZVQPwAAgBukIbRAOKVlzHarAUBjgexGdgFBvuxwV3IaQf0/jGEVzpTE7j9pAJGkbBDyPQAqeDgAAMQsAAAAAMCwBwBKCAICAw==",
+    "crc": 5870, "common": {"sid": {"sat": 23, "code": 0}, "toe": {"tow": 504000,
+    "wn": 2122}, "ura": 4096.0, "fit_interval": 14400, "valid": 1, "health_bits":
+    1}, "tgd": -8.381903171539307e-09, "c_rs": -57.96875, "c_rc": 195.78125, "c_uc":
+    -3.0472874641418457e-06, "c_us": 9.605661034584045e-06, "c_ic": -4.6566128730773926e-08,
+    "c_is": 9.313225746154785e-09, "dn": 4.459828626906499e-09, "m0": -0.5588799382441478,
+    "ecc": 0.001012304681353271, "sqrta": 5153.641044616699, "omega0": 2.2087226837653837,
+    "omegadot": -7.918901282595572e-09, "w": 1.828394362112756, "inc": 0.9614967370098824,
+    "inc_dot": 2.6286809236831773e-10, "af0": 5.916692316532135e-05, "af1": 5.5706550483591855e-12,
+    "af2": 0.0, "toc": {"tow": 504000, "wn": 2122}, "iode": 2, "iodc": 770}'
+  raw_packet: VYoAHMiLFwDAsAcASggAAIBFQDgAAAEBAAAQsgDgZ8IAyENDAIBMtgAoITcAAEizAAAgMs4lrSiiJzM+jMUkLlji4b8AAADg6ZVQPwAAgBukIbRAOKVlzHarAUBjgexGdgFBvuxwV3IaQf0/jGEVzpTE7j9pAJGkbBDyPQAqeDgAAMQsAAAAAMCwBwBKCAICA+4W
+  sbp:
+    crc: '0x16ee'
+    length: 139
+    msg_type: '0x8a'
+    payload: FwDAsAcASggAAIBFQDgAAAEBAAAQsgDgZ8IAyENDAIBMtgAoITcAAEizAAAgMs4lrSiiJzM+jMUkLlji4b8AAADg6ZVQPwAAgBukIbRAOKVlzHarAUBjgexGdgFBvuxwV3IaQf0/jGEVzpTE7j9pAJGkbBDyPQAqeDgAAMQsAAAAAMCwBwBKCAICAw==
+    preamble: '0x55'
+    sender: '0xc81c'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgEphemerisGal.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgEphemerisGal.yaml
@@ -1,0 +1,322 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgEphemerisGal v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.936384
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      af0: 0.0027377924416214223
+      af1: -4.3741010813391755e-11
+      af2: 0.0
+      bgd_e1e5a: 3.958120942115784e-09
+      bgd_e1e5b: 4.423782229423523e-09
+      c_ic: -2.7939677238464355e-08
+      c_is: 5.587935447692871e-09
+      c_rc: 280.125
+      c_rs: -72.71875
+      c_uc: -3.3099204301834106e-06
+      c_us: 3.242865204811096e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 14
+          sat: 26
+        toe:
+          tow: 499200
+          wn: 2122
+        ura: 3.119999885559082
+        valid: 1
+      dn: 2.8640478705183966e-09
+      ecc: 0.00023651926312595606
+      inc: 0.985511758817649
+      inc_dot: 7.10743891050207e-11
+      iodc: 64
+      iode: 64
+      m0: -0.6073780937012754
+      omega0: 0.9345657669068792
+      omegadot: -5.668450399426048e-09
+      source: 0
+      sqrta: 5440.6088581085205
+      toc:
+        tow: 499200
+        wn: 2122
+      w: 3.06917874848284
+    module: sbp.observation
+    name: MsgEphemerisGal
+  msg_type: '0x8d'
+  raw_json: '{"preamble": 85, "msg_type": 141, "sender": 51228, "length": 153, "payload":
+    "Gg4AngcASggUrkdAQDgAAAEAAACIMQAAmDEAcJHCABCMQwAgXrYAoFk2AADwsgAAwDGEnISdG5ooPiQfGC+kb+O/AAAAAEUALz8AACDem0C1QEZwmnf25+0/n7q08YZYOL7+fnKWrY0IQGw/vvRPie8/Dv+AXmqJ0z3///8fkW1mP/7/////C8i9AAAAAACeBwBKCEAAQAAA",
+    "crc": 16461, "common": {"sid": {"sat": 26, "code": 14}, "toe": {"tow": 499200,
+    "wn": 2122}, "ura": 3.119999885559082, "fit_interval": 14400, "valid": 1, "health_bits":
+    0}, "bgd_e1e5a": 3.958120942115784e-09, "bgd_e1e5b": 4.423782229423523e-09, "c_rs":
+    -72.71875, "c_rc": 280.125, "c_uc": -3.3099204301834106e-06, "c_us": 3.242865204811096e-06,
+    "c_ic": -2.7939677238464355e-08, "c_is": 5.587935447692871e-09, "dn": 2.8640478705183966e-09,
+    "m0": -0.6073780937012754, "ecc": 0.00023651926312595606, "sqrta": 5440.6088581085205,
+    "omega0": 0.9345657669068792, "omegadot": -5.668450399426048e-09, "w": 3.06917874848284,
+    "inc": 0.985511758817649, "inc_dot": 7.10743891050207e-11, "af0": 0.0027377924416214223,
+    "af1": -4.3741010813391755e-11, "af2": 0.0, "toc": {"tow": 499200, "wn": 2122},
+    "iode": 64, "iodc": 64, "source": 0}'
+  raw_packet: VY0AHMiZGg4AngcASggUrkdAQDgAAAEAAACIMQAAmDEAcJHCABCMQwAgXrYAoFk2AADwsgAAwDGEnISdG5ooPiQfGC+kb+O/AAAAAEUALz8AACDem0C1QEZwmnf25+0/n7q08YZYOL7+fnKWrY0IQGw/vvRPie8/Dv+AXmqJ0z3///8fkW1mP/7/////C8i9AAAAAACeBwBKCEAAQAAATUA=
+  sbp:
+    crc: '0x404d'
+    length: 153
+    msg_type: '0x8d'
+    payload: Gg4AngcASggUrkdAQDgAAAEAAACIMQAAmDEAcJHCABCMQwAgXrYAoFk2AADwsgAAwDGEnISdG5ooPiQfGC+kb+O/AAAAAEUALz8AACDem0C1QEZwmnf25+0/n7q08YZYOL7+fnKWrY0IQGw/vvRPie8/Dv+AXmqJ0z3///8fkW1mP/7/////C8i9AAAAAACeBwBKCEAAQAAA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: -0.00046285247663035983
+      af1: 1.84741111297626e-13
+      af2: 0.0
+      bgd_e1e5a: -5.3551048040390015e-09
+      bgd_e1e5b: -6.05359673500061e-09
+      c_ic: -9.313225746154785e-09
+      c_is: 4.6566128730773926e-08
+      c_rc: 288.8125
+      c_rs: -88.59375
+      c_uc: -4.239380359649658e-06
+      c_us: 2.8796494007110596e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 14
+          sat: 33
+        toe:
+          tow: 497400
+          wn: 2122
+        ura: 3.119999885559082
+        valid: 1
+      dn: 2.719756145903179e-09
+      ecc: 6.174109876155853e-05
+      inc: 0.9923100634800401
+      inc_dot: 3.893019302737314e-11
+      iodc: 61
+      iode: 61
+      m0: -2.1903136386461908
+      omega0: 0.9284548538028198
+      omegadot: -5.670593345831224e-09
+      source: 0
+      sqrta: 5440.603193283081
+      toc:
+        tow: 497400
+        wn: 2122
+      w: -2.6142072993586285
+    module: sbp.observation
+    name: MsgEphemerisGal
+  msg_type: '0x8d'
+  raw_json: '{"preamble": 85, "msg_type": 141, "sender": 51228, "length": 153, "payload":
+    "IQ74lgcASggUrkdAQDgAAAEAAAC4sQAA0LEAMLHCAGiQQwBAjrYAQEE2AAAgsgAASDPLv3yYzlwnPsa+LyjDhQHAAAAAAGAvED8AAOBqmkC1QIeoHPTmte0/A6FEIeJaOL6nrT2E5ekEwDxuxAgBwe8/Zg7CBfBmxT3///8/YFU+v/7//////0k9AAAAAPiWBwBKCD0APQAA",
+    "crc": 6313, "common": {"sid": {"sat": 33, "code": 14}, "toe": {"tow": 497400,
+    "wn": 2122}, "ura": 3.119999885559082, "fit_interval": 14400, "valid": 1, "health_bits":
+    0}, "bgd_e1e5a": -5.3551048040390015e-09, "bgd_e1e5b": -6.05359673500061e-09,
+    "c_rs": -88.59375, "c_rc": 288.8125, "c_uc": -4.239380359649658e-06, "c_us": 2.8796494007110596e-06,
+    "c_ic": -9.313225746154785e-09, "c_is": 4.6566128730773926e-08, "dn": 2.719756145903179e-09,
+    "m0": -2.1903136386461908, "ecc": 6.174109876155853e-05, "sqrta": 5440.603193283081,
+    "omega0": 0.9284548538028198, "omegadot": -5.670593345831224e-09, "w": -2.6142072993586285,
+    "inc": 0.9923100634800401, "inc_dot": 3.893019302737314e-11, "af0": -0.00046285247663035983,
+    "af1": 1.84741111297626e-13, "af2": 0.0, "toc": {"tow": 497400, "wn": 2122}, "iode":
+    61, "iodc": 61, "source": 0}'
+  raw_packet: VY0AHMiZIQ74lgcASggUrkdAQDgAAAEAAAC4sQAA0LEAMLHCAGiQQwBAjrYAQEE2AAAgsgAASDPLv3yYzlwnPsa+LyjDhQHAAAAAAGAvED8AAOBqmkC1QIeoHPTmte0/A6FEIeJaOL6nrT2E5ekEwDxuxAgBwe8/Zg7CBfBmxT3///8/YFU+v/7//////0k9AAAAAPiWBwBKCD0APQAAqRg=
+  sbp:
+    crc: '0x18a9'
+    length: 153
+    msg_type: '0x8d'
+    payload: IQ74lgcASggUrkdAQDgAAAEAAAC4sQAA0LEAMLHCAGiQQwBAjrYAQEE2AAAgsgAASDPLv3yYzlwnPsa+LyjDhQHAAAAAAGAvED8AAOBqmkC1QIeoHPTmte0/A6FEIeJaOL6nrT2E5ekEwDxuxAgBwe8/Zg7CBfBmxT3///8/YFU+v/7//////0k9AAAAAPiWBwBKCD0APQAA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 7.600791286677121e-05
+      af1: 9.436007530894129e-12
+      af2: 0.0
+      bgd_e1e5a: -5.587935447692871e-09
+      bgd_e1e5b: -5.820766091346741e-09
+      c_ic: -4.284083843231201e-08
+      c_is: -2.7939677238464355e-08
+      c_rc: 158.4375
+      c_rs: -7.65625
+      c_uc: -3.688037395477295e-07
+      c_us: 8.480623364448547e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 14
+          sat: 19
+        toe:
+          tow: 499200
+          wn: 2122
+        ura: 3.119999885559082
+        valid: 1
+      dn: 3.4029988914202875e-09
+      ecc: 7.352512329816818e-05
+      inc: 0.9602396632077127
+      inc_dot: 2.7608292853357283e-10
+      iodc: 64
+      iode: 64
+      m0: 0.9103355308317173
+      omega0: 3.0358214308795257
+      omegadot: -5.525230148013418e-09
+      source: 0
+      sqrta: 5440.609079360962
+      toc:
+        tow: 499200
+        wn: 2122
+      w: -1.2435193599955705
+    module: sbp.observation
+    name: MsgEphemerisGal
+  msg_type: '0x8d'
+  raw_json: '{"preamble": 85, "msg_type": 141, "sender": 51228, "length": 153, "payload":
+    "Ew4AngcASggUrkdAQDgAAAEAAADAsQAAyLEAAPXAAHAeQwAAxrQASA43AAA4swAA8LJzS0IRRjstPonjqfp3Ie0/AAAAADBGEz8AAKDsm0C1QOf8EL9cSQhAdL/4Bg67N74x+3GOdOXzv+OSuYdIuu4/Cndc+eb48j3/////zewTP///////v6Q9AAAAAACeBwBKCEAAQAAA",
+    "crc": 49923, "common": {"sid": {"sat": 19, "code": 14}, "toe": {"tow": 499200,
+    "wn": 2122}, "ura": 3.119999885559082, "fit_interval": 14400, "valid": 1, "health_bits":
+    0}, "bgd_e1e5a": -5.587935447692871e-09, "bgd_e1e5b": -5.820766091346741e-09,
+    "c_rs": -7.65625, "c_rc": 158.4375, "c_uc": -3.688037395477295e-07, "c_us": 8.480623364448547e-06,
+    "c_ic": -4.284083843231201e-08, "c_is": -2.7939677238464355e-08, "dn": 3.4029988914202875e-09,
+    "m0": 0.9103355308317173, "ecc": 7.352512329816818e-05, "sqrta": 5440.609079360962,
+    "omega0": 3.0358214308795257, "omegadot": -5.525230148013418e-09, "w": -1.2435193599955705,
+    "inc": 0.9602396632077127, "inc_dot": 2.7608292853357283e-10, "af0": 7.600791286677121e-05,
+    "af1": 9.436007530894129e-12, "af2": 0.0, "toc": {"tow": 499200, "wn": 2122},
+    "iode": 64, "iodc": 64, "source": 0}'
+  raw_packet: VY0AHMiZEw4AngcASggUrkdAQDgAAAEAAADAsQAAyLEAAPXAAHAeQwAAxrQASA43AAA4swAA8LJzS0IRRjstPonjqfp3Ie0/AAAAADBGEz8AAKDsm0C1QOf8EL9cSQhAdL/4Bg67N74x+3GOdOXzv+OSuYdIuu4/Cndc+eb48j3/////zewTP///////v6Q9AAAAAACeBwBKCEAAQAAAA8M=
+  sbp:
+    crc: '0xc303'
+    length: 153
+    msg_type: '0x8d'
+    payload: Ew4AngcASggUrkdAQDgAAAEAAADAsQAAyLEAAPXAAHAeQwAAxrQASA43AAA4swAA8LJzS0IRRjstPonjqfp3Ie0/AAAAADBGEz8AAKDsm0C1QOf8EL9cSQhAdL/4Bg67N74x+3GOdOXzv+OSuYdIuu4/Cndc+eb48j3/////zewTP///////v6Q9AAAAAACeBwBKCEAAQAAA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: 0.0027377924416214223
+      af1: -4.3741010813391755e-11
+      af2: 0.0
+      bgd_e1e5a: 3.958120942115784e-09
+      bgd_e1e5b: 4.423782229423523e-09
+      c_ic: -2.7939677238464355e-08
+      c_is: 5.587935447692871e-09
+      c_rc: 280.125
+      c_rs: -72.71875
+      c_uc: -3.3099204301834106e-06
+      c_us: 3.242865204811096e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 14
+          sat: 26
+        toe:
+          tow: 499200
+          wn: 2122
+        ura: 3.119999885559082
+        valid: 1
+      dn: 2.8640478705183966e-09
+      ecc: 0.00023651926312595606
+      inc: 0.985511758817649
+      inc_dot: 7.10743891050207e-11
+      iodc: 64
+      iode: 64
+      m0: -0.6073780937012754
+      omega0: 0.9345657669068792
+      omegadot: -5.668450399426048e-09
+      source: 0
+      sqrta: 5440.6088581085205
+      toc:
+        tow: 499200
+        wn: 2122
+      w: 3.06917874848284
+    module: sbp.observation
+    name: MsgEphemerisGal
+  msg_type: '0x8d'
+  raw_json: '{"preamble": 85, "msg_type": 141, "sender": 51228, "length": 153, "payload":
+    "Gg4AngcASggUrkdAQDgAAAEAAACIMQAAmDEAcJHCABCMQwAgXrYAoFk2AADwsgAAwDGEnISdG5ooPiQfGC+kb+O/AAAAAEUALz8AACDem0C1QEZwmnf25+0/n7q08YZYOL7+fnKWrY0IQGw/vvRPie8/Dv+AXmqJ0z3///8fkW1mP/7/////C8i9AAAAAACeBwBKCEAAQAAA",
+    "crc": 16461, "common": {"sid": {"sat": 26, "code": 14}, "toe": {"tow": 499200,
+    "wn": 2122}, "ura": 3.119999885559082, "fit_interval": 14400, "valid": 1, "health_bits":
+    0}, "bgd_e1e5a": 3.958120942115784e-09, "bgd_e1e5b": 4.423782229423523e-09, "c_rs":
+    -72.71875, "c_rc": 280.125, "c_uc": -3.3099204301834106e-06, "c_us": 3.242865204811096e-06,
+    "c_ic": -2.7939677238464355e-08, "c_is": 5.587935447692871e-09, "dn": 2.8640478705183966e-09,
+    "m0": -0.6073780937012754, "ecc": 0.00023651926312595606, "sqrta": 5440.6088581085205,
+    "omega0": 0.9345657669068792, "omegadot": -5.668450399426048e-09, "w": 3.06917874848284,
+    "inc": 0.985511758817649, "inc_dot": 7.10743891050207e-11, "af0": 0.0027377924416214223,
+    "af1": -4.3741010813391755e-11, "af2": 0.0, "toc": {"tow": 499200, "wn": 2122},
+    "iode": 64, "iodc": 64, "source": 0}'
+  raw_packet: VY0AHMiZGg4AngcASggUrkdAQDgAAAEAAACIMQAAmDEAcJHCABCMQwAgXrYAoFk2AADwsgAAwDGEnISdG5ooPiQfGC+kb+O/AAAAAEUALz8AACDem0C1QEZwmnf25+0/n7q08YZYOL7+fnKWrY0IQGw/vvRPie8/Dv+AXmqJ0z3///8fkW1mP/7/////C8i9AAAAAACeBwBKCEAAQAAATUA=
+  sbp:
+    crc: '0x404d'
+    length: 153
+    msg_type: '0x8d'
+    payload: Gg4AngcASggUrkdAQDgAAAEAAACIMQAAmDEAcJHCABCMQwAgXrYAoFk2AADwsgAAwDGEnISdG5ooPiQfGC+kb+O/AAAAAEUALz8AACDem0C1QEZwmnf25+0/n7q08YZYOL7+fnKWrY0IQGw/vvRPie8/Dv+AXmqJ0z3///8fkW1mP/7/////C8i9AAAAAACeBwBKCEAAQAAA
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      af0: -0.0004740656004287302
+      af1: -2.70006239588838e-13
+      af2: 0.0
+      bgd_e1e5a: 2.561137080192566e-09
+      bgd_e1e5b: 2.7939677238464355e-09
+      c_ic: 4.470348358154297e-08
+      c_is: 1.862645149230957e-09
+      c_rc: 157.5625
+      c_rs: 111.4375
+      c_uc: 5.083158612251282e-06
+      c_us: 8.974224328994751e-06
+      common:
+        fit_interval: 14400
+        health_bits: 0
+        sid:
+          code: 14
+          sat: 31
+        toe:
+          tow: 499200
+          wn: 2122
+        ura: 3.119999885559082
+        valid: 1
+      dn: 2.6147517720495303e-09
+      ecc: 0.0004427171079441905
+      inc: 0.9805731419501476
+      inc_dot: -3.4072847842306404e-10
+      iodc: 64
+      iode: 64
+      m0: -1.4842457980979706
+      omega0: -1.152405318330012
+      omegadot: -5.347722754117964e-09
+      source: 0
+      sqrta: 5440.625150680542
+      toc:
+        tow: 499200
+        wn: 2122
+      w: -1.8186656891716209
+    module: sbp.observation
+    name: MsgEphemerisGal
+  msg_type: '0x8d'
+  raw_json: '{"preamble": 85, "msg_type": 141, "sender": 51228, "length": 153, "payload":
+    "Hw4AngcASggUrkdAQDgAAAEAAAAwMQAAQDEA4N5CAJAdQwCQqjYAkBY3AABAMwAAADFtjWZj5nUmPjXmoIV4v/e/AAAAgI8DPT8AAOAJoEC1QARsH49AcPK/Bl4+I+L3Nr4yl5UxQRn9vxJhAO3aYO8/A4QBpihq973///8/gBE/v////////1K9AAAAAACeBwBKCEAAQAAA",
+    "crc": 984, "common": {"sid": {"sat": 31, "code": 14}, "toe": {"tow": 499200,
+    "wn": 2122}, "ura": 3.119999885559082, "fit_interval": 14400, "valid": 1, "health_bits":
+    0}, "bgd_e1e5a": 2.561137080192566e-09, "bgd_e1e5b": 2.7939677238464355e-09, "c_rs":
+    111.4375, "c_rc": 157.5625, "c_uc": 5.083158612251282e-06, "c_us": 8.974224328994751e-06,
+    "c_ic": 4.470348358154297e-08, "c_is": 1.862645149230957e-09, "dn": 2.6147517720495303e-09,
+    "m0": -1.4842457980979706, "ecc": 0.0004427171079441905, "sqrta": 5440.625150680542,
+    "omega0": -1.152405318330012, "omegadot": -5.347722754117964e-09, "w": -1.8186656891716209,
+    "inc": 0.9805731419501476, "inc_dot": -3.4072847842306404e-10, "af0": -0.0004740656004287302,
+    "af1": -2.70006239588838e-13, "af2": 0.0, "toc": {"tow": 499200, "wn": 2122},
+    "iode": 64, "iodc": 64, "source": 0}'
+  raw_packet: VY0AHMiZHw4AngcASggUrkdAQDgAAAEAAAAwMQAAQDEA4N5CAJAdQwCQqjYAkBY3AABAMwAAADFtjWZj5nUmPjXmoIV4v/e/AAAAgI8DPT8AAOAJoEC1QARsH49AcPK/Bl4+I+L3Nr4yl5UxQRn9vxJhAO3aYO8/A4QBpihq973///8/gBE/v////////1K9AAAAAACeBwBKCEAAQAAA2AM=
+  sbp:
+    crc: '0x3d8'
+    length: 153
+    msg_type: '0x8d'
+    payload: Hw4AngcASggUrkdAQDgAAAEAAAAwMQAAQDEA4N5CAJAdQwCQqjYAkBY3AABAMwAAADFtjWZj5nUmPjXmoIV4v/e/AAAAgI8DPT8AAOAJoEC1QARsH49AcPK/Bl4+I+L3Nr4yl5UxQRn9vxJhAO3aYO8/A4QBpihq973///8/gBE/v////////1K9AAAAAACeBwBKCEAAQAAA
+    preamble: '0x55'
+    sender: '0xc81c'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgGloBiases.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgGloBiases.yaml
@@ -1,0 +1,29 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgGloBiases v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.731908
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      l1ca_bias: -24223
+      l1p_bias: 2662
+      l2ca_bias: 17592
+      l2p_bias: -19263
+      mask: 0
+    module: sbp.observation
+    name: MsgGloBiases
+  msg_type: '0x75'
+  raw_json: '{"preamble": 85, "msg_type": 117, "sender": 0, "length": 9, "payload":
+    "AGGhZgq4RMG0", "crc": 34650, "mask": 0, "l1ca_bias": -24223, "l1p_bias": 2662,
+    "l2ca_bias": 17592, "l2p_bias": -19263}'
+  raw_packet: VXUAAAAJAGGhZgq4RMG0Woc=
+  sbp:
+    crc: '0x875a'
+    length: 9
+    msg_type: '0x75'
+    payload: AGGhZgq4RMG0
+    preamble: '0x55'
+    sender: '0x0'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgObs.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgObs.yaml
@@ -1,0 +1,1137 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgObs v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:44.661785
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      header:
+        n_obs: 32
+        t:
+          ns_residual: 0
+          tow: 500066600
+          wn: 2122
+      obs:
+      - D:
+          f: 174
+          i: 2316
+        L:
+          f: 90
+          i: 116365234
+        P: 1107178409
+        cn0: 194
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 10
+      - D:
+          f: 206
+          i: -622
+        L:
+          f: 59
+          i: 113728883
+        P: 1082094334
+        cn0: 182
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 15
+      - D:
+          f: 247
+          i: -74
+        L:
+          f: 218
+          i: 121849073
+        P: 1159355403
+        cn0: 143
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 16
+      - D:
+          f: 246
+          i: -302
+        L:
+          f: 20
+          i: 107946145
+        P: 1027073434
+        cn0: 196
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 18
+      - D:
+          f: 238
+          i: 658
+        L:
+          f: 21
+          i: 106422425
+        P: 1012575700
+        cn0: 192
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 20
+      - D:
+          f: 73
+          i: 848
+        L:
+          f: 207
+          i: 107166419
+        P: 1019654584
+        cn0: 192
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 23
+      - D:
+          f: 41
+          i: 630
+        L:
+          f: 116
+          i: 80026675
+        P: 1019652097
+        cn0: 94
+        flags: 15
+        lock: 7
+        sid:
+          code: 10
+          sat: 23
+      - D:
+          f: 97
+          i: -1964
+        L:
+          f: 115
+          i: 121829843
+        P: 1159172437
+        cn0: 174
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 26
+      - D:
+          f: 184
+          i: -1467
+        L:
+          f: 144
+          i: 90976501
+        P: 1159167756
+        cn0: 182
+        flags: 15
+        lock: 8
+        sid:
+          code: 10
+          sat: 26
+      - D:
+          f: 159
+          i: 3307
+        L:
+          f: 130
+          i: 125646832
+        P: 1195489872
+        cn0: 156
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 27
+      - D:
+          f: 135
+          i: -3000
+        L:
+          f: 66
+          i: 117189767
+        P: 1115023575
+        cn0: 183
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 29
+      - D:
+          f: 217
+          i: 250
+        L:
+          f: 146
+          i: 93945485
+        P: 893861581
+        cn0: 194
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 18
+      - D:
+          f: 91
+          i: 187
+        L:
+          f: 67
+          i: 70154335
+        P: 893864622
+        cn0: 189
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 18
+      - D:
+          f: 35
+          i: 2861
+        L:
+          f: 219
+          i: 135124040
+        P: 1285662497
+        cn0: 156
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 19
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x4a'
+  raw_json: '{"preamble": 85, "msg_type": 74, "sender": 51228, "length": 249, "payload":
+    "KGnOHQAAAABKCCCpM/5BspfvBloMCa7CCA8KAP5yf0BzXccGO5L9zrYIDw8AC1waRfFEQwfatv/3jwgPEACa5Tc9oSBvBhTS/vbECA8SANStWjyZ4FcGFZIC7sAIDxQAuLHGPNM6YwbPUANJwAgPFwABqMY8MxzFBHR2AileBw8XClWRF0XT+UIHc1T4Ya4IDxoADH8XRfUwbAWQRfq4tggPGgpQukFH8Dd9B4LrDJ+cCA8bANfodUKHLPwGQkj0h7cIDx0AzT5HNY1+mQWS+gDZwggPEhCuSkc1X3guBEO7AFu9CA8SGyGnoUxI1A0I2y0LI5wIDxMQ",
+    "crc": 62086, "header": {"t": {"tow": 500066600, "ns_residual": 0, "wn": 2122},
+    "n_obs": 32}, "obs": [{"P": 1107178409, "L": {"i": 116365234, "f": 90}, "D": {"i":
+    2316, "f": 174}, "cn0": 194, "lock": 8, "flags": 15, "sid": {"sat": 10, "code":
+    0}}, {"P": 1082094334, "L": {"i": 113728883, "f": 59}, "D": {"i": -622, "f": 206},
+    "cn0": 182, "lock": 8, "flags": 15, "sid": {"sat": 15, "code": 0}}, {"P": 1159355403,
+    "L": {"i": 121849073, "f": 218}, "D": {"i": -74, "f": 247}, "cn0": 143, "lock":
+    8, "flags": 15, "sid": {"sat": 16, "code": 0}}, {"P": 1027073434, "L": {"i": 107946145,
+    "f": 20}, "D": {"i": -302, "f": 246}, "cn0": 196, "lock": 8, "flags": 15, "sid":
+    {"sat": 18, "code": 0}}, {"P": 1012575700, "L": {"i": 106422425, "f": 21}, "D":
+    {"i": 658, "f": 238}, "cn0": 192, "lock": 8, "flags": 15, "sid": {"sat": 20, "code":
+    0}}, {"P": 1019654584, "L": {"i": 107166419, "f": 207}, "D": {"i": 848, "f": 73},
+    "cn0": 192, "lock": 8, "flags": 15, "sid": {"sat": 23, "code": 0}}, {"P": 1019652097,
+    "L": {"i": 80026675, "f": 116}, "D": {"i": 630, "f": 41}, "cn0": 94, "lock": 7,
+    "flags": 15, "sid": {"sat": 23, "code": 10}}, {"P": 1159172437, "L": {"i": 121829843,
+    "f": 115}, "D": {"i": -1964, "f": 97}, "cn0": 174, "lock": 8, "flags": 15, "sid":
+    {"sat": 26, "code": 0}}, {"P": 1159167756, "L": {"i": 90976501, "f": 144}, "D":
+    {"i": -1467, "f": 184}, "cn0": 182, "lock": 8, "flags": 15, "sid": {"sat": 26,
+    "code": 10}}, {"P": 1195489872, "L": {"i": 125646832, "f": 130}, "D": {"i": 3307,
+    "f": 159}, "cn0": 156, "lock": 8, "flags": 15, "sid": {"sat": 27, "code": 0}},
+    {"P": 1115023575, "L": {"i": 117189767, "f": 66}, "D": {"i": -3000, "f": 135},
+    "cn0": 183, "lock": 8, "flags": 15, "sid": {"sat": 29, "code": 0}}, {"P": 893861581,
+    "L": {"i": 93945485, "f": 146}, "D": {"i": 250, "f": 217}, "cn0": 194, "lock":
+    8, "flags": 15, "sid": {"sat": 18, "code": 16}}, {"P": 893864622, "L": {"i": 70154335,
+    "f": 67}, "D": {"i": 187, "f": 91}, "cn0": 189, "lock": 8, "flags": 15, "sid":
+    {"sat": 18, "code": 27}}, {"P": 1285662497, "L": {"i": 135124040, "f": 219}, "D":
+    {"i": 2861, "f": 35}, "cn0": 156, "lock": 8, "flags": 15, "sid": {"sat": 19, "code":
+    16}}]}'
+  raw_packet: VUoAHMj5KGnOHQAAAABKCCCpM/5BspfvBloMCa7CCA8KAP5yf0BzXccGO5L9zrYIDw8AC1waRfFEQwfatv/3jwgPEACa5Tc9oSBvBhTS/vbECA8SANStWjyZ4FcGFZIC7sAIDxQAuLHGPNM6YwbPUANJwAgPFwABqMY8MxzFBHR2AileBw8XClWRF0XT+UIHc1T4Ya4IDxoADH8XRfUwbAWQRfq4tggPGgpQukFH8Dd9B4LrDJ+cCA8bANfodUKHLPwGQkj0h7cIDx0AzT5HNY1+mQWS+gDZwggPEhCuSkc1X3guBEO7AFu9CA8SGyGnoUxI1A0I2y0LI5wIDxMQhvI=
+  sbp:
+    crc: '0xf286'
+    length: 249
+    msg_type: '0x4a'
+    payload: KGnOHQAAAABKCCCpM/5BspfvBloMCa7CCA8KAP5yf0BzXccGO5L9zrYIDw8AC1waRfFEQwfatv/3jwgPEACa5Tc9oSBvBhTS/vbECA8SANStWjyZ4FcGFZIC7sAIDxQAuLHGPNM6YwbPUANJwAgPFwABqMY8MxzFBHR2AileBw8XClWRF0XT+UIHc1T4Ya4IDxoADH8XRfUwbAWQRfq4tggPGgpQukFH8Dd9B4LrDJ+cCA8bANfodUKHLPwGQkj0h7cIDx0AzT5HNY1+mQWS+gDZwggPEhCuSkc1X3guBEO7AFu9CA8SGyGnoUxI1A0I2y0LI5wIDxMQ
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      header:
+        n_obs: 33
+        t:
+          ns_residual: 0
+          tow: 500066600
+          wn: 2122
+      obs:
+      - D:
+          f: 162
+          i: 2136
+        L:
+          f: 217
+          i: 100904553
+        P: 1285665550
+        cn0: 158
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 19
+      - D:
+          f: 9
+          i: 1014
+        L:
+          f: 227
+          i: 86815905
+        P: 826025903
+        cn0: 162
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 20
+      - D:
+          f: 164
+          i: -1379
+        L:
+          f: 119
+          i: 127472422
+        P: 1212859775
+        cn0: 186
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 26
+      - D:
+          f: 207
+          i: -1030
+        L:
+          f: 254
+          i: 95190687
+        P: 1212862866
+        cn0: 175
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 26
+      - D:
+          f: 161
+          i: -2269
+        L:
+          f: 187
+          i: 143196366
+        P: 1362468169
+        cn0: 157
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 31
+      - D:
+          f: 238
+          i: -1695
+        L:
+          f: 71
+          i: 106932602
+        P: 1362471334
+        cn0: 162
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 31
+      - D:
+          f: 32
+          i: 544
+        L:
+          f: 240
+          i: 124747442
+        P: 1186932469
+        cn0: 193
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 33
+      - D:
+          f: 75
+          i: 406
+        L:
+          f: 229
+          i: 93155794
+        P: 1186935475
+        cn0: 188
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 33
+      - D:
+          f: 95
+          i: 1463
+        L:
+          f: 240
+          i: 115688457
+        P: 1110837559
+        cn0: 203
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 20
+      - D:
+          f: 177
+          i: 1899
+        L:
+          f: 177
+          i: 117071229
+        P: 1124114909
+        cn0: 195
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 29
+      - D:
+          f: 233
+          i: -999
+        L:
+          f: 156
+          i: 113535027
+        P: 1090160413
+        cn0: 202
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 30
+      - D:
+          f: 163
+          i: -1720
+        L:
+          f: 44
+          i: 118900160
+        P: 1141676284
+        cn0: 198
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 32
+      - D:
+          f: 212
+          i: -1296
+        L:
+          f: 187
+          i: 89603441
+        P: 1141673500
+        cn0: 106
+        flags: 15
+        lock: 8
+        sid:
+          code: 48
+          sat: 32
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x4a'
+  raw_json: '{"preamble": 85, "msg_type": 74, "sender": 51228, "length": 232, "payload":
+    "KGnOHQAAAABKCCEOs6FMaa4DBtlYCKKeCA8TG68nPDGhtCwF4/YDCaIIDxQQf8VKSCYTmQd3nfqkuggPGhCS0UpIn36sBf76+8+vCA8aG0mdNVHOAIkIuyP3oZ0IDx8Qpqk1UXqpXwZHYfnuoggPHxv1Jr9Gsn5vB/AgAiDBCA8hELMyv0bScY0F5ZYBS7wIDyEbNwk2QglE5QbwtwVfywgPFAzdoQBDfV36BrFrB7HDCA8dDB2H+kAzaMQGnBn86coIDx4M/JgMRMBFFgcsSPmjxggPIAwcjgxEcT1XBbvw+tRqCA8gMA==",
+    "crc": 24820, "header": {"t": {"tow": 500066600, "ns_residual": 0, "wn": 2122},
+    "n_obs": 33}, "obs": [{"P": 1285665550, "L": {"i": 100904553, "f": 217}, "D":
+    {"i": 2136, "f": 162}, "cn0": 158, "lock": 8, "flags": 15, "sid": {"sat": 19,
+    "code": 27}}, {"P": 826025903, "L": {"i": 86815905, "f": 227}, "D": {"i": 1014,
+    "f": 9}, "cn0": 162, "lock": 8, "flags": 15, "sid": {"sat": 20, "code": 16}},
+    {"P": 1212859775, "L": {"i": 127472422, "f": 119}, "D": {"i": -1379, "f": 164},
+    "cn0": 186, "lock": 8, "flags": 15, "sid": {"sat": 26, "code": 16}}, {"P": 1212862866,
+    "L": {"i": 95190687, "f": 254}, "D": {"i": -1030, "f": 207}, "cn0": 175, "lock":
+    8, "flags": 15, "sid": {"sat": 26, "code": 27}}, {"P": 1362468169, "L": {"i":
+    143196366, "f": 187}, "D": {"i": -2269, "f": 161}, "cn0": 157, "lock": 8, "flags":
+    15, "sid": {"sat": 31, "code": 16}}, {"P": 1362471334, "L": {"i": 106932602, "f":
+    71}, "D": {"i": -1695, "f": 238}, "cn0": 162, "lock": 8, "flags": 15, "sid": {"sat":
+    31, "code": 27}}, {"P": 1186932469, "L": {"i": 124747442, "f": 240}, "D": {"i":
+    544, "f": 32}, "cn0": 193, "lock": 8, "flags": 15, "sid": {"sat": 33, "code":
+    16}}, {"P": 1186935475, "L": {"i": 93155794, "f": 229}, "D": {"i": 406, "f": 75},
+    "cn0": 188, "lock": 8, "flags": 15, "sid": {"sat": 33, "code": 27}}, {"P": 1110837559,
+    "L": {"i": 115688457, "f": 240}, "D": {"i": 1463, "f": 95}, "cn0": 203, "lock":
+    8, "flags": 15, "sid": {"sat": 20, "code": 12}}, {"P": 1124114909, "L": {"i":
+    117071229, "f": 177}, "D": {"i": 1899, "f": 177}, "cn0": 195, "lock": 8, "flags":
+    15, "sid": {"sat": 29, "code": 12}}, {"P": 1090160413, "L": {"i": 113535027, "f":
+    156}, "D": {"i": -999, "f": 233}, "cn0": 202, "lock": 8, "flags": 15, "sid": {"sat":
+    30, "code": 12}}, {"P": 1141676284, "L": {"i": 118900160, "f": 44}, "D": {"i":
+    -1720, "f": 163}, "cn0": 198, "lock": 8, "flags": 15, "sid": {"sat": 32, "code":
+    12}}, {"P": 1141673500, "L": {"i": 89603441, "f": 187}, "D": {"i": -1296, "f":
+    212}, "cn0": 106, "lock": 8, "flags": 15, "sid": {"sat": 32, "code": 48}}]}'
+  raw_packet: VUoAHMjoKGnOHQAAAABKCCEOs6FMaa4DBtlYCKKeCA8TG68nPDGhtCwF4/YDCaIIDxQQf8VKSCYTmQd3nfqkuggPGhCS0UpIn36sBf76+8+vCA8aG0mdNVHOAIkIuyP3oZ0IDx8Qpqk1UXqpXwZHYfnuoggPHxv1Jr9Gsn5vB/AgAiDBCA8hELMyv0bScY0F5ZYBS7wIDyEbNwk2QglE5QbwtwVfywgPFAzdoQBDfV36BrFrB7HDCA8dDB2H+kAzaMQGnBn86coIDx4M/JgMRMBFFgcsSPmjxggPIAwcjgxEcT1XBbvw+tRqCA8gMPRg
+  sbp:
+    crc: '0x60f4'
+    length: 232
+    msg_type: '0x4a'
+    payload: KGnOHQAAAABKCCEOs6FMaa4DBtlYCKKeCA8TG68nPDGhtCwF4/YDCaIIDxQQf8VKSCYTmQd3nfqkuggPGhCS0UpIn36sBf76+8+vCA8aG0mdNVHOAIkIuyP3oZ0IDx8Qpqk1UXqpXwZHYfnuoggPHxv1Jr9Gsn5vB/AgAiDBCA8hELMyv0bScY0F5ZYBS7wIDyEbNwk2QglE5QbwtwVfywgPFAzdoQBDfV36BrFrB7HDCA8dDB2H+kAzaMQGnBn86coIDx4M/JgMRMBFFgcsSPmjxggPIAwcjgxEcT1XBbvw+tRqCA8gMA==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      header:
+        n_obs: 32
+        t:
+          ns_residual: 0
+          tow: 500066700
+          wn: 2122
+      obs:
+      - D:
+          f: 138
+          i: 2316
+        L:
+          f: 180
+          i: 116365002
+        P: 1107176200
+        cn0: 194
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 10
+      - D:
+          f: 141
+          i: -622
+        L:
+          f: 91
+          i: 113728945
+        P: 1082094925
+        cn0: 182
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 15
+      - D:
+          f: 197
+          i: -74
+        L:
+          f: 46
+          i: 121849081
+        P: 1159355472
+        cn0: 143
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 16
+      - D:
+          f: 194
+          i: -302
+        L:
+          f: 48
+          i: 107946175
+        P: 1027073722
+        cn0: 196
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 18
+      - D:
+          f: 182
+          i: 658
+        L:
+          f: 53
+          i: 106422359
+        P: 1012575075
+        cn0: 192
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 20
+      - D:
+          f: 14
+          i: 848
+        L:
+          f: 255
+          i: 107166334
+        P: 1019653778
+        cn0: 192
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 23
+      - D:
+          f: 243
+          i: 629
+        L:
+          f: 54
+          i: 80026612
+        P: 1019651294
+        cn0: 94
+        flags: 15
+        lock: 7
+        sid:
+          code: 10
+          sat: 23
+      - D:
+          f: 47
+          i: -1964
+        L:
+          f: 206
+          i: 121830039
+        P: 1159174306
+        cn0: 174
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 26
+      - D:
+          f: 140
+          i: -1467
+        L:
+          f: 54
+          i: 90976648
+        P: 1159169625
+        cn0: 182
+        flags: 15
+        lock: 8
+        sid:
+          code: 10
+          sat: 26
+      - D:
+          f: 130
+          i: 3307
+        L:
+          f: 195
+          i: 125646501
+        P: 1195486731
+        cn0: 156
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 27
+      - D:
+          f: 79
+          i: -3000
+        L:
+          f: 62
+          i: 117190067
+        P: 1115026428
+        cn0: 183
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 29
+      - D:
+          f: 150
+          i: 250
+        L:
+          f: 129
+          i: 93945460
+        P: 893861341
+        cn0: 195
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 18
+      - D:
+          f: 64
+          i: 187
+        L:
+          f: 137
+          i: 70154316
+        P: 893864384
+        cn0: 189
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 18
+      - D:
+          f: 17
+          i: 2861
+        L:
+          f: 193
+          i: 135123754
+        P: 1285659772
+        cn0: 156
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 19
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x4a'
+  raw_json: '{"preamble": 85, "msg_type": 74, "sender": 51228, "length": 249, "payload":
+    "jGnOHQAAAABKCCAIK/5BypbvBrQMCYrCCA8KAE11f0CxXccGW5L9jbYIDw8AUFwaRflEQwcutv/FjwgPEAC65jc9vyBvBjDS/sLECA8SAGOrWjxX4FcGNZICtsAIDxQAkq7GPH46Ywb/UAMOwAgPFwDepMY89BvFBDZ1AvNeBw8XCqKYF0WX+kIHzlT4L64IDxoAWYYXRYgxbAU2RfqMtggPGgoLrkFHpTZ9B8PrDIKcCA8bAPzzdUKzLfwGPkj0T7cIDx0A3T1HNXR+mQWB+gCWwwgPEhDASUc1THguBIm7AEC9CA8SG3ycoUwq0w0IwS0LEZwIDxMQ",
+    "crc": 31710, "header": {"t": {"tow": 500066700, "ns_residual": 0, "wn": 2122},
+    "n_obs": 32}, "obs": [{"P": 1107176200, "L": {"i": 116365002, "f": 180}, "D":
+    {"i": 2316, "f": 138}, "cn0": 194, "lock": 8, "flags": 15, "sid": {"sat": 10,
+    "code": 0}}, {"P": 1082094925, "L": {"i": 113728945, "f": 91}, "D": {"i": -622,
+    "f": 141}, "cn0": 182, "lock": 8, "flags": 15, "sid": {"sat": 15, "code": 0}},
+    {"P": 1159355472, "L": {"i": 121849081, "f": 46}, "D": {"i": -74, "f": 197}, "cn0":
+    143, "lock": 8, "flags": 15, "sid": {"sat": 16, "code": 0}}, {"P": 1027073722,
+    "L": {"i": 107946175, "f": 48}, "D": {"i": -302, "f": 194}, "cn0": 196, "lock":
+    8, "flags": 15, "sid": {"sat": 18, "code": 0}}, {"P": 1012575075, "L": {"i": 106422359,
+    "f": 53}, "D": {"i": 658, "f": 182}, "cn0": 192, "lock": 8, "flags": 15, "sid":
+    {"sat": 20, "code": 0}}, {"P": 1019653778, "L": {"i": 107166334, "f": 255}, "D":
+    {"i": 848, "f": 14}, "cn0": 192, "lock": 8, "flags": 15, "sid": {"sat": 23, "code":
+    0}}, {"P": 1019651294, "L": {"i": 80026612, "f": 54}, "D": {"i": 629, "f": 243},
+    "cn0": 94, "lock": 7, "flags": 15, "sid": {"sat": 23, "code": 10}}, {"P": 1159174306,
+    "L": {"i": 121830039, "f": 206}, "D": {"i": -1964, "f": 47}, "cn0": 174, "lock":
+    8, "flags": 15, "sid": {"sat": 26, "code": 0}}, {"P": 1159169625, "L": {"i": 90976648,
+    "f": 54}, "D": {"i": -1467, "f": 140}, "cn0": 182, "lock": 8, "flags": 15, "sid":
+    {"sat": 26, "code": 10}}, {"P": 1195486731, "L": {"i": 125646501, "f": 195}, "D":
+    {"i": 3307, "f": 130}, "cn0": 156, "lock": 8, "flags": 15, "sid": {"sat": 27,
+    "code": 0}}, {"P": 1115026428, "L": {"i": 117190067, "f": 62}, "D": {"i": -3000,
+    "f": 79}, "cn0": 183, "lock": 8, "flags": 15, "sid": {"sat": 29, "code": 0}},
+    {"P": 893861341, "L": {"i": 93945460, "f": 129}, "D": {"i": 250, "f": 150}, "cn0":
+    195, "lock": 8, "flags": 15, "sid": {"sat": 18, "code": 16}}, {"P": 893864384,
+    "L": {"i": 70154316, "f": 137}, "D": {"i": 187, "f": 64}, "cn0": 189, "lock":
+    8, "flags": 15, "sid": {"sat": 18, "code": 27}}, {"P": 1285659772, "L": {"i":
+    135123754, "f": 193}, "D": {"i": 2861, "f": 17}, "cn0": 156, "lock": 8, "flags":
+    15, "sid": {"sat": 19, "code": 16}}]}'
+  raw_packet: VUoAHMj5jGnOHQAAAABKCCAIK/5BypbvBrQMCYrCCA8KAE11f0CxXccGW5L9jbYIDw8AUFwaRflEQwcutv/FjwgPEAC65jc9vyBvBjDS/sLECA8SAGOrWjxX4FcGNZICtsAIDxQAkq7GPH46Ywb/UAMOwAgPFwDepMY89BvFBDZ1AvNeBw8XCqKYF0WX+kIHzlT4L64IDxoAWYYXRYgxbAU2RfqMtggPGgoLrkFHpTZ9B8PrDIKcCA8bAPzzdUKzLfwGPkj0T7cIDx0A3T1HNXR+mQWB+gCWwwgPEhDASUc1THguBIm7AEC9CA8SG3ycoUwq0w0IwS0LEZwIDxMQ3ns=
+  sbp:
+    crc: '0x7bde'
+    length: 249
+    msg_type: '0x4a'
+    payload: jGnOHQAAAABKCCAIK/5BypbvBrQMCYrCCA8KAE11f0CxXccGW5L9jbYIDw8AUFwaRflEQwcutv/FjwgPEAC65jc9vyBvBjDS/sLECA8SAGOrWjxX4FcGNZICtsAIDxQAkq7GPH46Ywb/UAMOwAgPFwDepMY89BvFBDZ1AvNeBw8XCqKYF0WX+kIHzlT4L64IDxoAWYYXRYgxbAU2RfqMtggPGgoLrkFHpTZ9B8PrDIKcCA8bAPzzdUKzLfwGPkj0T7cIDx0A3T1HNXR+mQWB+gCWwwgPEhDASUc1THguBIm7AEC9CA8SG3ycoUwq0w0IwS0LEZwIDxMQ
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      header:
+        n_obs: 33
+        t:
+          ns_residual: 0
+          tow: 500066700
+          wn: 2122
+      obs:
+      - D:
+          f: 127
+          i: 2136
+        L:
+          f: 52
+          i: 100904340
+        P: 1285662828
+        cn0: 158
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 19
+      - D:
+          f: 54
+          i: 1014
+        L:
+          f: 118
+          i: 86815804
+        P: 826024941
+        cn0: 162
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 20
+      - D:
+          f: 151
+          i: -1379
+        L:
+          f: 77
+          i: 127472560
+        P: 1212861088
+        cn0: 186
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 26
+      - D:
+          f: 174
+          i: -1030
+        L:
+          f: 237
+          i: 95190790
+        P: 1212864175
+        cn0: 175
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 26
+      - D:
+          f: 145
+          i: -2269
+        L:
+          f: 166
+          i: 143196593
+        P: 1362470325
+        cn0: 157
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 31
+      - D:
+          f: 205
+          i: -1695
+        L:
+          f: 181
+          i: 106932771
+        P: 1362473491
+        cn0: 162
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 31
+      - D:
+          f: 253
+          i: 543
+        L:
+          f: 138
+          i: 124747388
+        P: 1186931944
+        cn0: 194
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 33
+      - D:
+          f: 62
+          i: 406
+        L:
+          f: 70
+          i: 93155754
+        P: 1186934959
+        cn0: 188
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 33
+      - D:
+          f: 51
+          i: 1463
+        L:
+          f: 157
+          i: 115688311
+        P: 1110836156
+        cn0: 203
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 20
+      - D:
+          f: 125
+          i: 1899
+        L:
+          f: 189
+          i: 117071039
+        P: 1124113084
+        cn0: 195
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 29
+      - D:
+          f: 178
+          i: -999
+        L:
+          f: 111
+          i: 113535127
+        P: 1090161369
+        cn0: 202
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 30
+      - D:
+          f: 145
+          i: -1720
+        L:
+          f: 29
+          i: 118900332
+        P: 1141677934
+        cn0: 198
+        flags: 15
+        lock: 8
+        sid:
+          code: 12
+          sat: 32
+      - D:
+          f: 172
+          i: -1296
+        L:
+          f: 62
+          i: 89603571
+        P: 1141675150
+        cn0: 106
+        flags: 15
+        lock: 8
+        sid:
+          code: 48
+          sat: 32
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x4a'
+  raw_json: '{"preamble": 85, "msg_type": 74, "sender": 51228, "length": 232, "payload":
+    "jGnOHQAAAABKCCFsqKFMlK0DBjRYCH+eCA8TG+0jPDE8tCwFdvYDNqIIDxQQoMpKSLATmQdNnfqXuggPGhCv1kpIBn+sBe36+66vCA8aG7WlNVGxAYkIpiP3kZ0IDx8QE7I1USOqXwa1YfnNoggPHxvoJL9GfH5vB4ofAv3CCA8hEK8wv0aqcY0FRpYBPrwIDyEbvAM2QndD5QadtwUzywgPFAy8mgBDv1z6Br1rB33DCA8dDNmK+kCXaMQGbxn8ssoIDx4Mbp8MRGxGFgcdSPmRxggPIAyOlAxE8z1XBT7w+qxqCA8gMA==",
+    "crc": 52480, "header": {"t": {"tow": 500066700, "ns_residual": 0, "wn": 2122},
+    "n_obs": 33}, "obs": [{"P": 1285662828, "L": {"i": 100904340, "f": 52}, "D": {"i":
+    2136, "f": 127}, "cn0": 158, "lock": 8, "flags": 15, "sid": {"sat": 19, "code":
+    27}}, {"P": 826024941, "L": {"i": 86815804, "f": 118}, "D": {"i": 1014, "f": 54},
+    "cn0": 162, "lock": 8, "flags": 15, "sid": {"sat": 20, "code": 16}}, {"P": 1212861088,
+    "L": {"i": 127472560, "f": 77}, "D": {"i": -1379, "f": 151}, "cn0": 186, "lock":
+    8, "flags": 15, "sid": {"sat": 26, "code": 16}}, {"P": 1212864175, "L": {"i":
+    95190790, "f": 237}, "D": {"i": -1030, "f": 174}, "cn0": 175, "lock": 8, "flags":
+    15, "sid": {"sat": 26, "code": 27}}, {"P": 1362470325, "L": {"i": 143196593, "f":
+    166}, "D": {"i": -2269, "f": 145}, "cn0": 157, "lock": 8, "flags": 15, "sid":
+    {"sat": 31, "code": 16}}, {"P": 1362473491, "L": {"i": 106932771, "f": 181}, "D":
+    {"i": -1695, "f": 205}, "cn0": 162, "lock": 8, "flags": 15, "sid": {"sat": 31,
+    "code": 27}}, {"P": 1186931944, "L": {"i": 124747388, "f": 138}, "D": {"i": 543,
+    "f": 253}, "cn0": 194, "lock": 8, "flags": 15, "sid": {"sat": 33, "code": 16}},
+    {"P": 1186934959, "L": {"i": 93155754, "f": 70}, "D": {"i": 406, "f": 62}, "cn0":
+    188, "lock": 8, "flags": 15, "sid": {"sat": 33, "code": 27}}, {"P": 1110836156,
+    "L": {"i": 115688311, "f": 157}, "D": {"i": 1463, "f": 51}, "cn0": 203, "lock":
+    8, "flags": 15, "sid": {"sat": 20, "code": 12}}, {"P": 1124113084, "L": {"i":
+    117071039, "f": 189}, "D": {"i": 1899, "f": 125}, "cn0": 195, "lock": 8, "flags":
+    15, "sid": {"sat": 29, "code": 12}}, {"P": 1090161369, "L": {"i": 113535127, "f":
+    111}, "D": {"i": -999, "f": 178}, "cn0": 202, "lock": 8, "flags": 15, "sid": {"sat":
+    30, "code": 12}}, {"P": 1141677934, "L": {"i": 118900332, "f": 29}, "D": {"i":
+    -1720, "f": 145}, "cn0": 198, "lock": 8, "flags": 15, "sid": {"sat": 32, "code":
+    12}}, {"P": 1141675150, "L": {"i": 89603571, "f": 62}, "D": {"i": -1296, "f":
+    172}, "cn0": 106, "lock": 8, "flags": 15, "sid": {"sat": 32, "code": 48}}]}'
+  raw_packet: VUoAHMjojGnOHQAAAABKCCFsqKFMlK0DBjRYCH+eCA8TG+0jPDE8tCwFdvYDNqIIDxQQoMpKSLATmQdNnfqXuggPGhCv1kpIBn+sBe36+66vCA8aG7WlNVGxAYkIpiP3kZ0IDx8QE7I1USOqXwa1YfnNoggPHxvoJL9GfH5vB4ofAv3CCA8hEK8wv0aqcY0FRpYBPrwIDyEbvAM2QndD5QadtwUzywgPFAy8mgBDv1z6Br1rB33DCA8dDNmK+kCXaMQGbxn8ssoIDx4Mbp8MRGxGFgcdSPmRxggPIAyOlAxE8z1XBT7w+qxqCA8gMADN
+  sbp:
+    crc: '0xcd00'
+    length: 232
+    msg_type: '0x4a'
+    payload: jGnOHQAAAABKCCFsqKFMlK0DBjRYCH+eCA8TG+0jPDE8tCwFdvYDNqIIDxQQoMpKSLATmQdNnfqXuggPGhCv1kpIBn+sBe36+66vCA8aG7WlNVGxAYkIpiP3kZ0IDx8QE7I1USOqXwa1YfnNoggPHxvoJL9GfH5vB4ofAv3CCA8hEK8wv0aqcY0FRpYBPrwIDyEbvAM2QndD5QadtwUzywgPFAy8mgBDv1z6Br1rB33DCA8dDNmK+kCXaMQGbxn8ssoIDx4Mbp8MRGxGFgcdSPmRxggPIAyOlAxE8z1XBT7w+qxqCA8gMA==
+    preamble: '0x55'
+    sender: '0xc81c'
+
+- msg:
+    fields:
+      header:
+        n_obs: 32
+        t:
+          ns_residual: 0
+          tow: 500066800
+          wn: 2122
+      obs:
+      - D:
+          f: 82
+          i: 2316
+        L:
+          f: 18
+          i: 116364771
+        P: 1107173997
+        cn0: 194
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 10
+      - D:
+          f: 144
+          i: -622
+        L:
+          f: 130
+          i: 113729007
+        P: 1082095516
+        cn0: 182
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 15
+      - D:
+          f: 122
+          i: -74
+        L:
+          f: 138
+          i: 121849088
+        P: 1159355544
+        cn0: 143
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 16
+      - D:
+          f: 183
+          i: -302
+        L:
+          f: 82
+          i: 107946205
+        P: 1027074009
+        cn0: 196
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 18
+      - D:
+          f: 168
+          i: 658
+        L:
+          f: 86
+          i: 106422293
+        P: 1012574444
+        cn0: 192
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 20
+      - D:
+          f: 243
+          i: 847
+        L:
+          f: 50
+          i: 107166250
+        P: 1019652975
+        cn0: 192
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 23
+      - D:
+          f: 3
+          i: 631
+        L:
+          f: 226
+          i: 80026548
+        P: 1019650487
+        cn0: 94
+        flags: 15
+        lock: 7
+        sid:
+          code: 10
+          sat: 23
+      - D:
+          f: 247
+          i: -1965
+        L:
+          f: 55
+          i: 121830236
+        P: 1159176175
+        cn0: 174
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 26
+      - D:
+          f: 124
+          i: -1467
+        L:
+          f: 222
+          i: 90976794
+        P: 1159171491
+        cn0: 182
+        flags: 15
+        lock: 8
+        sid:
+          code: 10
+          sat: 26
+      - D:
+          f: 87
+          i: 3307
+        L:
+          f: 10
+          i: 125646171
+        P: 1195483584
+        cn0: 156
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 27
+      - D:
+          f: 50
+          i: -3000
+        L:
+          f: 50
+          i: 117190367
+        P: 1115029287
+        cn0: 184
+        flags: 15
+        lock: 8
+        sid:
+          code: 0
+          sat: 29
+      - D:
+          f: 99
+          i: 250
+        L:
+          f: 120
+          i: 93945435
+        P: 893861103
+        cn0: 195
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 18
+      - D:
+          f: 3
+          i: 187
+        L:
+          f: 216
+          i: 70154297
+        P: 893864144
+        cn0: 189
+        flags: 15
+        lock: 8
+        sid:
+          code: 27
+          sat: 18
+      - D:
+          f: 223
+          i: 2860
+        L:
+          f: 171
+          i: 135123468
+        P: 1285657053
+        cn0: 156
+        flags: 15
+        lock: 8
+        sid:
+          code: 16
+          sat: 19
+    module: sbp.observation
+    name: MsgObs
+  msg_type: '0x4a'
+  raw_json: '{"preamble": 85, "msg_type": 74, "sender": 51228, "length": 249, "payload":
+    "8GnOHQAAAABKCCBtIv5B45XvBhIMCVLCCA8KAJx3f0DvXccGgpL9kLYIDw8AmFwaRQBFQweKtv96jwgPEADZ5zc93SBvBlLS/rfECA8SAOyoWjwV4FcGVpICqMAIDxQAb6vGPCo6YwYyTwPzwAgPFwC3ocY8tBvFBOJ3AgNeBw8XCu+fF0Vc+0IHN1P4964IDxoAo40XRRoybAXeRfp8tggPGgrAoUFHWzV9BwrrDFecCA8bACf/dULfLvwGMkj0MrgIDx0A7zxHNVt+mQV4+gBjwwgPEhDQSEc1OXguBNi7AAO9CA8SG92RoUwM0g0IqywL35wIDxMQ",
+    "crc": 51241, "header": {"t": {"tow": 500066800, "ns_residual": 0, "wn": 2122},
+    "n_obs": 32}, "obs": [{"P": 1107173997, "L": {"i": 116364771, "f": 18}, "D": {"i":
+    2316, "f": 82}, "cn0": 194, "lock": 8, "flags": 15, "sid": {"sat": 10, "code":
+    0}}, {"P": 1082095516, "L": {"i": 113729007, "f": 130}, "D": {"i": -622, "f":
+    144}, "cn0": 182, "lock": 8, "flags": 15, "sid": {"sat": 15, "code": 0}}, {"P":
+    1159355544, "L": {"i": 121849088, "f": 138}, "D": {"i": -74, "f": 122}, "cn0":
+    143, "lock": 8, "flags": 15, "sid": {"sat": 16, "code": 0}}, {"P": 1027074009,
+    "L": {"i": 107946205, "f": 82}, "D": {"i": -302, "f": 183}, "cn0": 196, "lock":
+    8, "flags": 15, "sid": {"sat": 18, "code": 0}}, {"P": 1012574444, "L": {"i": 106422293,
+    "f": 86}, "D": {"i": 658, "f": 168}, "cn0": 192, "lock": 8, "flags": 15, "sid":
+    {"sat": 20, "code": 0}}, {"P": 1019652975, "L": {"i": 107166250, "f": 50}, "D":
+    {"i": 847, "f": 243}, "cn0": 192, "lock": 8, "flags": 15, "sid": {"sat": 23, "code":
+    0}}, {"P": 1019650487, "L": {"i": 80026548, "f": 226}, "D": {"i": 631, "f": 3},
+    "cn0": 94, "lock": 7, "flags": 15, "sid": {"sat": 23, "code": 10}}, {"P": 1159176175,
+    "L": {"i": 121830236, "f": 55}, "D": {"i": -1965, "f": 247}, "cn0": 174, "lock":
+    8, "flags": 15, "sid": {"sat": 26, "code": 0}}, {"P": 1159171491, "L": {"i": 90976794,
+    "f": 222}, "D": {"i": -1467, "f": 124}, "cn0": 182, "lock": 8, "flags": 15, "sid":
+    {"sat": 26, "code": 10}}, {"P": 1195483584, "L": {"i": 125646171, "f": 10}, "D":
+    {"i": 3307, "f": 87}, "cn0": 156, "lock": 8, "flags": 15, "sid": {"sat": 27, "code":
+    0}}, {"P": 1115029287, "L": {"i": 117190367, "f": 50}, "D": {"i": -3000, "f":
+    50}, "cn0": 184, "lock": 8, "flags": 15, "sid": {"sat": 29, "code": 0}}, {"P":
+    893861103, "L": {"i": 93945435, "f": 120}, "D": {"i": 250, "f": 99}, "cn0": 195,
+    "lock": 8, "flags": 15, "sid": {"sat": 18, "code": 16}}, {"P": 893864144, "L":
+    {"i": 70154297, "f": 216}, "D": {"i": 187, "f": 3}, "cn0": 189, "lock": 8, "flags":
+    15, "sid": {"sat": 18, "code": 27}}, {"P": 1285657053, "L": {"i": 135123468, "f":
+    171}, "D": {"i": 2860, "f": 223}, "cn0": 156, "lock": 8, "flags": 15, "sid": {"sat":
+    19, "code": 16}}]}'
+  raw_packet: VUoAHMj58GnOHQAAAABKCCBtIv5B45XvBhIMCVLCCA8KAJx3f0DvXccGgpL9kLYIDw8AmFwaRQBFQweKtv96jwgPEADZ5zc93SBvBlLS/rfECA8SAOyoWjwV4FcGVpICqMAIDxQAb6vGPCo6YwYyTwPzwAgPFwC3ocY8tBvFBOJ3AgNeBw8XCu+fF0Vc+0IHN1P4964IDxoAo40XRRoybAXeRfp8tggPGgrAoUFHWzV9BwrrDFecCA8bACf/dULfLvwGMkj0MrgIDx0A7zxHNVt+mQV4+gBjwwgPEhDQSEc1OXguBNi7AAO9CA8SG92RoUwM0g0IqywL35wIDxMQKcg=
+  sbp:
+    crc: '0xc829'
+    length: 249
+    msg_type: '0x4a'
+    payload: 8GnOHQAAAABKCCBtIv5B45XvBhIMCVLCCA8KAJx3f0DvXccGgpL9kLYIDw8AmFwaRQBFQweKtv96jwgPEADZ5zc93SBvBlLS/rfECA8SAOyoWjwV4FcGVpICqMAIDxQAb6vGPCo6YwYyTwPzwAgPFwC3ocY8tBvFBOJ3AgNeBw8XCu+fF0Vc+0IHN1P4964IDxoAo40XRRoybAXeRfp8tggPGgrAoUFHWzV9BwrrDFecCA8bACf/dULfLvwGMkj0MrgIDx0A7zxHNVt+mQV4+gBjwwgPEhDQSEc1OXguBNi7AAO9CA8SG92RoUwM0g0IqywL35wIDxMQ
+    preamble: '0x55'
+    sender: '0xc81c'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/observation/test_MsgOsr.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/observation/test_MsgOsr.yaml
@@ -1,0 +1,809 @@
+---
+description: Unit tests for swiftnav.sbp.observation MsgOsr v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.734948
+package: sbp.observation
+tests:
+
+- msg:
+    fields:
+      header:
+        n_obs: 48
+        t:
+          ns_residual: 0
+          tow: 500067000
+          wn: 2122
+      obs:
+      - L:
+          f: 50
+          i: 116151947
+        P: 1105149520
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 4
+        sid:
+          code: 0
+          sat: 10
+        tropo_std: 4
+      - L:
+          f: 127
+          i: 125017303
+        P: 1189500172
+        flags: 3
+        iono_std: 23
+        lock: 15
+        range_std: 8
+        sid:
+          code: 0
+          sat: 13
+        tropo_std: 8
+      - L:
+          f: 201
+          i: 113832765
+        P: 1083082776
+        flags: 3
+        iono_std: 14
+        lock: 15
+        range_std: 4
+        sid:
+          code: 0
+          sat: 15
+        tropo_std: 4
+      - L:
+          f: 187
+          i: 122025164
+        P: 1161030963
+        flags: 3
+        iono_std: 19
+        lock: 15
+        range_std: 5
+        sid:
+          code: 0
+          sat: 16
+        tropo_std: 5
+      - L:
+          f: 235
+          i: 106426926
+        P: 1012618628
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 3
+        sid:
+          code: 0
+          sat: 20
+        tropo_std: 3
+      - L:
+          f: 109
+          i: 121679544
+        P: 1157743089
+        flags: 3
+        iono_std: 15
+        lock: 15
+        range_std: 6
+        sid:
+          code: 0
+          sat: 26
+        tropo_std: 6
+      - L:
+          f: 54
+          i: 126017004
+        P: 1199012469
+        flags: 3
+        iono_std: 21
+        lock: 15
+        range_std: 8
+        sid:
+          code: 0
+          sat: 27
+        tropo_std: 8
+      - L:
+          f: 51
+          i: 116857049
+        P: 1111857937
+        flags: 3
+        iono_std: 15
+        lock: 15
+        range_std: 4
+        sid:
+          code: 0
+          sat: 29
+        tropo_std: 4
+      - L:
+          f: 142
+          i: 86736835
+        P: 1105149525
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 4
+        sid:
+          code: 9
+          sat: 10
+        tropo_std: 4
+      - L:
+          f: 99
+          i: 90864581
+        P: 1157743179
+        flags: 3
+        iono_std: 26
+        lock: 15
+        range_std: 6
+        sid:
+          code: 9
+          sat: 26
+        tropo_std: 6
+      - L:
+          f: 199
+          i: 94103597
+        P: 1199012562
+        flags: 3
+        iono_std: 37
+        lock: 15
+        range_std: 8
+        sid:
+          code: 9
+          sat: 27
+        tropo_std: 8
+      - L:
+          f: 46
+          i: 136731388
+        P: 1300956156
+        flags: 3
+        iono_std: 16
+        lock: 15
+        range_std: 5
+        sid:
+          code: 14
+          sat: 7
+        tropo_std: 5
+    module: sbp.observation
+    name: MsgOsr
+  msg_type: '0x640'
+  raw_json: '{"preamble": 85, "msg_type": 1600, "sender": 0, "length": 239, "payload":
+    "uGrOHQAAAABKCDBQPt9Bi1bsBjIPAwoAAAAEAAQADFXmRteccwd/DwMNABcACAAIABiIjkA988gGyQ8DDwAOAAQABAAz7TNFzPRFB7sPAxAAEwAFAAUAhFVbPC7yVwbrDwMUAAAAAwADAPHBAUW4rkAHbQ8DGgAPAAYABgB1endH7N2CBzYPAxsAFQAIAAgAEZtFQtkY9wYzDwMdAA8ABAAEAFU+30HDfysFjg8DCgkAAAQABABLwgFFxXtqBWMPAxoJGgAGAAYA0np3Ry3omwXHDwMbCSUACAAIAPwDi038WiYILg8DBw4QAAUABQA=",
+    "crc": 23746, "header": {"t": {"tow": 500067000, "ns_residual": 0, "wn": 2122},
+    "n_obs": 48}, "obs": [{"P": 1105149520, "L": {"i": 116151947, "f": 50}, "lock":
+    15, "flags": 3, "sid": {"sat": 10, "code": 0}, "iono_std": 0, "tropo_std": 4,
+    "range_std": 4}, {"P": 1189500172, "L": {"i": 125017303, "f": 127}, "lock": 15,
+    "flags": 3, "sid": {"sat": 13, "code": 0}, "iono_std": 23, "tropo_std": 8, "range_std":
+    8}, {"P": 1083082776, "L": {"i": 113832765, "f": 201}, "lock": 15, "flags": 3,
+    "sid": {"sat": 15, "code": 0}, "iono_std": 14, "tropo_std": 4, "range_std": 4},
+    {"P": 1161030963, "L": {"i": 122025164, "f": 187}, "lock": 15, "flags": 3, "sid":
+    {"sat": 16, "code": 0}, "iono_std": 19, "tropo_std": 5, "range_std": 5}, {"P":
+    1012618628, "L": {"i": 106426926, "f": 235}, "lock": 15, "flags": 3, "sid": {"sat":
+    20, "code": 0}, "iono_std": 0, "tropo_std": 3, "range_std": 3}, {"P": 1157743089,
+    "L": {"i": 121679544, "f": 109}, "lock": 15, "flags": 3, "sid": {"sat": 26, "code":
+    0}, "iono_std": 15, "tropo_std": 6, "range_std": 6}, {"P": 1199012469, "L": {"i":
+    126017004, "f": 54}, "lock": 15, "flags": 3, "sid": {"sat": 27, "code": 0}, "iono_std":
+    21, "tropo_std": 8, "range_std": 8}, {"P": 1111857937, "L": {"i": 116857049, "f":
+    51}, "lock": 15, "flags": 3, "sid": {"sat": 29, "code": 0}, "iono_std": 15, "tropo_std":
+    4, "range_std": 4}, {"P": 1105149525, "L": {"i": 86736835, "f": 142}, "lock":
+    15, "flags": 3, "sid": {"sat": 10, "code": 9}, "iono_std": 0, "tropo_std": 4,
+    "range_std": 4}, {"P": 1157743179, "L": {"i": 90864581, "f": 99}, "lock": 15,
+    "flags": 3, "sid": {"sat": 26, "code": 9}, "iono_std": 26, "tropo_std": 6, "range_std":
+    6}, {"P": 1199012562, "L": {"i": 94103597, "f": 199}, "lock": 15, "flags": 3,
+    "sid": {"sat": 27, "code": 9}, "iono_std": 37, "tropo_std": 8, "range_std": 8},
+    {"P": 1300956156, "L": {"i": 136731388, "f": 46}, "lock": 15, "flags": 3, "sid":
+    {"sat": 7, "code": 14}, "iono_std": 16, "tropo_std": 5, "range_std": 5}]}'
+  raw_packet: VUAGAADvuGrOHQAAAABKCDBQPt9Bi1bsBjIPAwoAAAAEAAQADFXmRteccwd/DwMNABcACAAIABiIjkA988gGyQ8DDwAOAAQABAAz7TNFzPRFB7sPAxAAEwAFAAUAhFVbPC7yVwbrDwMUAAAAAwADAPHBAUW4rkAHbQ8DGgAPAAYABgB1endH7N2CBzYPAxsAFQAIAAgAEZtFQtkY9wYzDwMdAA8ABAAEAFU+30HDfysFjg8DCgkAAAQABABLwgFFxXtqBWMPAxoJGgAGAAYA0np3Ry3omwXHDwMbCSUACAAIAPwDi038WiYILg8DBw4QAAUABQDCXA==
+  sbp:
+    crc: '0x5cc2'
+    length: 239
+    msg_type: '0x640'
+    payload: uGrOHQAAAABKCDBQPt9Bi1bsBjIPAwoAAAAEAAQADFXmRteccwd/DwMNABcACAAIABiIjkA988gGyQ8DDwAOAAQABAAz7TNFzPRFB7sPAxAAEwAFAAUAhFVbPC7yVwbrDwMUAAAAAwADAPHBAUW4rkAHbQ8DGgAPAAYABgB1endH7N2CBzYPAxsAFQAIAAgAEZtFQtkY9wYzDwMdAA8ABAAEAFU+30HDfysFjg8DCgkAAAQABABLwgFFxXtqBWMPAxoJGgAGAAYA0np3Ry3omwXHDwMbCSUACAAIAPwDi038WiYILg8DBw4QAAUABQA=
+    preamble: '0x55'
+    sender: '0x0'
+
+- msg:
+    fields:
+      header:
+        n_obs: 49
+        t:
+          ns_residual: 0
+          tow: 500067000
+          wn: 2122
+      obs:
+      - L:
+          f: 155
+          i: 129213369
+        P: 1229424282
+        flags: 3
+        iono_std: 18
+        lock: 15
+        range_std: 6
+        sid:
+          code: 14
+          sat: 12
+        tropo_std: 6
+      - L:
+          f: 1
+          i: 134680566
+        P: 1281443030
+        flags: 3
+        iono_std: 16
+        lock: 15
+        range_std: 5
+        sid:
+          code: 14
+          sat: 19
+        tropo_std: 5
+      - L:
+          f: 132
+          i: 136348058
+        P: 1297310494
+        flags: 3
+        iono_std: 27
+        lock: 15
+        range_std: 10
+        sid:
+          code: 14
+          sat: 24
+        tropo_std: 10
+      - L:
+          f: 117
+          i: 127470589
+        P: 1212842668
+        flags: 3
+        iono_std: 14
+        lock: 15
+        range_std: 4
+        sid:
+          code: 14
+          sat: 26
+        tropo_std: 4
+      - L:
+          f: 239
+          i: 143024215
+        P: 1360830624
+        flags: 3
+        iono_std: 24
+        lock: 15
+        range_std: 8
+        sid:
+          code: 14
+          sat: 31
+        tropo_std: 8
+      - L:
+          f: 124
+          i: 124948083
+        P: 1188841423
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 3
+        sid:
+          code: 14
+          sat: 33
+        tropo_std: 3
+      - L:
+          f: 20
+          i: 102104602
+        P: 1300956492
+        flags: 3
+        iono_std: 29
+        lock: 15
+        range_std: 5
+        sid:
+          code: 26
+          sat: 7
+        tropo_std: 5
+      - L:
+          f: 121
+          i: 96490498
+        P: 1229424446
+        flags: 3
+        iono_std: 32
+        lock: 15
+        range_std: 6
+        sid:
+          code: 26
+          sat: 12
+        tropo_std: 6
+      - L:
+          f: 30
+          i: 100573145
+        P: 1281443278
+        flags: 3
+        iono_std: 28
+        lock: 15
+        range_std: 5
+        sid:
+          code: 26
+          sat: 19
+        tropo_std: 5
+      - L:
+          f: 15
+          i: 101818322
+        P: 1297311454
+        flags: 3
+        iono_std: 48
+        lock: 15
+        range_std: 10
+        sid:
+          code: 26
+          sat: 24
+        tropo_std: 10
+      - L:
+          f: 82
+          i: 95189069
+        P: 1212843012
+        flags: 3
+        iono_std: 24
+        lock: 15
+        range_std: 4
+        sid:
+          code: 26
+          sat: 26
+        tropo_std: 4
+      - L:
+          f: 32
+          i: 106803785
+        P: 1360831014
+        flags: 3
+        iono_std: 43
+        lock: 15
+        range_std: 8
+        sid:
+          code: 26
+          sat: 31
+        tropo_std: 8
+    module: sbp.observation
+    name: MsgOsr
+  msg_type: '0x640'
+  raw_json: '{"preamble": 85, "msg_type": 1600, "sender": 0, "length": 239, "payload":
+    "uGrOHQAAAABKCDGahkdJuaOzB5sPAwwOEgAGAAYA1kRhTPYPBwgBDwMTDhAABQAFAB5jU02agSAIhA8DGA4bAAoACgCsgkpI/QuZB3UPAxoODgAEAAQAoKAcUVdghgjvDwMfDhgACAAIAM9H3EZzjnIHfA8DIQ4AAAMAAwBMBYtNGv4VBhQPAwcaHQAFAAUAPodHSQJUwAV5DwMMGiAABgAGAM5FYUzZn/4FHg8DExocAAUABQDeZlNN0p8RBg8PAxgaMAAKAAoABIRKSE14rAVSDwMaGhgABAAEACaiHFFJsl0GIA8DHxorAAgACAA=",
+    "crc": 60993, "header": {"t": {"tow": 500067000, "ns_residual": 0, "wn": 2122},
+    "n_obs": 49}, "obs": [{"P": 1229424282, "L": {"i": 129213369, "f": 155}, "lock":
+    15, "flags": 3, "sid": {"sat": 12, "code": 14}, "iono_std": 18, "tropo_std": 6,
+    "range_std": 6}, {"P": 1281443030, "L": {"i": 134680566, "f": 1}, "lock": 15,
+    "flags": 3, "sid": {"sat": 19, "code": 14}, "iono_std": 16, "tropo_std": 5, "range_std":
+    5}, {"P": 1297310494, "L": {"i": 136348058, "f": 132}, "lock": 15, "flags": 3,
+    "sid": {"sat": 24, "code": 14}, "iono_std": 27, "tropo_std": 10, "range_std":
+    10}, {"P": 1212842668, "L": {"i": 127470589, "f": 117}, "lock": 15, "flags": 3,
+    "sid": {"sat": 26, "code": 14}, "iono_std": 14, "tropo_std": 4, "range_std": 4},
+    {"P": 1360830624, "L": {"i": 143024215, "f": 239}, "lock": 15, "flags": 3, "sid":
+    {"sat": 31, "code": 14}, "iono_std": 24, "tropo_std": 8, "range_std": 8}, {"P":
+    1188841423, "L": {"i": 124948083, "f": 124}, "lock": 15, "flags": 3, "sid": {"sat":
+    33, "code": 14}, "iono_std": 0, "tropo_std": 3, "range_std": 3}, {"P": 1300956492,
+    "L": {"i": 102104602, "f": 20}, "lock": 15, "flags": 3, "sid": {"sat": 7, "code":
+    26}, "iono_std": 29, "tropo_std": 5, "range_std": 5}, {"P": 1229424446, "L": {"i":
+    96490498, "f": 121}, "lock": 15, "flags": 3, "sid": {"sat": 12, "code": 26}, "iono_std":
+    32, "tropo_std": 6, "range_std": 6}, {"P": 1281443278, "L": {"i": 100573145, "f":
+    30}, "lock": 15, "flags": 3, "sid": {"sat": 19, "code": 26}, "iono_std": 28, "tropo_std":
+    5, "range_std": 5}, {"P": 1297311454, "L": {"i": 101818322, "f": 15}, "lock":
+    15, "flags": 3, "sid": {"sat": 24, "code": 26}, "iono_std": 48, "tropo_std": 10,
+    "range_std": 10}, {"P": 1212843012, "L": {"i": 95189069, "f": 82}, "lock": 15,
+    "flags": 3, "sid": {"sat": 26, "code": 26}, "iono_std": 24, "tropo_std": 4, "range_std":
+    4}, {"P": 1360831014, "L": {"i": 106803785, "f": 32}, "lock": 15, "flags": 3,
+    "sid": {"sat": 31, "code": 26}, "iono_std": 43, "tropo_std": 8, "range_std": 8}]}'
+  raw_packet: VUAGAADvuGrOHQAAAABKCDGahkdJuaOzB5sPAwwOEgAGAAYA1kRhTPYPBwgBDwMTDhAABQAFAB5jU02agSAIhA8DGA4bAAoACgCsgkpI/QuZB3UPAxoODgAEAAQAoKAcUVdghgjvDwMfDhgACAAIAM9H3EZzjnIHfA8DIQ4AAAMAAwBMBYtNGv4VBhQPAwcaHQAFAAUAPodHSQJUwAV5DwMMGiAABgAGAM5FYUzZn/4FHg8DExocAAUABQDeZlNN0p8RBg8PAxgaMAAKAAoABIRKSE14rAVSDwMaGhgABAAEACaiHFFJsl0GIA8DHxorAAgACABB7g==
+  sbp:
+    crc: '0xee41'
+    length: 239
+    msg_type: '0x640'
+    payload: uGrOHQAAAABKCDGahkdJuaOzB5sPAwwOEgAGAAYA1kRhTPYPBwgBDwMTDhAABQAFAB5jU02agSAIhA8DGA4bAAoACgCsgkpI/QuZB3UPAxoODgAEAAQAoKAcUVdghgjvDwMfDhgACAAIAM9H3EZzjnIHfA8DIQ4AAAMAAwBMBYtNGv4VBhQPAwcaHQAFAAUAPodHSQJUwAV5DwMMGiAABgAGAM5FYUzZn/4FHg8DExocAAUABQDeZlNN0p8RBg8PAxgaMAAKAAoABIRKSE14rAVSDwMaGhgABAAEACaiHFFJsl0GIA8DHxorAAgACAA=
+    preamble: '0x55'
+    sender: '0x0'
+
+- msg:
+    fields:
+      header:
+        n_obs: 50
+        t:
+          ns_residual: 0
+          tow: 500067000
+          wn: 2122
+      obs:
+      - L:
+          f: 167
+          i: 93305386
+        P: 1188841619
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 3
+        sid:
+          code: 26
+          sat: 33
+        tropo_std: 3
+    module: sbp.observation
+    name: MsgOsr
+  msg_type: '0x640'
+  raw_json: '{"preamble": 85, "msg_type": 1600, "sender": 0, "length": 30, "payload":
+    "uGrOHQAAAABKCDKTSNxGKrqPBacPAyEaAAADAAMA", "crc": 43772, "header": {"t": {"tow":
+    500067000, "ns_residual": 0, "wn": 2122}, "n_obs": 50}, "obs": [{"P": 1188841619,
+    "L": {"i": 93305386, "f": 167}, "lock": 15, "flags": 3, "sid": {"sat": 33, "code":
+    26}, "iono_std": 0, "tropo_std": 3, "range_std": 3}]}'
+  raw_packet: VUAGAAAeuGrOHQAAAABKCDKTSNxGKrqPBacPAyEaAAADAAMA/Ko=
+  sbp:
+    crc: '0xaafc'
+    length: 30
+    msg_type: '0x640'
+    payload: uGrOHQAAAABKCDKTSNxGKrqPBacPAyEaAAADAAMA
+    preamble: '0x55'
+    sender: '0x0'
+
+- msg:
+    fields:
+      header:
+        n_obs: 48
+        t:
+          ns_residual: 0
+          tow: 500068000
+          wn: 2122
+      obs:
+      - L:
+          f: 34
+          i: 116149690
+        P: 1105128044
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 4
+        sid:
+          code: 0
+          sat: 10
+        tropo_std: 4
+      - L:
+          f: 248
+          i: 125019015
+        P: 1189516465
+        flags: 3
+        iono_std: 23
+        lock: 15
+        range_std: 8
+        sid:
+          code: 0
+          sat: 13
+        tropo_std: 8
+      - L:
+          f: 82
+          i: 113833457
+        P: 1083089356
+        flags: 3
+        iono_std: 14
+        lock: 15
+        range_std: 4
+        sid:
+          code: 0
+          sat: 15
+        tropo_std: 4
+      - L:
+          f: 184
+          i: 122025174
+        P: 1161031058
+        flags: 3
+        iono_std: 19
+        lock: 15
+        range_std: 5
+        sid:
+          code: 0
+          sat: 16
+        tropo_std: 5
+      - L:
+          f: 96
+          i: 106426329
+        P: 1012612942
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 3
+        sid:
+          code: 0
+          sat: 20
+        tropo_std: 3
+      - L:
+          f: 152
+          i: 121681446
+        P: 1157761187
+        flags: 3
+        iono_std: 15
+        lock: 15
+        range_std: 6
+        sid:
+          code: 0
+          sat: 26
+        tropo_std: 6
+      - L:
+          f: 49
+          i: 126013682
+        P: 1198980861
+        flags: 3
+        iono_std: 21
+        lock: 15
+        range_std: 8
+        sid:
+          code: 0
+          sat: 27
+        tropo_std: 8
+      - L:
+          f: 117
+          i: 116859996
+        P: 1111885979
+        flags: 3
+        iono_std: 15
+        lock: 15
+        range_std: 4
+        sid:
+          code: 0
+          sat: 29
+        tropo_std: 4
+      - L:
+          f: 23
+          i: 86735150
+        P: 1105128049
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 4
+        sid:
+          code: 9
+          sat: 10
+        tropo_std: 4
+      - L:
+          f: 214
+          i: 90866001
+        P: 1157761278
+        flags: 3
+        iono_std: 26
+        lock: 15
+        range_std: 6
+        sid:
+          code: 9
+          sat: 26
+        tropo_std: 6
+      - L:
+          f: 13
+          i: 94101117
+        P: 1198980954
+        flags: 3
+        iono_std: 38
+        lock: 15
+        range_std: 8
+        sid:
+          code: 9
+          sat: 27
+        tropo_std: 8
+      - L:
+          f: 172
+          i: 136733083
+        P: 1300972289
+        flags: 3
+        iono_std: 16
+        lock: 15
+        range_std: 5
+        sid:
+          code: 14
+          sat: 7
+        tropo_std: 5
+    module: sbp.observation
+    name: MsgOsr
+  msg_type: '0x640'
+  raw_json: '{"preamble": 85, "msg_type": 1600, "sender": 0, "length": 239, "payload":
+    "oG7OHQAAAABKCDBs6t5Buk3sBiIPAwoAAAAEAAQAsZTmRoejcwf4DwMNABcACAAIAMyhjkDx9cgGUg8DDwAOAAQABACS7TNF1vRFB7gPAxAAEwAFAAUATj9bPNnvVwZgDwMUAAAAAwADAKMIAkUmtkAHmA8DGgAPAAYABgD9/nZH8tCCBzEPAxsAFQAIAAgAmwhGQlwk9wZ1DwMdAA8ABAAEAHHq3kEueSsFFw8DCgkAAAQABAD+CAJFUYFqBdYPAxoJGgAGAAYAWv92R33emwUNDwMbCSYACAAIAAFDi02bYSYIrA8DBw4QAAUABQA=",
+    "crc": 17042, "header": {"t": {"tow": 500068000, "ns_residual": 0, "wn": 2122},
+    "n_obs": 48}, "obs": [{"P": 1105128044, "L": {"i": 116149690, "f": 34}, "lock":
+    15, "flags": 3, "sid": {"sat": 10, "code": 0}, "iono_std": 0, "tropo_std": 4,
+    "range_std": 4}, {"P": 1189516465, "L": {"i": 125019015, "f": 248}, "lock": 15,
+    "flags": 3, "sid": {"sat": 13, "code": 0}, "iono_std": 23, "tropo_std": 8, "range_std":
+    8}, {"P": 1083089356, "L": {"i": 113833457, "f": 82}, "lock": 15, "flags": 3,
+    "sid": {"sat": 15, "code": 0}, "iono_std": 14, "tropo_std": 4, "range_std": 4},
+    {"P": 1161031058, "L": {"i": 122025174, "f": 184}, "lock": 15, "flags": 3, "sid":
+    {"sat": 16, "code": 0}, "iono_std": 19, "tropo_std": 5, "range_std": 5}, {"P":
+    1012612942, "L": {"i": 106426329, "f": 96}, "lock": 15, "flags": 3, "sid": {"sat":
+    20, "code": 0}, "iono_std": 0, "tropo_std": 3, "range_std": 3}, {"P": 1157761187,
+    "L": {"i": 121681446, "f": 152}, "lock": 15, "flags": 3, "sid": {"sat": 26, "code":
+    0}, "iono_std": 15, "tropo_std": 6, "range_std": 6}, {"P": 1198980861, "L": {"i":
+    126013682, "f": 49}, "lock": 15, "flags": 3, "sid": {"sat": 27, "code": 0}, "iono_std":
+    21, "tropo_std": 8, "range_std": 8}, {"P": 1111885979, "L": {"i": 116859996, "f":
+    117}, "lock": 15, "flags": 3, "sid": {"sat": 29, "code": 0}, "iono_std": 15, "tropo_std":
+    4, "range_std": 4}, {"P": 1105128049, "L": {"i": 86735150, "f": 23}, "lock": 15,
+    "flags": 3, "sid": {"sat": 10, "code": 9}, "iono_std": 0, "tropo_std": 4, "range_std":
+    4}, {"P": 1157761278, "L": {"i": 90866001, "f": 214}, "lock": 15, "flags": 3,
+    "sid": {"sat": 26, "code": 9}, "iono_std": 26, "tropo_std": 6, "range_std": 6},
+    {"P": 1198980954, "L": {"i": 94101117, "f": 13}, "lock": 15, "flags": 3, "sid":
+    {"sat": 27, "code": 9}, "iono_std": 38, "tropo_std": 8, "range_std": 8}, {"P":
+    1300972289, "L": {"i": 136733083, "f": 172}, "lock": 15, "flags": 3, "sid": {"sat":
+    7, "code": 14}, "iono_std": 16, "tropo_std": 5, "range_std": 5}]}'
+  raw_packet: VUAGAADvoG7OHQAAAABKCDBs6t5Buk3sBiIPAwoAAAAEAAQAsZTmRoejcwf4DwMNABcACAAIAMyhjkDx9cgGUg8DDwAOAAQABACS7TNF1vRFB7gPAxAAEwAFAAUATj9bPNnvVwZgDwMUAAAAAwADAKMIAkUmtkAHmA8DGgAPAAYABgD9/nZH8tCCBzEPAxsAFQAIAAgAmwhGQlwk9wZ1DwMdAA8ABAAEAHHq3kEueSsFFw8DCgkAAAQABAD+CAJFUYFqBdYPAxoJGgAGAAYAWv92R33emwUNDwMbCSYACAAIAAFDi02bYSYIrA8DBw4QAAUABQCSQg==
+  sbp:
+    crc: '0x4292'
+    length: 239
+    msg_type: '0x640'
+    payload: oG7OHQAAAABKCDBs6t5Buk3sBiIPAwoAAAAEAAQAsZTmRoejcwf4DwMNABcACAAIAMyhjkDx9cgGUg8DDwAOAAQABACS7TNF1vRFB7gPAxAAEwAFAAUATj9bPNnvVwZgDwMUAAAAAwADAKMIAkUmtkAHmA8DGgAPAAYABgD9/nZH8tCCBzEPAxsAFQAIAAgAmwhGQlwk9wZ1DwMdAA8ABAAEAHHq3kEueSsFFw8DCgkAAAQABAD+CAJFUYFqBdYPAxoJGgAGAAYAWv92R33emwUNDwMbCSYACAAIAAFDi02bYSYIrA8DBw4QAAUABQA=
+    preamble: '0x55'
+    sender: '0x0'
+
+- msg:
+    fields:
+      header:
+        n_obs: 49
+        t:
+          ns_residual: 0
+          tow: 500068000
+          wn: 2122
+      obs:
+      - L:
+          f: 21
+          i: 129211360
+        P: 1229405162
+        flags: 3
+        iono_std: 18
+        lock: 15
+        range_std: 6
+        sid:
+          code: 14
+          sat: 12
+        tropo_std: 6
+      - L:
+          f: 93
+          i: 134677736
+        P: 1281416107
+        flags: 3
+        iono_std: 16
+        lock: 15
+        range_std: 5
+        sid:
+          code: 14
+          sat: 19
+        tropo_std: 5
+      - L:
+          f: 124
+          i: 136348546
+        P: 1297315137
+        flags: 3
+        iono_std: 27
+        lock: 15
+        range_std: 10
+        sid:
+          code: 14
+          sat: 24
+        tropo_std: 10
+      - L:
+          f: 82
+          i: 127471916
+        P: 1212855293
+        flags: 3
+        iono_std: 14
+        lock: 15
+        range_std: 4
+        sid:
+          code: 14
+          sat: 26
+        tropo_std: 4
+      - L:
+          f: 249
+          i: 143026439
+        P: 1360851786
+        flags: 3
+        iono_std: 24
+        lock: 15
+        range_std: 8
+        sid:
+          code: 14
+          sat: 31
+        tropo_std: 8
+      - L:
+          f: 103
+          i: 124947513
+        P: 1188835998
+        flags: 3
+        iono_std: 0
+        lock: 15
+        range_std: 3
+        sid:
+          code: 14
+          sat: 33
+        tropo_std: 3
+      - L:
+          f: 49
+          i: 102105868
+        P: 1300972624
+        flags: 3
+        iono_std: 29
+        lock: 15
+        range_std: 5
+        sid:
+          code: 26
+          sat: 7
+        tropo_std: 5
+      - L:
+          f: 219
+          i: 96488997
+        P: 1229405326
+        flags: 3
+        iono_std: 32
+        lock: 15
+        range_std: 6
+        sid:
+          code: 26
+          sat: 12
+        tropo_std: 6
+      - L:
+          f: 19
+          i: 100571032
+        P: 1281416355
+        flags: 3
+        iono_std: 28
+        lock: 15
+        range_std: 5
+        sid:
+          code: 26
+          sat: 19
+        tropo_std: 5
+      - L:
+          f: 116
+          i: 101818686
+        P: 1297316097
+        flags: 3
+        iono_std: 48
+        lock: 15
+        range_std: 10
+        sid:
+          code: 26
+          sat: 24
+        tropo_std: 10
+      - L:
+          f: 40
+          i: 95190060
+        P: 1212855637
+        flags: 3
+        iono_std: 24
+        lock: 15
+        range_std: 4
+        sid:
+          code: 26
+          sat: 26
+        tropo_std: 4
+      - L:
+          f: 239
+          i: 106805445
+        P: 1360852176
+        flags: 3
+        iono_std: 43
+        lock: 15
+        range_std: 8
+        sid:
+          code: 26
+          sat: 31
+        tropo_std: 8
+    module: sbp.observation
+    name: MsgOsr
+  msg_type: '0x640'
+  raw_json: '{"preamble": 85, "msg_type": 1600, "sender": 0, "length": 239, "payload":
+    "oG7OHQAAAABKCDHqO0dJ4JuzBxUPAwwOEgAGAAYAq9tgTOgEBwhdDwMTDhAABQAFAEF1U02CgyAIfA8DGA4bAAoACgD9s0pILBGZB1IPAxoODgAEAAQASvMcUQdphgj5DwMfDhgACAAIAJ4y3EY5jHIHZw8DIQ4AAAMAAwBQRItNDAMWBjEPAwcaHQAFAAUAjjxHSSVOwAXbDwMMGiAABgAGAKPcYEyYl/4FEw8DExocAAUABQABeVNNPqERBnQPAxgaMAAKAAoAVbVKSCx8rAUoDwMaGhgABAAEAND0HFHFuF0G7w8DHxorAAgACAA=",
+    "crc": 26582, "header": {"t": {"tow": 500068000, "ns_residual": 0, "wn": 2122},
+    "n_obs": 49}, "obs": [{"P": 1229405162, "L": {"i": 129211360, "f": 21}, "lock":
+    15, "flags": 3, "sid": {"sat": 12, "code": 14}, "iono_std": 18, "tropo_std": 6,
+    "range_std": 6}, {"P": 1281416107, "L": {"i": 134677736, "f": 93}, "lock": 15,
+    "flags": 3, "sid": {"sat": 19, "code": 14}, "iono_std": 16, "tropo_std": 5, "range_std":
+    5}, {"P": 1297315137, "L": {"i": 136348546, "f": 124}, "lock": 15, "flags": 3,
+    "sid": {"sat": 24, "code": 14}, "iono_std": 27, "tropo_std": 10, "range_std":
+    10}, {"P": 1212855293, "L": {"i": 127471916, "f": 82}, "lock": 15, "flags": 3,
+    "sid": {"sat": 26, "code": 14}, "iono_std": 14, "tropo_std": 4, "range_std": 4},
+    {"P": 1360851786, "L": {"i": 143026439, "f": 249}, "lock": 15, "flags": 3, "sid":
+    {"sat": 31, "code": 14}, "iono_std": 24, "tropo_std": 8, "range_std": 8}, {"P":
+    1188835998, "L": {"i": 124947513, "f": 103}, "lock": 15, "flags": 3, "sid": {"sat":
+    33, "code": 14}, "iono_std": 0, "tropo_std": 3, "range_std": 3}, {"P": 1300972624,
+    "L": {"i": 102105868, "f": 49}, "lock": 15, "flags": 3, "sid": {"sat": 7, "code":
+    26}, "iono_std": 29, "tropo_std": 5, "range_std": 5}, {"P": 1229405326, "L": {"i":
+    96488997, "f": 219}, "lock": 15, "flags": 3, "sid": {"sat": 12, "code": 26}, "iono_std":
+    32, "tropo_std": 6, "range_std": 6}, {"P": 1281416355, "L": {"i": 100571032, "f":
+    19}, "lock": 15, "flags": 3, "sid": {"sat": 19, "code": 26}, "iono_std": 28, "tropo_std":
+    5, "range_std": 5}, {"P": 1297316097, "L": {"i": 101818686, "f": 116}, "lock":
+    15, "flags": 3, "sid": {"sat": 24, "code": 26}, "iono_std": 48, "tropo_std": 10,
+    "range_std": 10}, {"P": 1212855637, "L": {"i": 95190060, "f": 40}, "lock": 15,
+    "flags": 3, "sid": {"sat": 26, "code": 26}, "iono_std": 24, "tropo_std": 4, "range_std":
+    4}, {"P": 1360852176, "L": {"i": 106805445, "f": 239}, "lock": 15, "flags": 3,
+    "sid": {"sat": 31, "code": 26}, "iono_std": 43, "tropo_std": 8, "range_std": 8}]}'
+  raw_packet: VUAGAADvoG7OHQAAAABKCDHqO0dJ4JuzBxUPAwwOEgAGAAYAq9tgTOgEBwhdDwMTDhAABQAFAEF1U02CgyAIfA8DGA4bAAoACgD9s0pILBGZB1IPAxoODgAEAAQASvMcUQdphgj5DwMfDhgACAAIAJ4y3EY5jHIHZw8DIQ4AAAMAAwBQRItNDAMWBjEPAwcaHQAFAAUAjjxHSSVOwAXbDwMMGiAABgAGAKPcYEyYl/4FEw8DExocAAUABQABeVNNPqERBnQPAxgaMAAKAAoAVbVKSCx8rAUoDwMaGhgABAAEAND0HFHFuF0G7w8DHxorAAgACADWZw==
+  sbp:
+    crc: '0x67d6'
+    length: 239
+    msg_type: '0x640'
+    payload: oG7OHQAAAABKCDHqO0dJ4JuzBxUPAwwOEgAGAAYAq9tgTOgEBwhdDwMTDhAABQAFAEF1U02CgyAIfA8DGA4bAAoACgD9s0pILBGZB1IPAxoODgAEAAQASvMcUQdphgj5DwMfDhgACAAIAJ4y3EY5jHIHZw8DIQ4AAAMAAwBQRItNDAMWBjEPAwcaHQAFAAUAjjxHSSVOwAXbDwMMGiAABgAGAKPcYEyYl/4FEw8DExocAAUABQABeVNNPqERBnQPAxgaMAAKAAoAVbVKSCx8rAUoDwMaGhgABAAEAND0HFHFuF0G7w8DHxorAAgACAA=
+    preamble: '0x55'
+    sender: '0x0'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/solution_meta/test_MsgSolnMeta.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/solution_meta/test_MsgSolnMeta.yaml
@@ -1,0 +1,202 @@
+---
+description: Unit tests for swiftnav.sbp.solution_meta MsgSolnMeta v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.596975
+package: sbp.solution_meta
+tests:
+
+- msg:
+    fields:
+      age_corrections: 5
+      alignment_status: 2
+      hdop: 89
+      last_used_gnss_pos_tow: 500066600
+      last_used_gnss_vel_tow: 500066600
+      n_sats: 11
+      pdop: 184
+      sol_in:
+      - flags: 0
+        sensor_type: 0
+      - flags: 2
+        sensor_type: 1
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      vdop: 162
+    module: sbp.solution_meta
+    name: MsgSolnMeta
+  msg_type: '0xff0f'
+  raw_json: '{"preamble": 85, "msg_type": 65295, "sender": 789, "length": 28, "payload":
+    "uABZAKIACwUAAihpzh0oac4dAAABAgAAAAAAAA==", "crc": 61701, "pdop": 184, "hdop":
+    89, "vdop": 162, "n_sats": 11, "age_corrections": 5, "alignment_status": 2, "last_used_gnss_pos_tow":
+    500066600, "last_used_gnss_vel_tow": 500066600, "sol_in": [{"sensor_type": 0,
+    "flags": 0}, {"sensor_type": 1, "flags": 2}, {"sensor_type": 0, "flags": 0}, {"sensor_type":
+    0, "flags": 0}, {"sensor_type": 0, "flags": 0}]}'
+  raw_packet: VQ//FQMcuABZAKIACwUAAihpzh0oac4dAAABAgAAAAAAAAXx
+  sbp:
+    crc: '0xf105'
+    length: 28
+    msg_type: '0xff0f'
+    payload: uABZAKIACwUAAihpzh0oac4dAAABAgAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      age_corrections: 6
+      alignment_status: 2
+      hdop: 89
+      last_used_gnss_pos_tow: 500066700
+      last_used_gnss_vel_tow: 500066700
+      n_sats: 11
+      pdop: 184
+      sol_in:
+      - flags: 0
+        sensor_type: 0
+      - flags: 2
+        sensor_type: 1
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      vdop: 162
+    module: sbp.solution_meta
+    name: MsgSolnMeta
+  msg_type: '0xff0f'
+  raw_json: '{"preamble": 85, "msg_type": 65295, "sender": 789, "length": 28, "payload":
+    "uABZAKIACwYAAoxpzh2Mac4dAAABAgAAAAAAAA==", "crc": 19021, "pdop": 184, "hdop":
+    89, "vdop": 162, "n_sats": 11, "age_corrections": 6, "alignment_status": 2, "last_used_gnss_pos_tow":
+    500066700, "last_used_gnss_vel_tow": 500066700, "sol_in": [{"sensor_type": 0,
+    "flags": 0}, {"sensor_type": 1, "flags": 2}, {"sensor_type": 0, "flags": 0}, {"sensor_type":
+    0, "flags": 0}, {"sensor_type": 0, "flags": 0}]}'
+  raw_packet: VQ//FQMcuABZAKIACwYAAoxpzh2Mac4dAAABAgAAAAAAAE1K
+  sbp:
+    crc: '0x4a4d'
+    length: 28
+    msg_type: '0xff0f'
+    payload: uABZAKIACwYAAoxpzh2Mac4dAAABAgAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      age_corrections: 7
+      alignment_status: 2
+      hdop: 89
+      last_used_gnss_pos_tow: 500066800
+      last_used_gnss_vel_tow: 500066800
+      n_sats: 11
+      pdop: 184
+      sol_in:
+      - flags: 0
+        sensor_type: 0
+      - flags: 2
+        sensor_type: 1
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      vdop: 162
+    module: sbp.solution_meta
+    name: MsgSolnMeta
+  msg_type: '0xff0f'
+  raw_json: '{"preamble": 85, "msg_type": 65295, "sender": 789, "length": 28, "payload":
+    "uABZAKIACwcAAvBpzh3wac4dAAABAgAAAAAAAA==", "crc": 1157, "pdop": 184, "hdop":
+    89, "vdop": 162, "n_sats": 11, "age_corrections": 7, "alignment_status": 2, "last_used_gnss_pos_tow":
+    500066800, "last_used_gnss_vel_tow": 500066800, "sol_in": [{"sensor_type": 0,
+    "flags": 0}, {"sensor_type": 1, "flags": 2}, {"sensor_type": 0, "flags": 0}, {"sensor_type":
+    0, "flags": 0}, {"sensor_type": 0, "flags": 0}]}'
+  raw_packet: VQ//FQMcuABZAKIACwcAAvBpzh3wac4dAAABAgAAAAAAAIUE
+  sbp:
+    crc: '0x485'
+    length: 28
+    msg_type: '0xff0f'
+    payload: uABZAKIACwcAAvBpzh3wac4dAAABAgAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      age_corrections: 8
+      alignment_status: 2
+      hdop: 89
+      last_used_gnss_pos_tow: 500066900
+      last_used_gnss_vel_tow: 500066900
+      n_sats: 11
+      pdop: 184
+      sol_in:
+      - flags: 0
+        sensor_type: 0
+      - flags: 2
+        sensor_type: 1
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      vdop: 162
+    module: sbp.solution_meta
+    name: MsgSolnMeta
+  msg_type: '0xff0f'
+  raw_json: '{"preamble": 85, "msg_type": 65295, "sender": 789, "length": 28, "payload":
+    "uABZAKIACwgAAlRqzh1Uas4dAAABAgAAAAAAAA==", "crc": 59779, "pdop": 184, "hdop":
+    89, "vdop": 162, "n_sats": 11, "age_corrections": 8, "alignment_status": 2, "last_used_gnss_pos_tow":
+    500066900, "last_used_gnss_vel_tow": 500066900, "sol_in": [{"sensor_type": 0,
+    "flags": 0}, {"sensor_type": 1, "flags": 2}, {"sensor_type": 0, "flags": 0}, {"sensor_type":
+    0, "flags": 0}, {"sensor_type": 0, "flags": 0}]}'
+  raw_packet: VQ//FQMcuABZAKIACwgAAlRqzh1Uas4dAAABAgAAAAAAAIPp
+  sbp:
+    crc: '0xe983'
+    length: 28
+    msg_type: '0xff0f'
+    payload: uABZAKIACwgAAlRqzh1Uas4dAAABAgAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      age_corrections: 9
+      alignment_status: 2
+      hdop: 89
+      last_used_gnss_pos_tow: 500067000
+      last_used_gnss_vel_tow: 500067000
+      n_sats: 11
+      pdop: 184
+      sol_in:
+      - flags: 0
+        sensor_type: 0
+      - flags: 2
+        sensor_type: 1
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      - flags: 0
+        sensor_type: 0
+      vdop: 162
+    module: sbp.solution_meta
+    name: MsgSolnMeta
+  msg_type: '0xff0f'
+  raw_json: '{"preamble": 85, "msg_type": 65295, "sender": 789, "length": 28, "payload":
+    "uABZAKIACwkAArhqzh24as4dAAABAgAAAAAAAA==", "crc": 8994, "pdop": 184, "hdop":
+    89, "vdop": 162, "n_sats": 11, "age_corrections": 9, "alignment_status": 2, "last_used_gnss_pos_tow":
+    500067000, "last_used_gnss_vel_tow": 500067000, "sol_in": [{"sensor_type": 0,
+    "flags": 0}, {"sensor_type": 1, "flags": 2}, {"sensor_type": 0, "flags": 0}, {"sensor_type":
+    0, "flags": 0}, {"sensor_type": 0, "flags": 0}]}'
+  raw_packet: VQ//FQMcuABZAKIACwkAArhqzh24as4dAAABAgAAAAAAACIj
+  sbp:
+    crc: '0x2322'
+    length: 28
+    msg_type: '0xff0f'
+    payload: uABZAKIACwkAArhqzh24as4dAAABAgAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/system/test_MsgGroupMeta_autogen.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/system/test_MsgGroupMeta_autogen.yaml
@@ -1,0 +1,79 @@
+---
+description: Unit tests for swiftnav.sbp.system MsgGroupMeta v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.123637
+package: sbp.system
+tests:
+
+- msg:
+    fields:
+      flags: 1
+      group_id: 1
+      group_msgs:
+      - 258
+      - 259
+      - 522
+      - 529
+      - 521
+      - 532
+      - 526
+      - 530
+      - 525
+      - 533
+      - 545
+      - 65283
+      - 65286
+      - 65295
+      n_group_msgs: 14
+    module: sbp.system
+    name: MsgGroupMeta
+  msg_type: '0xff0a'
+  raw_json: '{"preamble": 85, "msg_type": 65290, "sender": 789, "length": 31, "payload":
+    "AQEOAgEDAQoCEQIJAhQCDgISAg0CFQIhAgP/Bv8P/w==", "crc": 43363, "group_id": 1, "flags":
+    1, "n_group_msgs": 14, "group_msgs": [258, 259, 522, 529, 521, 532, 526, 530,
+    525, 533, 545, 65283, 65286, 65295]}'
+  raw_packet: VQr/FQMfAQEOAgEDAQoCEQIJAhQCDgISAg0CFQIhAgP/Bv8P/2Op
+  sbp:
+    crc: '0xa963'
+    length: 31
+    msg_type: '0xff0a'
+    payload: AQEOAgEDAQoCEQIJAhQCDgISAg0CFQIhAgP/Bv8P/w==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      flags: 2
+      group_id: 1
+      group_msgs:
+      - 258
+      - 259
+      - 522
+      - 529
+      - 521
+      - 532
+      - 526
+      - 530
+      - 525
+      - 533
+      - 545
+      - 65283
+      - 65286
+      - 65295
+      n_group_msgs: 14
+    module: sbp.system
+    name: MsgGroupMeta
+  msg_type: '0xff0a'
+  raw_json: '{"preamble": 85, "msg_type": 65290, "sender": 789, "length": 31, "payload":
+    "AQIOAgEDAQoCEQIJAhQCDgISAg0CFQIhAgP/Bv8P/w==", "crc": 45634, "group_id": 1, "flags":
+    2, "n_group_msgs": 14, "group_msgs": [258, 259, 522, 529, 521, 532, 526, 530,
+    525, 533, 545, 65283, 65286, 65295]}'
+  raw_packet: VQr/FQMfAQIOAgEDAQoCEQIJAhQCDgISAg0CFQIhAgP/Bv8P/0Ky
+  sbp:
+    crc: '0xb242'
+    length: 31
+    msg_type: '0xff0a'
+    payload: AQIOAgEDAQoCEQIJAhQCDgISAg0CFQIhAgP/Bv8P/w==
+    preamble: '0x55'
+    sender: '0x315'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/system/test_MsgInsStatus.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/system/test_MsgInsStatus.yaml
@@ -1,0 +1,92 @@
+---
+description: Unit tests for swiftnav.sbp.system MsgInsStatus v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.553018
+package: sbp.system
+tests:
+
+- msg:
+    fields:
+      flags: 536870921
+    module: sbp.system
+    name: MsgInsStatus
+  msg_type: '0xff03'
+  raw_json: '{"preamble": 85, "msg_type": 65283, "sender": 789, "length": 4, "payload":
+    "CQAAIA==", "crc": 26404, "flags": 536870921}'
+  raw_packet: VQP/FQMECQAAICRn
+  sbp:
+    crc: '0x6724'
+    length: 4
+    msg_type: '0xff03'
+    payload: CQAAIA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      flags: 536872970
+    module: sbp.system
+    name: MsgInsStatus
+  msg_type: '0xff03'
+  raw_json: '{"preamble": 85, "msg_type": 65283, "sender": 789, "length": 4, "payload":
+    "CggAIA==", "crc": 21849, "flags": 536872970}'
+  raw_packet: VQP/FQMECggAIFlV
+  sbp:
+    crc: '0x5559'
+    length: 4
+    msg_type: '0xff03'
+    payload: CggAIA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      flags: 536875018
+    module: sbp.system
+    name: MsgInsStatus
+  msg_type: '0xff03'
+  raw_json: '{"preamble": 85, "msg_type": 65283, "sender": 789, "length": 4, "payload":
+    "ChAAIA==", "crc": 49051, "flags": 536875018}'
+  raw_packet: VQP/FQMEChAAIJu/
+  sbp:
+    crc: '0xbf9b'
+    length: 4
+    msg_type: '0xff03'
+    payload: ChAAIA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      flags: 536872970
+    module: sbp.system
+    name: MsgInsStatus
+  msg_type: '0xff03'
+  raw_json: '{"preamble": 85, "msg_type": 65283, "sender": 789, "length": 4, "payload":
+    "CggAIA==", "crc": 21849, "flags": 536872970}'
+  raw_packet: VQP/FQMECggAIFlV
+  sbp:
+    crc: '0x5559'
+    length: 4
+    msg_type: '0xff03'
+    payload: CggAIA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      flags: 536875018
+    module: sbp.system
+    name: MsgInsStatus
+  msg_type: '0xff03'
+  raw_json: '{"preamble": 85, "msg_type": 65283, "sender": 789, "length": 4, "payload":
+    "ChAAIA==", "crc": 49051, "flags": 536875018}'
+  raw_packet: VQP/FQMEChAAIJu/
+  sbp:
+    crc: '0xbf9b'
+    length: 4
+    msg_type: '0xff03'
+    payload: ChAAIA==
+    preamble: '0x55'
+    sender: '0x315'
+version: 3.4.1.dev12+g7ff5295c
+...

--- a/spec/tests/yaml/swiftnav/sbp/system/test_MsgInsUpdates.yaml
+++ b/spec/tests/yaml/swiftnav/sbp/system/test_MsgInsUpdates.yaml
@@ -1,0 +1,127 @@
+---
+description: Unit tests for swiftnav.sbp.system MsgInsUpdates v3.4.1.dev12+g7ff5295c.
+generated_on: 2020-09-18 18:23:45.570601
+package: sbp.system
+tests:
+
+- msg:
+    fields:
+      gnsspos: 0
+      gnssvel: 0
+      nhc: 0
+      speed: 0
+      tow: 500066600
+      wheelticks: 0
+      zerovel: 0
+    module: sbp.system
+    name: MsgInsUpdates
+  msg_type: '0xff06'
+  raw_json: '{"preamble": 85, "msg_type": 65286, "sender": 789, "length": 10, "payload":
+    "KGnOHQAAAAAAAA==", "crc": 15017, "tow": 500066600, "gnsspos": 0, "gnssvel": 0,
+    "wheelticks": 0, "speed": 0, "nhc": 0, "zerovel": 0}'
+  raw_packet: VQb/FQMKKGnOHQAAAAAAAKk6
+  sbp:
+    crc: '0x3aa9'
+    length: 10
+    msg_type: '0xff06'
+    payload: KGnOHQAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      gnsspos: 0
+      gnssvel: 0
+      nhc: 0
+      speed: 0
+      tow: 500066700
+      wheelticks: 0
+      zerovel: 0
+    module: sbp.system
+    name: MsgInsUpdates
+  msg_type: '0xff06'
+  raw_json: '{"preamble": 85, "msg_type": 65286, "sender": 789, "length": 10, "payload":
+    "jGnOHQAAAAAAAA==", "crc": 19109, "tow": 500066700, "gnsspos": 0, "gnssvel": 0,
+    "wheelticks": 0, "speed": 0, "nhc": 0, "zerovel": 0}'
+  raw_packet: VQb/FQMKjGnOHQAAAAAAAKVK
+  sbp:
+    crc: '0x4aa5'
+    length: 10
+    msg_type: '0xff06'
+    payload: jGnOHQAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      gnsspos: 0
+      gnssvel: 0
+      nhc: 0
+      speed: 0
+      tow: 500066800
+      wheelticks: 0
+      zerovel: 0
+    module: sbp.system
+    name: MsgInsUpdates
+  msg_type: '0xff06'
+  raw_json: '{"preamble": 85, "msg_type": 65286, "sender": 789, "length": 10, "payload":
+    "8GnOHQAAAAAAAA==", "crc": 29274, "tow": 500066800, "gnsspos": 0, "gnssvel": 0,
+    "wheelticks": 0, "speed": 0, "nhc": 0, "zerovel": 0}'
+  raw_packet: VQb/FQMK8GnOHQAAAAAAAFpy
+  sbp:
+    crc: '0x725a'
+    length: 10
+    msg_type: '0xff06'
+    payload: 8GnOHQAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      gnsspos: 0
+      gnssvel: 0
+      nhc: 0
+      speed: 0
+      tow: 500066900
+      wheelticks: 0
+      zerovel: 0
+    module: sbp.system
+    name: MsgInsUpdates
+  msg_type: '0xff06'
+  raw_json: '{"preamble": 85, "msg_type": 65286, "sender": 789, "length": 10, "payload":
+    "VGrOHQAAAAAAAA==", "crc": 12050, "tow": 500066900, "gnsspos": 0, "gnssvel": 0,
+    "wheelticks": 0, "speed": 0, "nhc": 0, "zerovel": 0}'
+  raw_packet: VQb/FQMKVGrOHQAAAAAAABIv
+  sbp:
+    crc: '0x2f12'
+    length: 10
+    msg_type: '0xff06'
+    payload: VGrOHQAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+
+- msg:
+    fields:
+      gnsspos: 0
+      gnssvel: 0
+      nhc: 0
+      speed: 0
+      tow: 500067000
+      wheelticks: 0
+      zerovel: 0
+    module: sbp.system
+    name: MsgInsUpdates
+  msg_type: '0xff06'
+  raw_json: '{"preamble": 85, "msg_type": 65286, "sender": 789, "length": 10, "payload":
+    "uGrOHQAAAAAAAA==", "crc": 26447, "tow": 500067000, "gnsspos": 0, "gnssvel": 0,
+    "wheelticks": 0, "speed": 0, "nhc": 0, "zerovel": 0}'
+  raw_packet: VQb/FQMKuGrOHQAAAAAAAE9n
+  sbp:
+    crc: '0x674f'
+    length: 10
+    msg_type: '0xff06'
+    payload: uGrOHQAAAAAAAA==
+    preamble: '0x55'
+    sender: '0x315'
+version: 3.4.1.dev12+g7ff5295c
+...


### PR DESCRIPTION
Use the old build_test_data script to generate test for new messages.  Thank @mookerji !

Given we weren't testing new messages, new tests failing is probable and I see that on my desktop.  Either our spec in this library is wrong, or we aren't generating the new messages according to spec.

TODO: investigate and fix any failing tests either in the generator, in the auto-test generator, in the client libraries, or in the producer of the messages.