### PR TITLE
Replace zero is variable arrays with macro for custom replacements [DO NOT MERGE]

### DIFF
--- a/c/include/libsbp/acquisition.h
+++ b/c/include/libsbp/acquisition.h
@@ -147,7 +147,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_ACQ_SV_PROFILE     0x002E
 
 typedef struct SBP_ATTR_PACKED {
-  acq_sv_profile_t acq_sv_profile[0]; /**< SV profiles during acquisition time */
+  acq_sv_profile_t acq_sv_profile[SBP_VARIABLE_ARRAY_SIZE]; /**< SV profiles during acquisition time */
 } msg_acq_sv_profile_t;
 
 
@@ -158,7 +158,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_ACQ_SV_PROFILE_DEP 0x001E
 
 typedef struct SBP_ATTR_PACKED {
-  acq_sv_profile_dep_t acq_sv_profile[0]; /**< SV profiles during acquisition time */
+  acq_sv_profile_dep_t acq_sv_profile[SBP_VARIABLE_ARRAY_SIZE]; /**< SV profiles during acquisition time */
 } msg_acq_sv_profile_dep_t;
 
 

--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -75,7 +75,7 @@ SBP_PACK_START
 
 typedef struct SBP_ATTR_PACKED {
   u32 flags;      /**< Bootloader flags */
-  char version[0]; /**< Bootloader version number */
+  char version[SBP_VARIABLE_ARRAY_SIZE]; /**< Bootloader version number */
 } msg_bootloader_handshake_resp_t;
 
 
@@ -127,7 +127,7 @@ on the right.
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A 0x00B0
 
 typedef struct SBP_ATTR_PACKED {
-  u8 handshake[0]; /**< Version number string (not NULL terminated) */
+  u8 handshake[SBP_VARIABLE_ARRAY_SIZE]; /**< Version number string (not NULL terminated) */
 } msg_bootloader_handshake_dep_a_t;
 
 

--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -50,6 +50,11 @@ typedef uint64_t u64;
 
 #endif
 
+/** Macro for handling variable array size */
+#ifndef SBP_VARIABLE_ARRAY_SIZE
+#define SBP_VARIABLE_ARRAY_SIZE 0
+#endif
+
 /* Set packing based upon toolchain */
 #if defined(__GNUC__) || defined(__clang__)
 
@@ -67,7 +72,7 @@ typedef uint64_t u64;
 
 #if !defined(SBP_PACK_START) || !defined(SBP_PACK_END) || !defined(SBP_ATTR_PACKED)
 #error Unknown compiler, please override SBP_PACK_START, SBP_PACK_END, and SBP_ATTR_PACKED
-#endif 
+#endif
 
 #endif /* toolchaing packing macros */
 

--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -52,7 +52,7 @@ typedef struct SBP_ATTR_PACKED {
   u32 sequence;      /**< Read sequence number */
   u32 offset;        /**< File offset [bytes] */
   u8 chunk_size;    /**< Chunk size to read [bytes] */
-  char filename[0];   /**< Name of the file to read from */
+  char filename[SBP_VARIABLE_ARRAY_SIZE]; /**< Name of the file to read from */
 } msg_fileio_read_req_t;
 
 
@@ -68,7 +68,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
-  u8 contents[0]; /**< Contents of read file */
+  u8 contents[SBP_VARIABLE_ARRAY_SIZE]; /**< Contents of read file */
 } msg_fileio_read_resp_t;
 
 
@@ -91,7 +91,7 @@ typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
   u32 offset;      /**< The offset to skip the first n elements of the file list
  */
-  char dirname[0];  /**< Name of the directory to list */
+  char dirname[SBP_VARIABLE_ARRAY_SIZE]; /**< Name of the directory to list */
 } msg_fileio_read_dir_req_t;
 
 
@@ -108,7 +108,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
-  u8 contents[0]; /**< Contents of read directory */
+  u8 contents[SBP_VARIABLE_ARRAY_SIZE]; /**< Contents of read directory */
 } msg_fileio_read_dir_resp_t;
 
 
@@ -122,7 +122,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_FILEIO_REMOVE        0x00AC
 
 typedef struct SBP_ATTR_PACKED {
-  char filename[0]; /**< Name of the file to delete */
+  char filename[SBP_VARIABLE_ARRAY_SIZE]; /**< Name of the file to delete */
 } msg_fileio_remove_t;
 
 
@@ -142,8 +142,8 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Write sequence number */
   u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
-  char filename[0]; /**< Name of the file to write to */
-  u8 data[0];     /**< Variable-length array of data to write */
+  char filename[SBP_VARIABLE_ARRAY_SIZE]; /**< Name of the file to write to */
+  u8 data[SBP_VARIABLE_ARRAY_SIZE]; /**< Variable-length array of data to write */
 } msg_fileio_write_req_t;
 
 

--- a/c/include/libsbp/flash.h
+++ b/c/include/libsbp/flash.h
@@ -62,7 +62,7 @@ typedef struct SBP_ATTR_PACKED {
   u8 addr_len;      /**< Length of set of addresses to program, counting up from
 starting address
  [bytes] */
-  u8 data[0];       /**< Data to program addresses with, with length N=addr_len */
+  u8 data[SBP_VARIABLE_ARRAY_SIZE]; /**< Data to program addresses with, with length N=addr_len */
 } msg_flash_program_t;
 
 

--- a/c/include/libsbp/linux.h
+++ b/c/include/libsbp/linux.h
@@ -40,7 +40,7 @@ typedef struct SBP_ATTR_PACKED {
   u16 pid;        /**< the PID of the process */
   u8 pcpu;       /**< percent of cpu used, expressed as a fraction of 256 */
   char tname[15];  /**< fixed length string representing the thread name */
-  char cmdline[0]; /**< the command line (as much as it fits in the remaining packet) */
+  char cmdline[SBP_VARIABLE_ARRAY_SIZE]; /**< the command line (as much as it fits in the remaining packet) */
 } msg_linux_cpu_state_t;
 
 
@@ -56,7 +56,7 @@ typedef struct SBP_ATTR_PACKED {
   u16 pid;        /**< the PID of the process */
   u8 pmem;       /**< percent of memory used, expressed as a fraction of 256 */
   char tname[15];  /**< fixed length string representing the thread name */
-  char cmdline[0]; /**< the command line (as much as it fits in the remaining packet) */
+  char cmdline[SBP_VARIABLE_ARRAY_SIZE]; /**< the command line (as much as it fits in the remaining packet) */
 } msg_linux_mem_state_t;
 
 
@@ -96,7 +96,7 @@ typedef struct SBP_ATTR_PACKED {
   0x100 (last-ack), 0x200 (listen), 0x400 (closing), 0x800 (unconnected),
   and 0x8000 (unknown)
  */
-  char cmdline[0];       /**< the command line of the process in question */
+  char cmdline[SBP_VARIABLE_ARRAY_SIZE]; /**< the command line of the process in question */
 } msg_linux_process_socket_counts_t;
 
 
@@ -124,7 +124,7 @@ typedef struct SBP_ATTR_PACKED {
   char address_of_largest[64]; /**< Address of the largest queue, remote or local depending on the directionality
 of the connection.
  */
-  char cmdline[0];            /**< the command line of the process in question */
+  char cmdline[SBP_VARIABLE_ARRAY_SIZE]; /**< the command line of the process in question */
 } msg_linux_process_socket_queues_t;
 
 
@@ -156,7 +156,7 @@ typedef struct SBP_ATTR_PACKED {
   u8 index;       /**< sequence of this status message, values from 0-9 */
   u16 pid;         /**< the PID of the process in question */
   u16 fd_count;    /**< a count of the number of file descriptors opened by the process */
-  char cmdline[0];  /**< the command line of the process in question */
+  char cmdline[SBP_VARIABLE_ARRAY_SIZE]; /**< the command line of the process in question */
 } msg_linux_process_fd_count_t;
 
 
@@ -168,7 +168,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sys_fd_count;    /**< count of total FDs open on the system */
-  char most_opened[0];  /**< A null delimited list of strings which alternates between
+  char most_opened[SBP_VARIABLE_ARRAY_SIZE]; /**< A null delimited list of strings which alternates between
 a string representation of the process count and the file
 name whose count it being reported.  That is, in C string
 syntax "32\0/var/log/syslog\012\0/tmp/foo\0" with the end

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -57,7 +57,7 @@ SBP_PACK_START
 
 typedef struct SBP_ATTR_PACKED {
   u8 level;    /**< Logging level */
-  char text[0];  /**< Human-readable string */
+  char text[SBP_VARIABLE_ARRAY_SIZE]; /**< Human-readable string */
 } msg_log_t;
 
 
@@ -76,7 +76,7 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   u8 source;         /**< source identifier */
   u8 protocol;       /**< protocol identifier */
-  char fwd_payload[0]; /**< variable length wrapped binary message */
+  char fwd_payload[SBP_VARIABLE_ARRAY_SIZE]; /**< variable length wrapped binary message */
 } msg_fwd_t;
 
 
@@ -87,7 +87,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_PRINT_DEP 0x0010
 
 typedef struct SBP_ATTR_PACKED {
-  char text[0]; /**< Human-readable string */
+  char text[SBP_VARIABLE_ARRAY_SIZE]; /**< Human-readable string */
 } msg_print_dep_t;
 
 

--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -126,7 +126,7 @@ from 0 to 15 and the most significant nibble is reserved for future use.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_t header;    /**< Header of a GPS observation message */
-  packed_obs_content_t obs[0];    /**< Pseudorange and carrier phase observation for a
+  packed_obs_content_t obs[SBP_VARIABLE_ARRAY_SIZE]; /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
 } msg_obs_t;
@@ -868,7 +868,7 @@ carrier phase ambiguity may have changed.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
-  packed_obs_content_dep_a_t obs[0];    /**< Pseudorange and carrier phase observation for a
+  packed_obs_content_dep_a_t obs[SBP_VARIABLE_ARRAY_SIZE]; /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
 } msg_obs_dep_a_t;
@@ -887,7 +887,7 @@ satellite being tracked.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
-  packed_obs_content_dep_b_t obs[0];    /**< Pseudorange and carrier phase observation for a
+  packed_obs_content_dep_b_t obs[SBP_VARIABLE_ARRAY_SIZE]; /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
 } msg_obs_dep_b_t;
@@ -907,7 +907,7 @@ satellite being tracked.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
-  packed_obs_content_dep_c_t obs[0];    /**< Pseudorange and carrier phase observation for a
+  packed_obs_content_dep_c_t obs[SBP_VARIABLE_ARRAY_SIZE]; /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
 } msg_obs_dep_c_t;
@@ -1217,7 +1217,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_SV_AZ_EL                 0x0097
 
 typedef struct SBP_ATTR_PACKED {
-  sv_az_el_t azel[0]; /**< Azimuth and elevation per satellite */
+  sv_az_el_t azel[SBP_VARIABLE_ARRAY_SIZE]; /**< Azimuth and elevation per satellite */
 } msg_sv_az_el_t;
 
 
@@ -1229,7 +1229,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_t header;    /**< Header of a GPS observation message */
-  packed_osr_content_t obs[0];    /**< Network correction for a
+  packed_osr_content_t obs[SBP_VARIABLE_ARRAY_SIZE]; /**< Network correction for a
 satellite signal.
  */
 } msg_osr_t;

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -359,7 +359,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
-  char command[0];  /**< Command line to execute */
+  char command[SBP_VARIABLE_ARRAY_SIZE]; /**< Command line to execute */
 } msg_command_req_t;
 
 
@@ -387,7 +387,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
-  char line[0];     /**< Line of standard output or standard error */
+  char line[SBP_VARIABLE_ARRAY_SIZE]; /**< Line of standard output or standard error */
 } msg_command_output_t;
 
 
@@ -621,7 +621,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_NETWORK_BANDWIDTH_USAGE 0x00BD
 
 typedef struct SBP_ATTR_PACKED {
-  network_usage_t interfaces[0]; /**< Usage measurement array */
+  network_usage_t interfaces[SBP_VARIABLE_ARRAY_SIZE]; /**< Usage measurement array */
 } msg_network_bandwidth_usage_t;
 
 
@@ -636,7 +636,7 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   s8 signal_strength;      /**< Received cell signal strength in dBm, zero translates to unknown [dBm] */
   float signal_error_rate;    /**< BER as reported by the modem, zero translates to unknown */
-  u8 reserved[0];          /**< Unspecified data TBD for this schema */
+  u8 reserved[SBP_VARIABLE_ARRAY_SIZE]; /**< Unspecified data TBD for this schema */
 } msg_cell_modem_status_t;
 
 
@@ -657,7 +657,7 @@ typedef struct SBP_ATTR_PACKED {
  [dB] */
   float amplitude_unit;     /**< Amplitude unit value of points in this packet
  [dB] */
-  u8 amplitude_value[0]; /**< Amplitude values (in the above units) of points in this packet
+  u8 amplitude_value[SBP_VARIABLE_ARRAY_SIZE]; /**< Amplitude values (in the above units) of points in this packet
  */
 } msg_specan_dep_t;
 
@@ -679,7 +679,7 @@ typedef struct SBP_ATTR_PACKED {
  [dB] */
   float amplitude_unit;     /**< Amplitude unit value of points in this packet
  [dB] */
-  u8 amplitude_value[0]; /**< Amplitude values (in the above units) of points in this packet
+  u8 amplitude_value[SBP_VARIABLE_ARRAY_SIZE]; /**< Amplitude values (in the above units) of points in this packet
  */
 } msg_specan_t;
 

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -74,7 +74,7 @@ SBP_PACK_START
 #define SBP_MSG_SETTINGS_WRITE              0x00A0
 
 typedef struct SBP_ATTR_PACKED {
-  char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0"
  */
 } msg_settings_write_t;
@@ -112,7 +112,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 status;     /**< Write status */
-  char setting[0]; /**< A NULL-terminated and delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0" 
  */
 } msg_settings_write_resp_t;
@@ -132,7 +132,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_SETTINGS_READ_REQ           0x00A4
 
 typedef struct SBP_ATTR_PACKED {
-  char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0"
  */
 } msg_settings_read_req_t;
@@ -151,7 +151,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_SETTINGS_READ_RESP          0x00A5
 
 typedef struct SBP_ATTR_PACKED {
-  char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0"
  
  */
@@ -192,7 +192,7 @@ typedef struct SBP_ATTR_PACKED {
   u16 index;      /**< An index into the device settings, with values ranging from
 0 to length(settings)
  */
-  char setting[0]; /**< A NULL-terminated and delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0FORMAT_TYPE\0"
  */
 } msg_settings_read_by_index_resp_t;
@@ -214,7 +214,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_SETTINGS_REGISTER           0x00AE
 
 typedef struct SBP_ATTR_PACKED {
-  char setting[0]; /**< A NULL-terminated and delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE".
  */
 } msg_settings_register_t;
@@ -246,7 +246,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 status;     /**< Register status */
-  char setting[0]; /**< A NULL-terminated and delimited string with contents
+  char setting[SBP_VARIABLE_ARRAY_SIZE]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE". The meaning of value is defined
 according to the status field.
  */

--- a/c/include/libsbp/solution_meta.h
+++ b/c/include/libsbp/solution_meta.h
@@ -76,7 +76,7 @@ typedef struct SBP_ATTR_PACKED {
   u8 alignment_status;          /**< State of alignment and the status and receipt of the alignment inputs */
   u32 last_used_gnss_pos_tow;    /**< Tow of last-used GNSS position measurement [ms] */
   u32 last_used_gnss_vel_tow;    /**< Tow of last-used GNSS velocity measurement [ms] */
-  solution_input_type_t sol_in[0];                 /**< Array of Metadata describing the sensors potentially involved in the solution. Each element in the array represents a single sensor type and consists of flags containing (meta)data pertaining to that specific single sensor. Refer to each (XX)InputType descriptor in the present doc. */
+  solution_input_type_t sol_in[SBP_VARIABLE_ARRAY_SIZE]; /**< Array of Metadata describing the sensors potentially involved in the solution. Each element in the array represents a single sensor type and consists of flags containing (meta)data pertaining to that specific single sensor. Refer to each (XX)InputType descriptor in the present doc. */
 } msg_soln_meta_t;
 
 

--- a/c/include/libsbp/ssr.h
+++ b/c/include/libsbp/ssr.h
@@ -179,7 +179,7 @@ stddev <= (3^class * (1 + value/16) - 1) * 10 TECU
 typedef struct SBP_ATTR_PACKED {
   u16 index;                     /**< Index of the grid point */
   tropospheric_delay_correction_no_std_t tropo_delay_correction;    /**< Wet and hydrostatic vertical delays */
-  stec_residual_no_std_t stec_residuals[0];         /**< STEC residuals for each satellite */
+  stec_residual_no_std_t stec_residuals[SBP_VARIABLE_ARRAY_SIZE]; /**< STEC residuals for each satellite */
 } grid_element_no_std_t;
 
 
@@ -192,7 +192,7 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   u16 index;                     /**< Index of the grid point */
   tropospheric_delay_correction_t tropo_delay_correction;    /**< Wet and hydrostatic vertical delays (mean, stddev) */
-  stec_residual_t stec_residuals[0];         /**< STEC residuals for each satellite (mean, stddev) */
+  stec_residual_t stec_residuals[SBP_VARIABLE_ARRAY_SIZE]; /**< STEC residuals for each satellite (mean, stddev) */
 } grid_element_t;
 
 
@@ -247,7 +247,7 @@ following RTCM DF391 specification.
 SSR is used to indicate a change in the SSR
 generating configuration
  */
-  code_biases_content_t biases[0];          /**< Code biases for the different satellite signals */
+  code_biases_content_t biases[SBP_VARIABLE_ARRAY_SIZE]; /**< Code biases for the different satellite signals */
 } msg_ssr_code_biases_t;
 
 
@@ -278,7 +278,7 @@ generating configuration
  */
   u16 yaw;                /**< Satellite yaw angle [1 / 256 semi-circle] */
   s8 yaw_rate;           /**< Satellite yaw angle rate [1 / 8192 semi-circle / s] */
-  phase_biases_content_t biases[0];          /**< Phase biases corrections for a
+  phase_biases_content_t biases[SBP_VARIABLE_ARRAY_SIZE]; /**< Phase biases corrections for a
 satellite being tracked.
  */
 } msg_ssr_phase_biases_t;
@@ -297,7 +297,7 @@ satellite being tracked.
 
 typedef struct SBP_ATTR_PACKED {
   stec_header_t header;           /**< Header of a STEC polynomial coeffcient message. */
-  stec_sat_element_t stec_sat_list[0]; /**< Array of STEC polynomial coeffcients for each space vehicle. */
+  stec_sat_element_t stec_sat_list[SBP_VARIABLE_ARRAY_SIZE]; /**< Array of STEC polynomial coeffcients for each space vehicle. */
 } msg_ssr_stec_correction_t;
 
 
@@ -479,7 +479,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   stec_header_dep_a_t header;           /**< Header of a STEC message */
-  stec_sat_element_t stec_sat_list[0]; /**< Array of STEC information for each space vehicle */
+  stec_sat_element_t stec_sat_list[SBP_VARIABLE_ARRAY_SIZE]; /**< Array of STEC information for each space vehicle */
 } msg_ssr_stec_correction_dep_a_t;
 
 
@@ -505,7 +505,7 @@ and standard deviation)
 
 typedef struct SBP_ATTR_PACKED {
   grid_definition_header_dep_a_t header;      /**< Header of a Gridded Correction message */
-  u8 rle_list[0]; /**< Run Length Encode list of quadrants that contain valid data.
+  u8 rle_list[SBP_VARIABLE_ARRAY_SIZE]; /**< Run Length Encode list of quadrants that contain valid data.
 The spec describes the encoding scheme in detail, but
 essentially the index of the quadrants that contain transitions between
 valid and invalid (and vice versa) are encoded as u8 integers.

--- a/c/include/libsbp/system.h
+++ b/c/include/libsbp/system.h
@@ -98,7 +98,7 @@ typedef struct SBP_ATTR_PACKED {
   u8 flags;          /**< Status flags */
   u16 latency;        /**< Latency of observation receipt [deci-seconds] */
   u8 num_signals;    /**< Number of signals from base station */
-  char source[0];      /**< Corrections source string */
+  char source[SBP_VARIABLE_ARRAY_SIZE]; /**< Corrections source string */
 } msg_dgnss_status_t;
 
 
@@ -330,7 +330,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 id;           /**< Index representing the type of telemetry in use.  It is implemention defined. */
-  char telemetry[0]; /**< Comma separated list of values as defined by the index */
+  char telemetry[SBP_VARIABLE_ARRAY_SIZE]; /**< Comma separated list of values as defined by the index */
 } msg_csac_telemetry_t;
 
 
@@ -344,7 +344,7 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 id;                  /**< Index representing the type of telemetry in use.  It is implemention defined. */
-  char telemetry_labels[0]; /**< Comma separated list of telemetry field values */
+  char telemetry_labels[SBP_VARIABLE_ARRAY_SIZE]; /**< Comma separated list of telemetry field values */
 } msg_csac_telemetry_labels_t;
 
 
@@ -539,7 +539,7 @@ typedef struct SBP_ATTR_PACKED {
   u8 group_id;        /**< Id of the Msgs Group, 0 is Unknown, 1 is Bestpos, 2 is Gnss */
   u8 flags;           /**< Status flags (reserved) */
   u8 n_group_msgs;    /**< Size of list group_msgs */
-  u16 group_msgs[0];   /**< An inorder list of message types included in the Solution Group,
+  u16 group_msgs[SBP_VARIABLE_ARRAY_SIZE]; /**< An inorder list of message types included in the Solution Group,
 including GROUP_META itself
  */
 } msg_group_meta_t;

--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -550,7 +550,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_TRACKING_STATE                0x0041
 
 typedef struct SBP_ATTR_PACKED {
-  tracking_channel_state_t states[0]; /**< Signal tracking channel state */
+  tracking_channel_state_t states[SBP_VARIABLE_ARRAY_SIZE]; /**< Signal tracking channel state */
 } msg_tracking_state_t;
 
 
@@ -578,7 +578,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_MEASUREMENT_STATE             0x0061
 
 typedef struct SBP_ATTR_PACKED {
-  measurement_state_t states[0]; /**< ME signal tracking channel state */
+  measurement_state_t states[SBP_VARIABLE_ARRAY_SIZE]; /**< ME signal tracking channel state */
 } msg_measurement_state_t;
 
 
@@ -664,7 +664,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_TRACKING_STATE_DEP_A          0x0016
 
 typedef struct SBP_ATTR_PACKED {
-  tracking_channel_state_dep_a_t states[0]; /**< Satellite tracking channel state */
+  tracking_channel_state_dep_a_t states[SBP_VARIABLE_ARRAY_SIZE]; /**< Satellite tracking channel state */
 } msg_tracking_state_dep_a_t;
 
 
@@ -687,7 +687,7 @@ typedef struct SBP_ATTR_PACKED {
 #define SBP_MSG_TRACKING_STATE_DEP_B          0x0013
 
 typedef struct SBP_ATTR_PACKED {
-  tracking_channel_state_dep_b_t states[0]; /**< Signal tracking channel state */
+  tracking_channel_state_dep_b_t states[SBP_VARIABLE_ARRAY_SIZE]; /**< Signal tracking channel state */
 } msg_tracking_state_dep_b_t;
 
 

--- a/c/include/libsbp/user.h
+++ b/c/include/libsbp/user.h
@@ -36,7 +36,7 @@ SBP_PACK_START
 #define SBP_MSG_USER_DATA 0x0800
 
 typedef struct SBP_ATTR_PACKED {
-  u8 contents[0]; /**< User data payload */
+  u8 contents[SBP_VARIABLE_ARRAY_SIZE]; /**< User data payload */
 } msg_user_data_t;
 
 

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -79,11 +79,11 @@ def mk_size(field):
   if name == "string" and field.options.get('size', None):
     return "%s[%d];" % (field.identifier, field.options.get('size').value)
   elif name == "string":
-    return "%s[0];" % field.identifier
+    return "%s[SBP_VARIABLE_ARRAY_SIZE];" % field.identifier
   elif name == "array" and field.options.get('size', None):
     return "%s[%d];" % (field.identifier, field.options.get('size').value)
   elif name == "array":
-    return "%s[0];" % field.identifier
+    return "%s[SBP_VARIABLE_ARRAY_SIZE];" % field.identifier
   else:
     return '%s;' % field.identifier
 


### PR DESCRIPTION
This would allow a user to define `SBP_VARIABLE_ARRAY_SIZE` before including `sbp.h`. This would allow for variable arrays to have either `0` or nothing to be used.