### PR TITLE
Add Rust message handlers

### DIFF
--- a/generator/sbpg/targets/resources/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_template.rs
@@ -123,4 +123,15 @@ impl crate::serialize::SbpSerialize for (((m.identifier|camel_case))) {
         ((*- endif *))
     }
 }
+
+((*- if m.is_real_message *))
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<(((m.identifier|camel_case))), T> where T: FnMut(&(((m.identifier|camel_case)))) {
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::(((m.identifier|camel_case)))(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
+((*- endif *))
 ((* endfor *))

--- a/rust/sbp/src/handler.rs
+++ b/rust/sbp/src/handler.rs
@@ -1,0 +1,27 @@
+use std::marker::PhantomData;
+
+pub trait HandleSbpMessage {
+    fn handle_message(&mut self, _msg: &crate::messages::SBP);
+}
+
+pub struct Handler<T: crate::messages::SBPMessage, U: FnMut(&T)> {
+    func: U,
+    phantom_data: PhantomData<T>,
+}
+
+impl<T, U> Handler<T, U>
+where
+    T: crate::messages::SBPMessage,
+    U: FnMut(&T),
+{
+    pub fn new(func: U) -> Self {
+        Self {
+            func,
+            phantom_data: PhantomData,
+        }
+    }
+
+    pub fn handle(&mut self, msg: &T) {
+        (self.func)(msg)
+    }
+}

--- a/rust/sbp/src/lib.rs
+++ b/rust/sbp/src/lib.rs
@@ -3,6 +3,7 @@
 //! see the protocol specification documentation at https://github.com/swift-nav/libsbp/tree/master/docs
 
 pub mod framer;
+mod handler;
 pub mod messages;
 pub mod parser;
 pub mod serialize;

--- a/rust/sbp/src/messages/acquisition.rs
+++ b/rust/sbp/src/messages/acquisition.rs
@@ -309,6 +309,17 @@ impl crate::serialize::SbpSerialize for MsgAcqResult {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAcqResult, T>
+where
+    T: FnMut(&MsgAcqResult),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAcqResult(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -378,6 +389,17 @@ impl crate::serialize::SbpSerialize for MsgAcqResultDepA {
         size += self.cf.sbp_size();
         size += self.prn.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAcqResultDepA, T>
+where
+    T: FnMut(&MsgAcqResultDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAcqResultDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -450,6 +472,17 @@ impl crate::serialize::SbpSerialize for MsgAcqResultDepB {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAcqResultDepB, T>
+where
+    T: FnMut(&MsgAcqResultDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAcqResultDepB(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -519,6 +552,17 @@ impl crate::serialize::SbpSerialize for MsgAcqResultDepC {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAcqResultDepC, T>
+where
+    T: FnMut(&MsgAcqResultDepC),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAcqResultDepC(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Acquisition perfomance measurement and debug
 ///
@@ -574,6 +618,17 @@ impl crate::serialize::SbpSerialize for MsgAcqSvProfile {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAcqSvProfile, T>
+where
+    T: FnMut(&MsgAcqSvProfile),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAcqSvProfile(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated.
 ///
@@ -626,5 +681,16 @@ impl crate::serialize::SbpSerialize for MsgAcqSvProfileDep {
         let mut size = 0;
         size += self.acq_sv_profile.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAcqSvProfileDep, T>
+where
+    T: FnMut(&MsgAcqSvProfileDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAcqSvProfileDep(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/bootload.rs
+++ b/rust/sbp/src/messages/bootload.rs
@@ -81,6 +81,17 @@ impl crate::serialize::SbpSerialize for MsgBootloaderHandshakeDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBootloaderHandshakeDepA, T>
+where
+    T: FnMut(&MsgBootloaderHandshakeDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBootloaderHandshakeDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Bootloading handshake request (host => device)
 ///
@@ -128,6 +139,17 @@ impl crate::serialize::SbpSerialize for MsgBootloaderHandshakeReq {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBootloaderHandshakeReq, T>
+where
+    T: FnMut(&MsgBootloaderHandshakeReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBootloaderHandshakeReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -193,6 +215,17 @@ impl crate::serialize::SbpSerialize for MsgBootloaderHandshakeResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBootloaderHandshakeResp, T>
+where
+    T: FnMut(&MsgBootloaderHandshakeResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBootloaderHandshakeResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Bootloader jump to application (host => device)
 ///
@@ -247,6 +280,17 @@ impl crate::serialize::SbpSerialize for MsgBootloaderJumpToApp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBootloaderJumpToApp, T>
+where
+    T: FnMut(&MsgBootloaderJumpToApp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBootloaderJumpToApp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Read FPGA device ID over UART request (host => device)
 ///
@@ -297,6 +341,17 @@ impl crate::serialize::SbpSerialize for MsgNapDeviceDnaReq {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgNapDeviceDnaReq, T>
+where
+    T: FnMut(&MsgNapDeviceDnaReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgNapDeviceDnaReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -356,5 +411,16 @@ impl crate::serialize::SbpSerialize for MsgNapDeviceDnaResp {
         let mut size = 0;
         size += self.dna.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgNapDeviceDnaResp, T>
+where
+    T: FnMut(&MsgNapDeviceDnaResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgNapDeviceDnaResp(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/ext_events.rs
+++ b/rust/sbp/src/messages/ext_events.rs
@@ -100,3 +100,14 @@ impl crate::serialize::SbpSerialize for MsgExtEvent {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgExtEvent, T>
+where
+    T: FnMut(&MsgExtEvent),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgExtEvent(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}

--- a/rust/sbp/src/messages/file_io.rs
+++ b/rust/sbp/src/messages/file_io.rs
@@ -87,6 +87,17 @@ impl crate::serialize::SbpSerialize for MsgFileioConfigReq {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioConfigReq, T>
+where
+    T: FnMut(&MsgFileioConfigReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioConfigReq(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Response with advice on the optimal configuration for FileIO.
 
@@ -158,6 +169,17 @@ impl crate::serialize::SbpSerialize for MsgFileioConfigResp {
         size += self.batch_size.sbp_size();
         size += self.fileio_version.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioConfigResp, T>
+where
+    T: FnMut(&MsgFileioConfigResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioConfigResp(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -233,6 +255,17 @@ impl crate::serialize::SbpSerialize for MsgFileioReadDirReq {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioReadDirReq, T>
+where
+    T: FnMut(&MsgFileioReadDirReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioReadDirReq(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Files listed in a directory (host <= device)
 ///
@@ -295,6 +328,17 @@ impl crate::serialize::SbpSerialize for MsgFileioReadDirResp {
         size += self.sequence.sbp_size();
         size += self.contents.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioReadDirResp, T>
+where
+    T: FnMut(&MsgFileioReadDirResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioReadDirResp(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -373,6 +417,17 @@ impl crate::serialize::SbpSerialize for MsgFileioReadReq {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioReadReq, T>
+where
+    T: FnMut(&MsgFileioReadReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioReadReq(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// File read from the file system (host <= device)
 ///
@@ -436,6 +491,17 @@ impl crate::serialize::SbpSerialize for MsgFileioReadResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioReadResp, T>
+where
+    T: FnMut(&MsgFileioReadResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioReadResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Delete a file from the file system (host => device)
 ///
@@ -491,6 +557,17 @@ impl crate::serialize::SbpSerialize for MsgFileioRemove {
         let mut size = 0;
         size += self.filename.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioRemove, T>
+where
+    T: FnMut(&MsgFileioRemove),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioRemove(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -569,6 +646,17 @@ impl crate::serialize::SbpSerialize for MsgFileioWriteReq {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioWriteReq, T>
+where
+    T: FnMut(&MsgFileioWriteReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioWriteReq(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// File written to (host <= device)
 ///
@@ -625,5 +713,16 @@ impl crate::serialize::SbpSerialize for MsgFileioWriteResp {
         let mut size = 0;
         size += self.sequence.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFileioWriteResp, T>
+where
+    T: FnMut(&MsgFileioWriteResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFileioWriteResp(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/flash.rs
+++ b/rust/sbp/src/messages/flash.rs
@@ -84,6 +84,17 @@ impl crate::serialize::SbpSerialize for MsgFlashDone {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFlashDone, T>
+where
+    T: FnMut(&MsgFlashDone),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFlashDone(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Erase sector of device flash memory (host => device).
 ///
@@ -145,6 +156,17 @@ impl crate::serialize::SbpSerialize for MsgFlashErase {
         size += self.target.sbp_size();
         size += self.sector_num.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFlashErase, T>
+where
+    T: FnMut(&MsgFlashErase),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFlashErase(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -221,6 +243,17 @@ impl crate::serialize::SbpSerialize for MsgFlashProgram {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFlashProgram, T>
+where
+    T: FnMut(&MsgFlashProgram),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFlashProgram(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Read STM or M25 flash address request (host => device).
 ///
@@ -289,6 +322,17 @@ impl crate::serialize::SbpSerialize for MsgFlashReadReq {
         size += self.addr_start.sbp_size();
         size += self.addr_len.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFlashReadReq, T>
+where
+    T: FnMut(&MsgFlashReadReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFlashReadReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -361,6 +405,17 @@ impl crate::serialize::SbpSerialize for MsgFlashReadResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFlashReadResp, T>
+where
+    T: FnMut(&MsgFlashReadResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFlashReadResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Write M25 flash status register (host => device)
 ///
@@ -414,6 +469,17 @@ impl crate::serialize::SbpSerialize for MsgM25FlashWriteStatus {
         let mut size = 0;
         size += self.status.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgM25FlashWriteStatus, T>
+where
+    T: FnMut(&MsgM25FlashWriteStatus),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgM25FlashWriteStatus(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -471,6 +537,17 @@ impl crate::serialize::SbpSerialize for MsgStmFlashLockSector {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgStmFlashLockSector, T>
+where
+    T: FnMut(&MsgStmFlashLockSector),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgStmFlashLockSector(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Unlock sector of STM flash memory (host => device)
 ///
@@ -526,6 +603,17 @@ impl crate::serialize::SbpSerialize for MsgStmFlashUnlockSector {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgStmFlashUnlockSector, T>
+where
+    T: FnMut(&MsgStmFlashUnlockSector),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgStmFlashUnlockSector(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Read device's hardcoded unique ID request (host => device)
 
@@ -575,6 +663,17 @@ impl crate::serialize::SbpSerialize for MsgStmUniqueIdReq {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgStmUniqueIdReq, T>
+where
+    T: FnMut(&MsgStmUniqueIdReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgStmUniqueIdReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -633,5 +732,16 @@ impl crate::serialize::SbpSerialize for MsgStmUniqueIdResp {
         let mut size = 0;
         size += self.stm_id.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgStmUniqueIdResp, T>
+where
+    T: FnMut(&MsgStmUniqueIdResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgStmUniqueIdResp(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/imu.rs
+++ b/rust/sbp/src/messages/imu.rs
@@ -88,6 +88,17 @@ impl crate::serialize::SbpSerialize for MsgImuAux {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgImuAux, T>
+where
+    T: FnMut(&MsgImuAux),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgImuAux(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Raw IMU data
 ///
@@ -183,5 +194,16 @@ impl crate::serialize::SbpSerialize for MsgImuRaw {
         size += self.gyr_y.sbp_size();
         size += self.gyr_z.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgImuRaw, T>
+where
+    T: FnMut(&MsgImuRaw),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgImuRaw(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/linux.rs
+++ b/rust/sbp/src/messages/linux.rs
@@ -98,6 +98,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxCpuState {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxCpuState, T>
+where
+    T: FnMut(&MsgLinuxCpuState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxCpuState(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// List CPU state on the system
 ///
@@ -173,6 +184,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxMemState {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxMemState, T>
+where
+    T: FnMut(&MsgLinuxMemState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxMemState(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Summary of processes with large amounts of open file descriptors
 ///
@@ -242,6 +264,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxProcessFdCount {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxProcessFdCount, T>
+where
+    T: FnMut(&MsgLinuxProcessFdCount),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxProcessFdCount(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Summary of open file descriptors on the system
 ///
@@ -303,6 +336,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxProcessFdSummary {
         size += self.sys_fd_count.sbp_size();
         size += self.most_opened.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxProcessFdSummary, T>
+where
+    T: FnMut(&MsgLinuxProcessFdSummary),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxProcessFdSummary(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -386,6 +430,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxProcessSocketCounts {
         size += self.socket_states.sbp_size();
         size += self.cmdline.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxProcessSocketCounts, T>
+where
+    T: FnMut(&MsgLinuxProcessSocketCounts),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxProcessSocketCounts(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -482,6 +537,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxProcessSocketQueues {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxProcessSocketQueues, T>
+where
+    T: FnMut(&MsgLinuxProcessSocketQueues),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxProcessSocketQueues(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Summary of socket usage across the system
 ///
@@ -553,6 +619,17 @@ impl crate::serialize::SbpSerialize for MsgLinuxSocketUsage {
         size += self.socket_state_counts.sbp_size();
         size += self.socket_type_counts.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxSocketUsage, T>
+where
+    T: FnMut(&MsgLinuxSocketUsage),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxSocketUsage(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -632,5 +709,16 @@ impl crate::serialize::SbpSerialize for MsgLinuxSysState {
         size += self.procs_stopping.sbp_size();
         size += self.pid_count.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLinuxSysState, T>
+where
+    T: FnMut(&MsgLinuxSysState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLinuxSysState(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/logging.rs
+++ b/rust/sbp/src/messages/logging.rs
@@ -93,6 +93,17 @@ impl crate::serialize::SbpSerialize for MsgFwd {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFwd, T>
+where
+    T: FnMut(&MsgFwd),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFwd(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Plaintext logging messages with levels
 ///
@@ -154,6 +165,17 @@ impl crate::serialize::SbpSerialize for MsgLog {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgLog, T>
+where
+    T: FnMut(&MsgLog),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgLog(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -206,5 +228,16 @@ impl crate::serialize::SbpSerialize for MsgPrintDep {
         let mut size = 0;
         size += self.text.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPrintDep, T>
+where
+    T: FnMut(&MsgPrintDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPrintDep(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/mag.rs
+++ b/rust/sbp/src/messages/mag.rs
@@ -97,3 +97,14 @@ impl crate::serialize::SbpSerialize for MsgMagRaw {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgMagRaw, T>
+where
+    T: FnMut(&MsgMagRaw),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgMagRaw(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -100,6 +100,17 @@ impl crate::serialize::SbpSerialize for MsgAgeCorrections {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAgeCorrections, T>
+where
+    T: FnMut(&MsgAgeCorrections),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAgeCorrections(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Baseline Position in ECEF
 ///
@@ -186,6 +197,17 @@ impl crate::serialize::SbpSerialize for MsgBaselineECEF {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBaselineECEF, T>
+where
+    T: FnMut(&MsgBaselineECEF),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBaselineECEF(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -276,6 +298,17 @@ impl crate::serialize::SbpSerialize for MsgBaselineECEFDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBaselineECEFDepA, T>
+where
+    T: FnMut(&MsgBaselineECEFDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBaselineECEFDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Heading relative to True North
 ///
@@ -345,6 +378,17 @@ impl crate::serialize::SbpSerialize for MsgBaselineHeadingDepA {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBaselineHeadingDepA, T>
+where
+    T: FnMut(&MsgBaselineHeadingDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBaselineHeadingDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -441,6 +485,17 @@ impl crate::serialize::SbpSerialize for MsgBaselineNED {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBaselineNED, T>
+where
+    T: FnMut(&MsgBaselineNED),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBaselineNED(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Baseline in NED
 ///
@@ -535,6 +590,17 @@ impl crate::serialize::SbpSerialize for MsgBaselineNEDDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBaselineNEDDepA, T>
+where
+    T: FnMut(&MsgBaselineNEDDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBaselineNEDDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Dilution of Precision
 ///
@@ -622,6 +688,17 @@ impl crate::serialize::SbpSerialize for MsgDops {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgDops, T>
+where
+    T: FnMut(&MsgDops),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgDops(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Dilution of Precision
 ///
@@ -701,6 +778,17 @@ impl crate::serialize::SbpSerialize for MsgDopsDepA {
         size += self.hdop.sbp_size();
         size += self.vdop.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgDopsDepA, T>
+where
+    T: FnMut(&MsgDopsDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgDopsDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -785,6 +873,17 @@ impl crate::serialize::SbpSerialize for MsgGPSTime {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGPSTime, T>
+where
+    T: FnMut(&MsgGPSTime),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGPSTime(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GPS Time (v1.0)
 ///
@@ -867,6 +966,17 @@ impl crate::serialize::SbpSerialize for MsgGPSTimeDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGPSTimeDepA, T>
+where
+    T: FnMut(&MsgGPSTimeDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGPSTimeDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GPS Time
 ///
@@ -947,6 +1057,17 @@ impl crate::serialize::SbpSerialize for MsgGPSTimeGnss {
         size += self.ns_residual.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGPSTimeGnss, T>
+where
+    T: FnMut(&MsgGPSTimeGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGPSTimeGnss(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1038,6 +1159,17 @@ impl crate::serialize::SbpSerialize for MsgPosECEF {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosECEF, T>
+where
+    T: FnMut(&MsgPosECEF),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosECEF(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1157,6 +1289,17 @@ impl crate::serialize::SbpSerialize for MsgPosECEFCov {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosECEFCov, T>
+where
+    T: FnMut(&MsgPosECEFCov),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosECEFCov(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Position in ECEF
 ///
@@ -1274,6 +1417,17 @@ impl crate::serialize::SbpSerialize for MsgPosECEFCovGnss {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosECEFCovGnss, T>
+where
+    T: FnMut(&MsgPosECEFCovGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosECEFCovGnss(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Single-point position in ECEF
 ///
@@ -1365,6 +1519,17 @@ impl crate::serialize::SbpSerialize for MsgPosECEFDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosECEFDepA, T>
+where
+    T: FnMut(&MsgPosECEFDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosECEFDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Position in ECEF
 ///
@@ -1454,6 +1619,17 @@ impl crate::serialize::SbpSerialize for MsgPosECEFGnss {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosECEFGnss, T>
+where
+    T: FnMut(&MsgPosECEFGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosECEFGnss(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1550,6 +1726,17 @@ impl crate::serialize::SbpSerialize for MsgPosLLH {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosLLH, T>
+where
+    T: FnMut(&MsgPosLLH),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosLLH(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1668,6 +1855,17 @@ impl crate::serialize::SbpSerialize for MsgPosLLHCov {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosLLHCov, T>
+where
+    T: FnMut(&MsgPosLLHCov),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosLLHCov(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Geodetic Position
 ///
@@ -1784,6 +1982,17 @@ impl crate::serialize::SbpSerialize for MsgPosLLHCovGnss {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosLLHCovGnss, T>
+where
+    T: FnMut(&MsgPosLLHCovGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosLLHCovGnss(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Geodetic Position
 ///
@@ -1878,6 +2087,17 @@ impl crate::serialize::SbpSerialize for MsgPosLLHDepA {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosLLHDepA, T>
+where
+    T: FnMut(&MsgPosLLHDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosLLHDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1976,6 +2196,17 @@ impl crate::serialize::SbpSerialize for MsgPosLLHGnss {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgPosLLHGnss, T>
+where
+    T: FnMut(&MsgPosLLHGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgPosLLHGnss(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Computed Position and Protection Level
 ///
@@ -2060,6 +2291,17 @@ impl crate::serialize::SbpSerialize for MsgProtectionLevel {
         size += self.height.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgProtectionLevel, T>
+where
+    T: FnMut(&MsgProtectionLevel),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgProtectionLevel(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -2157,6 +2399,17 @@ impl crate::serialize::SbpSerialize for MsgUtcTime {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgUtcTime, T>
+where
+    T: FnMut(&MsgUtcTime),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgUtcTime(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// UTC Time
 ///
@@ -2250,6 +2503,17 @@ impl crate::serialize::SbpSerialize for MsgUtcTimeGnss {
         size += self.seconds.sbp_size();
         size += self.ns.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgUtcTimeGnss, T>
+where
+    T: FnMut(&MsgUtcTimeGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgUtcTimeGnss(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -2368,6 +2632,17 @@ impl crate::serialize::SbpSerialize for MsgVelBody {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelBody, T>
+where
+    T: FnMut(&MsgVelBody),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelBody(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Velocity in ECEF
 ///
@@ -2452,6 +2727,17 @@ impl crate::serialize::SbpSerialize for MsgVelECEF {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelECEF, T>
+where
+    T: FnMut(&MsgVelECEF),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelECEF(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -2565,6 +2851,17 @@ impl crate::serialize::SbpSerialize for MsgVelECEFCov {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelECEFCov, T>
+where
+    T: FnMut(&MsgVelECEFCov),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelECEFCov(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Velocity in ECEF
 ///
@@ -2676,6 +2973,17 @@ impl crate::serialize::SbpSerialize for MsgVelECEFCovGnss {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelECEFCovGnss, T>
+where
+    T: FnMut(&MsgVelECEFCovGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelECEFCovGnss(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Velocity in ECEF
 ///
@@ -2762,6 +3070,17 @@ impl crate::serialize::SbpSerialize for MsgVelECEFDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelECEFDepA, T>
+where
+    T: FnMut(&MsgVelECEFDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelECEFDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Velocity in ECEF
 ///
@@ -2846,6 +3165,17 @@ impl crate::serialize::SbpSerialize for MsgVelECEFGnss {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelECEFGnss, T>
+where
+    T: FnMut(&MsgVelECEFGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelECEFGnss(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -2938,6 +3268,17 @@ impl crate::serialize::SbpSerialize for MsgVelNED {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelNED, T>
+where
+    T: FnMut(&MsgVelNED),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelNED(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -3054,6 +3395,17 @@ impl crate::serialize::SbpSerialize for MsgVelNEDCov {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelNEDCov, T>
+where
+    T: FnMut(&MsgVelNEDCov),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelNEDCov(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Velocity in NED
 ///
@@ -3168,6 +3520,17 @@ impl crate::serialize::SbpSerialize for MsgVelNEDCovGnss {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelNEDCovGnss, T>
+where
+    T: FnMut(&MsgVelNEDCovGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelNEDCovGnss(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Velocity in NED
 ///
@@ -3260,6 +3623,17 @@ impl crate::serialize::SbpSerialize for MsgVelNEDDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelNEDDepA, T>
+where
+    T: FnMut(&MsgVelNEDDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelNEDDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GNSS-only Velocity in NED
 ///
@@ -3350,5 +3724,16 @@ impl crate::serialize::SbpSerialize for MsgVelNEDGnss {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgVelNEDGnss, T>
+where
+    T: FnMut(&MsgVelNEDGnss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgVelNEDGnss(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/ndb.rs
+++ b/rust/sbp/src/messages/ndb.rs
@@ -120,3 +120,14 @@ impl crate::serialize::SbpSerialize for MsgNdbEvent {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgNdbEvent, T>
+where
+    T: FnMut(&MsgNdbEvent),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgNdbEvent(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -737,6 +737,17 @@ impl crate::serialize::SbpSerialize for MsgAlmanacGlo {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAlmanacGlo, T>
+where
+    T: FnMut(&MsgAlmanacGlo),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAlmanacGlo(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for GLO
 ///
@@ -828,6 +839,17 @@ impl crate::serialize::SbpSerialize for MsgAlmanacGloDep {
         size += self.epsilon.sbp_size();
         size += self.omega.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAlmanacGloDep, T>
+where
+    T: FnMut(&MsgAlmanacGloDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAlmanacGloDep(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -932,6 +954,17 @@ impl crate::serialize::SbpSerialize for MsgAlmanacGPS {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAlmanacGPS, T>
+where
+    T: FnMut(&MsgAlmanacGPS),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAlmanacGPS(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for GPS
 ///
@@ -1034,6 +1067,17 @@ impl crate::serialize::SbpSerialize for MsgAlmanacGPSDep {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAlmanacGPSDep, T>
+where
+    T: FnMut(&MsgAlmanacGPSDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAlmanacGPSDep(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Base station position in ECEF
 ///
@@ -1103,6 +1147,17 @@ impl crate::serialize::SbpSerialize for MsgBasePosECEF {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBasePosECEF, T>
+where
+    T: FnMut(&MsgBasePosECEF),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBasePosECEF(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Base station position
 ///
@@ -1169,6 +1224,17 @@ impl crate::serialize::SbpSerialize for MsgBasePosLLH {
         size += self.lon.sbp_size();
         size += self.height.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBasePosLLH, T>
+where
+    T: FnMut(&MsgBasePosLLH),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBasePosLLH(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1347,6 +1413,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisBds {
         size += self.iode.sbp_size();
         size += self.iodc.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisBds, T>
+where
+    T: FnMut(&MsgEphemerisBds),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisBds(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1530,6 +1607,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisDepA {
         size += self.healthy.sbp_size();
         size += self.prn.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisDepA, T>
+where
+    T: FnMut(&MsgEphemerisDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1718,6 +1806,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisDepB {
         size += self.prn.sbp_size();
         size += self.iode.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisDepB, T>
+where
+    T: FnMut(&MsgEphemerisDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisDepB(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1922,6 +2021,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisDepC {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisDepC, T>
+where
+    T: FnMut(&MsgEphemerisDepC),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisDepC(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris
 ///
@@ -2124,6 +2234,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisDepD {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisDepD, T>
+where
+    T: FnMut(&MsgEphemerisDepD),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisDepD(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for Galileo
 ///
@@ -2305,6 +2426,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGal {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGal, T>
+where
+    T: FnMut(&MsgEphemerisGal),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGal(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -2479,6 +2611,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGalDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGalDepA, T>
+where
+    T: FnMut(&MsgEphemerisGalDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGalDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for GLO
 ///
@@ -2577,6 +2720,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGlo {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGlo, T>
+where
+    T: FnMut(&MsgEphemerisGlo),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGlo(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for GLO
 ///
@@ -2660,6 +2814,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGloDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGloDepA, T>
+where
+    T: FnMut(&MsgEphemerisGloDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGloDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for GLO
 ///
@@ -2741,6 +2906,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGloDepB {
         size += self.vel.sbp_size();
         size += self.acc.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGloDepB, T>
+where
+    T: FnMut(&MsgEphemerisGloDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGloDepB(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -2836,6 +3012,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGloDepC {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGloDepC, T>
+where
+    T: FnMut(&MsgEphemerisGloDepC),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGloDepC(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -2929,6 +3116,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGloDepD {
         size += self.fcn.sbp_size();
         size += self.iod.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGloDepD, T>
+where
+    T: FnMut(&MsgEphemerisGloDepD),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGloDepD(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -3103,6 +3301,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGPS {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGPS, T>
+where
+    T: FnMut(&MsgEphemerisGPS),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGPS(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite broadcast ephemeris for GPS
 ///
@@ -3275,6 +3484,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGPSDepE {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGPSDepE, T>
+where
+    T: FnMut(&MsgEphemerisGPSDepE),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGPSDepE(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -3442,6 +3662,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisGPSDepF {
         size += self.iode.sbp_size();
         size += self.iodc.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisGPSDepF, T>
+where
+    T: FnMut(&MsgEphemerisGPSDepF),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisGPSDepF(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -3614,6 +3845,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisQzss {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisQzss, T>
+where
+    T: FnMut(&MsgEphemerisQzss),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisQzss(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -3689,6 +3931,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisSbas {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisSbas, T>
+where
+    T: FnMut(&MsgEphemerisSbas),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisSbas(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -3762,6 +4015,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisSbasDepA {
         size += self.a_gf0.sbp_size();
         size += self.a_gf1.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisSbasDepA, T>
+where
+    T: FnMut(&MsgEphemerisSbasDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisSbasDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -3844,6 +4108,17 @@ impl crate::serialize::SbpSerialize for MsgEphemerisSbasDepB {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgEphemerisSbasDepB, T>
+where
+    T: FnMut(&MsgEphemerisSbasDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgEphemerisSbasDepB(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GLONASS L1/L2 Code-Phase biases
 ///
@@ -3921,6 +4196,17 @@ impl crate::serialize::SbpSerialize for MsgGloBiases {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGloBiases, T>
+where
+    T: FnMut(&MsgGloBiases),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGloBiases(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -3974,6 +4260,17 @@ impl crate::serialize::SbpSerialize for MsgGnssCapb {
         size += self.t_nmct.sbp_size();
         size += self.gc.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGnssCapb, T>
+where
+    T: FnMut(&MsgGnssCapb),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGnssCapb(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -4053,6 +4350,17 @@ impl crate::serialize::SbpSerialize for MsgGroupDelay {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGroupDelay, T>
+where
+    T: FnMut(&MsgGroupDelay),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGroupDelay(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Group Delay
 ///
@@ -4130,6 +4438,17 @@ impl crate::serialize::SbpSerialize for MsgGroupDelayDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGroupDelayDepA, T>
+where
+    T: FnMut(&MsgGroupDelayDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGroupDelayDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Group Delay
 ///
@@ -4205,6 +4524,17 @@ impl crate::serialize::SbpSerialize for MsgGroupDelayDepB {
         size += self.isc_l1ca.sbp_size();
         size += self.isc_l2c.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGroupDelayDepB, T>
+where
+    T: FnMut(&MsgGroupDelayDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGroupDelayDepB(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -4295,6 +4625,17 @@ impl crate::serialize::SbpSerialize for MsgIono {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgIono, T>
+where
+    T: FnMut(&MsgIono),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgIono(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// GPS satellite observations
 ///
@@ -4360,6 +4701,17 @@ impl crate::serialize::SbpSerialize for MsgObs {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgObs, T>
+where
+    T: FnMut(&MsgObs),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgObs(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -4417,6 +4769,17 @@ impl crate::serialize::SbpSerialize for MsgObsDepA {
         size += self.header.sbp_size();
         size += self.obs.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgObsDepA, T>
+where
+    T: FnMut(&MsgObsDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgObsDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -4481,6 +4844,17 @@ impl crate::serialize::SbpSerialize for MsgObsDepB {
         size += self.header.sbp_size();
         size += self.obs.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgObsDepB, T>
+where
+    T: FnMut(&MsgObsDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgObsDepB(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -4548,6 +4922,17 @@ impl crate::serialize::SbpSerialize for MsgObsDepC {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgObsDepC, T>
+where
+    T: FnMut(&MsgObsDepC),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgObsDepC(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// OSR corrections
 ///
@@ -4607,6 +4992,17 @@ impl crate::serialize::SbpSerialize for MsgOsr {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgOsr, T>
+where
+    T: FnMut(&MsgOsr),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgOsr(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Satellite azimuths and elevations
 ///
@@ -4660,6 +5056,17 @@ impl crate::serialize::SbpSerialize for MsgSvAzEl {
         let mut size = 0;
         size += self.azel.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSvAzEl, T>
+where
+    T: FnMut(&MsgSvAzEl),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSvAzEl(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -4719,6 +5126,17 @@ impl crate::serialize::SbpSerialize for MsgSvConfigurationGPSDep {
         size += self.t_nmct.sbp_size();
         size += self.l2c_mask.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSvConfigurationGPSDep, T>
+where
+    T: FnMut(&MsgSvConfigurationGPSDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSvConfigurationGPSDep(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 

--- a/rust/sbp/src/messages/orientation.rs
+++ b/rust/sbp/src/messages/orientation.rs
@@ -104,6 +104,17 @@ impl crate::serialize::SbpSerialize for MsgAngularRate {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAngularRate, T>
+where
+    T: FnMut(&MsgAngularRate),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAngularRate(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Heading relative to True North
 ///
@@ -174,6 +185,17 @@ impl crate::serialize::SbpSerialize for MsgBaselineHeading {
         size += self.n_sats.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgBaselineHeading, T>
+where
+    T: FnMut(&MsgBaselineHeading),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgBaselineHeading(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -267,6 +289,17 @@ impl crate::serialize::SbpSerialize for MsgOrientEuler {
         size += self.yaw_accuracy.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgOrientEuler, T>
+where
+    T: FnMut(&MsgOrientEuler),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgOrientEuler(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -370,5 +403,16 @@ impl crate::serialize::SbpSerialize for MsgOrientQuat {
         size += self.z_accuracy.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgOrientQuat, T>
+where
+    T: FnMut(&MsgOrientQuat),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgOrientQuat(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/piksi.rs
+++ b/rust/sbp/src/messages/piksi.rs
@@ -142,6 +142,17 @@ impl crate::serialize::SbpSerialize for MsgAlmanac {
         0
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgAlmanac, T>
+where
+    T: FnMut(&MsgAlmanac),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgAlmanac(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Cell modem information update message
 ///
@@ -208,6 +219,17 @@ impl crate::serialize::SbpSerialize for MsgCellModemStatus {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCellModemStatus, T>
+where
+    T: FnMut(&MsgCellModemStatus),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCellModemStatus(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Command output
 ///
@@ -268,6 +290,17 @@ impl crate::serialize::SbpSerialize for MsgCommandOutput {
         size += self.sequence.sbp_size();
         size += self.line.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCommandOutput, T>
+where
+    T: FnMut(&MsgCommandOutput),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCommandOutput(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -331,6 +364,17 @@ impl crate::serialize::SbpSerialize for MsgCommandReq {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCommandReq, T>
+where
+    T: FnMut(&MsgCommandReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCommandReq(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Exit code from executed command (device => host)
 ///
@@ -391,6 +435,17 @@ impl crate::serialize::SbpSerialize for MsgCommandResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCommandResp, T>
+where
+    T: FnMut(&MsgCommandResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCommandResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Legacy message for CW interference channel (Piksi => host)
 ///
@@ -440,6 +495,17 @@ impl crate::serialize::SbpSerialize for MsgCwResults {
         0
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCwResults, T>
+where
+    T: FnMut(&MsgCwResults),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCwResults(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Legacy message for CW interference channel (host => Piksi)
 ///
@@ -487,6 +553,17 @@ impl crate::serialize::SbpSerialize for MsgCwStart {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCwStart, T>
+where
+    T: FnMut(&MsgCwStart),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCwStart(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -565,6 +642,17 @@ impl crate::serialize::SbpSerialize for MsgDeviceMonitor {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgDeviceMonitor, T>
+where
+    T: FnMut(&MsgDeviceMonitor),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgDeviceMonitor(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// RF AGC status
 ///
@@ -629,6 +717,17 @@ impl crate::serialize::SbpSerialize for MsgFrontEndGain {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgFrontEndGain, T>
+where
+    T: FnMut(&MsgFrontEndGain),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgFrontEndGain(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// State of the Integer Ambiguity Resolution (IAR) process
 ///
@@ -686,6 +785,17 @@ impl crate::serialize::SbpSerialize for MsgIarState {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgIarState, T>
+where
+    T: FnMut(&MsgIarState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgIarState(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -731,6 +841,17 @@ impl crate::serialize::SbpSerialize for MsgInitBaseDep {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgInitBaseDep, T>
+where
+    T: FnMut(&MsgInitBaseDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgInitBaseDep(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -793,6 +914,17 @@ impl crate::serialize::SbpSerialize for MsgMaskSatellite {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgMaskSatellite, T>
+where
+    T: FnMut(&MsgMaskSatellite),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgMaskSatellite(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -852,6 +984,17 @@ impl crate::serialize::SbpSerialize for MsgMaskSatelliteDep {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgMaskSatelliteDep, T>
+where
+    T: FnMut(&MsgMaskSatelliteDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgMaskSatelliteDep(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Bandwidth usage reporting message
 ///
@@ -906,6 +1049,17 @@ impl crate::serialize::SbpSerialize for MsgNetworkBandwidthUsage {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgNetworkBandwidthUsage, T>
+where
+    T: FnMut(&MsgNetworkBandwidthUsage),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgNetworkBandwidthUsage(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Request state of Piksi network interfaces
 ///
@@ -952,6 +1106,17 @@ impl crate::serialize::SbpSerialize for MsgNetworkStateReq {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgNetworkStateReq, T>
+where
+    T: FnMut(&MsgNetworkStateReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgNetworkStateReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1045,6 +1210,17 @@ impl crate::serialize::SbpSerialize for MsgNetworkStateResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgNetworkStateResp, T>
+where
+    T: FnMut(&MsgNetworkStateResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgNetworkStateResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Reset the device (host => Piksi)
 ///
@@ -1100,6 +1276,17 @@ impl crate::serialize::SbpSerialize for MsgReset {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgReset, T>
+where
+    T: FnMut(&MsgReset),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgReset(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Reset the device (host => Piksi)
 ///
@@ -1146,6 +1333,17 @@ impl crate::serialize::SbpSerialize for MsgResetDep {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgResetDep, T>
+where
+    T: FnMut(&MsgResetDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgResetDep(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1203,6 +1401,17 @@ impl crate::serialize::SbpSerialize for MsgResetFilters {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgResetFilters, T>
+where
+    T: FnMut(&MsgResetFilters),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgResetFilters(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Send GPS time from host (host => Piksi)
 ///
@@ -1249,6 +1458,17 @@ impl crate::serialize::SbpSerialize for MsgSetTime {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSetTime, T>
+where
+    T: FnMut(&MsgSetTime),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSetTime(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1335,6 +1555,17 @@ impl crate::serialize::SbpSerialize for MsgSpecan {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSpecan, T>
+where
+    T: FnMut(&MsgSpecan),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSpecan(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -1419,6 +1650,17 @@ impl crate::serialize::SbpSerialize for MsgSpecanDep {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSpecanDep, T>
+where
+    T: FnMut(&MsgSpecanDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSpecanDep(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// State of an RTOS thread
 ///
@@ -1484,6 +1726,17 @@ impl crate::serialize::SbpSerialize for MsgThreadState {
         size += self.cpu.sbp_size();
         size += self.stack_free.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgThreadState, T>
+where
+    T: FnMut(&MsgThreadState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgThreadState(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1568,6 +1821,17 @@ impl crate::serialize::SbpSerialize for MsgUartState {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgUartState, T>
+where
+    T: FnMut(&MsgUartState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgUartState(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -1635,6 +1899,17 @@ impl crate::serialize::SbpSerialize for MsgUartStateDepa {
         size += self.uart_ftdi.sbp_size();
         size += self.latency.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgUartStateDepa, T>
+where
+    T: FnMut(&MsgUartStateDepa),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgUartStateDepa(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 

--- a/rust/sbp/src/messages/sbas.rs
+++ b/rust/sbp/src/messages/sbas.rs
@@ -93,3 +93,14 @@ impl crate::serialize::SbpSerialize for MsgSbasRaw {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSbasRaw, T>
+where
+    T: FnMut(&MsgSbasRaw),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSbasRaw(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}

--- a/rust/sbp/src/messages/settings.rs
+++ b/rust/sbp/src/messages/settings.rs
@@ -95,6 +95,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsReadByIndexDone {
         0
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsReadByIndexDone, T>
+where
+    T: FnMut(&MsgSettingsReadByIndexDone),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsReadByIndexDone(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Read setting by direct index (host => device)
 ///
@@ -150,6 +161,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsReadByIndexReq {
         let mut size = 0;
         size += self.index.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsReadByIndexReq, T>
+where
+    T: FnMut(&MsgSettingsReadByIndexReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsReadByIndexReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -222,6 +244,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsReadByIndexResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsReadByIndexResp, T>
+where
+    T: FnMut(&MsgSettingsReadByIndexResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsReadByIndexResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Read device configuration settings (host => device)
 ///
@@ -282,6 +315,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsReadReq {
         let mut size = 0;
         size += self.setting.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsReadReq, T>
+where
+    T: FnMut(&MsgSettingsReadReq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsReadReq(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -345,6 +389,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsReadResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsReadResp, T>
+where
+    T: FnMut(&MsgSettingsReadResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsReadResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Register setting and default value (device => host)
 ///
@@ -400,6 +455,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsRegister {
         let mut size = 0;
         size += self.setting.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsRegister, T>
+where
+    T: FnMut(&MsgSettingsRegister),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsRegister(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -466,6 +532,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsRegisterResp {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsRegisterResp, T>
+where
+    T: FnMut(&MsgSettingsRegisterResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsRegisterResp(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Save settings to flash (host => device)
 ///
@@ -512,6 +589,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsSave {
 
     fn sbp_size(&self) -> usize {
         0
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsSave, T>
+where
+    T: FnMut(&MsgSettingsSave),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsSave(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -573,6 +661,17 @@ impl crate::serialize::SbpSerialize for MsgSettingsWrite {
         let mut size = 0;
         size += self.setting.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsWrite, T>
+where
+    T: FnMut(&MsgSettingsWrite),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsWrite(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -639,5 +738,16 @@ impl crate::serialize::SbpSerialize for MsgSettingsWriteResp {
         size += self.status.sbp_size();
         size += self.setting.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSettingsWriteResp, T>
+where
+    T: FnMut(&MsgSettingsWriteResp),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSettingsWriteResp(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/solution_meta.rs
+++ b/rust/sbp/src/messages/solution_meta.rs
@@ -218,6 +218,17 @@ impl crate::serialize::SbpSerialize for MsgSolnMeta {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSolnMeta, T>
+where
+    T: FnMut(&MsgSolnMeta),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSolnMeta(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -320,6 +331,17 @@ impl crate::serialize::SbpSerialize for MsgSolnMetaDepA {
         size += self.last_used_gnss_vel_tow.sbp_size();
         size += self.sol_in.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSolnMetaDepA, T>
+where
+    T: FnMut(&MsgSolnMetaDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSolnMetaDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -535,6 +535,17 @@ impl crate::serialize::SbpSerialize for MsgSsrCodeBiases {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrCodeBiases, T>
+where
+    T: FnMut(&MsgSsrCodeBiases),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrCodeBiases(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Gridded troposphere and STEC correction residuals.
 ///
@@ -596,6 +607,17 @@ impl crate::serialize::SbpSerialize for MsgSsrGriddedCorrection {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrGriddedCorrection, T>
+where
+    T: FnMut(&MsgSsrGriddedCorrection),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrGriddedCorrection(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -652,6 +674,17 @@ impl crate::serialize::SbpSerialize for MsgSsrGriddedCorrectionDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrGriddedCorrectionDepA, T>
+where
+    T: FnMut(&MsgSsrGriddedCorrectionDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrGriddedCorrectionDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -705,6 +738,18 @@ impl crate::serialize::SbpSerialize for MsgSsrGriddedCorrectionNoStdDepA {
         size += self.header.sbp_size();
         size += self.element.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage
+    for crate::handler::Handler<MsgSsrGriddedCorrectionNoStdDepA, T>
+where
+    T: FnMut(&MsgSsrGriddedCorrectionNoStdDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrGriddedCorrectionNoStdDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -763,6 +808,17 @@ impl crate::serialize::SbpSerialize for MsgSsrGridDefinitionDepA {
         size += self.header.sbp_size();
         size += self.rle_list.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrGridDefinitionDepA, T>
+where
+    T: FnMut(&MsgSsrGridDefinitionDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrGridDefinitionDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -889,6 +945,17 @@ impl crate::serialize::SbpSerialize for MsgSsrOrbitClock {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrOrbitClock, T>
+where
+    T: FnMut(&MsgSsrOrbitClock),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrOrbitClock(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -1006,6 +1073,17 @@ impl crate::serialize::SbpSerialize for MsgSsrOrbitClockDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrOrbitClockDepA, T>
+where
+    T: FnMut(&MsgSsrOrbitClockDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrOrbitClockDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Precise phase biases correction
 ///
@@ -1107,6 +1185,17 @@ impl crate::serialize::SbpSerialize for MsgSsrPhaseBiases {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrPhaseBiases, T>
+where
+    T: FnMut(&MsgSsrPhaseBiases),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrPhaseBiases(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// STEC correction polynomial coeffcients.
 ///
@@ -1171,6 +1260,17 @@ impl crate::serialize::SbpSerialize for MsgSsrStecCorrection {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrStecCorrection, T>
+where
+    T: FnMut(&MsgSsrStecCorrection),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrStecCorrection(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -1224,6 +1324,17 @@ impl crate::serialize::SbpSerialize for MsgSsrStecCorrectionDepA {
         size += self.header.sbp_size();
         size += self.stec_sat_list.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrStecCorrectionDepA, T>
+where
+    T: FnMut(&MsgSsrStecCorrectionDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrStecCorrectionDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -1345,6 +1456,17 @@ impl crate::serialize::SbpSerialize for MsgSsrTileDefinition {
         size += self.cols.sbp_size();
         size += self.bitmask.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgSsrTileDefinition, T>
+where
+    T: FnMut(&MsgSsrTileDefinition),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgSsrTileDefinition(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 

--- a/rust/sbp/src/messages/system.rs
+++ b/rust/sbp/src/messages/system.rs
@@ -84,6 +84,17 @@ impl crate::serialize::SbpSerialize for MsgCsacTelemetry {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCsacTelemetry, T>
+where
+    T: FnMut(&MsgCsacTelemetry),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCsacTelemetry(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Experimental telemetry message labels
 ///
@@ -144,6 +155,17 @@ impl crate::serialize::SbpSerialize for MsgCsacTelemetryLabels {
         size += self.id.sbp_size();
         size += self.telemetry_labels.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgCsacTelemetryLabels, T>
+where
+    T: FnMut(&MsgCsacTelemetryLabels),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgCsacTelemetryLabels(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -217,6 +239,17 @@ impl crate::serialize::SbpSerialize for MsgDgnssStatus {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgDgnssStatus, T>
+where
+    T: FnMut(&MsgDgnssStatus),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgDgnssStatus(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Offset of the local time with respect to GNSS time
 ///
@@ -286,6 +319,17 @@ impl crate::serialize::SbpSerialize for MsgGnssTimeOffset {
         size += self.microseconds.sbp_size();
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGnssTimeOffset, T>
+where
+    T: FnMut(&MsgGnssTimeOffset),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGnssTimeOffset(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -359,6 +403,17 @@ impl crate::serialize::SbpSerialize for MsgGroupMeta {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgGroupMeta, T>
+where
+    T: FnMut(&MsgGroupMeta),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgGroupMeta(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// System heartbeat message
 ///
@@ -422,6 +477,17 @@ impl crate::serialize::SbpSerialize for MsgHeartbeat {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgHeartbeat, T>
+where
+    T: FnMut(&MsgHeartbeat),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgHeartbeat(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Inertial Navigation System status message
 ///
@@ -475,6 +541,17 @@ impl crate::serialize::SbpSerialize for MsgInsStatus {
         let mut size = 0;
         size += self.flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgInsStatus, T>
+where
+    T: FnMut(&MsgInsStatus),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgInsStatus(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -562,6 +639,17 @@ impl crate::serialize::SbpSerialize for MsgInsUpdates {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgInsUpdates, T>
+where
+    T: FnMut(&MsgInsUpdates),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgInsUpdates(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// System start-up message
 ///
@@ -627,5 +715,16 @@ impl crate::serialize::SbpSerialize for MsgStartup {
         size += self.startup_type.sbp_size();
         size += self.reserved.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgStartup, T>
+where
+    T: FnMut(&MsgStartup),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgStartup(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }

--- a/rust/sbp/src/messages/tracking.rs
+++ b/rust/sbp/src/messages/tracking.rs
@@ -80,6 +80,17 @@ impl crate::serialize::SbpSerialize for MsgMeasurementState {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgMeasurementState, T>
+where
+    T: FnMut(&MsgMeasurementState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgMeasurementState(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Tracking channel correlations
 ///
@@ -145,6 +156,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingIq {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingIq, T>
+where
+    T: FnMut(&MsgTrackingIq),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingIq(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -207,6 +229,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingIqDepA {
         size += self.sid.sbp_size();
         size += self.corrs.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingIqDepA, T>
+where
+    T: FnMut(&MsgTrackingIqDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingIqDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -274,6 +307,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingIqDepB {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingIqDepB, T>
+where
+    T: FnMut(&MsgTrackingIqDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingIqDepB(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Signal tracking channel states
 ///
@@ -330,6 +374,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingState {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingState, T>
+where
+    T: FnMut(&MsgTrackingState),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingState(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated
 ///
@@ -384,6 +439,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingStateDepA {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingStateDepA, T>
+where
+    T: FnMut(&MsgTrackingStateDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingStateDepA(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Deprecated.
 ///
@@ -436,6 +502,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingStateDepB {
         let mut size = 0;
         size += self.states.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingStateDepB, T>
+where
+    T: FnMut(&MsgTrackingStateDepB),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingStateDepB(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 
@@ -598,6 +675,17 @@ impl crate::serialize::SbpSerialize for MsgTrackingStateDetailedDep {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgTrackingStateDetailedDep, T>
+where
+    T: FnMut(&MsgTrackingStateDetailedDep),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingStateDetailedDep(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Detailed signal tracking channel states. DEPRECATED.
 ///
@@ -757,6 +845,18 @@ impl crate::serialize::SbpSerialize for MsgTrackingStateDetailedDepA {
         size += self.pset_flags.sbp_size();
         size += self.misc_flags.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage
+    for crate::handler::Handler<MsgTrackingStateDetailedDepA, T>
+where
+    T: FnMut(&MsgTrackingStateDetailedDepA),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgTrackingStateDetailedDepA(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }
 

--- a/rust/sbp/src/messages/user.rs
+++ b/rust/sbp/src/messages/user.rs
@@ -78,3 +78,14 @@ impl crate::serialize::SbpSerialize for MsgUserData {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgUserData, T>
+where
+    T: FnMut(&MsgUserData),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgUserData(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -95,6 +95,17 @@ impl crate::serialize::SbpSerialize for MsgOdometry {
         size
     }
 }
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgOdometry, T>
+where
+    T: FnMut(&MsgOdometry),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgOdometry(msg) => self.handle(msg),
+            _ => (),
+        }
+    }
+}
 
 /// Accumulated wheeltick count message
 ///
@@ -176,5 +187,16 @@ impl crate::serialize::SbpSerialize for MsgWheeltick {
         size += self.source.sbp_size();
         size += self.ticks.sbp_size();
         size
+    }
+}
+impl<T> crate::handler::HandleSbpMessage for crate::handler::Handler<MsgWheeltick, T>
+where
+    T: FnMut(&MsgWheeltick),
+{
+    fn handle_message(&mut self, msg: &crate::messages::SBP) {
+        match msg {
+            crate::messages::SBP::MsgWheeltick(msg) => self.handle(msg),
+            _ => (),
+        }
     }
 }


### PR DESCRIPTION
This PR adds the ability to register message handler objects to the rust parser. Each handler object is able to handle a single message type. As the parser processes SBP messages it calls the appropriate message handler for each message.

This is done by defining a trait (`HandleSbpMessage`) which has a single function that takes in a reference to a `SBP` message enum. We then define a struct (`Handler`) which is generic over an implementor of `SBPMessage` and an implementor of `FnMut(&Msg)`. We then provide implementations of `Handler` for each SBP message type, these implementations match on the enum variant that represents the corresponding message type and calls the function object with the unwrapped message or does nothing if the enum variant doesn't match. These implementations are stil generic over the `FnMut` parameter. Finally the parser has a function that takes in a `FnMut` object and wraps it in a `Handler` instance and stores that in a `Box<dyn HandleSbpMessage>` and stores those in a vector. The parser had to be further modified to explicitly state the lifetime requirements of the handler objects.