### PR TITLE
[INFRA-335]Add support for Windows in the Java portion of the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,13 @@ quicktype-elm: 				deps-quicktype-elm 				gen-quicktype-elm 				test-quicktype-e
 
 # Prerequisite verification
 verify-prereq-generator:
+ifdef WINDOWS
+	@python --version 1> nul 2> nul || (echo I require `python` but it's not installed. Aborting. & echo. & echo. & echo Have you installed Python? & echo. & exit 1)
+	@pip --version 1> nul 2> nul || (echo I require `pip` but it's not installed. Aborting. & echo. & echo. & echo Have you installed pip? & echo. & exit 1)
+else
 	@command -v python 1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`python\` but it's not installed. Aborting.\n\nHave you installed Python?\n"; exit 1; }
 	@command -v pip    1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`pip\` but it's not installed.  Aborting.\n\nHave you installed pip?\n"; exit 1; }
+endif
 
 verify-prereq-c: verify-prereq-generator
 	@command -v checkmk      1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`checkmk\` but it's not installed. Aborting.\n\nHave you installed checkmk? See the C readme at \`c/README.md\` for setup instructions.\n"; exit 1; }
@@ -110,7 +115,11 @@ verify-prereq-javascript: verify-prereq-generator
 	@command -v mocha  1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`mocha\` but it's not installed. Aborting.\n\nHave you installed mocha? See the JavaScript readme at \`javascript/README.md\` for setup instructions.\n"; exit 1; }
 
 verify-prereq-java: verify-prereq-generator
+ifdef WINDOWS
+	@gradle --version 1> nul 2> nul || (echo I require `gradle` but it's not installed. Aborting. & echo. & echo. & echo Have you installed gradle? See the Java readme at `java/README.rst` for setup instructions. & echo. & exit 1)
+else
 	@command -v gradle  1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`gradle\` but it's not installed. Aborting.\n\nHave you installed gradle? See the Java readme at \`java/README.rst\` for setup instructions.\n"; exit 1; }
+endif
 
 verify-prereq-haskell: verify-prereq-generator
 
@@ -209,7 +218,7 @@ gen-javascript:
 
 gen-java:
 	$(call announce-begin,"Generating Java bindings")
-	cd $(SWIFTNAV_ROOT)/generator; \
+	cd $(SWIFTNAV_ROOT)/generator && \
 	$(SBP_GEN_BIN) -i $(SBP_SPEC_DIR) \
 		       -o $(SWIFTNAV_ROOT)/java/src/ \
 		       -r $(SBP_MAJOR_VERSION).$(SBP_MINOR_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ quicktype-elm: 				deps-quicktype-elm 				gen-quicktype-elm 				test-quicktype-e
 
 # Prerequisite verification
 verify-prereq-generator:
-ifdef WINDOWS
+ifeq ($(OS), Windows_NT)
 	@python --version 1> nul 2> nul || (echo I require `python` but it's not installed. Aborting. & echo. & echo. & echo Have you installed Python? & echo. & exit 1)
 	@pip --version 1> nul 2> nul || (echo I require `pip` but it's not installed. Aborting. & echo. & echo. & echo Have you installed pip? & echo. & exit 1)
 else
@@ -115,7 +115,7 @@ verify-prereq-javascript: verify-prereq-generator
 	@command -v mocha  1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`mocha\` but it's not installed. Aborting.\n\nHave you installed mocha? See the JavaScript readme at \`javascript/README.md\` for setup instructions.\n"; exit 1; }
 
 verify-prereq-java: verify-prereq-generator
-ifdef WINDOWS
+ifeq ($(OS), Windows_NT)
 	@gradle --version 1> nul 2> nul || (echo I require `gradle` but it's not installed. Aborting. & echo. & echo. & echo Have you installed gradle? See the Java readme at `java/README.rst` for setup instructions. & echo. & exit 1)
 else
 	@command -v gradle  1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`gradle\` but it's not installed. Aborting.\n\nHave you installed gradle? See the Java readme at \`java/README.rst\` for setup instructions.\n"; exit 1; }


### PR DESCRIPTION
Addressing the issue risen here: https://github.com/swift-nav/libsbp/issues/847

## How to Run
In order to run in Windows set the environment variable first:
```
set WINDOWS=1
make java
```
In order to run on Unix do not set the environment variable.

## Changes
For verify-prereq-generator and verify-prereq-java, the checks for python, pip, and gradle have been changed to check for versions and simultaneously validates they are available on the PATH.

## Validation
For both Windows and Ubuntu the first two steps required after cloning the libsbp repo.
```cd path/to/libsbp/python && python setup.py install```
```cd path/to/libspb/generator && pip install -r requirements.txt```

### Windows 10 Setup:
Git: git version 2.30.0.windows.1
Make: GNU Make 3.81
Java: openjdk version "1.8.0_275"
Gradle: Gradle 6.7.1
Python: Python 2.7.17
Pip: pip 19.2.3 from c:\python27\lib\site-packages\pip (python 2.7)

### Ubuntu 20.4 Setup:
Git: git version 2.25.1
Make: GNU Make 4.2.1
Java: openjdk version "1.8.0_275"
Gradle: Gradle 6.7.1
Python: Python 2.7.18
Pip: pip 20.3.3 from /usr/local/lib/python2.7/dist-packages/pip (python 2.7)

