### PR TITLE
Optional variable sized arrays

### DIFF
--- a/c/include/libsbp/acquisition.h
+++ b/c/include/libsbp/acquisition.h
@@ -145,10 +145,12 @@ typedef struct SBP_ATTR_PACKED {
  * The message is used to debug and measure the performance.
  */
 #define SBP_MSG_ACQ_SV_PROFILE     0x002E
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   acq_sv_profile_t acq_sv_profile[0]; /**< SV profiles during acquisition time */
 } msg_acq_sv_profile_t;
+#endif
 
 
 /** Deprecated.
@@ -156,10 +158,12 @@ typedef struct SBP_ATTR_PACKED {
 * Deprecated.
  */
 #define SBP_MSG_ACQ_SV_PROFILE_DEP 0x001E
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   acq_sv_profile_dep_t acq_sv_profile[0]; /**< SV profiles during acquisition time */
 } msg_acq_sv_profile_dep_t;
+#endif
 
 
 /** \} */

--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -75,7 +75,9 @@ SBP_PACK_START
 
 typedef struct SBP_ATTR_PACKED {
   u32 flags;      /**< Bootloader flags */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char version[0]; /**< Bootloader version number */
+#endif
 } msg_bootloader_handshake_resp_t;
 
 
@@ -125,10 +127,12 @@ on the right.
 * Deprecated.
  */
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A 0x00B0
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   u8 handshake[0]; /**< Version number string (not NULL terminated) */
 } msg_bootloader_handshake_dep_a_t;
+#endif
 
 
 /** \} */

--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -52,7 +52,9 @@ typedef struct SBP_ATTR_PACKED {
   u32 sequence;      /**< Read sequence number */
   u32 offset;        /**< File offset [bytes] */
   u8 chunk_size;    /**< Chunk size to read [bytes] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char filename[0];   /**< Name of the file to read from */
+#endif
 } msg_fileio_read_req_t;
 
 
@@ -68,7 +70,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 contents[0]; /**< Contents of read file */
+#endif
 } msg_fileio_read_resp_t;
 
 
@@ -91,7 +95,9 @@ typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
   u32 offset;      /**< The offset to skip the first n elements of the file list
  */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char dirname[0];  /**< Name of the directory to list */
+#endif
 } msg_fileio_read_dir_req_t;
 
 
@@ -108,7 +114,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Read sequence number */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 contents[0]; /**< Contents of read directory */
+#endif
 } msg_fileio_read_dir_resp_t;
 
 
@@ -120,10 +128,12 @@ typedef struct SBP_ATTR_PACKED {
  * process this message when it is received from sender ID 0x42.
  */
 #define SBP_MSG_FILEIO_REMOVE        0x00AC
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   char filename[0]; /**< Name of the file to delete */
 } msg_fileio_remove_t;
+#endif
 
 
 /** Write to file (host => device)
@@ -142,8 +152,12 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Write sequence number */
   u32 offset;      /**< Offset into the file at which to start writing in bytes [bytes] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char filename[0]; /**< Name of the file to write to */
+#endif
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 data[0];     /**< Variable-length array of data to write */
+#endif
 } msg_fileio_write_req_t;
 
 

--- a/c/include/libsbp/flash.h
+++ b/c/include/libsbp/flash.h
@@ -62,7 +62,9 @@ typedef struct SBP_ATTR_PACKED {
   u8 addr_len;      /**< Length of set of addresses to program, counting up from
 starting address
  [bytes] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 data[0];       /**< Data to program addresses with, with length N=addr_len */
+#endif
 } msg_flash_program_t;
 
 

--- a/c/include/libsbp/linux.h
+++ b/c/include/libsbp/linux.h
@@ -40,7 +40,9 @@ typedef struct SBP_ATTR_PACKED {
   u16 pid;        /**< the PID of the process */
   u8 pcpu;       /**< percent of cpu used, expressed as a fraction of 256 */
   char tname[15];  /**< fixed length string representing the thread name */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char cmdline[0]; /**< the command line (as much as it fits in the remaining packet) */
+#endif
 } msg_linux_cpu_state_t;
 
 
@@ -56,7 +58,9 @@ typedef struct SBP_ATTR_PACKED {
   u16 pid;        /**< the PID of the process */
   u8 pmem;       /**< percent of memory used, expressed as a fraction of 256 */
   char tname[15];  /**< fixed length string representing the thread name */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char cmdline[0]; /**< the command line (as much as it fits in the remaining packet) */
+#endif
 } msg_linux_mem_state_t;
 
 
@@ -96,7 +100,9 @@ typedef struct SBP_ATTR_PACKED {
   0x100 (last-ack), 0x200 (listen), 0x400 (closing), 0x800 (unconnected),
   and 0x8000 (unknown)
  */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char cmdline[0];       /**< the command line of the process in question */
+#endif
 } msg_linux_process_socket_counts_t;
 
 
@@ -124,7 +130,9 @@ typedef struct SBP_ATTR_PACKED {
   char address_of_largest[64]; /**< Address of the largest queue, remote or local depending on the directionality
 of the connection.
  */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char cmdline[0];            /**< the command line of the process in question */
+#endif
 } msg_linux_process_socket_queues_t;
 
 
@@ -156,7 +164,9 @@ typedef struct SBP_ATTR_PACKED {
   u8 index;       /**< sequence of this status message, values from 0-9 */
   u16 pid;         /**< the PID of the process in question */
   u16 fd_count;    /**< a count of the number of file descriptors opened by the process */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char cmdline[0];  /**< the command line of the process in question */
+#endif
 } msg_linux_process_fd_count_t;
 
 
@@ -168,12 +178,14 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sys_fd_count;    /**< count of total FDs open on the system */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char most_opened[0];  /**< A null delimited list of strings which alternates between
 a string representation of the process count and the file
 name whose count it being reported.  That is, in C string
 syntax "32\0/var/log/syslog\012\0/tmp/foo\0" with the end
 of the list being 2 NULL terminators in a row.
  */
+#endif
 } msg_linux_process_fd_summary_t;
 
 

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -57,7 +57,9 @@ SBP_PACK_START
 
 typedef struct SBP_ATTR_PACKED {
   u8 level;    /**< Logging level */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char text[0];  /**< Human-readable string */
+#endif
 } msg_log_t;
 
 
@@ -76,7 +78,9 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   u8 source;         /**< source identifier */
   u8 protocol;       /**< protocol identifier */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char fwd_payload[0]; /**< variable length wrapped binary message */
+#endif
 } msg_fwd_t;
 
 
@@ -85,10 +89,12 @@ typedef struct SBP_ATTR_PACKED {
 * Deprecated.
  */
 #define SBP_MSG_PRINT_DEP 0x0010
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   char text[0]; /**< Human-readable string */
 } msg_print_dep_t;
+#endif
 
 
 /** \} */

--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -126,9 +126,11 @@ from 0 to 15 and the most significant nibble is reserved for future use.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_t header;    /**< Header of a GPS observation message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   packed_obs_content_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
+#endif
 } msg_obs_t;
 
 
@@ -868,9 +870,11 @@ carrier phase ambiguity may have changed.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   packed_obs_content_dep_a_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
+#endif
 } msg_obs_dep_a_t;
 
 
@@ -887,9 +891,11 @@ satellite being tracked.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   packed_obs_content_dep_b_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
+#endif
 } msg_obs_dep_b_t;
 
 
@@ -907,9 +913,11 @@ satellite being tracked.
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_dep_t header;    /**< Header of a GPS observation message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   packed_obs_content_dep_c_t obs[0];    /**< Pseudorange and carrier phase observation for a
 satellite being tracked.
  */
+#endif
 } msg_obs_dep_c_t;
 
 
@@ -1215,10 +1223,12 @@ typedef struct SBP_ATTR_PACKED {
  * that the device does have ephemeris or almanac for.
  */
 #define SBP_MSG_SV_AZ_EL                 0x0097
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   sv_az_el_t azel[0]; /**< Azimuth and elevation per satellite */
 } msg_sv_az_el_t;
+#endif
 
 
 /** OSR corrections
@@ -1229,9 +1239,11 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   observation_header_t header;    /**< Header of a GPS observation message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   packed_osr_content_t obs[0];    /**< Network correction for a
 satellite signal.
  */
+#endif
 } msg_osr_t;
 
 

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -359,7 +359,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char command[0];  /**< Command line to execute */
+#endif
 } msg_command_req_t;
 
 
@@ -387,7 +389,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u32 sequence;    /**< Sequence number */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char line[0];     /**< Line of standard output or standard error */
+#endif
 } msg_command_output_t;
 
 
@@ -619,10 +623,12 @@ typedef struct SBP_ATTR_PACKED {
  * The bandwidth usage, a list of usage by interface. 
  */
 #define SBP_MSG_NETWORK_BANDWIDTH_USAGE 0x00BD
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   network_usage_t interfaces[0]; /**< Usage measurement array */
 } msg_network_bandwidth_usage_t;
+#endif
 
 
 /** Cell modem information update message
@@ -636,7 +642,9 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   s8 signal_strength;      /**< Received cell signal strength in dBm, zero translates to unknown [dBm] */
   float signal_error_rate;    /**< BER as reported by the modem, zero translates to unknown */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 reserved[0];          /**< Unspecified data TBD for this schema */
+#endif
 } msg_cell_modem_status_t;
 
 
@@ -657,8 +665,10 @@ typedef struct SBP_ATTR_PACKED {
  [dB] */
   float amplitude_unit;     /**< Amplitude unit value of points in this packet
  [dB] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 amplitude_value[0]; /**< Amplitude values (in the above units) of points in this packet
  */
+#endif
 } msg_specan_dep_t;
 
 
@@ -679,8 +689,10 @@ typedef struct SBP_ATTR_PACKED {
  [dB] */
   float amplitude_unit;     /**< Amplitude unit value of points in this packet
  [dB] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 amplitude_value[0]; /**< Amplitude values (in the above units) of points in this packet
  */
+#endif
 } msg_specan_t;
 
 

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -72,12 +72,14 @@ SBP_PACK_START
  * "solution\0soln_freq\010\0".
  */
 #define SBP_MSG_SETTINGS_WRITE              0x00A0
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0"
  */
 } msg_settings_write_t;
+#endif
 
 
 /** Acknowledgement with status of MSG_SETTINGS_WRITE
@@ -112,9 +114,11 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 status;     /**< Write status */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char setting[0]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0" 
  */
+#endif
 } msg_settings_write_resp_t;
 
 
@@ -130,12 +134,14 @@ typedef struct SBP_ATTR_PACKED {
  * message (msg_id 0x00A5).
  */
 #define SBP_MSG_SETTINGS_READ_REQ           0x00A4
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
 "SECTION_SETTING\0SETTING\0"
  */
 } msg_settings_read_req_t;
+#endif
 
 
 /** Read device configuration settings (host <= device)
@@ -149,6 +155,7 @@ typedef struct SBP_ATTR_PACKED {
  * "solution\0soln_freq\010\0".
  */
 #define SBP_MSG_SETTINGS_READ_RESP          0x00A5
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and NULL-delimited string with contents
@@ -156,6 +163,7 @@ typedef struct SBP_ATTR_PACKED {
  
  */
 } msg_settings_read_resp_t;
+#endif
 
 
 /** Read setting by direct index (host => device)
@@ -192,9 +200,11 @@ typedef struct SBP_ATTR_PACKED {
   u16 index;      /**< An index into the device settings, with values ranging from
 0 to length(settings)
  */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char setting[0]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE\0FORMAT_TYPE\0"
  */
+#endif
 } msg_settings_read_by_index_resp_t;
 
 
@@ -212,12 +222,14 @@ typedef struct SBP_ATTR_PACKED {
  * for this setting to set the initial value.
  */
 #define SBP_MSG_SETTINGS_REGISTER           0x00AE
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   char setting[0]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE".
  */
 } msg_settings_register_t;
+#endif
 
 
 /** Register setting and default value (device <= host)
@@ -246,10 +258,12 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 status;     /**< Register status */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char setting[0]; /**< A NULL-terminated and delimited string with contents
 "SECTION_SETTING\0SETTING\0VALUE". The meaning of value is defined
 according to the status field.
  */
+#endif
 } msg_settings_register_resp_t;
 
 

--- a/c/include/libsbp/solution_meta.h
+++ b/c/include/libsbp/solution_meta.h
@@ -76,7 +76,9 @@ typedef struct SBP_ATTR_PACKED {
   u8 alignment_status;          /**< State of alignment and the status and receipt of the alignment inputs */
   u32 last_used_gnss_pos_tow;    /**< Tow of last-used GNSS position measurement [ms] */
   u32 last_used_gnss_vel_tow;    /**< Tow of last-used GNSS velocity measurement [ms] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   solution_input_type_t sol_in[0];                 /**< Array of Metadata describing the sensors potentially involved in the solution. Each element in the array represents a single sensor type and consists of flags containing (meta)data pertaining to that specific single sensor. Refer to each (XX)InputType descriptor in the present doc. */
+#endif
 } msg_soln_meta_t;
 
 

--- a/c/include/libsbp/ssr.h
+++ b/c/include/libsbp/ssr.h
@@ -179,7 +179,9 @@ stddev <= (3^class * (1 + value/16) - 1) * 10 TECU
 typedef struct SBP_ATTR_PACKED {
   u16 index;                     /**< Index of the grid point */
   tropospheric_delay_correction_no_std_t tropo_delay_correction;    /**< Wet and hydrostatic vertical delays */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   stec_residual_no_std_t stec_residuals[0];         /**< STEC residuals for each satellite */
+#endif
 } grid_element_no_std_t;
 
 
@@ -192,7 +194,9 @@ typedef struct SBP_ATTR_PACKED {
 typedef struct SBP_ATTR_PACKED {
   u16 index;                     /**< Index of the grid point */
   tropospheric_delay_correction_t tropo_delay_correction;    /**< Wet and hydrostatic vertical delays (mean, stddev) */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   stec_residual_t stec_residuals[0];         /**< STEC residuals for each satellite (mean, stddev) */
+#endif
 } grid_element_t;
 
 
@@ -247,7 +251,9 @@ following RTCM DF391 specification.
 SSR is used to indicate a change in the SSR
 generating configuration
  */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   code_biases_content_t biases[0];          /**< Code biases for the different satellite signals */
+#endif
 } msg_ssr_code_biases_t;
 
 
@@ -278,9 +284,11 @@ generating configuration
  */
   u16 yaw;                /**< Satellite yaw angle [1 / 256 semi-circle] */
   s8 yaw_rate;           /**< Satellite yaw angle rate [1 / 8192 semi-circle / s] */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   phase_biases_content_t biases[0];          /**< Phase biases corrections for a
 satellite being tracked.
  */
+#endif
 } msg_ssr_phase_biases_t;
 
 
@@ -297,7 +305,9 @@ satellite being tracked.
 
 typedef struct SBP_ATTR_PACKED {
   stec_header_t header;           /**< Header of a STEC polynomial coeffcient message. */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   stec_sat_element_t stec_sat_list[0]; /**< Array of STEC polynomial coeffcients for each space vehicle. */
+#endif
 } msg_ssr_stec_correction_t;
 
 
@@ -479,7 +489,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   stec_header_dep_a_t header;           /**< Header of a STEC message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   stec_sat_element_t stec_sat_list[0]; /**< Array of STEC information for each space vehicle */
+#endif
 } msg_ssr_stec_correction_dep_a_t;
 
 
@@ -505,11 +517,13 @@ and standard deviation)
 
 typedef struct SBP_ATTR_PACKED {
   grid_definition_header_dep_a_t header;      /**< Header of a Gridded Correction message */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u8 rle_list[0]; /**< Run Length Encode list of quadrants that contain valid data.
 The spec describes the encoding scheme in detail, but
 essentially the index of the quadrants that contain transitions between
 valid and invalid (and vice versa) are encoded as u8 integers.
  */
+#endif
 } msg_ssr_grid_definition_dep_a_t;
 
 

--- a/c/include/libsbp/system.h
+++ b/c/include/libsbp/system.h
@@ -98,7 +98,9 @@ typedef struct SBP_ATTR_PACKED {
   u8 flags;          /**< Status flags */
   u16 latency;        /**< Latency of observation receipt [deci-seconds] */
   u8 num_signals;    /**< Number of signals from base station */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char source[0];      /**< Corrections source string */
+#endif
 } msg_dgnss_status_t;
 
 
@@ -330,7 +332,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 id;           /**< Index representing the type of telemetry in use.  It is implemention defined. */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char telemetry[0]; /**< Comma separated list of values as defined by the index */
+#endif
 } msg_csac_telemetry_t;
 
 
@@ -344,7 +348,9 @@ typedef struct SBP_ATTR_PACKED {
 
 typedef struct SBP_ATTR_PACKED {
   u8 id;                  /**< Index representing the type of telemetry in use.  It is implemention defined. */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   char telemetry_labels[0]; /**< Comma separated list of telemetry field values */
+#endif
 } msg_csac_telemetry_labels_t;
 
 
@@ -539,9 +545,11 @@ typedef struct SBP_ATTR_PACKED {
   u8 group_id;        /**< Id of the Msgs Group, 0 is Unknown, 1 is Bestpos, 2 is Gnss */
   u8 flags;           /**< Status flags (reserved) */
   u8 n_group_msgs;    /**< Size of list group_msgs */
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
   u16 group_msgs[0];   /**< An inorder list of message types included in the Solution Group,
 including GROUP_META itself
  */
+#endif
 } msg_group_meta_t;
 
 

--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -548,10 +548,12 @@ typedef struct SBP_ATTR_PACKED {
  * measurements for all tracked satellites.
  */
 #define SBP_MSG_TRACKING_STATE                0x0041
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   tracking_channel_state_t states[0]; /**< Signal tracking channel state */
 } msg_tracking_state_t;
+#endif
 
 
 /** Measurement Engine signal tracking channel state
@@ -576,10 +578,12 @@ typedef struct SBP_ATTR_PACKED {
  * measurements for all tracked satellites.
  */
 #define SBP_MSG_MEASUREMENT_STATE             0x0061
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   measurement_state_t states[0]; /**< ME signal tracking channel state */
 } msg_measurement_state_t;
+#endif
 
 
 /** Complex correlation structure
@@ -662,10 +666,12 @@ typedef struct SBP_ATTR_PACKED {
 * Deprecated.
  */
 #define SBP_MSG_TRACKING_STATE_DEP_A          0x0016
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   tracking_channel_state_dep_a_t states[0]; /**< Satellite tracking channel state */
 } msg_tracking_state_dep_a_t;
+#endif
 
 
 /** Deprecated.
@@ -685,10 +691,12 @@ typedef struct SBP_ATTR_PACKED {
 * Deprecated.
  */
 #define SBP_MSG_TRACKING_STATE_DEP_B          0x0013
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   tracking_channel_state_dep_b_t states[0]; /**< Signal tracking channel state */
 } msg_tracking_state_dep_b_t;
+#endif
 
 
 /** \} */

--- a/c/include/libsbp/user.h
+++ b/c/include/libsbp/user.h
@@ -34,10 +34,12 @@ SBP_PACK_START
  * maximum length of 255 bytes per message.
  */
 #define SBP_MSG_USER_DATA 0x0800
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
 
 typedef struct SBP_ATTR_PACKED {
   u8 contents[0]; /**< User data payload */
 } msg_user_data_t;
+#endif
 
 
 /** \} */

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -46,6 +46,19 @@ CONSTRUCT_CODE = set(['u8', 'u16', 'u32', 'u64', 's8', 's16', 's32',
 
 COLLISIONS = set(['GnssSignal', 'GPSTime'])
 
+def field_is_variable_sized(field):
+  """Tests a field for variable sizing if array or string
+  """
+  name = field.type_id
+  if name == "string" or name == "array":
+    size = field.options.get('size', None)
+    if size is not None:
+      return False
+    else:
+      return True
+  else:
+    return False
+
 def convert(value):
   """Converts to a C language appropriate identifier format.
 
@@ -124,6 +137,7 @@ def create_bitfield_macros(field, msg):
                                                       value_numerical))
   return "\n".join(ret_list)
 
+JENV.filters['field_is_variable_sized'] = field_is_variable_sized
 JENV.filters['commentify'] = commentify
 JENV.filters['mk_id'] = mk_id
 JENV.filters['mk_size'] = mk_size

--- a/generator/sbpg/targets/resources/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/sbp_messages_template.h
@@ -50,15 +50,36 @@ SBP_PACK_START
 ((*- endfor *))
 ((*- endif *))
 
+((*- if m.fields|first == m.fields|last *))
+((*- if (m.fields|first)|field_is_variable_sized *))
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
+((*- endif *))
+((*- endif *))
+
 typedef struct SBP_ATTR_PACKED {
   ((*- for f in m.fields *))
+  ((*- if m.fields|first != m.fields|last *))
+  ((*- if f|field_is_variable_sized *))
+#ifndef SBP_DISABLE_VARIABLE_SIZED_ARRAYS
+  ((*- endif *))
+  ((*- endif *))
   ((*- if f.desc *))
   (((f|mk_id))) ((((f|mk_size).ljust(m.max_fid_len+4)))) /**< (((f.desc))) ((* if f.units *))[(((f.units)))] ((* endif *))*/
   ((*- else *))
   (((f|mk_id))) ((((f|mk_size).ljust(m.max_fid_len+4))))
   ((*- endif *))
+  ((*- if m.fields|first != m.fields|last *))
+  ((*- if f|field_is_variable_sized *))
+#endif
+  ((*- endif *))
+  ((*- endif *))
   ((*- endfor *))
 } (((m.identifier|convert)));
+((*- if m.fields|first == m.fields|last *))
+((*- if (m.fields|first)|field_is_variable_sized *))
+#endif
+((*- endif *))
+((*- endif *))
 ((*- endif *))
 
 ((* endfor *))


### PR DESCRIPTION
Introduces `SBP_DISABLE_VARIABLE_SIZED_ARRAYS` define to allow for variable sized arrays to be excluded.

In order to exclude, a user must define the above macro before including any header from `include/libsbp` either in source or via compiler define.