### PR TITLE
Better sync support

### DIFF
--- a/generator/sbpg/targets/resources/sbp-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp-cargo.toml
@@ -18,26 +18,29 @@ keywords = ["encoding", "parsing"]
 
 [features]
 default = ["blocking"]
+blocking = []
+async = ["futures", "pin-project-lite"]
 sbp_serde = ["serde"]
 json = ["serde_json", "serde", "base64"]
-blocking = ["futures/executor"]
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
 byteorder = "1.2.1"
-bytes = "0.5.6"
+bytes = "0.6"
 crc16 = "*"
 enum_dispatch = "0.3.4"
-futures = { version = "0.3.8", default-features = false }
-futures_codec = "0.4.1"
 log = "0.4.11"
 nom = "6.0.1"
 thiserror = "1.0.22"
+
+futures = { version = "0.3.8", optional = true }
+pin-project-lite = { version = "0.2.0", optional = true }
+
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-base64 = {version = "0.13", optional = true}
+base64 = { version = "0.13", optional = true }
 
 [dev-dependencies]
 serialport = "2.1.0"

--- a/generator/sbpg/targets/resources/sbp2json-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp2json-cargo.toml
@@ -13,7 +13,8 @@ edition = "2018"
 
 [dependencies.sbp]
 path = "../sbp"
-features = ["sbp_serde", "json"]
+default-features = false
+features = ["sbp_serde", "json", "async"]
 
 [dependencies]
 structopt = "0.3"

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -18,26 +18,29 @@ keywords = ["encoding", "parsing"]
 
 [features]
 default = ["blocking"]
+blocking = []
+async = ["futures", "pin-project-lite"]
 sbp_serde = ["serde"]
 json = ["serde_json", "serde", "base64"]
-blocking = ["futures/executor"]
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
 byteorder = "1.2.1"
-bytes = "0.5.6"
+bytes = "0.6"
 crc16 = "*"
 enum_dispatch = "0.3.4"
-futures = { version = "0.3.8", default-features = false }
-futures_codec = "0.4.1"
 log = "0.4.11"
 nom = "6.0.1"
 thiserror = "1.0.22"
+
+futures = { version = "0.3.8", optional = true }
+pin-project-lite = { version = "0.2.0", optional = true }
+
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-base64 = {version = "0.13", optional = true}
+base64 = { version = "0.13", optional = true }
 
 [dev-dependencies]
 serialport = "2.1.0"

--- a/rust/sbp/src/cfg.rs
+++ b/rust/sbp/src/cfg.rs
@@ -1,0 +1,34 @@
+// https://github.com/tokio-rs/tokio/blob/master/tokio-util/src/cfg.rs
+
+#[macro_export]
+macro_rules! cfg_async {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "async")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+            $item
+        )*
+    }
+}
+
+#[macro_export]
+macro_rules! cfg_blocking {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "blocking")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+            $item
+        )*
+    }
+}
+
+#[macro_export]
+macro_rules! cfg_json {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "json")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+            $item
+        )*
+    }
+}

--- a/rust/sbp/src/codec/blocking/framed_read.rs
+++ b/rust/sbp/src/codec/blocking/framed_read.rs
@@ -1,0 +1,123 @@
+use std::io::{self, Read};
+
+use bytes::BytesMut;
+
+use crate::codec::Decoder;
+
+const INITIAL_CAPACITY: usize = 8 * 1024;
+
+pub struct FramedRead<T, D> {
+    inner: FramedReadImpl<T, D>,
+}
+
+impl<T, D> FramedRead<T, D>
+where
+    T: Read,
+    D: Decoder,
+{
+    /// Creates a new `FramedRead` transport with the given `Decoder`.
+    pub fn new(inner: T, decoder: D) -> Self {
+        Self {
+            inner: FramedReadImpl {
+                inner,
+                decoder,
+                buffer: BytesMut::with_capacity(INITIAL_CAPACITY),
+            },
+        }
+    }
+
+    /// Release the I/O and Decoder
+    pub fn release(self) -> (T, D) {
+        self.inner.release()
+    }
+
+    /// Consumes the `FramedRead`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.release().0
+    }
+
+    /// Returns a reference to the underlying decoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying decoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn decoder(&self) -> &D {
+        &self.inner.decoder
+    }
+
+    /// Returns a mutable reference to the underlying decoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying decoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn decoder_mut(&mut self) -> &mut D {
+        &mut self.inner.decoder
+    }
+
+    /// Returns a reference to the read buffer.
+    pub fn buffer(&self) -> &BytesMut {
+        &self.inner.buffer
+    }
+}
+
+impl<T, D> Iterator for FramedRead<T, D>
+where
+    T: Read,
+    D: Decoder,
+    D::Error: From<io::Error>,
+{
+    type Item = Result<D::Item, D::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+struct FramedReadImpl<T, D> {
+    inner: T,
+    decoder: D,
+    buffer: BytesMut,
+}
+
+impl<T, D> FramedReadImpl<T, D> {
+    pub fn release(self) -> (T, D) {
+        (self.inner, self.decoder)
+    }
+}
+
+impl<T, D> Iterator for FramedReadImpl<T, D>
+where
+    T: Read,
+    D: Decoder,
+    D::Error: From<io::Error>,
+{
+    type Item = Result<D::Item, D::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.decoder.decode(&mut self.buffer) {
+            Ok(Some(item)) => return Some(Ok(item)),
+            Err(e) => return Some(Err(e)),
+            Ok(None) => (),
+        };
+
+        let mut buf = [0u8; INITIAL_CAPACITY];
+
+        loop {
+            let n = match self.inner.read(&mut buf) {
+                Ok(n) => n,
+                Err(e) => return Some(Err(e.into())),
+            };
+
+            self.buffer.extend_from_slice(&buf[..n]);
+
+            match self.decoder.decode(&mut self.buffer) {
+                Ok(Some(item)) => return Some(Ok(item)),
+                Ok(None) if n == 0 => return None,
+                Err(e) => return Some(Err(e)),
+                _ => continue,
+            };
+        }
+    }
+}

--- a/rust/sbp/src/codec/blocking/mod.rs
+++ b/rust/sbp/src/codec/blocking/mod.rs
@@ -1,0 +1,2 @@
+mod framed_read;
+pub use framed_read::FramedRead;

--- a/rust/sbp/src/codec/decoder.rs
+++ b/rust/sbp/src/codec/decoder.rs
@@ -1,0 +1,23 @@
+use std::io::Error;
+
+use bytes::BytesMut;
+
+/// Decoding of frames via buffers, for use with `FramedRead`.
+pub trait Decoder {
+    /// The type of items returned by `decode`
+    type Item;
+    /// The type of decoding errors.
+    type Error: From<Error>;
+
+    /// Decode an item from the src `BytesMut` into an item
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error>;
+
+    /// Called when the input stream reaches EOF, signaling a last attempt to decode
+    ///
+    /// # Notes
+    ///
+    /// The default implementation of this method invokes the `Decoder::decode` method.
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.decode(src)
+    }
+}

--- a/rust/sbp/src/codec/encoder.rs
+++ b/rust/sbp/src/codec/encoder.rs
@@ -1,0 +1,14 @@
+use std::io::Error;
+
+use bytes::BytesMut;
+
+/// Encoding of messages as bytes, for use with `FramedWrite`.
+pub trait Encoder {
+    /// The type of items consumed by `encode`
+    type Item;
+    /// The type of encoding errors.
+    type Error: From<Error>;
+
+    /// Encodes an item into the `BytesMut` provided by dst.
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
+}

--- a/rust/sbp/src/codec/framed_read.rs
+++ b/rust/sbp/src/codec/framed_read.rs
@@ -1,0 +1,220 @@
+use std::{
+    io,
+    marker::Unpin,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::BytesMut;
+use futures::{
+    io::AsyncRead,
+    ready,
+    sink::Sink,
+    stream::{Stream, TryStreamExt},
+};
+use pin_project_lite::pin_project;
+
+use super::{fuse::Fuse, Decoder};
+
+const INITIAL_CAPACITY: usize = 8 * 1024;
+
+/// A `Stream` of messages decoded from an `AsyncRead`.
+///
+/// # Example
+/// ```
+/// use futures_codec::{BytesCodec, FramedRead};
+/// use futures::TryStreamExt;
+/// use bytes::{Bytes};
+///
+/// let buf = [3u8; 3];
+/// let mut framed = FramedRead::new(&buf[..], BytesCodec);
+///
+/// # futures::executor::block_on(async move {
+/// if let Some(bytes) = framed.try_next().await? {
+///     assert_eq!(bytes, Bytes::copy_from_slice(&buf[..]));
+/// }
+/// # Ok::<_, std::io::Error>(())
+/// # }).unwrap();
+/// ```
+#[derive(Debug)]
+pub struct FramedRead<T, D> {
+    inner: FramedReadImpl<Fuse<T, D>>,
+}
+
+impl<T, D> Deref for FramedRead<T, D> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T, D> DerefMut for FramedRead<T, D> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T, D> FramedRead<T, D>
+where
+    T: AsyncRead,
+    D: Decoder,
+{
+    /// Creates a new `FramedRead` transport with the given `Decoder`.
+    pub fn new(inner: T, decoder: D) -> Self {
+        Self {
+            inner: FramedReadImpl::new(Fuse::new(inner, decoder)),
+        }
+    }
+
+    /// Release the I/O and Decoder
+    pub fn release(self) -> (T, D) {
+        let fuse = self.inner.release();
+        (fuse.t, fuse.u)
+    }
+
+    /// Consumes the `FramedRead`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.release().0
+    }
+
+    /// Returns a reference to the underlying decoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying decoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn decoder(&self) -> &D {
+        &self.inner.u
+    }
+
+    /// Returns a mutable reference to the underlying decoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying decoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn decoder_mut(&mut self) -> &mut D {
+        &mut self.inner.u
+    }
+
+    /// Returns a reference to the read buffer.
+    pub fn read_buffer(&self) -> &BytesMut {
+        &self.inner.buffer
+    }
+}
+
+impl<T, D> Stream for FramedRead<T, D>
+where
+    T: AsyncRead + Unpin,
+    D: Decoder,
+{
+    type Item = Result<D::Item, D::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.try_poll_next_unpin(cx)
+    }
+}
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct FramedReadImpl<T> {
+        #[pin]
+        inner: T,
+        buffer: BytesMut,
+    }
+}
+
+impl<T> FramedReadImpl<T> {
+    pub fn new(inner: T) -> FramedReadImpl<T> {
+        FramedReadImpl {
+            inner,
+            buffer: BytesMut::with_capacity(INITIAL_CAPACITY),
+        }
+    }
+
+    pub fn release(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> Deref for FramedReadImpl<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for FramedReadImpl<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> Stream for FramedReadImpl<T>
+where
+    T: AsyncRead + Decoder + Unpin,
+{
+    type Item = Result<T::Item, T::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+
+        if let Some(item) = this.inner.decode(&mut this.buffer)? {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
+        let mut buf = [0u8; INITIAL_CAPACITY];
+
+        loop {
+            let n = ready!(Pin::new(&mut this.inner).poll_read(cx, &mut buf))?;
+            this.buffer.extend_from_slice(&buf[..n]);
+
+            let ended = n == 0;
+
+            match this.inner.decode(&mut this.buffer)? {
+                Some(item) => return Poll::Ready(Some(Ok(item))),
+                None if ended => {
+                    if this.buffer.is_empty() {
+                        return Poll::Ready(None);
+                    } else {
+                        match this.inner.decode_eof(&mut this.buffer)? {
+                            Some(item) => return Poll::Ready(Some(Ok(item))),
+                            None if this.buffer.is_empty() => return Poll::Ready(None),
+                            None => {
+                                return Poll::Ready(Some(Err(io::Error::new(
+                                    io::ErrorKind::UnexpectedEof,
+                                    "bytes remaining in stream",
+                                )
+                                .into())));
+                            }
+                        }
+                    }
+                }
+                _ => continue,
+            }
+        }
+    }
+}
+
+impl<T, I> Sink<I> for FramedReadImpl<T>
+where
+    T: Sink<I> + Unpin,
+{
+    type Error = T::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_ready(cx)
+    }
+    fn start_send(self: Pin<&mut Self>, item: I) -> Result<(), Self::Error> {
+        self.project().inner.start_send(item)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_close(cx)
+    }
+}

--- a/rust/sbp/src/codec/framed_write.rs
+++ b/rust/sbp/src/codec/framed_write.rs
@@ -1,0 +1,271 @@
+use std::{
+    io::{Error, ErrorKind},
+    marker::Unpin,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, BytesMut};
+use futures::{
+    io::{AsyncRead, AsyncWrite},
+    ready,
+    sink::Sink,
+};
+use pin_project_lite::pin_project;
+
+use super::{fuse::Fuse, Encoder};
+
+// 2^17 bytes, which is slightly over 60% of the default
+// TCP send buffer size (SO_SNDBUF)
+const DEFAULT_SEND_HIGH_WATER_MARK: usize = 131072;
+
+pin_project! {
+    /// A `Sink` of frames encoded to an `AsyncWrite`.
+    ///
+    /// # Example
+    /// ```
+    /// use bytes::Bytes;
+    /// use futures_codec::{FramedWrite, BytesCodec};
+    /// use futures::SinkExt;
+    ///
+    /// # futures::executor::block_on(async move {
+    /// let mut buf = Vec::new();
+    /// let mut framed = FramedWrite::new(&mut buf, BytesCodec {});
+    ///
+    /// let bytes = Bytes::from("Hello World!");
+    /// framed.send(bytes.clone()).await?;
+    ///
+    /// assert_eq!(&buf[..], &bytes[..]);
+    /// # Ok::<_, std::io::Error>(())
+    /// # }).unwrap();
+    /// ```
+    #[derive(Debug)]
+    pub struct FramedWrite<T, E> {
+        #[pin]
+        inner: FramedWriteImpl<Fuse<T, E>>,
+    }
+}
+
+impl<T, E> FramedWrite<T, E>
+where
+    T: AsyncWrite,
+    E: Encoder,
+{
+    /// Creates a new `FramedWrite` transport with the given `Encoder`.
+    pub fn new(inner: T, encoder: E) -> Self {
+        Self {
+            inner: FramedWriteImpl::new(Fuse::new(inner, encoder)),
+        }
+    }
+
+    /// High-water mark for writes, in bytes
+    ///
+    /// The send *high-water mark* prevents the `FramedWrite`
+    /// from accepting additional messages to send when its
+    /// buffer exceeds this length, in bytes. Attempts to enqueue
+    /// additional messages will be deferred until progress is
+    /// made on the underlying `AsyncWrite`. This applies
+    /// back-pressure on fast senders and prevents unbounded
+    /// buffer growth.
+    ///
+    /// See [`set_send_high_water_mark()`](#method.set_send_high_water_mark).
+    pub fn send_high_water_mark(&self) -> usize {
+        self.inner.high_water_mark
+    }
+
+    /// Sets high-water mark for writes, in bytes
+    ///
+    /// The send *high-water mark* prevents the `FramedWrite`
+    /// from accepting additional messages to send when its
+    /// buffer exceeds this length, in bytes. Attempts to enqueue
+    /// additional messages will be deferred until progress is
+    /// made on the underlying `AsyncWrite`. This applies
+    /// back-pressure on fast senders and prevents unbounded
+    /// buffer growth.
+    ///
+    /// The default high-water mark is 2^17 bytes. Applications
+    /// which desire low latency may wish to reduce this value.
+    /// There is little point to increasing this value beyond
+    /// your socket's `SO_SNDBUF` size. On linux, this defaults
+    /// to 212992 bytes but is user-adjustable.
+    pub fn set_send_high_water_mark(&mut self, hwm: usize) {
+        self.inner.high_water_mark = hwm;
+    }
+
+    /// Release the I/O and Encoder
+    pub fn release(self) -> (T, E) {
+        let fuse = self.inner.release();
+        (fuse.t, fuse.u)
+    }
+
+    /// Consumes the `FramedWrite`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.release().0
+    }
+
+    /// Returns a reference to the underlying encoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying encoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn encoder(&self) -> &E {
+        &self.inner.u
+    }
+
+    /// Returns a mutable reference to the underlying encoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying encoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn encoder_mut(&mut self) -> &mut E {
+        &mut self.inner.u
+    }
+}
+
+impl<T, E> Sink<E::Item> for FramedWrite<T, E>
+where
+    T: AsyncWrite + Unpin,
+    E: Encoder,
+{
+    type Error = E::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_ready(cx)
+    }
+    fn start_send(self: Pin<&mut Self>, item: E::Item) -> Result<(), Self::Error> {
+        self.project().inner.start_send(item)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+// impl<T, E> Deref for FramedWrite<T, E> {
+//     type Target = T;
+
+//     fn deref(&self) -> &T {
+//         &self.inner
+//     }
+// }
+
+// impl<T, E> DerefMut for FramedWrite<T, E> {
+//     fn deref_mut(&mut self) -> &mut T {
+//         &mut self.inner
+//     }
+// }
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct FramedWriteImpl<T> {
+        #[pin]
+        pub inner: T,
+        pub high_water_mark: usize,
+        buffer: BytesMut,
+    }
+}
+
+impl<T> FramedWriteImpl<T> {
+    pub fn new(inner: T) -> Self {
+        FramedWriteImpl {
+            inner,
+            high_water_mark: DEFAULT_SEND_HIGH_WATER_MARK,
+            buffer: BytesMut::with_capacity(1028 * 8),
+        }
+    }
+
+    pub fn release(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> Deref for FramedWriteImpl<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for FramedWriteImpl<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for FramedWriteImpl<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, Error>> {
+        self.project().inner.poll_read(cx, buf)
+    }
+}
+
+impl<T> Sink<T::Item> for FramedWriteImpl<T>
+where
+    T: AsyncWrite + Encoder + Unpin,
+{
+    type Error = T::Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        let this = &mut *self;
+        while this.buffer.len() >= this.high_water_mark {
+            let num_write = ready!(Pin::new(&mut this.inner).poll_write(cx, &this.buffer))?;
+
+            if num_write == 0 {
+                return Poll::Ready(Err(err_eof().into()));
+            }
+
+            this.buffer.advance(num_write);
+        }
+
+        Poll::Ready(Ok(()))
+    }
+    fn start_send(mut self: Pin<&mut Self>, item: T::Item) -> Result<(), Self::Error> {
+        let this = &mut *self;
+        this.inner.encode(item, &mut this.buffer)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        let mut this = self.project();
+
+        while !this.buffer.is_empty() {
+            let num_write = ready!(Pin::new(&mut this.inner).poll_write(cx, &this.buffer))?;
+
+            if num_write == 0 {
+                return Poll::Ready(Err(err_eof().into()));
+            }
+
+            this.buffer.advance(num_write);
+        }
+
+        this.inner.poll_flush(cx).map_err(Into::into)
+    }
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        ready!(self.as_mut().poll_flush(cx))?;
+        self.project().inner.poll_close(cx).map_err(Into::into)
+    }
+}
+
+impl<T: super::Decoder> super::Decoder for FramedWriteImpl<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.inner.decode(src)
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.inner.decode_eof(src)
+    }
+}
+
+fn err_eof() -> Error {
+    Error::new(ErrorKind::UnexpectedEof, "End of file")
+}

--- a/rust/sbp/src/codec/fuse.rs
+++ b/rust/sbp/src/codec/fuse.rs
@@ -1,0 +1,87 @@
+use std::{
+    io::Error,
+    marker::Unpin,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::io::{AsyncRead, AsyncWrite};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[derive(Debug)]
+    pub(crate) struct Fuse<T, U> {
+        #[pin]
+        pub t: T,
+        pub u: U,
+    }
+}
+
+impl<T, U> Fuse<T, U> {
+    pub(crate) fn new(t: T, u: U) -> Self {
+        Self { t, u }
+    }
+}
+
+impl<T, U> Deref for Fuse<T, U> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.t
+    }
+}
+
+impl<T, U> DerefMut for Fuse<T, U> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.t
+    }
+}
+
+impl<T: AsyncRead + Unpin, U> AsyncRead for Fuse<T, U> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, Error>> {
+        self.project().t.poll_read(cx, buf)
+    }
+}
+
+impl<T: AsyncWrite + Unpin, U> AsyncWrite for Fuse<T, U> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        self.project().t.poll_write(cx, buf)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
+        self.project().t.poll_flush(cx)
+    }
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
+        self.project().t.poll_close(cx)
+    }
+}
+
+impl<T, U: super::Decoder> super::Decoder for Fuse<T, U> {
+    type Item = U::Item;
+    type Error = U::Error;
+
+    fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.u.decode(src)
+    }
+
+    fn decode_eof(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.u.decode_eof(src)
+    }
+}
+
+impl<T, U: super::Encoder> super::Encoder for Fuse<T, U> {
+    type Item = U::Item;
+    type Error = U::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut bytes::BytesMut) -> Result<(), Self::Error> {
+        self.u.encode(item, dst)
+    }
+}

--- a/rust/sbp2json/Cargo.toml
+++ b/rust/sbp2json/Cargo.toml
@@ -13,7 +13,8 @@ edition = "2018"
 
 [dependencies.sbp]
 path = "../sbp"
-features = ["sbp_serde", "json"]
+default-features = false
+features = ["sbp_serde", "json", "async"]
 
 [dependencies]
 structopt = "0.3"


### PR DESCRIPTION
This pulls in what we were using out of `futures_codec`, and adds `blocking::FramedRead`. So we can reuse all the encoding/decoding stuff, but backed by a sync `Read`.

Not really sure what the equality for `blocking::FramedWrite` would look like. For the async version it's centered around the futures [Sink](https://docs.rs/futures/0.3.8/futures/sink/trait.Sink.html) trait, and I'm not sure what the equivalent is for iterators (if it exists). So for now there is no blocking equivalent for the conversion functions