### PR TITLE
Bump check submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       language: python
       python: 3.7-dev
       before_install:
+        - sudo rm $(which cmake) # Remove Travis-provided CMake (too old)
         - sudo apt-get -qq update
         - sudo apt-get install gcc python2.7 python2.7-dev
         # https://linuxize.com/post/how-to-install-python-3-8-on-ubuntu-18-04/
@@ -54,6 +55,7 @@ matrix:
     - env:
         - TRAVIS_TARGET=default JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
       before_install:
+        - sudo rm $(which cmake) # Remove Travis-provided CMake (too old)
         - mkdir -p $HOME/texlive && curl -L https://github.com/urdh/texlive-blob/releases/download/20160619/texlive.tar.xz | tar -JxC $HOME/texlive
         - export PATH="$PATH:$HOME/texlive/bin/x86_64-linux"
         # Install stack
@@ -104,6 +106,7 @@ matrix:
       python:
         - "3.7"
       before_install:
+        - sudo rm $(which cmake) # Remove Travis-provided CMake (too old)
         - source ./scripts/travis_benchmark_install.bash
       script:
         - ./scripts/travis_benchmark.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ matrix:
     - env:
         - TRAVIS_TARGET=codecov
         - CMAKEFLAGS="-DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug"
+      before_install:
+        - sudo rm $(which cmake) # Remove Travis-provided CMake (too old)
       script:
         - make test-c
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ language: generic
 
 addons:
   apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ bionic main'
+        key_url: https://apt.kitware.com/keys/kitware-archive-latest.asc
     packages:
       - build-essential
       - doxygen

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -38,7 +38,6 @@ RUN \
       texlive-science \
       texlive-fonts-extra \
       check \
-      cmake \
       ccache \
       pkg-config \
       doxygen \
@@ -65,6 +64,12 @@ RUN add-apt-repository ppa:deadsnakes/ppa \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --no-modify-path \
   && curl -sSL https://get.haskellstack.org/ | sh \
   && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+  && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' \ 
+  && apt-get update \
+  && apt-get install -y \
+    cmake
 
 # Add a "dockerdev" user with sudo capabilities
 # 1000 is the first user ID issued on Ubuntu; might


### PR DESCRIPTION
This PR bumps the check submodule to fix compiling issues on the latest bundled clang on macOS (Apple clang version 12.0.0 (clang-1200.0.32.2)).

Since the new version of libcheck requires CMake > 3.13, this PR also updates the build images to make a current version available.