### PR TITLE
Add environment markers to requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,6 +3,7 @@ pyftdi==0.13.*
 pylibftdi
 pyserial
 requests==2.20.*
-numpy~=1.18
-pybase64
-python-rapidjson==0.9.1
+numpy~=1.18 ; python_version >= '3.0'
+pybase64 ; python_version >= '3.0'
+python-rapidjson==0.9.1 ; python_version >= '3.0'
+

--- a/python/requirements_nojit.txt
+++ b/python/requirements_nojit.txt
@@ -1,5 +1,0 @@
-construct==2.9.33
-pyftdi==0.13.*
-pylibftdi
-pyserial
-requests==2.20.*

--- a/python/setup.py
+++ b/python/setup.py
@@ -185,12 +185,11 @@ if __name__ == "__main__":
     else:
         print('Detected LIBSBP_BUILD_ANY, building without sbp.jit support...')
 
-    if sys.version_info.major == 2 and sys.version_info.minor == 7:
-        with open(os.path.join(setup_py_dir, 'requirements_nojit.txt')) as f:
-            INSTALL_REQUIRES = [i.strip() for i in f.readlines() if not exclude_jit_libs(i.strip())]
-    else:
-        with open(os.path.join(setup_py_dir, 'requirements.txt')) as f:
-            INSTALL_REQUIRES = [i.strip() for i in f.readlines() if not exclude_jit_libs(i.strip())]
+    with open(os.path.join(setup_py_dir, 'requirements.txt')) as f:
+        INSTALL_REQUIRES = [
+            i.strip()
+            for i in f.readlines() if not exclude_jit_libs(i.strip())
+        ]
 
     with open(os.path.join(setup_py_dir, 'test_requirements.txt')) as f:
         TEST_REQUIRES = [i.strip() for i in f.readlines()]

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -7,7 +7,6 @@ deps = py35-jit,py37-jit,py38-jit: -r{toxinidir}/setup_requirements.txt
        py35-jit,py37-jit,py38-jit: -r{toxinidir}/requirements.txt
        py35-nojit,py37-nojit,py38-nojit: python-rapidjson==0.9.1
        py27-nojit,py35-nojit,py37-nojit,py38-nojit: -r{toxinidir}/setup_requirements_nojit.txt
-       py27-nojit,py35-nojit,py37-nojit,py38-nojit: -r{toxinidir}/requirements_nojit.txt
        -r{toxinidir}/test_requirements.txt
 commands =
   py.test -v tests/


### PR DESCRIPTION
[PEP-508](https://www.python.org/dev/peps/pep-0508/) dictates how dependencies are expected to be declared in python packages. Instead of embedding logic into `setup.py` to dynamically generate the dependency list based on predefined rules, PEP-508 requires that this logic be declared via  [Environment Markers](https://www.python.org/dev/peps/pep-0508/#environment-markers) embedded in the dependency specification itself. 

 Since popular Python dependency managers such as Pipenv and Poetry expect packages to abide by PEP-508, this PR will allow `sbp` to be installable error-free using these tools, whereas currently the poetry install operation is failing with the following exception:

```
The current project's Python requirement (>=2.7,<3.0) is not compatible with some of the required packages Python requirement:
    - python-rapidjson requires Python >=3.4, so it will not be satisfied for Python >=2.7,<3.0
  
  Because sbp (3.4.4) depends on python-rapidjson (0.9.1) which requires Python >=3.4, sbp is forbidden.
  So, because lumpdk-py2 depends on sbp (3.4.4), version solving failed.
```

