### PR TITLE
[WIP] Take advantage of const generics in the Rust parser

### DIFF
--- a/generator/sbpg/targets/resources/sbp_messages_mod.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_mod.rs
@@ -26,6 +26,7 @@ use self::unknown::Unknown;
 use serde::{Serialize, Deserialize};
 use crate::serialize::SbpSerialize;
 use crate::framer::FramerError;
+use crate::parser::SbpParse;
 
 pub trait SBPMessage: SbpSerialize {
     fn get_message_type(&self) -> u16;
@@ -48,7 +49,7 @@ impl SBP {
         let x: Result<SBP, crate::Error> = match msg_id {
             ((*- for m in msgs *))
             (((m.sbp_id))) => {
-                let mut msg = (((m.identifier|camel_case)))::parse(payload)?;
+                let mut msg: (((m.identifier|camel_case))) = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::(((m.identifier|camel_case)))(msg))
             },

--- a/generator/sbpg/targets/resources/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_template.rs
@@ -15,6 +15,9 @@
 
 //! (((description | replace("\n", "\n//! "))))
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian,ReadBytesExt};
@@ -72,12 +75,12 @@ impl (((m.identifier|camel_case))) {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<(((m.identifier|camel_case)))>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[(((m.identifier|camel_case))); N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push( (((m.identifier|camel_case)))::parse(buf)? );
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
     ((*- endif *))
 }

--- a/generator/sbpg/targets/resources/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_template.rs
@@ -15,17 +15,11 @@
 
 //! (((description | replace("\n", "\n//! "))))
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian,ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Serialize, Deserialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, UnboundedSbpString, BoundedSbpString};
 
 ((*- for i in includes *))
 use super::(((i)))::*;
@@ -53,36 +47,18 @@ pub struct (((m.identifier|camel_case))) {
     ((*- endfor *))
 }
 
-impl (((m.identifier|camel_case))) {
+impl SbpParse<(((m.identifier|camel_case)))> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<(((m.identifier|camel_case))), crate::Error> {
+    fn parse(&mut self) -> crate::Result<(((m.identifier|camel_case)))> {
         Ok( (((m.identifier|camel_case))){
             ((*- if m.is_real_message *))
             sender_id: None,
             ((*- endif *))
             ((*- for f in m.fields *))
-            (((f.identifier))): (((f|parse_type)))?,
+            (((f.identifier))): self.parse()?,
             ((*- endfor *))
         } )
     }
-
-    ((*- if not m.is_real_message *))
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<(((m.identifier|camel_case)))>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push( (((m.identifier|camel_case)))::parse(buf)? );
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[(((m.identifier|camel_case))); N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push( (((m.identifier|camel_case)))::parse(buf)? );
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
-    }
-    ((*- endif *))
 }
 
 ((*- if m.is_real_message *))

--- a/generator/sbpg/targets/rust.py
+++ b/generator/sbpg/targets/rust.py
@@ -52,8 +52,7 @@ TYPE_MAP = {'u8': 'u8',
             's32': 'i32',
             's64': 'i64',
             'float': 'f32',
-            'double': 'f64',
-            'string': 'SbpString'}
+            'double': 'f64'}
 
 def type_map(field):
   if field.type_id in TYPE_MAP:
@@ -64,6 +63,11 @@ def type_map(field):
         return "[{}; {}]".format(TYPE_MAP.get(t,t), field.options.get('size').value)
     else:
         return "Vec<{}>".format(TYPE_MAP.get(t, t))
+  elif field.type_id == 'string':
+      if field.options.get('size', None):
+          return "BoundedSbpString<{}>".format(field.options.get('size').value)
+      else:
+          return "UnboundedSbpString"
   else:
     return field.type_id
 

--- a/generator/sbpg/targets/rust.py
+++ b/generator/sbpg/targets/rust.py
@@ -60,7 +60,10 @@ def type_map(field):
     return TYPE_MAP[field.type_id]
   elif field.type_id == 'array':
     t = field.options['fill'].value
-    return "Vec<{}>".format(TYPE_MAP.get(t, t))
+    if field.options.get('size', None):
+        return "[{}; {}]".format(TYPE_MAP.get(t,t), field.options.get('size').value)
+    else:
+        return "Vec<{}>".format(TYPE_MAP.get(t, t))
   else:
     return field.type_id
 
@@ -88,12 +91,12 @@ def parse_type(field):
     t = field.options['fill'].value
     if t in TYPE_MAP.keys():
       if 'size' in field.options:
-        return 'crate::parser::read_%s_array_limit(_buf, %d)' % (t, field.options['size'].value)
+        return 'crate::parser::read_%s_array_fixed(_buf)' % t
       else:
         return 'crate::parser::read_%s_array(_buf)' % t
     else:
       if 'size' in field.options:
-        return '%s::parse_array_limit(_buf, %d)' % (t, field.options['size'].value)
+        return '%s::parse_array_fixed(_buf)' % t
       else:
         return '%s::parse_array(_buf)' % t
   else:

--- a/rust/sbp/src/messages/acquisition.rs
+++ b/rust/sbp/src/messages/acquisition.rs
@@ -14,18 +14,12 @@
 //****************************************************************************/
 //! Satellite acquisition messages from the device.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Acq perfomance measurement and debug
 ///
@@ -63,40 +57,23 @@ pub struct AcqSvProfile {
     pub cp: u32,
 }
 
-impl AcqSvProfile {
+impl SbpParse<AcqSvProfile> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<AcqSvProfile, crate::Error> {
+    fn parse(&mut self) -> crate::Result<AcqSvProfile> {
         Ok( AcqSvProfile{
-            job_type: _buf.read_u8()?,
-            status: _buf.read_u8()?,
-            cn0: _buf.read_u16::<LittleEndian>()?,
-            int_time: _buf.read_u8()?,
-            sid: GnssSignal::parse(_buf)?,
-            bin_width: _buf.read_u16::<LittleEndian>()?,
-            timestamp: _buf.read_u32::<LittleEndian>()?,
-            time_spent: _buf.read_u32::<LittleEndian>()?,
-            cf_min: _buf.read_i32::<LittleEndian>()?,
-            cf_max: _buf.read_i32::<LittleEndian>()?,
-            cf: _buf.read_i32::<LittleEndian>()?,
-            cp: _buf.read_u32::<LittleEndian>()?,
+            job_type: self.parse()?,
+            status: self.parse()?,
+            cn0: self.parse()?,
+            int_time: self.parse()?,
+            sid: self.parse()?,
+            bin_width: self.parse()?,
+            timestamp: self.parse()?,
+            time_spent: self.parse()?,
+            cf_min: self.parse()?,
+            cf_max: self.parse()?,
+            cf: self.parse()?,
+            cp: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AcqSvProfile>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(AcqSvProfile::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[AcqSvProfile; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(AcqSvProfile::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -169,40 +146,23 @@ pub struct AcqSvProfileDep {
     pub cp: u32,
 }
 
-impl AcqSvProfileDep {
+impl SbpParse<AcqSvProfileDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<AcqSvProfileDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<AcqSvProfileDep> {
         Ok( AcqSvProfileDep{
-            job_type: _buf.read_u8()?,
-            status: _buf.read_u8()?,
-            cn0: _buf.read_u16::<LittleEndian>()?,
-            int_time: _buf.read_u8()?,
-            sid: GnssSignalDep::parse(_buf)?,
-            bin_width: _buf.read_u16::<LittleEndian>()?,
-            timestamp: _buf.read_u32::<LittleEndian>()?,
-            time_spent: _buf.read_u32::<LittleEndian>()?,
-            cf_min: _buf.read_i32::<LittleEndian>()?,
-            cf_max: _buf.read_i32::<LittleEndian>()?,
-            cf: _buf.read_i32::<LittleEndian>()?,
-            cp: _buf.read_u32::<LittleEndian>()?,
+            job_type: self.parse()?,
+            status: self.parse()?,
+            cn0: self.parse()?,
+            int_time: self.parse()?,
+            sid: self.parse()?,
+            bin_width: self.parse()?,
+            timestamp: self.parse()?,
+            time_spent: self.parse()?,
+            cf_min: self.parse()?,
+            cf_max: self.parse()?,
+            cf: self.parse()?,
+            cp: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AcqSvProfileDep>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(AcqSvProfileDep::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[AcqSvProfileDep; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(AcqSvProfileDep::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -264,15 +224,15 @@ pub struct MsgAcqResult {
     pub sid: GnssSignal,
 }
 
-impl MsgAcqResult {
+impl SbpParse<MsgAcqResult> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResult, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAcqResult> {
         Ok( MsgAcqResult{
             sender_id: None,
-            cn0: _buf.read_f32::<LittleEndian>()?,
-            cp: _buf.read_f32::<LittleEndian>()?,
-            cf: _buf.read_f32::<LittleEndian>()?,
-            sid: GnssSignal::parse(_buf)?,
+            cn0: self.parse()?,
+            cp: self.parse()?,
+            cf: self.parse()?,
+            sid: self.parse()?,
         } )
     }
 }
@@ -335,15 +295,15 @@ pub struct MsgAcqResultDepA {
     pub prn: u8,
 }
 
-impl MsgAcqResultDepA {
+impl SbpParse<MsgAcqResultDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAcqResultDepA> {
         Ok( MsgAcqResultDepA{
             sender_id: None,
-            snr: _buf.read_f32::<LittleEndian>()?,
-            cp: _buf.read_f32::<LittleEndian>()?,
-            cf: _buf.read_f32::<LittleEndian>()?,
-            prn: _buf.read_u8()?,
+            snr: self.parse()?,
+            cp: self.parse()?,
+            cf: self.parse()?,
+            prn: self.parse()?,
         } )
     }
 }
@@ -405,15 +365,15 @@ pub struct MsgAcqResultDepB {
     pub sid: GnssSignalDep,
 }
 
-impl MsgAcqResultDepB {
+impl SbpParse<MsgAcqResultDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAcqResultDepB> {
         Ok( MsgAcqResultDepB{
             sender_id: None,
-            snr: _buf.read_f32::<LittleEndian>()?,
-            cp: _buf.read_f32::<LittleEndian>()?,
-            cf: _buf.read_f32::<LittleEndian>()?,
-            sid: GnssSignalDep::parse(_buf)?,
+            snr: self.parse()?,
+            cp: self.parse()?,
+            cf: self.parse()?,
+            sid: self.parse()?,
         } )
     }
 }
@@ -474,15 +434,15 @@ pub struct MsgAcqResultDepC {
     pub sid: GnssSignalDep,
 }
 
-impl MsgAcqResultDepC {
+impl SbpParse<MsgAcqResultDepC> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqResultDepC, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAcqResultDepC> {
         Ok( MsgAcqResultDepC{
             sender_id: None,
-            cn0: _buf.read_f32::<LittleEndian>()?,
-            cp: _buf.read_f32::<LittleEndian>()?,
-            cf: _buf.read_f32::<LittleEndian>()?,
-            sid: GnssSignalDep::parse(_buf)?,
+            cn0: self.parse()?,
+            cp: self.parse()?,
+            cf: self.parse()?,
+            sid: self.parse()?,
         } )
     }
 }
@@ -538,12 +498,12 @@ pub struct MsgAcqSvProfile {
     pub acq_sv_profile: Vec<AcqSvProfile>,
 }
 
-impl MsgAcqSvProfile {
+impl SbpParse<MsgAcqSvProfile> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqSvProfile, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAcqSvProfile> {
         Ok( MsgAcqSvProfile{
             sender_id: None,
-            acq_sv_profile: AcqSvProfile::parse_array(_buf)?,
+            acq_sv_profile: self.parse()?,
         } )
     }
 }
@@ -592,12 +552,12 @@ pub struct MsgAcqSvProfileDep {
     pub acq_sv_profile: Vec<AcqSvProfileDep>,
 }
 
-impl MsgAcqSvProfileDep {
+impl SbpParse<MsgAcqSvProfileDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAcqSvProfileDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAcqSvProfileDep> {
         Ok( MsgAcqSvProfileDep{
             sender_id: None,
-            acq_sv_profile: AcqSvProfileDep::parse_array(_buf)?,
+            acq_sv_profile: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/acquisition.rs
+++ b/rust/sbp/src/messages/acquisition.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Satellite acquisition messages from the device.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -86,12 +89,14 @@ impl AcqSvProfile {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<AcqSvProfile>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[AcqSvProfile; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(AcqSvProfile::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -190,15 +195,14 @@ impl AcqSvProfileDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<AcqSvProfileDep>, crate::Error> {
+    ) -> Result<[AcqSvProfileDep; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(AcqSvProfileDep::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/bootload.rs
+++ b/rust/sbp/src/messages/bootload.rs
@@ -19,17 +19,11 @@
 //! host request and the device response.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Deprecated
 ///
@@ -44,12 +38,12 @@ pub struct MsgBootloaderHandshakeDepA {
     pub handshake: Vec<u8>,
 }
 
-impl MsgBootloaderHandshakeDepA {
+impl SbpParse<MsgBootloaderHandshakeDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBootloaderHandshakeDepA> {
         Ok( MsgBootloaderHandshakeDepA{
             sender_id: None,
-            handshake: crate::parser::read_u8_array(_buf)?,
+            handshake: self.parse()?,
         } )
     }
 }
@@ -98,9 +92,9 @@ pub struct MsgBootloaderHandshakeReq {
     pub sender_id: Option<u16>,
 }
 
-impl MsgBootloaderHandshakeReq {
+impl SbpParse<MsgBootloaderHandshakeReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBootloaderHandshakeReq> {
         Ok( MsgBootloaderHandshakeReq{
             sender_id: None,
         } )
@@ -150,16 +144,16 @@ pub struct MsgBootloaderHandshakeResp {
     /// Bootloader flags
     pub flags: u32,
     /// Bootloader version number
-    pub version: SbpString,
+    pub version: UnboundedSbpString,
 }
 
-impl MsgBootloaderHandshakeResp {
+impl SbpParse<MsgBootloaderHandshakeResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderHandshakeResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBootloaderHandshakeResp> {
         Ok( MsgBootloaderHandshakeResp{
             sender_id: None,
-            flags: _buf.read_u32::<LittleEndian>()?,
-            version: crate::parser::read_string(_buf)?,
+            flags: self.parse()?,
+            version: self.parse()?,
         } )
     }
 }
@@ -210,12 +204,12 @@ pub struct MsgBootloaderJumpToApp {
     pub jump: u8,
 }
 
-impl MsgBootloaderJumpToApp {
+impl SbpParse<MsgBootloaderJumpToApp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBootloaderJumpToApp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBootloaderJumpToApp> {
         Ok( MsgBootloaderJumpToApp{
             sender_id: None,
-            jump: _buf.read_u8()?,
+            jump: self.parse()?,
         } )
     }
 }
@@ -267,9 +261,9 @@ pub struct MsgNapDeviceDnaReq {
     pub sender_id: Option<u16>,
 }
 
-impl MsgNapDeviceDnaReq {
+impl SbpParse<MsgNapDeviceDnaReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgNapDeviceDnaReq> {
         Ok( MsgNapDeviceDnaReq{
             sender_id: None,
         } )
@@ -321,12 +315,12 @@ pub struct MsgNapDeviceDnaResp {
     pub dna: [u8; 8],
 }
 
-impl MsgNapDeviceDnaResp {
+impl SbpParse<MsgNapDeviceDnaResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgNapDeviceDnaResp> {
         Ok( MsgNapDeviceDnaResp{
             sender_id: None,
-            dna: crate::parser::read_u8_array_fixed(_buf)?,
+            dna: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/bootload.rs
+++ b/rust/sbp/src/messages/bootload.rs
@@ -19,6 +19,9 @@
 //! host request and the device response.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -315,7 +318,7 @@ impl crate::serialize::SbpSerialize for MsgNapDeviceDnaReq {
 pub struct MsgNapDeviceDnaResp {
     pub sender_id: Option<u16>,
     /// 57-bit SwiftNAP FPGA Device ID. Remaining bits are padded on the right.
-    pub dna: Vec<u8>,
+    pub dna: [u8; 8],
 }
 
 impl MsgNapDeviceDnaResp {
@@ -323,7 +326,7 @@ impl MsgNapDeviceDnaResp {
     pub fn parse(_buf: &mut &[u8]) -> Result<MsgNapDeviceDnaResp, crate::Error> {
         Ok( MsgNapDeviceDnaResp{
             sender_id: None,
-            dna: crate::parser::read_u8_array_limit(_buf, 8)?,
+            dna: crate::parser::read_u8_array_fixed(_buf)?,
         } )
     }
 }

--- a/rust/sbp/src/messages/ext_events.rs
+++ b/rust/sbp/src/messages/ext_events.rs
@@ -16,6 +16,9 @@
 //! e.g. camera shutter time.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/ext_events.rs
+++ b/rust/sbp/src/messages/ext_events.rs
@@ -16,17 +16,11 @@
 //! e.g. camera shutter time.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Reports timestamped external pin event
 ///
@@ -51,16 +45,16 @@ pub struct MsgExtEvent {
     pub pin: u8,
 }
 
-impl MsgExtEvent {
+impl SbpParse<MsgExtEvent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgExtEvent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgExtEvent> {
         Ok( MsgExtEvent{
             sender_id: None,
-            wn: _buf.read_u16::<LittleEndian>()?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            ns_residual: _buf.read_i32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
-            pin: _buf.read_u8()?,
+            wn: self.parse()?,
+            tow: self.parse()?,
+            ns_residual: self.parse()?,
+            flags: self.parse()?,
+            pin: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/file_io.rs
+++ b/rust/sbp/src/messages/file_io.rs
@@ -22,6 +22,9 @@
 //! host request and the device response.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/file_io.rs
+++ b/rust/sbp/src/messages/file_io.rs
@@ -22,17 +22,11 @@
 //! host request and the device response.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Request advice on the optimal configuration for FileIO.
 ///
@@ -50,12 +44,12 @@ pub struct MsgFileioConfigReq {
     pub sequence: u32,
 }
 
-impl MsgFileioConfigReq {
+impl SbpParse<MsgFileioConfigReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioConfigReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioConfigReq> {
         Ok( MsgFileioConfigReq{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
+            sequence: self.parse()?,
         } )
     }
 }
@@ -114,15 +108,15 @@ pub struct MsgFileioConfigResp {
     pub fileio_version: u32,
 }
 
-impl MsgFileioConfigResp {
+impl SbpParse<MsgFileioConfigResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioConfigResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioConfigResp> {
         Ok( MsgFileioConfigResp{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            window_size: _buf.read_u32::<LittleEndian>()?,
-            batch_size: _buf.read_u32::<LittleEndian>()?,
-            fileio_version: _buf.read_u32::<LittleEndian>()?,
+            sequence: self.parse()?,
+            window_size: self.parse()?,
+            batch_size: self.parse()?,
+            fileio_version: self.parse()?,
         } )
     }
 }
@@ -187,17 +181,17 @@ pub struct MsgFileioReadDirReq {
     /// The offset to skip the first n elements of the file list
     pub offset: u32,
     /// Name of the directory to list
-    pub dirname: SbpString,
+    pub dirname: UnboundedSbpString,
 }
 
-impl MsgFileioReadDirReq {
+impl SbpParse<MsgFileioReadDirReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadDirReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioReadDirReq> {
         Ok( MsgFileioReadDirReq{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            offset: _buf.read_u32::<LittleEndian>()?,
-            dirname: crate::parser::read_string(_buf)?,
+            sequence: self.parse()?,
+            offset: self.parse()?,
+            dirname: self.parse()?,
         } )
     }
 }
@@ -257,13 +251,13 @@ pub struct MsgFileioReadDirResp {
     pub contents: Vec<u8>,
 }
 
-impl MsgFileioReadDirResp {
+impl SbpParse<MsgFileioReadDirResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadDirResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioReadDirResp> {
         Ok( MsgFileioReadDirResp{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            contents: crate::parser::read_u8_array(_buf)?,
+            sequence: self.parse()?,
+            contents: self.parse()?,
         } )
     }
 }
@@ -324,18 +318,18 @@ pub struct MsgFileioReadReq {
     /// Chunk size to read
     pub chunk_size: u8,
     /// Name of the file to read from
-    pub filename: SbpString,
+    pub filename: UnboundedSbpString,
 }
 
-impl MsgFileioReadReq {
+impl SbpParse<MsgFileioReadReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioReadReq> {
         Ok( MsgFileioReadReq{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            offset: _buf.read_u32::<LittleEndian>()?,
-            chunk_size: _buf.read_u8()?,
-            filename: crate::parser::read_string(_buf)?,
+            sequence: self.parse()?,
+            offset: self.parse()?,
+            chunk_size: self.parse()?,
+            filename: self.parse()?,
         } )
     }
 }
@@ -396,13 +390,13 @@ pub struct MsgFileioReadResp {
     pub contents: Vec<u8>,
 }
 
-impl MsgFileioReadResp {
+impl SbpParse<MsgFileioReadResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioReadResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioReadResp> {
         Ok( MsgFileioReadResp{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            contents: crate::parser::read_u8_array(_buf)?,
+            sequence: self.parse()?,
+            contents: self.parse()?,
         } )
     }
 }
@@ -453,15 +447,15 @@ impl crate::serialize::SbpSerialize for MsgFileioReadResp {
 pub struct MsgFileioRemove {
     pub sender_id: Option<u16>,
     /// Name of the file to delete
-    pub filename: SbpString,
+    pub filename: UnboundedSbpString,
 }
 
-impl MsgFileioRemove {
+impl SbpParse<MsgFileioRemove> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioRemove, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioRemove> {
         Ok( MsgFileioRemove{
             sender_id: None,
-            filename: crate::parser::read_string(_buf)?,
+            filename: self.parse()?,
         } )
     }
 }
@@ -518,20 +512,20 @@ pub struct MsgFileioWriteReq {
     /// Offset into the file at which to start writing in bytes
     pub offset: u32,
     /// Name of the file to write to
-    pub filename: SbpString,
+    pub filename: UnboundedSbpString,
     /// Variable-length array of data to write
     pub data: Vec<u8>,
 }
 
-impl MsgFileioWriteReq {
+impl SbpParse<MsgFileioWriteReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioWriteReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioWriteReq> {
         Ok( MsgFileioWriteReq{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            offset: _buf.read_u32::<LittleEndian>()?,
-            filename: crate::parser::read_string(_buf)?,
-            data: crate::parser::read_u8_array(_buf)?,
+            sequence: self.parse()?,
+            offset: self.parse()?,
+            filename: self.parse()?,
+            data: self.parse()?,
         } )
     }
 }
@@ -590,12 +584,12 @@ pub struct MsgFileioWriteResp {
     pub sequence: u32,
 }
 
-impl MsgFileioWriteResp {
+impl SbpParse<MsgFileioWriteResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFileioWriteResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFileioWriteResp> {
         Ok( MsgFileioWriteResp{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
+            sequence: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/flash.rs
+++ b/rust/sbp/src/messages/flash.rs
@@ -19,17 +19,11 @@
 //! to Piksi Multi.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Flash response message (host <= device).
 ///
@@ -47,12 +41,12 @@ pub struct MsgFlashDone {
     pub response: u8,
 }
 
-impl MsgFlashDone {
+impl SbpParse<MsgFlashDone> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashDone, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFlashDone> {
         Ok( MsgFlashDone{
             sender_id: None,
-            response: _buf.read_u8()?,
+            response: self.parse()?,
         } )
     }
 }
@@ -107,13 +101,13 @@ pub struct MsgFlashErase {
     pub sector_num: u32,
 }
 
-impl MsgFlashErase {
+impl SbpParse<MsgFlashErase> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashErase, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFlashErase> {
         Ok( MsgFlashErase{
             sender_id: None,
-            target: _buf.read_u8()?,
-            sector_num: _buf.read_u32::<LittleEndian>()?,
+            target: self.parse()?,
+            sector_num: self.parse()?,
         } )
     }
 }
@@ -175,15 +169,15 @@ pub struct MsgFlashProgram {
     pub data: Vec<u8>,
 }
 
-impl MsgFlashProgram {
+impl SbpParse<MsgFlashProgram> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashProgram, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFlashProgram> {
         Ok( MsgFlashProgram{
             sender_id: None,
-            target: _buf.read_u8()?,
-            addr_start: crate::parser::read_u8_array_fixed(_buf)?,
-            addr_len: _buf.read_u8()?,
-            data: crate::parser::read_u8_array(_buf)?,
+            target: self.parse()?,
+            addr_start: self.parse()?,
+            addr_len: self.parse()?,
+            data: self.parse()?,
         } )
     }
 }
@@ -248,14 +242,14 @@ pub struct MsgFlashReadReq {
     pub addr_len: u8,
 }
 
-impl MsgFlashReadReq {
+impl SbpParse<MsgFlashReadReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashReadReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFlashReadReq> {
         Ok( MsgFlashReadReq{
             sender_id: None,
-            target: _buf.read_u8()?,
-            addr_start: crate::parser::read_u8_array_fixed(_buf)?,
-            addr_len: _buf.read_u8()?,
+            target: self.parse()?,
+            addr_start: self.parse()?,
+            addr_len: self.parse()?,
         } )
     }
 }
@@ -318,14 +312,14 @@ pub struct MsgFlashReadResp {
     pub addr_len: u8,
 }
 
-impl MsgFlashReadResp {
+impl SbpParse<MsgFlashReadResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFlashReadResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFlashReadResp> {
         Ok( MsgFlashReadResp{
             sender_id: None,
-            target: _buf.read_u8()?,
-            addr_start: crate::parser::read_u8_array_fixed(_buf)?,
-            addr_len: _buf.read_u8()?,
+            target: self.parse()?,
+            addr_start: self.parse()?,
+            addr_len: self.parse()?,
         } )
     }
 }
@@ -379,12 +373,12 @@ pub struct MsgM25FlashWriteStatus {
     pub status: [u8; 1],
 }
 
-impl MsgM25FlashWriteStatus {
+impl SbpParse<MsgM25FlashWriteStatus> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgM25FlashWriteStatus, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgM25FlashWriteStatus> {
         Ok( MsgM25FlashWriteStatus{
             sender_id: None,
-            status: crate::parser::read_u8_array_fixed(_buf)?,
+            status: self.parse()?,
         } )
     }
 }
@@ -434,12 +428,12 @@ pub struct MsgStmFlashLockSector {
     pub sector: u32,
 }
 
-impl MsgStmFlashLockSector {
+impl SbpParse<MsgStmFlashLockSector> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmFlashLockSector, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgStmFlashLockSector> {
         Ok( MsgStmFlashLockSector{
             sender_id: None,
-            sector: _buf.read_u32::<LittleEndian>()?,
+            sector: self.parse()?,
         } )
     }
 }
@@ -489,12 +483,12 @@ pub struct MsgStmFlashUnlockSector {
     pub sector: u32,
 }
 
-impl MsgStmFlashUnlockSector {
+impl SbpParse<MsgStmFlashUnlockSector> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmFlashUnlockSector, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgStmFlashUnlockSector> {
         Ok( MsgStmFlashUnlockSector{
             sender_id: None,
-            sector: _buf.read_u32::<LittleEndian>()?,
+            sector: self.parse()?,
         } )
     }
 }
@@ -545,9 +539,9 @@ pub struct MsgStmUniqueIdReq {
     pub sender_id: Option<u16>,
 }
 
-impl MsgStmUniqueIdReq {
+impl SbpParse<MsgStmUniqueIdReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgStmUniqueIdReq> {
         Ok( MsgStmUniqueIdReq{
             sender_id: None,
         } )
@@ -598,12 +592,12 @@ pub struct MsgStmUniqueIdResp {
     pub stm_id: [u8; 12],
 }
 
-impl MsgStmUniqueIdResp {
+impl SbpParse<MsgStmUniqueIdResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgStmUniqueIdResp> {
         Ok( MsgStmUniqueIdResp{
             sender_id: None,
-            stm_id: crate::parser::read_u8_array_fixed(_buf)?,
+            stm_id: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/flash.rs
+++ b/rust/sbp/src/messages/flash.rs
@@ -19,6 +19,9 @@
 //! to Piksi Multi.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -165,7 +168,7 @@ pub struct MsgFlashProgram {
     /// Target flags
     pub target: u8,
     /// Starting address offset to program
-    pub addr_start: Vec<u8>,
+    pub addr_start: [u8; 3],
     /// Length of set of addresses to program, counting up from starting address
     pub addr_len: u8,
     /// Data to program addresses with, with length N=addr_len
@@ -178,7 +181,7 @@ impl MsgFlashProgram {
         Ok( MsgFlashProgram{
             sender_id: None,
             target: _buf.read_u8()?,
-            addr_start: crate::parser::read_u8_array_limit(_buf, 3)?,
+            addr_start: crate::parser::read_u8_array_fixed(_buf)?,
             addr_len: _buf.read_u8()?,
             data: crate::parser::read_u8_array(_buf)?,
         } )
@@ -240,7 +243,7 @@ pub struct MsgFlashReadReq {
     /// Target flags
     pub target: u8,
     /// Starting address offset to read from
-    pub addr_start: Vec<u8>,
+    pub addr_start: [u8; 3],
     /// Length of set of addresses to read, counting up from starting address
     pub addr_len: u8,
 }
@@ -251,7 +254,7 @@ impl MsgFlashReadReq {
         Ok( MsgFlashReadReq{
             sender_id: None,
             target: _buf.read_u8()?,
-            addr_start: crate::parser::read_u8_array_limit(_buf, 3)?,
+            addr_start: crate::parser::read_u8_array_fixed(_buf)?,
             addr_len: _buf.read_u8()?,
         } )
     }
@@ -310,7 +313,7 @@ pub struct MsgFlashReadResp {
     /// Target flags
     pub target: u8,
     /// Starting address offset to read from
-    pub addr_start: Vec<u8>,
+    pub addr_start: [u8; 3],
     /// Length of set of addresses to read, counting up from starting address
     pub addr_len: u8,
 }
@@ -321,7 +324,7 @@ impl MsgFlashReadResp {
         Ok( MsgFlashReadResp{
             sender_id: None,
             target: _buf.read_u8()?,
-            addr_start: crate::parser::read_u8_array_limit(_buf, 3)?,
+            addr_start: crate::parser::read_u8_array_fixed(_buf)?,
             addr_len: _buf.read_u8()?,
         } )
     }
@@ -373,7 +376,7 @@ impl crate::serialize::SbpSerialize for MsgFlashReadResp {
 pub struct MsgM25FlashWriteStatus {
     pub sender_id: Option<u16>,
     /// Byte to write to the M25 flash status register
-    pub status: Vec<u8>,
+    pub status: [u8; 1],
 }
 
 impl MsgM25FlashWriteStatus {
@@ -381,7 +384,7 @@ impl MsgM25FlashWriteStatus {
     pub fn parse(_buf: &mut &[u8]) -> Result<MsgM25FlashWriteStatus, crate::Error> {
         Ok( MsgM25FlashWriteStatus{
             sender_id: None,
-            status: crate::parser::read_u8_array_limit(_buf, 1)?,
+            status: crate::parser::read_u8_array_fixed(_buf)?,
         } )
     }
 }
@@ -592,7 +595,7 @@ impl crate::serialize::SbpSerialize for MsgStmUniqueIdReq {
 pub struct MsgStmUniqueIdResp {
     pub sender_id: Option<u16>,
     /// Device unique ID
-    pub stm_id: Vec<u8>,
+    pub stm_id: [u8; 12],
 }
 
 impl MsgStmUniqueIdResp {
@@ -600,7 +603,7 @@ impl MsgStmUniqueIdResp {
     pub fn parse(_buf: &mut &[u8]) -> Result<MsgStmUniqueIdResp, crate::Error> {
         Ok( MsgStmUniqueIdResp{
             sender_id: None,
-            stm_id: crate::parser::read_u8_array_limit(_buf, 12)?,
+            stm_id: crate::parser::read_u8_array_fixed(_buf)?,
         } )
     }
 }

--- a/rust/sbp/src/messages/gnss.rs
+++ b/rust/sbp/src/messages/gnss.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Various structs shared between modules
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -56,12 +59,14 @@ impl CarrierPhase {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<CarrierPhase>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[CarrierPhase; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(CarrierPhase::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -117,12 +122,14 @@ impl GPSTime {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTime>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[GPSTime; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GPSTime::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -175,12 +182,14 @@ impl GPSTimeDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTimeDep>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[GPSTimeDep; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GPSTimeDep::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -231,12 +240,14 @@ impl GPSTimeSec {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GPSTimeSec>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[GPSTimeSec; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GPSTimeSec::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -286,12 +297,14 @@ impl GnssSignal {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssSignal>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[GnssSignal; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GnssSignal::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -345,15 +358,14 @@ impl GnssSignalDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<GnssSignalDep>, crate::Error> {
+    ) -> Result<[GnssSignalDep; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GnssSignalDep::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -405,12 +417,12 @@ impl SvId {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<SvId>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[SvId; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(SvId::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/gnss.rs
+++ b/rust/sbp/src/messages/gnss.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Various structs shared between modules
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// GNSS carrier phase measurement.
 ///
@@ -43,30 +37,13 @@ pub struct CarrierPhase {
     pub f: u8,
 }
 
-impl CarrierPhase {
+impl SbpParse<CarrierPhase> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<CarrierPhase, crate::Error> {
+    fn parse(&mut self) -> crate::Result<CarrierPhase> {
         Ok( CarrierPhase{
-            i: _buf.read_i32::<LittleEndian>()?,
-            f: _buf.read_u8()?,
+            i: self.parse()?,
+            f: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CarrierPhase>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(CarrierPhase::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[CarrierPhase; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(CarrierPhase::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -105,31 +82,14 @@ pub struct GPSTime {
     pub wn: u16,
 }
 
-impl GPSTime {
+impl SbpParse<GPSTime> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTime, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GPSTime> {
         Ok( GPSTime{
-            tow: _buf.read_u32::<LittleEndian>()?,
-            ns_residual: _buf.read_i32::<LittleEndian>()?,
-            wn: _buf.read_u16::<LittleEndian>()?,
+            tow: self.parse()?,
+            ns_residual: self.parse()?,
+            wn: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTime>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GPSTime::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GPSTime; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GPSTime::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -166,30 +126,13 @@ pub struct GPSTimeDep {
     pub wn: u16,
 }
 
-impl GPSTimeDep {
+impl SbpParse<GPSTimeDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTimeDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GPSTimeDep> {
         Ok( GPSTimeDep{
-            tow: _buf.read_u32::<LittleEndian>()?,
-            wn: _buf.read_u16::<LittleEndian>()?,
+            tow: self.parse()?,
+            wn: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTimeDep>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GPSTimeDep::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GPSTimeDep; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GPSTimeDep::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -224,30 +167,13 @@ pub struct GPSTimeSec {
     pub wn: u16,
 }
 
-impl GPSTimeSec {
+impl SbpParse<GPSTimeSec> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GPSTimeSec, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GPSTimeSec> {
         Ok( GPSTimeSec{
-            tow: _buf.read_u32::<LittleEndian>()?,
-            wn: _buf.read_u16::<LittleEndian>()?,
+            tow: self.parse()?,
+            wn: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GPSTimeSec>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GPSTimeSec::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GPSTimeSec; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GPSTimeSec::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -281,30 +207,13 @@ pub struct GnssSignal {
     pub code: u8,
 }
 
-impl GnssSignal {
+impl SbpParse<GnssSignal> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GnssSignal, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GnssSignal> {
         Ok( GnssSignal{
-            sat: _buf.read_u8()?,
-            code: _buf.read_u8()?,
+            sat: self.parse()?,
+            code: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssSignal>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GnssSignal::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GnssSignal; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GnssSignal::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -341,31 +250,14 @@ pub struct GnssSignalDep {
     pub reserved: u8,
 }
 
-impl GnssSignalDep {
+impl SbpParse<GnssSignalDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GnssSignalDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GnssSignalDep> {
         Ok( GnssSignalDep{
-            sat: _buf.read_u16::<LittleEndian>()?,
-            code: _buf.read_u8()?,
-            reserved: _buf.read_u8()?,
+            sat: self.parse()?,
+            code: self.parse()?,
+            reserved: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssSignalDep>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GnssSignalDep::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GnssSignalDep; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GnssSignalDep::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -401,28 +293,13 @@ pub struct SvId {
     pub constellation: u8,
 }
 
-impl SvId {
+impl SbpParse<SvId> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<SvId, crate::Error> {
+    fn parse(&mut self) -> crate::Result<SvId> {
         Ok( SvId{
-            satId: _buf.read_u8()?,
-            constellation: _buf.read_u8()?,
+            satId: self.parse()?,
+            constellation: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SvId>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(SvId::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[SvId; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(SvId::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/imu.rs
+++ b/rust/sbp/src/messages/imu.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Inertial Measurement Unit (IMU) messages.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Auxiliary IMU data
 ///
@@ -45,14 +39,14 @@ pub struct MsgImuAux {
     pub imu_conf: u8,
 }
 
-impl MsgImuAux {
+impl SbpParse<MsgImuAux> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgImuAux, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgImuAux> {
         Ok( MsgImuAux{
             sender_id: None,
-            imu_type: _buf.read_u8()?,
-            temp: _buf.read_i16::<LittleEndian>()?,
-            imu_conf: _buf.read_u8()?,
+            imu_type: self.parse()?,
+            temp: self.parse()?,
+            imu_conf: self.parse()?,
         } )
     }
 }
@@ -127,19 +121,19 @@ pub struct MsgImuRaw {
     pub gyr_z: i16,
 }
 
-impl MsgImuRaw {
+impl SbpParse<MsgImuRaw> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgImuRaw, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgImuRaw> {
         Ok( MsgImuRaw{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            tow_f: _buf.read_u8()?,
-            acc_x: _buf.read_i16::<LittleEndian>()?,
-            acc_y: _buf.read_i16::<LittleEndian>()?,
-            acc_z: _buf.read_i16::<LittleEndian>()?,
-            gyr_x: _buf.read_i16::<LittleEndian>()?,
-            gyr_y: _buf.read_i16::<LittleEndian>()?,
-            gyr_z: _buf.read_i16::<LittleEndian>()?,
+            tow: self.parse()?,
+            tow_f: self.parse()?,
+            acc_x: self.parse()?,
+            acc_y: self.parse()?,
+            acc_z: self.parse()?,
+            gyr_x: self.parse()?,
+            gyr_y: self.parse()?,
+            gyr_z: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/imu.rs
+++ b/rust/sbp/src/messages/imu.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Inertial Measurement Unit (IMU) messages.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/linux.rs
+++ b/rust/sbp/src/messages/linux.rs
@@ -15,17 +15,11 @@
 //! Linux state monitoring.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// List CPU state on the system
 ///
@@ -44,21 +38,21 @@ pub struct MsgLinuxCpuState {
     /// percent of cpu used, expressed as a fraction of 256
     pub pcpu: u8,
     /// fixed length string representing the thread name
-    pub tname: SbpString,
+    pub tname: BoundedSbpString<15>,
     /// the command line (as much as it fits in the remaining packet)
-    pub cmdline: SbpString,
+    pub cmdline: UnboundedSbpString,
 }
 
-impl MsgLinuxCpuState {
+impl SbpParse<MsgLinuxCpuState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxCpuState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxCpuState> {
         Ok( MsgLinuxCpuState{
             sender_id: None,
-            index: _buf.read_u8()?,
-            pid: _buf.read_u16::<LittleEndian>()?,
-            pcpu: _buf.read_u8()?,
-            tname: crate::parser::read_string_limit(_buf, 15)?,
-            cmdline: crate::parser::read_string(_buf)?,
+            index: self.parse()?,
+            pid: self.parse()?,
+            pcpu: self.parse()?,
+            tname: self.parse()?,
+            cmdline: self.parse()?,
         } )
     }
 }
@@ -119,21 +113,21 @@ pub struct MsgLinuxMemState {
     /// percent of memory used, expressed as a fraction of 256
     pub pmem: u8,
     /// fixed length string representing the thread name
-    pub tname: SbpString,
+    pub tname: BoundedSbpString<15>,
     /// the command line (as much as it fits in the remaining packet)
-    pub cmdline: SbpString,
+    pub cmdline: UnboundedSbpString,
 }
 
-impl MsgLinuxMemState {
+impl SbpParse<MsgLinuxMemState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxMemState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxMemState> {
         Ok( MsgLinuxMemState{
             sender_id: None,
-            index: _buf.read_u8()?,
-            pid: _buf.read_u16::<LittleEndian>()?,
-            pmem: _buf.read_u8()?,
-            tname: crate::parser::read_string_limit(_buf, 15)?,
-            cmdline: crate::parser::read_string(_buf)?,
+            index: self.parse()?,
+            pid: self.parse()?,
+            pmem: self.parse()?,
+            tname: self.parse()?,
+            cmdline: self.parse()?,
         } )
     }
 }
@@ -193,18 +187,18 @@ pub struct MsgLinuxProcessFdCount {
     /// a count of the number of file descriptors opened by the process
     pub fd_count: u16,
     /// the command line of the process in question
-    pub cmdline: SbpString,
+    pub cmdline: UnboundedSbpString,
 }
 
-impl MsgLinuxProcessFdCount {
+impl SbpParse<MsgLinuxProcessFdCount> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessFdCount, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxProcessFdCount> {
         Ok( MsgLinuxProcessFdCount{
             sender_id: None,
-            index: _buf.read_u8()?,
-            pid: _buf.read_u16::<LittleEndian>()?,
-            fd_count: _buf.read_u16::<LittleEndian>()?,
-            cmdline: crate::parser::read_string(_buf)?,
+            index: self.parse()?,
+            pid: self.parse()?,
+            fd_count: self.parse()?,
+            cmdline: self.parse()?,
         } )
     }
 }
@@ -262,16 +256,16 @@ pub struct MsgLinuxProcessFdSummary {
     /// being reported.  That is, in C string syntax
     /// "32\0/var/log/syslog\012\0/tmp/foo\0" with the end of the list being 2
     /// NULL terminators in a row.
-    pub most_opened: SbpString,
+    pub most_opened: UnboundedSbpString,
 }
 
-impl MsgLinuxProcessFdSummary {
+impl SbpParse<MsgLinuxProcessFdSummary> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessFdSummary, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxProcessFdSummary> {
         Ok( MsgLinuxProcessFdSummary{
             sender_id: None,
-            sys_fd_count: _buf.read_u32::<LittleEndian>()?,
-            most_opened: crate::parser::read_string(_buf)?,
+            sys_fd_count: self.parse()?,
+            most_opened: self.parse()?,
         } )
     }
 }
@@ -333,20 +327,20 @@ pub struct MsgLinuxProcessSocketCounts {
     /// (listen), 0x400 (closing), 0x800 (unconnected),   and 0x8000 (unknown)
     pub socket_states: u16,
     /// the command line of the process in question
-    pub cmdline: SbpString,
+    pub cmdline: UnboundedSbpString,
 }
 
-impl MsgLinuxProcessSocketCounts {
+impl SbpParse<MsgLinuxProcessSocketCounts> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessSocketCounts, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxProcessSocketCounts> {
         Ok( MsgLinuxProcessSocketCounts{
             sender_id: None,
-            index: _buf.read_u8()?,
-            pid: _buf.read_u16::<LittleEndian>()?,
-            socket_count: _buf.read_u16::<LittleEndian>()?,
-            socket_types: _buf.read_u16::<LittleEndian>()?,
-            socket_states: _buf.read_u16::<LittleEndian>()?,
-            cmdline: crate::parser::read_string(_buf)?,
+            index: self.parse()?,
+            pid: self.parse()?,
+            socket_count: self.parse()?,
+            socket_types: self.parse()?,
+            socket_states: self.parse()?,
+            cmdline: self.parse()?,
         } )
     }
 }
@@ -419,24 +413,24 @@ pub struct MsgLinuxProcessSocketQueues {
     pub socket_states: u16,
     /// Address of the largest queue, remote or local depending on the
     /// directionality of the connection.
-    pub address_of_largest: SbpString,
+    pub address_of_largest: BoundedSbpString<64>,
     /// the command line of the process in question
-    pub cmdline: SbpString,
+    pub cmdline: UnboundedSbpString,
 }
 
-impl MsgLinuxProcessSocketQueues {
+impl SbpParse<MsgLinuxProcessSocketQueues> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxProcessSocketQueues, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxProcessSocketQueues> {
         Ok( MsgLinuxProcessSocketQueues{
             sender_id: None,
-            index: _buf.read_u8()?,
-            pid: _buf.read_u16::<LittleEndian>()?,
-            recv_queued: _buf.read_u16::<LittleEndian>()?,
-            send_queued: _buf.read_u16::<LittleEndian>()?,
-            socket_types: _buf.read_u16::<LittleEndian>()?,
-            socket_states: _buf.read_u16::<LittleEndian>()?,
-            address_of_largest: crate::parser::read_string_limit(_buf, 64)?,
-            cmdline: crate::parser::read_string(_buf)?,
+            index: self.parse()?,
+            pid: self.parse()?,
+            recv_queued: self.parse()?,
+            send_queued: self.parse()?,
+            socket_types: self.parse()?,
+            socket_states: self.parse()?,
+            address_of_largest: self.parse()?,
+            cmdline: self.parse()?,
         } )
     }
 }
@@ -509,15 +503,15 @@ pub struct MsgLinuxSocketUsage {
     pub socket_type_counts: [u16; 16],
 }
 
-impl MsgLinuxSocketUsage {
+impl SbpParse<MsgLinuxSocketUsage> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxSocketUsage, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxSocketUsage> {
         Ok( MsgLinuxSocketUsage{
             sender_id: None,
-            avg_queue_depth: _buf.read_u32::<LittleEndian>()?,
-            max_queue_depth: _buf.read_u32::<LittleEndian>()?,
-            socket_state_counts: crate::parser::read_u16_array_fixed(_buf)?,
-            socket_type_counts: crate::parser::read_u16_array_fixed(_buf)?,
+            avg_queue_depth: self.parse()?,
+            max_queue_depth: self.parse()?,
+            socket_state_counts: self.parse()?,
+            socket_type_counts: self.parse()?,
         } )
     }
 }
@@ -582,17 +576,17 @@ pub struct MsgLinuxSysState {
     pub pid_count: u16,
 }
 
-impl MsgLinuxSysState {
+impl SbpParse<MsgLinuxSysState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLinuxSysState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLinuxSysState> {
         Ok( MsgLinuxSysState{
             sender_id: None,
-            mem_total: _buf.read_u16::<LittleEndian>()?,
-            pcpu: _buf.read_u8()?,
-            pmem: _buf.read_u8()?,
-            procs_starting: _buf.read_u16::<LittleEndian>()?,
-            procs_stopping: _buf.read_u16::<LittleEndian>()?,
-            pid_count: _buf.read_u16::<LittleEndian>()?,
+            mem_total: self.parse()?,
+            pcpu: self.parse()?,
+            pmem: self.parse()?,
+            procs_starting: self.parse()?,
+            procs_stopping: self.parse()?,
+            pid_count: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/linux.rs
+++ b/rust/sbp/src/messages/linux.rs
@@ -15,6 +15,9 @@
 //! Linux state monitoring.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -499,11 +502,11 @@ pub struct MsgLinuxSocketUsage {
     /// A count for each socket type reported in the `socket_types_reported`
     /// field, the first entry corresponds to the first enabled bit in
     /// `types_reported`.
-    pub socket_state_counts: Vec<u16>,
+    pub socket_state_counts: [u16; 16],
     /// A count for each socket type reported in the `socket_types_reported`
     /// field, the first entry corresponds to the first enabled bit in
     /// `types_reported`.
-    pub socket_type_counts: Vec<u16>,
+    pub socket_type_counts: [u16; 16],
 }
 
 impl MsgLinuxSocketUsage {
@@ -513,8 +516,8 @@ impl MsgLinuxSocketUsage {
             sender_id: None,
             avg_queue_depth: _buf.read_u32::<LittleEndian>()?,
             max_queue_depth: _buf.read_u32::<LittleEndian>()?,
-            socket_state_counts: crate::parser::read_u16_array_limit(_buf, 16)?,
-            socket_type_counts: crate::parser::read_u16_array_limit(_buf, 16)?,
+            socket_state_counts: crate::parser::read_u16_array_fixed(_buf)?,
+            socket_type_counts: crate::parser::read_u16_array_fixed(_buf)?,
         } )
     }
 }

--- a/rust/sbp/src/messages/logging.rs
+++ b/rust/sbp/src/messages/logging.rs
@@ -15,17 +15,11 @@
 //! Logging and debugging messages from the device.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Wrapper for FWD a separate stream of information over SBP
 ///
@@ -47,17 +41,17 @@ pub struct MsgFwd {
     /// protocol identifier
     pub protocol: u8,
     /// variable length wrapped binary message
-    pub fwd_payload: SbpString,
+    pub fwd_payload: UnboundedSbpString,
 }
 
-impl MsgFwd {
+impl SbpParse<MsgFwd> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFwd, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFwd> {
         Ok( MsgFwd{
             sender_id: None,
-            source: _buf.read_u8()?,
-            protocol: _buf.read_u8()?,
-            fwd_payload: crate::parser::read_string(_buf)?,
+            source: self.parse()?,
+            protocol: self.parse()?,
+            fwd_payload: self.parse()?,
         } )
     }
 }
@@ -111,16 +105,16 @@ pub struct MsgLog {
     /// Logging level
     pub level: u8,
     /// Human-readable string
-    pub text: SbpString,
+    pub text: UnboundedSbpString,
 }
 
-impl MsgLog {
+impl SbpParse<MsgLog> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgLog, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgLog> {
         Ok( MsgLog{
             sender_id: None,
-            level: _buf.read_u8()?,
-            text: crate::parser::read_string(_buf)?,
+            level: self.parse()?,
+            text: self.parse()?,
         } )
     }
 }
@@ -168,15 +162,15 @@ impl crate::serialize::SbpSerialize for MsgLog {
 pub struct MsgPrintDep {
     pub sender_id: Option<u16>,
     /// Human-readable string
-    pub text: SbpString,
+    pub text: UnboundedSbpString,
 }
 
-impl MsgPrintDep {
+impl SbpParse<MsgPrintDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPrintDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPrintDep> {
         Ok( MsgPrintDep{
             sender_id: None,
-            text: crate::parser::read_string(_buf)?,
+            text: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/logging.rs
+++ b/rust/sbp/src/messages/logging.rs
@@ -15,6 +15,9 @@
 //! Logging and debugging messages from the device.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/mag.rs
+++ b/rust/sbp/src/messages/mag.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Magnetometer (mag) messages.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Raw magnetometer data
 ///
@@ -48,16 +42,16 @@ pub struct MsgMagRaw {
     pub mag_z: i16,
 }
 
-impl MsgMagRaw {
+impl SbpParse<MsgMagRaw> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMagRaw, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgMagRaw> {
         Ok( MsgMagRaw{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            tow_f: _buf.read_u8()?,
-            mag_x: _buf.read_i16::<LittleEndian>()?,
-            mag_y: _buf.read_i16::<LittleEndian>()?,
-            mag_z: _buf.read_i16::<LittleEndian>()?,
+            tow: self.parse()?,
+            tow_f: self.parse()?,
+            mag_x: self.parse()?,
+            mag_y: self.parse()?,
+            mag_z: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/mag.rs
+++ b/rust/sbp/src/messages/mag.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Magnetometer (mag) messages.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/mod.rs
+++ b/rust/sbp/src/messages/mod.rs
@@ -228,6 +228,7 @@ use self::vehicle::MsgOdometry;
 use self::vehicle::MsgWheeltick;
 
 use crate::framer::FramerError;
+use crate::parser::SbpParse;
 use crate::serialize::SbpSerialize;
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
@@ -443,972 +444,972 @@ impl SBP {
     pub fn parse(msg_id: u16, sender_id: u16, payload: &mut &[u8]) -> Result<SBP, crate::Error> {
         let x: Result<SBP, crate::Error> = match msg_id {
             16 => {
-                let mut msg = MsgPrintDep::parse(payload)?;
+                let mut msg: MsgPrintDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPrintDep(msg))
             }
             17 => {
-                let mut msg = MsgTrackingStateDetailedDep::parse(payload)?;
+                let mut msg: MsgTrackingStateDetailedDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingStateDetailedDep(msg))
             }
             19 => {
-                let mut msg = MsgTrackingStateDepB::parse(payload)?;
+                let mut msg: MsgTrackingStateDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingStateDepB(msg))
             }
             20 => {
-                let mut msg = MsgAcqResultDepB::parse(payload)?;
+                let mut msg: MsgAcqResultDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAcqResultDepB(msg))
             }
             21 => {
-                let mut msg = MsgAcqResultDepA::parse(payload)?;
+                let mut msg: MsgAcqResultDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAcqResultDepA(msg))
             }
             22 => {
-                let mut msg = MsgTrackingStateDepA::parse(payload)?;
+                let mut msg: MsgTrackingStateDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingStateDepA(msg))
             }
             23 => {
-                let mut msg = MsgThreadState::parse(payload)?;
+                let mut msg: MsgThreadState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgThreadState(msg))
             }
             24 => {
-                let mut msg = MsgUartStateDepa::parse(payload)?;
+                let mut msg: MsgUartStateDepa = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgUartStateDepa(msg))
             }
             25 => {
-                let mut msg = MsgIarState::parse(payload)?;
+                let mut msg: MsgIarState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgIarState(msg))
             }
             26 => {
-                let mut msg = MsgEphemerisDepA::parse(payload)?;
+                let mut msg: MsgEphemerisDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisDepA(msg))
             }
             27 => {
-                let mut msg = MsgMaskSatelliteDep::parse(payload)?;
+                let mut msg: MsgMaskSatelliteDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgMaskSatelliteDep(msg))
             }
             28 => {
-                let mut msg = MsgTrackingIqDepA::parse(payload)?;
+                let mut msg: MsgTrackingIqDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingIqDepA(msg))
             }
             29 => {
-                let mut msg = MsgUartState::parse(payload)?;
+                let mut msg: MsgUartState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgUartState(msg))
             }
             30 => {
-                let mut msg = MsgAcqSvProfileDep::parse(payload)?;
+                let mut msg: MsgAcqSvProfileDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAcqSvProfileDep(msg))
             }
             31 => {
-                let mut msg = MsgAcqResultDepC::parse(payload)?;
+                let mut msg: MsgAcqResultDepC = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAcqResultDepC(msg))
             }
             33 => {
-                let mut msg = MsgTrackingStateDetailedDepA::parse(payload)?;
+                let mut msg: MsgTrackingStateDetailedDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingStateDetailedDepA(msg))
             }
             34 => {
-                let mut msg = MsgResetFilters::parse(payload)?;
+                let mut msg: MsgResetFilters = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgResetFilters(msg))
             }
             35 => {
-                let mut msg = MsgInitBaseDep::parse(payload)?;
+                let mut msg: MsgInitBaseDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgInitBaseDep(msg))
             }
             43 => {
-                let mut msg = MsgMaskSatellite::parse(payload)?;
+                let mut msg: MsgMaskSatellite = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgMaskSatellite(msg))
             }
             44 => {
-                let mut msg = MsgTrackingIqDepB::parse(payload)?;
+                let mut msg: MsgTrackingIqDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingIqDepB(msg))
             }
             45 => {
-                let mut msg = MsgTrackingIq::parse(payload)?;
+                let mut msg: MsgTrackingIq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingIq(msg))
             }
             46 => {
-                let mut msg = MsgAcqSvProfile::parse(payload)?;
+                let mut msg: MsgAcqSvProfile = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAcqSvProfile(msg))
             }
             47 => {
-                let mut msg = MsgAcqResult::parse(payload)?;
+                let mut msg: MsgAcqResult = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAcqResult(msg))
             }
             65 => {
-                let mut msg = MsgTrackingState::parse(payload)?;
+                let mut msg: MsgTrackingState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgTrackingState(msg))
             }
             67 => {
-                let mut msg = MsgObsDepB::parse(payload)?;
+                let mut msg: MsgObsDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgObsDepB(msg))
             }
             68 => {
-                let mut msg = MsgBasePosLLH::parse(payload)?;
+                let mut msg: MsgBasePosLLH = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBasePosLLH(msg))
             }
             69 => {
-                let mut msg = MsgObsDepA::parse(payload)?;
+                let mut msg: MsgObsDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgObsDepA(msg))
             }
             70 => {
-                let mut msg = MsgEphemerisDepB::parse(payload)?;
+                let mut msg: MsgEphemerisDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisDepB(msg))
             }
             71 => {
-                let mut msg = MsgEphemerisDepC::parse(payload)?;
+                let mut msg: MsgEphemerisDepC = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisDepC(msg))
             }
             72 => {
-                let mut msg = MsgBasePosECEF::parse(payload)?;
+                let mut msg: MsgBasePosECEF = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBasePosECEF(msg))
             }
             73 => {
-                let mut msg = MsgObsDepC::parse(payload)?;
+                let mut msg: MsgObsDepC = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgObsDepC(msg))
             }
             74 => {
-                let mut msg = MsgObs::parse(payload)?;
+                let mut msg: MsgObs = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgObs(msg))
             }
             80 => {
-                let mut msg = MsgSpecanDep::parse(payload)?;
+                let mut msg: MsgSpecanDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSpecanDep(msg))
             }
             81 => {
-                let mut msg = MsgSpecan::parse(payload)?;
+                let mut msg: MsgSpecan = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSpecan(msg))
             }
             97 => {
-                let mut msg = MsgMeasurementState::parse(payload)?;
+                let mut msg: MsgMeasurementState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgMeasurementState(msg))
             }
             104 => {
-                let mut msg = MsgSetTime::parse(payload)?;
+                let mut msg: MsgSetTime = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSetTime(msg))
             }
             105 => {
-                let mut msg = MsgAlmanac::parse(payload)?;
+                let mut msg: MsgAlmanac = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAlmanac(msg))
             }
             112 => {
-                let mut msg = MsgAlmanacGPSDep::parse(payload)?;
+                let mut msg: MsgAlmanacGPSDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAlmanacGPSDep(msg))
             }
             113 => {
-                let mut msg = MsgAlmanacGloDep::parse(payload)?;
+                let mut msg: MsgAlmanacGloDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAlmanacGloDep(msg))
             }
             114 => {
-                let mut msg = MsgAlmanacGPS::parse(payload)?;
+                let mut msg: MsgAlmanacGPS = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAlmanacGPS(msg))
             }
             115 => {
-                let mut msg = MsgAlmanacGlo::parse(payload)?;
+                let mut msg: MsgAlmanacGlo = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAlmanacGlo(msg))
             }
             117 => {
-                let mut msg = MsgGloBiases::parse(payload)?;
+                let mut msg: MsgGloBiases = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGloBiases(msg))
             }
             128 => {
-                let mut msg = MsgEphemerisDepD::parse(payload)?;
+                let mut msg: MsgEphemerisDepD = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisDepD(msg))
             }
             129 => {
-                let mut msg = MsgEphemerisGPSDepE::parse(payload)?;
+                let mut msg: MsgEphemerisGPSDepE = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGPSDepE(msg))
             }
             130 => {
-                let mut msg = MsgEphemerisSbasDepA::parse(payload)?;
+                let mut msg: MsgEphemerisSbasDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisSbasDepA(msg))
             }
             131 => {
-                let mut msg = MsgEphemerisGloDepA::parse(payload)?;
+                let mut msg: MsgEphemerisGloDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGloDepA(msg))
             }
             132 => {
-                let mut msg = MsgEphemerisSbasDepB::parse(payload)?;
+                let mut msg: MsgEphemerisSbasDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisSbasDepB(msg))
             }
             133 => {
-                let mut msg = MsgEphemerisGloDepB::parse(payload)?;
+                let mut msg: MsgEphemerisGloDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGloDepB(msg))
             }
             134 => {
-                let mut msg = MsgEphemerisGPSDepF::parse(payload)?;
+                let mut msg: MsgEphemerisGPSDepF = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGPSDepF(msg))
             }
             135 => {
-                let mut msg = MsgEphemerisGloDepC::parse(payload)?;
+                let mut msg: MsgEphemerisGloDepC = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGloDepC(msg))
             }
             136 => {
-                let mut msg = MsgEphemerisGloDepD::parse(payload)?;
+                let mut msg: MsgEphemerisGloDepD = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGloDepD(msg))
             }
             137 => {
-                let mut msg = MsgEphemerisBds::parse(payload)?;
+                let mut msg: MsgEphemerisBds = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisBds(msg))
             }
             138 => {
-                let mut msg = MsgEphemerisGPS::parse(payload)?;
+                let mut msg: MsgEphemerisGPS = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGPS(msg))
             }
             139 => {
-                let mut msg = MsgEphemerisGlo::parse(payload)?;
+                let mut msg: MsgEphemerisGlo = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGlo(msg))
             }
             140 => {
-                let mut msg = MsgEphemerisSbas::parse(payload)?;
+                let mut msg: MsgEphemerisSbas = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisSbas(msg))
             }
             141 => {
-                let mut msg = MsgEphemerisGal::parse(payload)?;
+                let mut msg: MsgEphemerisGal = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGal(msg))
             }
             142 => {
-                let mut msg = MsgEphemerisQzss::parse(payload)?;
+                let mut msg: MsgEphemerisQzss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisQzss(msg))
             }
             144 => {
-                let mut msg = MsgIono::parse(payload)?;
+                let mut msg: MsgIono = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgIono(msg))
             }
             145 => {
-                let mut msg = MsgSvConfigurationGPSDep::parse(payload)?;
+                let mut msg: MsgSvConfigurationGPSDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSvConfigurationGPSDep(msg))
             }
             146 => {
-                let mut msg = MsgGroupDelayDepA::parse(payload)?;
+                let mut msg: MsgGroupDelayDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGroupDelayDepA(msg))
             }
             147 => {
-                let mut msg = MsgGroupDelayDepB::parse(payload)?;
+                let mut msg: MsgGroupDelayDepB = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGroupDelayDepB(msg))
             }
             148 => {
-                let mut msg = MsgGroupDelay::parse(payload)?;
+                let mut msg: MsgGroupDelay = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGroupDelay(msg))
             }
             149 => {
-                let mut msg = MsgEphemerisGalDepA::parse(payload)?;
+                let mut msg: MsgEphemerisGalDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgEphemerisGalDepA(msg))
             }
             150 => {
-                let mut msg = MsgGnssCapb::parse(payload)?;
+                let mut msg: MsgGnssCapb = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGnssCapb(msg))
             }
             151 => {
-                let mut msg = MsgSvAzEl::parse(payload)?;
+                let mut msg: MsgSvAzEl = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSvAzEl(msg))
             }
             160 => {
-                let mut msg = MsgSettingsWrite::parse(payload)?;
+                let mut msg: MsgSettingsWrite = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsWrite(msg))
             }
             161 => {
-                let mut msg = MsgSettingsSave::parse(payload)?;
+                let mut msg: MsgSettingsSave = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsSave(msg))
             }
             162 => {
-                let mut msg = MsgSettingsReadByIndexReq::parse(payload)?;
+                let mut msg: MsgSettingsReadByIndexReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsReadByIndexReq(msg))
             }
             163 => {
-                let mut msg = MsgFileioReadResp::parse(payload)?;
+                let mut msg: MsgFileioReadResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioReadResp(msg))
             }
             164 => {
-                let mut msg = MsgSettingsReadReq::parse(payload)?;
+                let mut msg: MsgSettingsReadReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsReadReq(msg))
             }
             165 => {
-                let mut msg = MsgSettingsReadResp::parse(payload)?;
+                let mut msg: MsgSettingsReadResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsReadResp(msg))
             }
             166 => {
-                let mut msg = MsgSettingsReadByIndexDone::parse(payload)?;
+                let mut msg: MsgSettingsReadByIndexDone = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsReadByIndexDone(msg))
             }
             167 => {
-                let mut msg = MsgSettingsReadByIndexResp::parse(payload)?;
+                let mut msg: MsgSettingsReadByIndexResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsReadByIndexResp(msg))
             }
             168 => {
-                let mut msg = MsgFileioReadReq::parse(payload)?;
+                let mut msg: MsgFileioReadReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioReadReq(msg))
             }
             169 => {
-                let mut msg = MsgFileioReadDirReq::parse(payload)?;
+                let mut msg: MsgFileioReadDirReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioReadDirReq(msg))
             }
             170 => {
-                let mut msg = MsgFileioReadDirResp::parse(payload)?;
+                let mut msg: MsgFileioReadDirResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioReadDirResp(msg))
             }
             171 => {
-                let mut msg = MsgFileioWriteResp::parse(payload)?;
+                let mut msg: MsgFileioWriteResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioWriteResp(msg))
             }
             172 => {
-                let mut msg = MsgFileioRemove::parse(payload)?;
+                let mut msg: MsgFileioRemove = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioRemove(msg))
             }
             173 => {
-                let mut msg = MsgFileioWriteReq::parse(payload)?;
+                let mut msg: MsgFileioWriteReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioWriteReq(msg))
             }
             174 => {
-                let mut msg = MsgSettingsRegister::parse(payload)?;
+                let mut msg: MsgSettingsRegister = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsRegister(msg))
             }
             175 => {
-                let mut msg = MsgSettingsWriteResp::parse(payload)?;
+                let mut msg: MsgSettingsWriteResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsWriteResp(msg))
             }
             176 => {
-                let mut msg = MsgBootloaderHandshakeDepA::parse(payload)?;
+                let mut msg: MsgBootloaderHandshakeDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBootloaderHandshakeDepA(msg))
             }
             177 => {
-                let mut msg = MsgBootloaderJumpToApp::parse(payload)?;
+                let mut msg: MsgBootloaderJumpToApp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBootloaderJumpToApp(msg))
             }
             178 => {
-                let mut msg = MsgResetDep::parse(payload)?;
+                let mut msg: MsgResetDep = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgResetDep(msg))
             }
             179 => {
-                let mut msg = MsgBootloaderHandshakeReq::parse(payload)?;
+                let mut msg: MsgBootloaderHandshakeReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBootloaderHandshakeReq(msg))
             }
             180 => {
-                let mut msg = MsgBootloaderHandshakeResp::parse(payload)?;
+                let mut msg: MsgBootloaderHandshakeResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBootloaderHandshakeResp(msg))
             }
             181 => {
-                let mut msg = MsgDeviceMonitor::parse(payload)?;
+                let mut msg: MsgDeviceMonitor = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgDeviceMonitor(msg))
             }
             182 => {
-                let mut msg = MsgReset::parse(payload)?;
+                let mut msg: MsgReset = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgReset(msg))
             }
             184 => {
-                let mut msg = MsgCommandReq::parse(payload)?;
+                let mut msg: MsgCommandReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCommandReq(msg))
             }
             185 => {
-                let mut msg = MsgCommandResp::parse(payload)?;
+                let mut msg: MsgCommandResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCommandResp(msg))
             }
             186 => {
-                let mut msg = MsgNetworkStateReq::parse(payload)?;
+                let mut msg: MsgNetworkStateReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgNetworkStateReq(msg))
             }
             187 => {
-                let mut msg = MsgNetworkStateResp::parse(payload)?;
+                let mut msg: MsgNetworkStateResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgNetworkStateResp(msg))
             }
             188 => {
-                let mut msg = MsgCommandOutput::parse(payload)?;
+                let mut msg: MsgCommandOutput = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCommandOutput(msg))
             }
             189 => {
-                let mut msg = MsgNetworkBandwidthUsage::parse(payload)?;
+                let mut msg: MsgNetworkBandwidthUsage = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgNetworkBandwidthUsage(msg))
             }
             190 => {
-                let mut msg = MsgCellModemStatus::parse(payload)?;
+                let mut msg: MsgCellModemStatus = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCellModemStatus(msg))
             }
             191 => {
-                let mut msg = MsgFrontEndGain::parse(payload)?;
+                let mut msg: MsgFrontEndGain = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFrontEndGain(msg))
             }
             192 => {
-                let mut msg = MsgCwResults::parse(payload)?;
+                let mut msg: MsgCwResults = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCwResults(msg))
             }
             193 => {
-                let mut msg = MsgCwStart::parse(payload)?;
+                let mut msg: MsgCwStart = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCwStart(msg))
             }
             221 => {
-                let mut msg = MsgNapDeviceDnaResp::parse(payload)?;
+                let mut msg: MsgNapDeviceDnaResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgNapDeviceDnaResp(msg))
             }
             222 => {
-                let mut msg = MsgNapDeviceDnaReq::parse(payload)?;
+                let mut msg: MsgNapDeviceDnaReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgNapDeviceDnaReq(msg))
             }
             224 => {
-                let mut msg = MsgFlashDone::parse(payload)?;
+                let mut msg: MsgFlashDone = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFlashDone(msg))
             }
             225 => {
-                let mut msg = MsgFlashReadResp::parse(payload)?;
+                let mut msg: MsgFlashReadResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFlashReadResp(msg))
             }
             226 => {
-                let mut msg = MsgFlashErase::parse(payload)?;
+                let mut msg: MsgFlashErase = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFlashErase(msg))
             }
             227 => {
-                let mut msg = MsgStmFlashLockSector::parse(payload)?;
+                let mut msg: MsgStmFlashLockSector = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgStmFlashLockSector(msg))
             }
             228 => {
-                let mut msg = MsgStmFlashUnlockSector::parse(payload)?;
+                let mut msg: MsgStmFlashUnlockSector = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgStmFlashUnlockSector(msg))
             }
             229 => {
-                let mut msg = MsgStmUniqueIdResp::parse(payload)?;
+                let mut msg: MsgStmUniqueIdResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgStmUniqueIdResp(msg))
             }
             230 => {
-                let mut msg = MsgFlashProgram::parse(payload)?;
+                let mut msg: MsgFlashProgram = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFlashProgram(msg))
             }
             231 => {
-                let mut msg = MsgFlashReadReq::parse(payload)?;
+                let mut msg: MsgFlashReadReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFlashReadReq(msg))
             }
             232 => {
-                let mut msg = MsgStmUniqueIdReq::parse(payload)?;
+                let mut msg: MsgStmUniqueIdReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgStmUniqueIdReq(msg))
             }
             243 => {
-                let mut msg = MsgM25FlashWriteStatus::parse(payload)?;
+                let mut msg: MsgM25FlashWriteStatus = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgM25FlashWriteStatus(msg))
             }
             256 => {
-                let mut msg = MsgGPSTimeDepA::parse(payload)?;
+                let mut msg: MsgGPSTimeDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGPSTimeDepA(msg))
             }
             257 => {
-                let mut msg = MsgExtEvent::parse(payload)?;
+                let mut msg: MsgExtEvent = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgExtEvent(msg))
             }
             258 => {
-                let mut msg = MsgGPSTime::parse(payload)?;
+                let mut msg: MsgGPSTime = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGPSTime(msg))
             }
             259 => {
-                let mut msg = MsgUtcTime::parse(payload)?;
+                let mut msg: MsgUtcTime = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgUtcTime(msg))
             }
             260 => {
-                let mut msg = MsgGPSTimeGnss::parse(payload)?;
+                let mut msg: MsgGPSTimeGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGPSTimeGnss(msg))
             }
             261 => {
-                let mut msg = MsgUtcTimeGnss::parse(payload)?;
+                let mut msg: MsgUtcTimeGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgUtcTimeGnss(msg))
             }
             431 => {
-                let mut msg = MsgSettingsRegisterResp::parse(payload)?;
+                let mut msg: MsgSettingsRegisterResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSettingsRegisterResp(msg))
             }
             512 => {
-                let mut msg = MsgPosECEFDepA::parse(payload)?;
+                let mut msg: MsgPosECEFDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosECEFDepA(msg))
             }
             513 => {
-                let mut msg = MsgPosLLHDepA::parse(payload)?;
+                let mut msg: MsgPosLLHDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosLLHDepA(msg))
             }
             514 => {
-                let mut msg = MsgBaselineECEFDepA::parse(payload)?;
+                let mut msg: MsgBaselineECEFDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBaselineECEFDepA(msg))
             }
             515 => {
-                let mut msg = MsgBaselineNEDDepA::parse(payload)?;
+                let mut msg: MsgBaselineNEDDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBaselineNEDDepA(msg))
             }
             516 => {
-                let mut msg = MsgVelECEFDepA::parse(payload)?;
+                let mut msg: MsgVelECEFDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelECEFDepA(msg))
             }
             517 => {
-                let mut msg = MsgVelNEDDepA::parse(payload)?;
+                let mut msg: MsgVelNEDDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelNEDDepA(msg))
             }
             518 => {
-                let mut msg = MsgDopsDepA::parse(payload)?;
+                let mut msg: MsgDopsDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgDopsDepA(msg))
             }
             519 => {
-                let mut msg = MsgBaselineHeadingDepA::parse(payload)?;
+                let mut msg: MsgBaselineHeadingDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBaselineHeadingDepA(msg))
             }
             520 => {
-                let mut msg = MsgDops::parse(payload)?;
+                let mut msg: MsgDops = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgDops(msg))
             }
             521 => {
-                let mut msg = MsgPosECEF::parse(payload)?;
+                let mut msg: MsgPosECEF = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosECEF(msg))
             }
             522 => {
-                let mut msg = MsgPosLLH::parse(payload)?;
+                let mut msg: MsgPosLLH = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosLLH(msg))
             }
             523 => {
-                let mut msg = MsgBaselineECEF::parse(payload)?;
+                let mut msg: MsgBaselineECEF = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBaselineECEF(msg))
             }
             524 => {
-                let mut msg = MsgBaselineNED::parse(payload)?;
+                let mut msg: MsgBaselineNED = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBaselineNED(msg))
             }
             525 => {
-                let mut msg = MsgVelECEF::parse(payload)?;
+                let mut msg: MsgVelECEF = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelECEF(msg))
             }
             526 => {
-                let mut msg = MsgVelNED::parse(payload)?;
+                let mut msg: MsgVelNED = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelNED(msg))
             }
             527 => {
-                let mut msg = MsgBaselineHeading::parse(payload)?;
+                let mut msg: MsgBaselineHeading = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgBaselineHeading(msg))
             }
             528 => {
-                let mut msg = MsgAgeCorrections::parse(payload)?;
+                let mut msg: MsgAgeCorrections = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAgeCorrections(msg))
             }
             529 => {
-                let mut msg = MsgPosLLHCov::parse(payload)?;
+                let mut msg: MsgPosLLHCov = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosLLHCov(msg))
             }
             530 => {
-                let mut msg = MsgVelNEDCov::parse(payload)?;
+                let mut msg: MsgVelNEDCov = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelNEDCov(msg))
             }
             531 => {
-                let mut msg = MsgVelBody::parse(payload)?;
+                let mut msg: MsgVelBody = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelBody(msg))
             }
             532 => {
-                let mut msg = MsgPosECEFCov::parse(payload)?;
+                let mut msg: MsgPosECEFCov = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosECEFCov(msg))
             }
             533 => {
-                let mut msg = MsgVelECEFCov::parse(payload)?;
+                let mut msg: MsgVelECEFCov = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelECEFCov(msg))
             }
             534 => {
-                let mut msg = MsgProtectionLevel::parse(payload)?;
+                let mut msg: MsgProtectionLevel = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgProtectionLevel(msg))
             }
             544 => {
-                let mut msg = MsgOrientQuat::parse(payload)?;
+                let mut msg: MsgOrientQuat = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgOrientQuat(msg))
             }
             545 => {
-                let mut msg = MsgOrientEuler::parse(payload)?;
+                let mut msg: MsgOrientEuler = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgOrientEuler(msg))
             }
             546 => {
-                let mut msg = MsgAngularRate::parse(payload)?;
+                let mut msg: MsgAngularRate = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgAngularRate(msg))
             }
             553 => {
-                let mut msg = MsgPosECEFGnss::parse(payload)?;
+                let mut msg: MsgPosECEFGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosECEFGnss(msg))
             }
             554 => {
-                let mut msg = MsgPosLLHGnss::parse(payload)?;
+                let mut msg: MsgPosLLHGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosLLHGnss(msg))
             }
             557 => {
-                let mut msg = MsgVelECEFGnss::parse(payload)?;
+                let mut msg: MsgVelECEFGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelECEFGnss(msg))
             }
             558 => {
-                let mut msg = MsgVelNEDGnss::parse(payload)?;
+                let mut msg: MsgVelNEDGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelNEDGnss(msg))
             }
             561 => {
-                let mut msg = MsgPosLLHCovGnss::parse(payload)?;
+                let mut msg: MsgPosLLHCovGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosLLHCovGnss(msg))
             }
             562 => {
-                let mut msg = MsgVelNEDCovGnss::parse(payload)?;
+                let mut msg: MsgVelNEDCovGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelNEDCovGnss(msg))
             }
             564 => {
-                let mut msg = MsgPosECEFCovGnss::parse(payload)?;
+                let mut msg: MsgPosECEFCovGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgPosECEFCovGnss(msg))
             }
             565 => {
-                let mut msg = MsgVelECEFCovGnss::parse(payload)?;
+                let mut msg: MsgVelECEFCovGnss = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgVelECEFCovGnss(msg))
             }
             1024 => {
-                let mut msg = MsgNdbEvent::parse(payload)?;
+                let mut msg: MsgNdbEvent = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgNdbEvent(msg))
             }
             1025 => {
-                let mut msg = MsgLog::parse(payload)?;
+                let mut msg: MsgLog = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLog(msg))
             }
             1026 => {
-                let mut msg = MsgFwd::parse(payload)?;
+                let mut msg: MsgFwd = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFwd(msg))
             }
             1500 => {
-                let mut msg = MsgSsrOrbitClockDepA::parse(payload)?;
+                let mut msg: MsgSsrOrbitClockDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrOrbitClockDepA(msg))
             }
             1501 => {
-                let mut msg = MsgSsrOrbitClock::parse(payload)?;
+                let mut msg: MsgSsrOrbitClock = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrOrbitClock(msg))
             }
             1505 => {
-                let mut msg = MsgSsrCodeBiases::parse(payload)?;
+                let mut msg: MsgSsrCodeBiases = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrCodeBiases(msg))
             }
             1510 => {
-                let mut msg = MsgSsrPhaseBiases::parse(payload)?;
+                let mut msg: MsgSsrPhaseBiases = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrPhaseBiases(msg))
             }
             1515 => {
-                let mut msg = MsgSsrStecCorrectionDepA::parse(payload)?;
+                let mut msg: MsgSsrStecCorrectionDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrStecCorrectionDepA(msg))
             }
             1520 => {
-                let mut msg = MsgSsrGriddedCorrectionNoStdDepA::parse(payload)?;
+                let mut msg: MsgSsrGriddedCorrectionNoStdDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrGriddedCorrectionNoStdDepA(msg))
             }
             1525 => {
-                let mut msg = MsgSsrGridDefinitionDepA::parse(payload)?;
+                let mut msg: MsgSsrGridDefinitionDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrGridDefinitionDepA(msg))
             }
             1526 => {
-                let mut msg = MsgSsrTileDefinition::parse(payload)?;
+                let mut msg: MsgSsrTileDefinition = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrTileDefinition(msg))
             }
             1530 => {
-                let mut msg = MsgSsrGriddedCorrectionDepA::parse(payload)?;
+                let mut msg: MsgSsrGriddedCorrectionDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrGriddedCorrectionDepA(msg))
             }
             1531 => {
-                let mut msg = MsgSsrStecCorrection::parse(payload)?;
+                let mut msg: MsgSsrStecCorrection = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrStecCorrection(msg))
             }
             1532 => {
-                let mut msg = MsgSsrGriddedCorrection::parse(payload)?;
+                let mut msg: MsgSsrGriddedCorrection = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSsrGriddedCorrection(msg))
             }
             1600 => {
-                let mut msg = MsgOsr::parse(payload)?;
+                let mut msg: MsgOsr = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgOsr(msg))
             }
             2048 => {
-                let mut msg = MsgUserData::parse(payload)?;
+                let mut msg: MsgUserData = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgUserData(msg))
             }
             2304 => {
-                let mut msg = MsgImuRaw::parse(payload)?;
+                let mut msg: MsgImuRaw = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgImuRaw(msg))
             }
             2305 => {
-                let mut msg = MsgImuAux::parse(payload)?;
+                let mut msg: MsgImuAux = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgImuAux(msg))
             }
             2306 => {
-                let mut msg = MsgMagRaw::parse(payload)?;
+                let mut msg: MsgMagRaw = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgMagRaw(msg))
             }
             2307 => {
-                let mut msg = MsgOdometry::parse(payload)?;
+                let mut msg: MsgOdometry = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgOdometry(msg))
             }
             2308 => {
-                let mut msg = MsgWheeltick::parse(payload)?;
+                let mut msg: MsgWheeltick = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgWheeltick(msg))
             }
             4097 => {
-                let mut msg = MsgFileioConfigReq::parse(payload)?;
+                let mut msg: MsgFileioConfigReq = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioConfigReq(msg))
             }
             4098 => {
-                let mut msg = MsgFileioConfigResp::parse(payload)?;
+                let mut msg: MsgFileioConfigResp = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgFileioConfigResp(msg))
             }
             30583 => {
-                let mut msg = MsgSbasRaw::parse(payload)?;
+                let mut msg: MsgSbasRaw = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSbasRaw(msg))
             }
             32512 => {
-                let mut msg = MsgLinuxCpuState::parse(payload)?;
+                let mut msg: MsgLinuxCpuState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxCpuState(msg))
             }
             32513 => {
-                let mut msg = MsgLinuxMemState::parse(payload)?;
+                let mut msg: MsgLinuxMemState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxMemState(msg))
             }
             32514 => {
-                let mut msg = MsgLinuxSysState::parse(payload)?;
+                let mut msg: MsgLinuxSysState = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxSysState(msg))
             }
             32515 => {
-                let mut msg = MsgLinuxProcessSocketCounts::parse(payload)?;
+                let mut msg: MsgLinuxProcessSocketCounts = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxProcessSocketCounts(msg))
             }
             32516 => {
-                let mut msg = MsgLinuxProcessSocketQueues::parse(payload)?;
+                let mut msg: MsgLinuxProcessSocketQueues = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxProcessSocketQueues(msg))
             }
             32517 => {
-                let mut msg = MsgLinuxSocketUsage::parse(payload)?;
+                let mut msg: MsgLinuxSocketUsage = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxSocketUsage(msg))
             }
             32518 => {
-                let mut msg = MsgLinuxProcessFdCount::parse(payload)?;
+                let mut msg: MsgLinuxProcessFdCount = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxProcessFdCount(msg))
             }
             32519 => {
-                let mut msg = MsgLinuxProcessFdSummary::parse(payload)?;
+                let mut msg: MsgLinuxProcessFdSummary = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgLinuxProcessFdSummary(msg))
             }
             65280 => {
-                let mut msg = MsgStartup::parse(payload)?;
+                let mut msg: MsgStartup = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgStartup(msg))
             }
             65282 => {
-                let mut msg = MsgDgnssStatus::parse(payload)?;
+                let mut msg: MsgDgnssStatus = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgDgnssStatus(msg))
             }
             65283 => {
-                let mut msg = MsgInsStatus::parse(payload)?;
+                let mut msg: MsgInsStatus = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgInsStatus(msg))
             }
             65284 => {
-                let mut msg = MsgCsacTelemetry::parse(payload)?;
+                let mut msg: MsgCsacTelemetry = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCsacTelemetry(msg))
             }
             65285 => {
-                let mut msg = MsgCsacTelemetryLabels::parse(payload)?;
+                let mut msg: MsgCsacTelemetryLabels = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgCsacTelemetryLabels(msg))
             }
             65286 => {
-                let mut msg = MsgInsUpdates::parse(payload)?;
+                let mut msg: MsgInsUpdates = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgInsUpdates(msg))
             }
             65287 => {
-                let mut msg = MsgGnssTimeOffset::parse(payload)?;
+                let mut msg: MsgGnssTimeOffset = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGnssTimeOffset(msg))
             }
             65290 => {
-                let mut msg = MsgGroupMeta::parse(payload)?;
+                let mut msg: MsgGroupMeta = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgGroupMeta(msg))
             }
             65294 => {
-                let mut msg = MsgSolnMeta::parse(payload)?;
+                let mut msg: MsgSolnMeta = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSolnMeta(msg))
             }
             65295 => {
-                let mut msg = MsgSolnMetaDepA::parse(payload)?;
+                let mut msg: MsgSolnMetaDepA = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgSolnMetaDepA(msg))
             }
             65535 => {
-                let mut msg = MsgHeartbeat::parse(payload)?;
+                let mut msg: MsgHeartbeat = payload.parse()?;
                 msg.set_sender_id(sender_id);
                 Ok(SBP::MsgHeartbeat(msg))
             }

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -38,6 +38,9 @@
 //! but not a Time of Measurement.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -38,17 +38,11 @@
 //! but not a Time of Measurement.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Age of corrections
 ///
@@ -66,13 +60,13 @@ pub struct MsgAgeCorrections {
     pub age: u16,
 }
 
-impl MsgAgeCorrections {
+impl SbpParse<MsgAgeCorrections> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAgeCorrections, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAgeCorrections> {
         Ok( MsgAgeCorrections{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            age: _buf.read_u16::<LittleEndian>()?,
+            tow: self.parse()?,
+            age: self.parse()?,
         } )
     }
 }
@@ -139,18 +133,18 @@ pub struct MsgBaselineECEF {
     pub flags: u8,
 }
 
-impl MsgBaselineECEF {
+impl SbpParse<MsgBaselineECEF> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineECEF, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBaselineECEF> {
         Ok( MsgBaselineECEF{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -227,18 +221,18 @@ pub struct MsgBaselineECEFDepA {
     pub flags: u8,
 }
 
-impl MsgBaselineECEFDepA {
+impl SbpParse<MsgBaselineECEFDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineECEFDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBaselineECEFDepA> {
         Ok( MsgBaselineECEFDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -307,15 +301,15 @@ pub struct MsgBaselineHeadingDepA {
     pub flags: u8,
 }
 
-impl MsgBaselineHeadingDepA {
+impl SbpParse<MsgBaselineHeadingDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineHeadingDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBaselineHeadingDepA> {
         Ok( MsgBaselineHeadingDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            heading: _buf.read_u32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            heading: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -389,19 +383,19 @@ pub struct MsgBaselineNED {
     pub flags: u8,
 }
 
-impl MsgBaselineNED {
+impl SbpParse<MsgBaselineNED> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineNED, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBaselineNED> {
         Ok( MsgBaselineNED{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -483,19 +477,19 @@ pub struct MsgBaselineNEDDepA {
     pub flags: u8,
 }
 
-impl MsgBaselineNEDDepA {
+impl SbpParse<MsgBaselineNEDDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineNEDDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBaselineNEDDepA> {
         Ok( MsgBaselineNEDDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -573,18 +567,18 @@ pub struct MsgDops {
     pub flags: u8,
 }
 
-impl MsgDops {
+impl SbpParse<MsgDops> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDops, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgDops> {
         Ok( MsgDops{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            gdop: _buf.read_u16::<LittleEndian>()?,
-            pdop: _buf.read_u16::<LittleEndian>()?,
-            tdop: _buf.read_u16::<LittleEndian>()?,
-            hdop: _buf.read_u16::<LittleEndian>()?,
-            vdop: _buf.read_u16::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            gdop: self.parse()?,
+            pdop: self.parse()?,
+            tdop: self.parse()?,
+            hdop: self.parse()?,
+            vdop: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -657,17 +651,17 @@ pub struct MsgDopsDepA {
     pub vdop: u16,
 }
 
-impl MsgDopsDepA {
+impl SbpParse<MsgDopsDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDopsDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgDopsDepA> {
         Ok( MsgDopsDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            gdop: _buf.read_u16::<LittleEndian>()?,
-            pdop: _buf.read_u16::<LittleEndian>()?,
-            tdop: _buf.read_u16::<LittleEndian>()?,
-            hdop: _buf.read_u16::<LittleEndian>()?,
-            vdop: _buf.read_u16::<LittleEndian>()?,
+            tow: self.parse()?,
+            gdop: self.parse()?,
+            pdop: self.parse()?,
+            tdop: self.parse()?,
+            hdop: self.parse()?,
+            vdop: self.parse()?,
         } )
     }
 }
@@ -745,15 +739,15 @@ pub struct MsgGPSTime {
     pub flags: u8,
 }
 
-impl MsgGPSTime {
+impl SbpParse<MsgGPSTime> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTime, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGPSTime> {
         Ok( MsgGPSTime{
             sender_id: None,
-            wn: _buf.read_u16::<LittleEndian>()?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            ns_residual: _buf.read_i32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            wn: self.parse()?,
+            tow: self.parse()?,
+            ns_residual: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -827,15 +821,15 @@ pub struct MsgGPSTimeDepA {
     pub flags: u8,
 }
 
-impl MsgGPSTimeDepA {
+impl SbpParse<MsgGPSTimeDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTimeDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGPSTimeDepA> {
         Ok( MsgGPSTimeDepA{
             sender_id: None,
-            wn: _buf.read_u16::<LittleEndian>()?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            ns_residual: _buf.read_i32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            wn: self.parse()?,
+            tow: self.parse()?,
+            ns_residual: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -909,15 +903,15 @@ pub struct MsgGPSTimeGnss {
     pub flags: u8,
 }
 
-impl MsgGPSTimeGnss {
+impl SbpParse<MsgGPSTimeGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGPSTimeGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGPSTimeGnss> {
         Ok( MsgGPSTimeGnss{
             sender_id: None,
-            wn: _buf.read_u16::<LittleEndian>()?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            ns_residual: _buf.read_i32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            wn: self.parse()?,
+            tow: self.parse()?,
+            ns_residual: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -991,18 +985,18 @@ pub struct MsgPosECEF {
     pub flags: u8,
 }
 
-impl MsgPosECEF {
+impl SbpParse<MsgPosECEF> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEF, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosECEF> {
         Ok( MsgPosECEF{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_f64::<LittleEndian>()?,
-            y: _buf.read_f64::<LittleEndian>()?,
-            z: _buf.read_f64::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1093,23 +1087,23 @@ pub struct MsgPosECEFCov {
     pub flags: u8,
 }
 
-impl MsgPosECEFCov {
+impl SbpParse<MsgPosECEFCov> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFCov, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosECEFCov> {
         Ok( MsgPosECEFCov{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_f64::<LittleEndian>()?,
-            y: _buf.read_f64::<LittleEndian>()?,
-            z: _buf.read_f64::<LittleEndian>()?,
-            cov_x_x: _buf.read_f32::<LittleEndian>()?,
-            cov_x_y: _buf.read_f32::<LittleEndian>()?,
-            cov_x_z: _buf.read_f32::<LittleEndian>()?,
-            cov_y_y: _buf.read_f32::<LittleEndian>()?,
-            cov_y_z: _buf.read_f32::<LittleEndian>()?,
-            cov_z_z: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            cov_x_x: self.parse()?,
+            cov_x_y: self.parse()?,
+            cov_x_z: self.parse()?,
+            cov_y_y: self.parse()?,
+            cov_y_z: self.parse()?,
+            cov_z_z: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1210,23 +1204,23 @@ pub struct MsgPosECEFCovGnss {
     pub flags: u8,
 }
 
-impl MsgPosECEFCovGnss {
+impl SbpParse<MsgPosECEFCovGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFCovGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosECEFCovGnss> {
         Ok( MsgPosECEFCovGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_f64::<LittleEndian>()?,
-            y: _buf.read_f64::<LittleEndian>()?,
-            z: _buf.read_f64::<LittleEndian>()?,
-            cov_x_x: _buf.read_f32::<LittleEndian>()?,
-            cov_x_y: _buf.read_f32::<LittleEndian>()?,
-            cov_x_z: _buf.read_f32::<LittleEndian>()?,
-            cov_y_y: _buf.read_f32::<LittleEndian>()?,
-            cov_y_z: _buf.read_f32::<LittleEndian>()?,
-            cov_z_z: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            cov_x_x: self.parse()?,
+            cov_x_y: self.parse()?,
+            cov_x_z: self.parse()?,
+            cov_y_y: self.parse()?,
+            cov_y_z: self.parse()?,
+            cov_z_z: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1316,18 +1310,18 @@ pub struct MsgPosECEFDepA {
     pub flags: u8,
 }
 
-impl MsgPosECEFDepA {
+impl SbpParse<MsgPosECEFDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosECEFDepA> {
         Ok( MsgPosECEFDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_f64::<LittleEndian>()?,
-            y: _buf.read_f64::<LittleEndian>()?,
-            z: _buf.read_f64::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1407,18 +1401,18 @@ pub struct MsgPosECEFGnss {
     pub flags: u8,
 }
 
-impl MsgPosECEFGnss {
+impl SbpParse<MsgPosECEFGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosECEFGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosECEFGnss> {
         Ok( MsgPosECEFGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_f64::<LittleEndian>()?,
-            y: _buf.read_f64::<LittleEndian>()?,
-            z: _buf.read_f64::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1500,19 +1494,19 @@ pub struct MsgPosLLH {
     pub flags: u8,
 }
 
-impl MsgPosLLH {
+impl SbpParse<MsgPosLLH> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLH, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosLLH> {
         Ok( MsgPosLLH{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1604,23 +1598,23 @@ pub struct MsgPosLLHCov {
     pub flags: u8,
 }
 
-impl MsgPosLLHCov {
+impl SbpParse<MsgPosLLHCov> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHCov, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosLLHCov> {
         Ok( MsgPosLLHCov{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
-            cov_n_n: _buf.read_f32::<LittleEndian>()?,
-            cov_n_e: _buf.read_f32::<LittleEndian>()?,
-            cov_n_d: _buf.read_f32::<LittleEndian>()?,
-            cov_e_e: _buf.read_f32::<LittleEndian>()?,
-            cov_e_d: _buf.read_f32::<LittleEndian>()?,
-            cov_d_d: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
+            cov_n_n: self.parse()?,
+            cov_n_e: self.parse()?,
+            cov_n_d: self.parse()?,
+            cov_e_e: self.parse()?,
+            cov_e_d: self.parse()?,
+            cov_d_d: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1720,23 +1714,23 @@ pub struct MsgPosLLHCovGnss {
     pub flags: u8,
 }
 
-impl MsgPosLLHCovGnss {
+impl SbpParse<MsgPosLLHCovGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHCovGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosLLHCovGnss> {
         Ok( MsgPosLLHCovGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
-            cov_n_n: _buf.read_f32::<LittleEndian>()?,
-            cov_n_e: _buf.read_f32::<LittleEndian>()?,
-            cov_n_d: _buf.read_f32::<LittleEndian>()?,
-            cov_e_e: _buf.read_f32::<LittleEndian>()?,
-            cov_e_d: _buf.read_f32::<LittleEndian>()?,
-            cov_d_d: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
+            cov_n_n: self.parse()?,
+            cov_n_e: self.parse()?,
+            cov_n_d: self.parse()?,
+            cov_e_e: self.parse()?,
+            cov_e_d: self.parse()?,
+            cov_d_d: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1828,19 +1822,19 @@ pub struct MsgPosLLHDepA {
     pub flags: u8,
 }
 
-impl MsgPosLLHDepA {
+impl SbpParse<MsgPosLLHDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosLLHDepA> {
         Ok( MsgPosLLHDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1924,19 +1918,19 @@ pub struct MsgPosLLHGnss {
     pub flags: u8,
 }
 
-impl MsgPosLLHGnss {
+impl SbpParse<MsgPosLLHGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgPosLLHGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgPosLLHGnss> {
         Ok( MsgPosLLHGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2013,18 +2007,18 @@ pub struct MsgProtectionLevel {
     pub flags: u8,
 }
 
-impl MsgProtectionLevel {
+impl SbpParse<MsgProtectionLevel> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgProtectionLevel, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgProtectionLevel> {
         Ok( MsgProtectionLevel{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            vpl: _buf.read_u16::<LittleEndian>()?,
-            hpl: _buf.read_u16::<LittleEndian>()?,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            vpl: self.parse()?,
+            hpl: self.parse()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2102,20 +2096,20 @@ pub struct MsgUtcTime {
     pub ns: u32,
 }
 
-impl MsgUtcTime {
+impl SbpParse<MsgUtcTime> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUtcTime, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgUtcTime> {
         Ok( MsgUtcTime{
             sender_id: None,
-            flags: _buf.read_u8()?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            year: _buf.read_u16::<LittleEndian>()?,
-            month: _buf.read_u8()?,
-            day: _buf.read_u8()?,
-            hours: _buf.read_u8()?,
-            minutes: _buf.read_u8()?,
-            seconds: _buf.read_u8()?,
-            ns: _buf.read_u32::<LittleEndian>()?,
+            flags: self.parse()?,
+            tow: self.parse()?,
+            year: self.parse()?,
+            month: self.parse()?,
+            day: self.parse()?,
+            hours: self.parse()?,
+            minutes: self.parse()?,
+            seconds: self.parse()?,
+            ns: self.parse()?,
         } )
     }
 }
@@ -2197,20 +2191,20 @@ pub struct MsgUtcTimeGnss {
     pub ns: u32,
 }
 
-impl MsgUtcTimeGnss {
+impl SbpParse<MsgUtcTimeGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUtcTimeGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgUtcTimeGnss> {
         Ok( MsgUtcTimeGnss{
             sender_id: None,
-            flags: _buf.read_u8()?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            year: _buf.read_u16::<LittleEndian>()?,
-            month: _buf.read_u8()?,
-            day: _buf.read_u8()?,
-            hours: _buf.read_u8()?,
-            minutes: _buf.read_u8()?,
-            seconds: _buf.read_u8()?,
-            ns: _buf.read_u32::<LittleEndian>()?,
+            flags: self.parse()?,
+            tow: self.parse()?,
+            year: self.parse()?,
+            month: self.parse()?,
+            day: self.parse()?,
+            hours: self.parse()?,
+            minutes: self.parse()?,
+            seconds: self.parse()?,
+            ns: self.parse()?,
         } )
     }
 }
@@ -2304,23 +2298,23 @@ pub struct MsgVelBody {
     pub flags: u8,
 }
 
-impl MsgVelBody {
+impl SbpParse<MsgVelBody> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelBody, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelBody> {
         Ok( MsgVelBody{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            cov_x_x: _buf.read_f32::<LittleEndian>()?,
-            cov_x_y: _buf.read_f32::<LittleEndian>()?,
-            cov_x_z: _buf.read_f32::<LittleEndian>()?,
-            cov_y_y: _buf.read_f32::<LittleEndian>()?,
-            cov_y_z: _buf.read_f32::<LittleEndian>()?,
-            cov_z_z: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            cov_x_x: self.parse()?,
+            cov_x_y: self.parse()?,
+            cov_x_z: self.parse()?,
+            cov_y_y: self.parse()?,
+            cov_y_z: self.parse()?,
+            cov_z_z: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2405,18 +2399,18 @@ pub struct MsgVelECEF {
     pub flags: u8,
 }
 
-impl MsgVelECEF {
+impl SbpParse<MsgVelECEF> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEF, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelECEF> {
         Ok( MsgVelECEF{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2501,23 +2495,23 @@ pub struct MsgVelECEFCov {
     pub flags: u8,
 }
 
-impl MsgVelECEFCov {
+impl SbpParse<MsgVelECEFCov> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFCov, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelECEFCov> {
         Ok( MsgVelECEFCov{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            cov_x_x: _buf.read_f32::<LittleEndian>()?,
-            cov_x_y: _buf.read_f32::<LittleEndian>()?,
-            cov_x_z: _buf.read_f32::<LittleEndian>()?,
-            cov_y_y: _buf.read_f32::<LittleEndian>()?,
-            cov_y_z: _buf.read_f32::<LittleEndian>()?,
-            cov_z_z: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            cov_x_x: self.parse()?,
+            cov_x_y: self.parse()?,
+            cov_x_z: self.parse()?,
+            cov_y_y: self.parse()?,
+            cov_y_z: self.parse()?,
+            cov_z_z: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2612,23 +2606,23 @@ pub struct MsgVelECEFCovGnss {
     pub flags: u8,
 }
 
-impl MsgVelECEFCovGnss {
+impl SbpParse<MsgVelECEFCovGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFCovGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelECEFCovGnss> {
         Ok( MsgVelECEFCovGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            cov_x_x: _buf.read_f32::<LittleEndian>()?,
-            cov_x_y: _buf.read_f32::<LittleEndian>()?,
-            cov_x_z: _buf.read_f32::<LittleEndian>()?,
-            cov_y_y: _buf.read_f32::<LittleEndian>()?,
-            cov_y_z: _buf.read_f32::<LittleEndian>()?,
-            cov_z_z: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            cov_x_x: self.parse()?,
+            cov_x_y: self.parse()?,
+            cov_x_z: self.parse()?,
+            cov_y_y: self.parse()?,
+            cov_y_z: self.parse()?,
+            cov_z_z: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2713,18 +2707,18 @@ pub struct MsgVelECEFDepA {
     pub flags: u8,
 }
 
-impl MsgVelECEFDepA {
+impl SbpParse<MsgVelECEFDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelECEFDepA> {
         Ok( MsgVelECEFDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2799,18 +2793,18 @@ pub struct MsgVelECEFGnss {
     pub flags: u8,
 }
 
-impl MsgVelECEFGnss {
+impl SbpParse<MsgVelECEFGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelECEFGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelECEFGnss> {
         Ok( MsgVelECEFGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2888,19 +2882,19 @@ pub struct MsgVelNED {
     pub flags: u8,
 }
 
-impl MsgVelNED {
+impl SbpParse<MsgVelNED> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNED, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelNED> {
         Ok( MsgVelNED{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -2990,23 +2984,23 @@ pub struct MsgVelNEDCov {
     pub flags: u8,
 }
 
-impl MsgVelNEDCov {
+impl SbpParse<MsgVelNEDCov> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDCov, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelNEDCov> {
         Ok( MsgVelNEDCov{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            cov_n_n: _buf.read_f32::<LittleEndian>()?,
-            cov_n_e: _buf.read_f32::<LittleEndian>()?,
-            cov_n_d: _buf.read_f32::<LittleEndian>()?,
-            cov_e_e: _buf.read_f32::<LittleEndian>()?,
-            cov_e_d: _buf.read_f32::<LittleEndian>()?,
-            cov_d_d: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            cov_n_n: self.parse()?,
+            cov_n_e: self.parse()?,
+            cov_n_d: self.parse()?,
+            cov_e_e: self.parse()?,
+            cov_e_d: self.parse()?,
+            cov_d_d: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -3104,23 +3098,23 @@ pub struct MsgVelNEDCovGnss {
     pub flags: u8,
 }
 
-impl MsgVelNEDCovGnss {
+impl SbpParse<MsgVelNEDCovGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDCovGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelNEDCovGnss> {
         Ok( MsgVelNEDCovGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            cov_n_n: _buf.read_f32::<LittleEndian>()?,
-            cov_n_e: _buf.read_f32::<LittleEndian>()?,
-            cov_n_d: _buf.read_f32::<LittleEndian>()?,
-            cov_e_e: _buf.read_f32::<LittleEndian>()?,
-            cov_e_d: _buf.read_f32::<LittleEndian>()?,
-            cov_d_d: _buf.read_f32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            cov_n_n: self.parse()?,
+            cov_n_e: self.parse()?,
+            cov_n_d: self.parse()?,
+            cov_e_e: self.parse()?,
+            cov_e_d: self.parse()?,
+            cov_d_d: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -3208,19 +3202,19 @@ pub struct MsgVelNEDDepA {
     pub flags: u8,
 }
 
-impl MsgVelNEDDepA {
+impl SbpParse<MsgVelNEDDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelNEDDepA> {
         Ok( MsgVelNEDDepA{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -3300,19 +3294,19 @@ pub struct MsgVelNEDGnss {
     pub flags: u8,
 }
 
-impl MsgVelNEDGnss {
+impl SbpParse<MsgVelNEDGnss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgVelNEDGnss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgVelNEDGnss> {
         Ok( MsgVelNEDGnss{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            n: _buf.read_i32::<LittleEndian>()?,
-            e: _buf.read_i32::<LittleEndian>()?,
-            d: _buf.read_i32::<LittleEndian>()?,
-            h_accuracy: _buf.read_u16::<LittleEndian>()?,
-            v_accuracy: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            n: self.parse()?,
+            e: self.parse()?,
+            d: self.parse()?,
+            h_accuracy: self.parse()?,
+            v_accuracy: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/ndb.rs
+++ b/rust/sbp/src/messages/ndb.rs
@@ -15,6 +15,9 @@
 //! Messages for logging NDB events.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/ndb.rs
+++ b/rust/sbp/src/messages/ndb.rs
@@ -15,18 +15,12 @@
 //! Messages for logging NDB events.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Navigation DataBase Event
 ///
@@ -62,19 +56,19 @@ pub struct MsgNdbEvent {
     pub original_sender: u16,
 }
 
-impl MsgNdbEvent {
+impl SbpParse<MsgNdbEvent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNdbEvent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgNdbEvent> {
         Ok( MsgNdbEvent{
             sender_id: None,
-            recv_time: _buf.read_u64::<LittleEndian>()?,
-            event: _buf.read_u8()?,
-            object_type: _buf.read_u8()?,
-            result: _buf.read_u8()?,
-            data_source: _buf.read_u8()?,
-            object_sid: GnssSignal::parse(_buf)?,
-            src_sid: GnssSignal::parse(_buf)?,
-            original_sender: _buf.read_u16::<LittleEndian>()?,
+            recv_time: self.parse()?,
+            event: self.parse()?,
+            object_type: self.parse()?,
+            result: self.parse()?,
+            data_source: self.parse()?,
+            object_sid: self.parse()?,
+            src_sid: self.parse()?,
+            original_sender: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Satellite observation messages from the device.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -71,15 +74,14 @@ impl AlmanacCommonContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<AlmanacCommonContent>, crate::Error> {
+    ) -> Result<[AlmanacCommonContent; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(AlmanacCommonContent::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -153,15 +155,14 @@ impl AlmanacCommonContentDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<AlmanacCommonContentDep>, crate::Error> {
+    ) -> Result<[AlmanacCommonContentDep; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(AlmanacCommonContentDep::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -222,15 +223,14 @@ impl CarrierPhaseDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<CarrierPhaseDepA>, crate::Error> {
+    ) -> Result<[CarrierPhaseDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(CarrierPhaseDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -282,12 +282,14 @@ impl Doppler {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Doppler>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[Doppler; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(Doppler::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -345,15 +347,14 @@ impl EphemerisCommonContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<EphemerisCommonContent>, crate::Error> {
+    ) -> Result<[EphemerisCommonContent; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(EphemerisCommonContent::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -419,15 +420,14 @@ impl EphemerisCommonContentDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<EphemerisCommonContentDepA>, crate::Error> {
+    ) -> Result<[EphemerisCommonContentDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(EphemerisCommonContentDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -493,15 +493,14 @@ impl EphemerisCommonContentDepB {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<EphemerisCommonContentDepB>, crate::Error> {
+    ) -> Result<[EphemerisCommonContentDepB; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(EphemerisCommonContentDepB::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -595,12 +594,14 @@ impl GnssCapb {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GnssCapb>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[GnssCapb; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GnssCapb::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -2502,11 +2503,11 @@ pub struct MsgEphemerisGlo {
     /// Equipment delay between L1 and L2
     pub d_tau: f32,
     /// Position of the SV at tb in PZ-90.02 coordinates system
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity vector of the SV at tb in PZ-90.02 coordinates system
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration vector of the SV at tb in PZ-90.02 coordinates sys
-    pub acc: Vec<f32>,
+    pub acc: [f32; 3],
     /// Frequency slot. FCN+8 (that is [1..14]). 0 or 0xFF for invalid
     pub fcn: u8,
     /// Issue of data. Equal to the 7 bits of the immediate data word t_b
@@ -2522,9 +2523,9 @@ impl MsgEphemerisGlo {
             gamma: _buf.read_f32::<LittleEndian>()?,
             tau: _buf.read_f32::<LittleEndian>()?,
             d_tau: _buf.read_f32::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_float_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_float_array_fixed(_buf)?,
             fcn: _buf.read_u8()?,
             iod: _buf.read_u8()?,
         } )
@@ -2598,11 +2599,11 @@ pub struct MsgEphemerisGloDepA {
     /// Correction to the SV time
     pub tau: f64,
     /// Position of the SV at tb in PZ-90.02 coordinates system
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity vector of the SV at tb in PZ-90.02 coordinates system
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration vector of the SV at tb in PZ-90.02 coordinates sys
-    pub acc: Vec<f64>,
+    pub acc: [f64; 3],
 }
 
 impl MsgEphemerisGloDepA {
@@ -2613,9 +2614,9 @@ impl MsgEphemerisGloDepA {
             common: EphemerisCommonContentDepA::parse(_buf)?,
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_double_array_fixed(_buf)?,
         } )
     }
 }
@@ -2681,11 +2682,11 @@ pub struct MsgEphemerisGloDepB {
     /// Correction to the SV time
     pub tau: f64,
     /// Position of the SV at tb in PZ-90.02 coordinates system
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity vector of the SV at tb in PZ-90.02 coordinates system
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration vector of the SV at tb in PZ-90.02 coordinates sys
-    pub acc: Vec<f64>,
+    pub acc: [f64; 3],
 }
 
 impl MsgEphemerisGloDepB {
@@ -2696,9 +2697,9 @@ impl MsgEphemerisGloDepB {
             common: EphemerisCommonContentDepB::parse(_buf)?,
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_double_array_fixed(_buf)?,
         } )
     }
 }
@@ -2766,11 +2767,11 @@ pub struct MsgEphemerisGloDepC {
     /// Equipment delay between L1 and L2
     pub d_tau: f64,
     /// Position of the SV at tb in PZ-90.02 coordinates system
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity vector of the SV at tb in PZ-90.02 coordinates system
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration vector of the SV at tb in PZ-90.02 coordinates sys
-    pub acc: Vec<f64>,
+    pub acc: [f64; 3],
     /// Frequency slot. FCN+8 (that is [1..14]). 0 or 0xFF for invalid
     pub fcn: u8,
 }
@@ -2784,9 +2785,9 @@ impl MsgEphemerisGloDepC {
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
             d_tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_double_array_fixed(_buf)?,
             fcn: _buf.read_u8()?,
         } )
     }
@@ -2856,11 +2857,11 @@ pub struct MsgEphemerisGloDepD {
     /// Equipment delay between L1 and L2
     pub d_tau: f64,
     /// Position of the SV at tb in PZ-90.02 coordinates system
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity vector of the SV at tb in PZ-90.02 coordinates system
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration vector of the SV at tb in PZ-90.02 coordinates sys
-    pub acc: Vec<f64>,
+    pub acc: [f64; 3],
     /// Frequency slot. FCN+8 (that is [1..14]). 0 or 0xFF for invalid
     pub fcn: u8,
     /// Issue of data. Equal to the 7 bits of the immediate data word t_b
@@ -2876,9 +2877,9 @@ impl MsgEphemerisGloDepD {
             gamma: _buf.read_f64::<LittleEndian>()?,
             tau: _buf.read_f64::<LittleEndian>()?,
             d_tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_double_array_fixed(_buf)?,
             fcn: _buf.read_u8()?,
             iod: _buf.read_u8()?,
         } )
@@ -3623,11 +3624,11 @@ pub struct MsgEphemerisSbas {
     /// Values common for all ephemeris types
     pub common: EphemerisCommonContent,
     /// Position of the GEO at time toe
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity of the GEO at time toe
-    pub vel: Vec<f32>,
+    pub vel: [f32; 3],
     /// Acceleration of the GEO at time toe
-    pub acc: Vec<f32>,
+    pub acc: [f32; 3],
     /// Time offset of the GEO clock w.r.t. SBAS Network Time
     pub a_gf0: f32,
     /// Drift of the GEO clock w.r.t. SBAS Network Time
@@ -3640,9 +3641,9 @@ impl MsgEphemerisSbas {
         Ok( MsgEphemerisSbas{
             sender_id: None,
             common: EphemerisCommonContent::parse(_buf)?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_float_array_limit(_buf, 3)?,
-            acc: crate::parser::read_float_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_float_array_fixed(_buf)?,
+            acc: crate::parser::read_float_array_fixed(_buf)?,
             a_gf0: _buf.read_f32::<LittleEndian>()?,
             a_gf1: _buf.read_f32::<LittleEndian>()?,
         } )
@@ -3698,11 +3699,11 @@ pub struct MsgEphemerisSbasDepA {
     /// Values common for all ephemeris types
     pub common: EphemerisCommonContentDepA,
     /// Position of the GEO at time toe
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity of the GEO at time toe
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration of the GEO at time toe
-    pub acc: Vec<f64>,
+    pub acc: [f64; 3],
     /// Time offset of the GEO clock w.r.t. SBAS Network Time
     pub a_gf0: f64,
     /// Drift of the GEO clock w.r.t. SBAS Network Time
@@ -3715,9 +3716,9 @@ impl MsgEphemerisSbasDepA {
         Ok( MsgEphemerisSbasDepA{
             sender_id: None,
             common: EphemerisCommonContentDepA::parse(_buf)?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_double_array_fixed(_buf)?,
             a_gf0: _buf.read_f64::<LittleEndian>()?,
             a_gf1: _buf.read_f64::<LittleEndian>()?,
         } )
@@ -3778,11 +3779,11 @@ pub struct MsgEphemerisSbasDepB {
     /// Values common for all ephemeris types
     pub common: EphemerisCommonContentDepB,
     /// Position of the GEO at time toe
-    pub pos: Vec<f64>,
+    pub pos: [f64; 3],
     /// Velocity of the GEO at time toe
-    pub vel: Vec<f64>,
+    pub vel: [f64; 3],
     /// Acceleration of the GEO at time toe
-    pub acc: Vec<f64>,
+    pub acc: [f64; 3],
     /// Time offset of the GEO clock w.r.t. SBAS Network Time
     pub a_gf0: f64,
     /// Drift of the GEO clock w.r.t. SBAS Network Time
@@ -3795,9 +3796,9 @@ impl MsgEphemerisSbasDepB {
         Ok( MsgEphemerisSbasDepB{
             sender_id: None,
             common: EphemerisCommonContentDepB::parse(_buf)?,
-            pos: crate::parser::read_double_array_limit(_buf, 3)?,
-            vel: crate::parser::read_double_array_limit(_buf, 3)?,
-            acc: crate::parser::read_double_array_limit(_buf, 3)?,
+            pos: crate::parser::read_double_array_fixed(_buf)?,
+            vel: crate::parser::read_double_array_fixed(_buf)?,
+            acc: crate::parser::read_double_array_fixed(_buf)?,
             a_gf0: _buf.read_f64::<LittleEndian>()?,
             a_gf1: _buf.read_f64::<LittleEndian>()?,
         } )
@@ -4753,15 +4754,14 @@ impl ObservationHeader {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<ObservationHeader>, crate::Error> {
+    ) -> Result<[ObservationHeader; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(ObservationHeader::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -4811,15 +4811,14 @@ impl ObservationHeaderDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<ObservationHeaderDep>, crate::Error> {
+    ) -> Result<[ObservationHeaderDep; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(ObservationHeaderDep::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -4896,15 +4895,14 @@ impl PackedObsContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<PackedObsContent>, crate::Error> {
+    ) -> Result<[PackedObsContent; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(PackedObsContent::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -4974,15 +4972,14 @@ impl PackedObsContentDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<PackedObsContentDepA>, crate::Error> {
+    ) -> Result<[PackedObsContentDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(PackedObsContentDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5049,15 +5046,14 @@ impl PackedObsContentDepB {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<PackedObsContentDepB>, crate::Error> {
+    ) -> Result<[PackedObsContentDepB; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(PackedObsContentDepB::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5125,15 +5121,14 @@ impl PackedObsContentDepC {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<PackedObsContentDepC>, crate::Error> {
+    ) -> Result<[PackedObsContentDepC; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(PackedObsContentDepC::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5211,15 +5206,14 @@ impl PackedOsrContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<PackedOsrContent>, crate::Error> {
+    ) -> Result<[PackedOsrContent; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(PackedOsrContent::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5283,12 +5277,12 @@ impl SvAzEl {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<SvAzEl>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[SvAzEl; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(SvAzEl::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -14,18 +14,12 @@
 //****************************************************************************/
 //! Satellite observation messages from the device.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 #[cfg_attr(feature = "sbp_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
@@ -54,34 +48,17 @@ pub struct AlmanacCommonContent {
     pub health_bits: u8,
 }
 
-impl AlmanacCommonContent {
+impl SbpParse<AlmanacCommonContent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<AlmanacCommonContent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<AlmanacCommonContent> {
         Ok( AlmanacCommonContent{
-            sid: GnssSignal::parse(_buf)?,
-            toa: GPSTimeSec::parse(_buf)?,
-            ura: _buf.read_f64::<LittleEndian>()?,
-            fit_interval: _buf.read_u32::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            health_bits: _buf.read_u8()?,
+            sid: self.parse()?,
+            toa: self.parse()?,
+            ura: self.parse()?,
+            fit_interval: self.parse()?,
+            valid: self.parse()?,
+            health_bits: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AlmanacCommonContent>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(AlmanacCommonContent::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[AlmanacCommonContent; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(AlmanacCommonContent::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -135,34 +112,17 @@ pub struct AlmanacCommonContentDep {
     pub health_bits: u8,
 }
 
-impl AlmanacCommonContentDep {
+impl SbpParse<AlmanacCommonContentDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<AlmanacCommonContentDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<AlmanacCommonContentDep> {
         Ok( AlmanacCommonContentDep{
-            sid: GnssSignalDep::parse(_buf)?,
-            toa: GPSTimeSec::parse(_buf)?,
-            ura: _buf.read_f64::<LittleEndian>()?,
-            fit_interval: _buf.read_u32::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            health_bits: _buf.read_u8()?,
+            sid: self.parse()?,
+            toa: self.parse()?,
+            ura: self.parse()?,
+            fit_interval: self.parse()?,
+            valid: self.parse()?,
+            health_bits: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<AlmanacCommonContentDep>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(AlmanacCommonContentDep::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[AlmanacCommonContentDep; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(AlmanacCommonContentDep::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -207,30 +167,13 @@ pub struct CarrierPhaseDepA {
     pub f: u8,
 }
 
-impl CarrierPhaseDepA {
+impl SbpParse<CarrierPhaseDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<CarrierPhaseDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<CarrierPhaseDepA> {
         Ok( CarrierPhaseDepA{
-            i: _buf.read_i32::<LittleEndian>()?,
-            f: _buf.read_u8()?,
+            i: self.parse()?,
+            f: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CarrierPhaseDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(CarrierPhaseDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[CarrierPhaseDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(CarrierPhaseDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -266,30 +209,13 @@ pub struct Doppler {
     pub f: u8,
 }
 
-impl Doppler {
+impl SbpParse<Doppler> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<Doppler, crate::Error> {
+    fn parse(&mut self) -> crate::Result<Doppler> {
         Ok( Doppler{
-            i: _buf.read_i16::<LittleEndian>()?,
-            f: _buf.read_u8()?,
+            i: self.parse()?,
+            f: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Doppler>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(Doppler::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[Doppler; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(Doppler::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -327,34 +253,17 @@ pub struct EphemerisCommonContent {
     pub health_bits: u8,
 }
 
-impl EphemerisCommonContent {
+impl SbpParse<EphemerisCommonContent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<EphemerisCommonContent> {
         Ok( EphemerisCommonContent{
-            sid: GnssSignal::parse(_buf)?,
-            toe: GPSTimeSec::parse(_buf)?,
-            ura: _buf.read_f32::<LittleEndian>()?,
-            fit_interval: _buf.read_u32::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            health_bits: _buf.read_u8()?,
+            sid: self.parse()?,
+            toe: self.parse()?,
+            ura: self.parse()?,
+            fit_interval: self.parse()?,
+            valid: self.parse()?,
+            health_bits: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContent>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(EphemerisCommonContent::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[EphemerisCommonContent; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(EphemerisCommonContent::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -400,34 +309,17 @@ pub struct EphemerisCommonContentDepA {
     pub health_bits: u8,
 }
 
-impl EphemerisCommonContentDepA {
+impl SbpParse<EphemerisCommonContentDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContentDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<EphemerisCommonContentDepA> {
         Ok( EphemerisCommonContentDepA{
-            sid: GnssSignalDep::parse(_buf)?,
-            toe: GPSTimeDep::parse(_buf)?,
-            ura: _buf.read_f64::<LittleEndian>()?,
-            fit_interval: _buf.read_u32::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            health_bits: _buf.read_u8()?,
+            sid: self.parse()?,
+            toe: self.parse()?,
+            ura: self.parse()?,
+            fit_interval: self.parse()?,
+            valid: self.parse()?,
+            health_bits: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContentDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(EphemerisCommonContentDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[EphemerisCommonContentDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(EphemerisCommonContentDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -473,34 +365,17 @@ pub struct EphemerisCommonContentDepB {
     pub health_bits: u8,
 }
 
-impl EphemerisCommonContentDepB {
+impl SbpParse<EphemerisCommonContentDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<EphemerisCommonContentDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<EphemerisCommonContentDepB> {
         Ok( EphemerisCommonContentDepB{
-            sid: GnssSignal::parse(_buf)?,
-            toe: GPSTimeSec::parse(_buf)?,
-            ura: _buf.read_f64::<LittleEndian>()?,
-            fit_interval: _buf.read_u32::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            health_bits: _buf.read_u8()?,
+            sid: self.parse()?,
+            toe: self.parse()?,
+            ura: self.parse()?,
+            fit_interval: self.parse()?,
+            valid: self.parse()?,
+            health_bits: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<EphemerisCommonContentDepB>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(EphemerisCommonContentDepB::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[EphemerisCommonContentDepB; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(EphemerisCommonContentDepB::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -565,43 +440,26 @@ pub struct GnssCapb {
     pub gal_e5: u64,
 }
 
-impl GnssCapb {
+impl SbpParse<GnssCapb> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GnssCapb, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GnssCapb> {
         Ok( GnssCapb{
-            gps_active: _buf.read_u64::<LittleEndian>()?,
-            gps_l2c: _buf.read_u64::<LittleEndian>()?,
-            gps_l5: _buf.read_u64::<LittleEndian>()?,
-            glo_active: _buf.read_u32::<LittleEndian>()?,
-            glo_l2of: _buf.read_u32::<LittleEndian>()?,
-            glo_l3: _buf.read_u32::<LittleEndian>()?,
-            sbas_active: _buf.read_u64::<LittleEndian>()?,
-            sbas_l5: _buf.read_u64::<LittleEndian>()?,
-            bds_active: _buf.read_u64::<LittleEndian>()?,
-            bds_d2nav: _buf.read_u64::<LittleEndian>()?,
-            bds_b2: _buf.read_u64::<LittleEndian>()?,
-            bds_b2a: _buf.read_u64::<LittleEndian>()?,
-            qzss_active: _buf.read_u32::<LittleEndian>()?,
-            gal_active: _buf.read_u64::<LittleEndian>()?,
-            gal_e5: _buf.read_u64::<LittleEndian>()?,
+            gps_active: self.parse()?,
+            gps_l2c: self.parse()?,
+            gps_l5: self.parse()?,
+            glo_active: self.parse()?,
+            glo_l2of: self.parse()?,
+            glo_l3: self.parse()?,
+            sbas_active: self.parse()?,
+            sbas_l5: self.parse()?,
+            bds_active: self.parse()?,
+            bds_d2nav: self.parse()?,
+            bds_b2: self.parse()?,
+            bds_b2a: self.parse()?,
+            qzss_active: self.parse()?,
+            gal_active: self.parse()?,
+            gal_e5: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GnssCapb>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GnssCapb::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GnssCapb; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GnssCapb::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -677,19 +535,19 @@ pub struct MsgAlmanacGlo {
     pub omega: f64,
 }
 
-impl MsgAlmanacGlo {
+impl SbpParse<MsgAlmanacGlo> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGlo, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAlmanacGlo> {
         Ok( MsgAlmanacGlo{
             sender_id: None,
-            common: AlmanacCommonContent::parse(_buf)?,
-            lambda_na: _buf.read_f64::<LittleEndian>()?,
-            t_lambda_na: _buf.read_f64::<LittleEndian>()?,
-            i: _buf.read_f64::<LittleEndian>()?,
-            t: _buf.read_f64::<LittleEndian>()?,
-            t_dot: _buf.read_f64::<LittleEndian>()?,
-            epsilon: _buf.read_f64::<LittleEndian>()?,
-            omega: _buf.read_f64::<LittleEndian>()?,
+            common: self.parse()?,
+            lambda_na: self.parse()?,
+            t_lambda_na: self.parse()?,
+            i: self.parse()?,
+            t: self.parse()?,
+            t_dot: self.parse()?,
+            epsilon: self.parse()?,
+            omega: self.parse()?,
         } )
     }
 }
@@ -770,19 +628,19 @@ pub struct MsgAlmanacGloDep {
     pub omega: f64,
 }
 
-impl MsgAlmanacGloDep {
+impl SbpParse<MsgAlmanacGloDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGloDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAlmanacGloDep> {
         Ok( MsgAlmanacGloDep{
             sender_id: None,
-            common: AlmanacCommonContentDep::parse(_buf)?,
-            lambda_na: _buf.read_f64::<LittleEndian>()?,
-            t_lambda_na: _buf.read_f64::<LittleEndian>()?,
-            i: _buf.read_f64::<LittleEndian>()?,
-            t: _buf.read_f64::<LittleEndian>()?,
-            t_dot: _buf.read_f64::<LittleEndian>()?,
-            epsilon: _buf.read_f64::<LittleEndian>()?,
-            omega: _buf.read_f64::<LittleEndian>()?,
+            common: self.parse()?,
+            lambda_na: self.parse()?,
+            t_lambda_na: self.parse()?,
+            i: self.parse()?,
+            t: self.parse()?,
+            t_dot: self.parse()?,
+            epsilon: self.parse()?,
+            omega: self.parse()?,
         } )
     }
 }
@@ -866,21 +724,21 @@ pub struct MsgAlmanacGPS {
     pub af1: f64,
 }
 
-impl MsgAlmanacGPS {
+impl SbpParse<MsgAlmanacGPS> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGPS, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAlmanacGPS> {
         Ok( MsgAlmanacGPS{
             sender_id: None,
-            common: AlmanacCommonContent::parse(_buf)?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
+            common: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
         } )
     }
 }
@@ -968,21 +826,21 @@ pub struct MsgAlmanacGPSDep {
     pub af1: f64,
 }
 
-impl MsgAlmanacGPSDep {
+impl SbpParse<MsgAlmanacGPSDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanacGPSDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAlmanacGPSDep> {
         Ok( MsgAlmanacGPSDep{
             sender_id: None,
-            common: AlmanacCommonContentDep::parse(_buf)?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
+            common: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
         } )
     }
 }
@@ -1058,14 +916,14 @@ pub struct MsgBasePosECEF {
     pub z: f64,
 }
 
-impl MsgBasePosECEF {
+impl SbpParse<MsgBasePosECEF> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBasePosECEF, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBasePosECEF> {
         Ok( MsgBasePosECEF{
             sender_id: None,
-            x: _buf.read_f64::<LittleEndian>()?,
-            y: _buf.read_f64::<LittleEndian>()?,
-            z: _buf.read_f64::<LittleEndian>()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
         } )
     }
 }
@@ -1126,14 +984,14 @@ pub struct MsgBasePosLLH {
     pub height: f64,
 }
 
-impl MsgBasePosLLH {
+impl SbpParse<MsgBasePosLLH> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBasePosLLH, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBasePosLLH> {
         Ok( MsgBasePosLLH{
             sender_id: None,
-            lat: _buf.read_f64::<LittleEndian>()?,
-            lon: _buf.read_f64::<LittleEndian>()?,
-            height: _buf.read_f64::<LittleEndian>()?,
+            lat: self.parse()?,
+            lon: self.parse()?,
+            height: self.parse()?,
         } )
     }
 }
@@ -1241,35 +1099,35 @@ pub struct MsgEphemerisBds {
     pub iodc: u16,
 }
 
-impl MsgEphemerisBds {
+impl SbpParse<MsgEphemerisBds> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisBds, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisBds> {
         Ok( MsgEphemerisBds{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            tgd1: _buf.read_f32::<LittleEndian>()?,
-            tgd2: _buf.read_f32::<LittleEndian>()?,
-            c_rs: _buf.read_f32::<LittleEndian>()?,
-            c_rc: _buf.read_f32::<LittleEndian>()?,
-            c_uc: _buf.read_f32::<LittleEndian>()?,
-            c_us: _buf.read_f32::<LittleEndian>()?,
-            c_ic: _buf.read_f32::<LittleEndian>()?,
-            c_is: _buf.read_f32::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f32::<LittleEndian>()?,
-            af2: _buf.read_f32::<LittleEndian>()?,
-            toc: GPSTimeSec::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
+            common: self.parse()?,
+            tgd1: self.parse()?,
+            tgd2: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
         } )
     }
 }
@@ -1418,37 +1276,37 @@ pub struct MsgEphemerisDepA {
     pub prn: u8,
 }
 
-impl MsgEphemerisDepA {
+impl SbpParse<MsgEphemerisDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisDepA> {
         Ok( MsgEphemerisDepA{
             sender_id: None,
-            tgd: _buf.read_f64::<LittleEndian>()?,
-            c_rs: _buf.read_f64::<LittleEndian>()?,
-            c_rc: _buf.read_f64::<LittleEndian>()?,
-            c_uc: _buf.read_f64::<LittleEndian>()?,
-            c_us: _buf.read_f64::<LittleEndian>()?,
-            c_ic: _buf.read_f64::<LittleEndian>()?,
-            c_is: _buf.read_f64::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f64::<LittleEndian>()?,
-            toe_tow: _buf.read_f64::<LittleEndian>()?,
-            toe_wn: _buf.read_u16::<LittleEndian>()?,
-            toc_tow: _buf.read_f64::<LittleEndian>()?,
-            toc_wn: _buf.read_u16::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            healthy: _buf.read_u8()?,
-            prn: _buf.read_u8()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toe_tow: self.parse()?,
+            toe_wn: self.parse()?,
+            toc_tow: self.parse()?,
+            toc_wn: self.parse()?,
+            valid: self.parse()?,
+            healthy: self.parse()?,
+            prn: self.parse()?,
         } )
     }
 }
@@ -1603,38 +1461,38 @@ pub struct MsgEphemerisDepB {
     pub iode: u8,
 }
 
-impl MsgEphemerisDepB {
+impl SbpParse<MsgEphemerisDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisDepB> {
         Ok( MsgEphemerisDepB{
             sender_id: None,
-            tgd: _buf.read_f64::<LittleEndian>()?,
-            c_rs: _buf.read_f64::<LittleEndian>()?,
-            c_rc: _buf.read_f64::<LittleEndian>()?,
-            c_uc: _buf.read_f64::<LittleEndian>()?,
-            c_us: _buf.read_f64::<LittleEndian>()?,
-            c_ic: _buf.read_f64::<LittleEndian>()?,
-            c_is: _buf.read_f64::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f64::<LittleEndian>()?,
-            toe_tow: _buf.read_f64::<LittleEndian>()?,
-            toe_wn: _buf.read_u16::<LittleEndian>()?,
-            toc_tow: _buf.read_f64::<LittleEndian>()?,
-            toc_wn: _buf.read_u16::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            healthy: _buf.read_u8()?,
-            prn: _buf.read_u8()?,
-            iode: _buf.read_u8()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toe_tow: self.parse()?,
+            toe_wn: self.parse()?,
+            toc_tow: self.parse()?,
+            toc_wn: self.parse()?,
+            valid: self.parse()?,
+            healthy: self.parse()?,
+            prn: self.parse()?,
+            iode: self.parse()?,
         } )
     }
 }
@@ -1799,40 +1657,40 @@ pub struct MsgEphemerisDepC {
     pub reserved: u32,
 }
 
-impl MsgEphemerisDepC {
+impl SbpParse<MsgEphemerisDepC> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepC, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisDepC> {
         Ok( MsgEphemerisDepC{
             sender_id: None,
-            tgd: _buf.read_f64::<LittleEndian>()?,
-            c_rs: _buf.read_f64::<LittleEndian>()?,
-            c_rc: _buf.read_f64::<LittleEndian>()?,
-            c_uc: _buf.read_f64::<LittleEndian>()?,
-            c_us: _buf.read_f64::<LittleEndian>()?,
-            c_ic: _buf.read_f64::<LittleEndian>()?,
-            c_is: _buf.read_f64::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f64::<LittleEndian>()?,
-            toe_tow: _buf.read_f64::<LittleEndian>()?,
-            toe_wn: _buf.read_u16::<LittleEndian>()?,
-            toc_tow: _buf.read_f64::<LittleEndian>()?,
-            toc_wn: _buf.read_u16::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            healthy: _buf.read_u8()?,
-            sid: GnssSignalDep::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
-            reserved: _buf.read_u32::<LittleEndian>()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toe_tow: self.parse()?,
+            toe_wn: self.parse()?,
+            toc_tow: self.parse()?,
+            toc_wn: self.parse()?,
+            valid: self.parse()?,
+            healthy: self.parse()?,
+            sid: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
+            reserved: self.parse()?,
         } )
     }
 }
@@ -2001,40 +1859,40 @@ pub struct MsgEphemerisDepD {
     pub reserved: u32,
 }
 
-impl MsgEphemerisDepD {
+impl SbpParse<MsgEphemerisDepD> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisDepD, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisDepD> {
         Ok( MsgEphemerisDepD{
             sender_id: None,
-            tgd: _buf.read_f64::<LittleEndian>()?,
-            c_rs: _buf.read_f64::<LittleEndian>()?,
-            c_rc: _buf.read_f64::<LittleEndian>()?,
-            c_uc: _buf.read_f64::<LittleEndian>()?,
-            c_us: _buf.read_f64::<LittleEndian>()?,
-            c_ic: _buf.read_f64::<LittleEndian>()?,
-            c_is: _buf.read_f64::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f64::<LittleEndian>()?,
-            toe_tow: _buf.read_f64::<LittleEndian>()?,
-            toe_wn: _buf.read_u16::<LittleEndian>()?,
-            toc_tow: _buf.read_f64::<LittleEndian>()?,
-            toc_wn: _buf.read_u16::<LittleEndian>()?,
-            valid: _buf.read_u8()?,
-            healthy: _buf.read_u8()?,
-            sid: GnssSignalDep::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
-            reserved: _buf.read_u32::<LittleEndian>()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toe_tow: self.parse()?,
+            toe_wn: self.parse()?,
+            toc_tow: self.parse()?,
+            toc_wn: self.parse()?,
+            valid: self.parse()?,
+            healthy: self.parse()?,
+            sid: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
+            reserved: self.parse()?,
         } )
     }
 }
@@ -2194,36 +2052,36 @@ pub struct MsgEphemerisGal {
     pub source: u8,
 }
 
-impl MsgEphemerisGal {
+impl SbpParse<MsgEphemerisGal> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGal, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGal> {
         Ok( MsgEphemerisGal{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            bgd_e1e5a: _buf.read_f32::<LittleEndian>()?,
-            bgd_e1e5b: _buf.read_f32::<LittleEndian>()?,
-            c_rs: _buf.read_f32::<LittleEndian>()?,
-            c_rc: _buf.read_f32::<LittleEndian>()?,
-            c_uc: _buf.read_f32::<LittleEndian>()?,
-            c_us: _buf.read_f32::<LittleEndian>()?,
-            c_ic: _buf.read_f32::<LittleEndian>()?,
-            c_is: _buf.read_f32::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f32::<LittleEndian>()?,
-            toc: GPSTimeSec::parse(_buf)?,
-            iode: _buf.read_u16::<LittleEndian>()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
-            source: _buf.read_u8()?,
+            common: self.parse()?,
+            bgd_e1e5a: self.parse()?,
+            bgd_e1e5b: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
+            source: self.parse()?,
         } )
     }
 }
@@ -2371,35 +2229,35 @@ pub struct MsgEphemerisGalDepA {
     pub iodc: u16,
 }
 
-impl MsgEphemerisGalDepA {
+impl SbpParse<MsgEphemerisGalDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGalDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGalDepA> {
         Ok( MsgEphemerisGalDepA{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            bgd_e1e5a: _buf.read_f32::<LittleEndian>()?,
-            bgd_e1e5b: _buf.read_f32::<LittleEndian>()?,
-            c_rs: _buf.read_f32::<LittleEndian>()?,
-            c_rc: _buf.read_f32::<LittleEndian>()?,
-            c_uc: _buf.read_f32::<LittleEndian>()?,
-            c_us: _buf.read_f32::<LittleEndian>()?,
-            c_ic: _buf.read_f32::<LittleEndian>()?,
-            c_is: _buf.read_f32::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f32::<LittleEndian>()?,
-            toc: GPSTimeSec::parse(_buf)?,
-            iode: _buf.read_u16::<LittleEndian>()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
+            common: self.parse()?,
+            bgd_e1e5a: self.parse()?,
+            bgd_e1e5b: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
         } )
     }
 }
@@ -2514,20 +2372,20 @@ pub struct MsgEphemerisGlo {
     pub iod: u8,
 }
 
-impl MsgEphemerisGlo {
+impl SbpParse<MsgEphemerisGlo> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGlo, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGlo> {
         Ok( MsgEphemerisGlo{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            gamma: _buf.read_f32::<LittleEndian>()?,
-            tau: _buf.read_f32::<LittleEndian>()?,
-            d_tau: _buf.read_f32::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_float_array_fixed(_buf)?,
-            fcn: _buf.read_u8()?,
-            iod: _buf.read_u8()?,
+            common: self.parse()?,
+            gamma: self.parse()?,
+            tau: self.parse()?,
+            d_tau: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
+            fcn: self.parse()?,
+            iod: self.parse()?,
         } )
     }
 }
@@ -2606,17 +2464,17 @@ pub struct MsgEphemerisGloDepA {
     pub acc: [f64; 3],
 }
 
-impl MsgEphemerisGloDepA {
+impl SbpParse<MsgEphemerisGloDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGloDepA> {
         Ok( MsgEphemerisGloDepA{
             sender_id: None,
-            common: EphemerisCommonContentDepA::parse(_buf)?,
-            gamma: _buf.read_f64::<LittleEndian>()?,
-            tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_double_array_fixed(_buf)?,
+            common: self.parse()?,
+            gamma: self.parse()?,
+            tau: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
         } )
     }
 }
@@ -2689,17 +2547,17 @@ pub struct MsgEphemerisGloDepB {
     pub acc: [f64; 3],
 }
 
-impl MsgEphemerisGloDepB {
+impl SbpParse<MsgEphemerisGloDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGloDepB> {
         Ok( MsgEphemerisGloDepB{
             sender_id: None,
-            common: EphemerisCommonContentDepB::parse(_buf)?,
-            gamma: _buf.read_f64::<LittleEndian>()?,
-            tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_double_array_fixed(_buf)?,
+            common: self.parse()?,
+            gamma: self.parse()?,
+            tau: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
         } )
     }
 }
@@ -2776,19 +2634,19 @@ pub struct MsgEphemerisGloDepC {
     pub fcn: u8,
 }
 
-impl MsgEphemerisGloDepC {
+impl SbpParse<MsgEphemerisGloDepC> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepC, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGloDepC> {
         Ok( MsgEphemerisGloDepC{
             sender_id: None,
-            common: EphemerisCommonContentDepB::parse(_buf)?,
-            gamma: _buf.read_f64::<LittleEndian>()?,
-            tau: _buf.read_f64::<LittleEndian>()?,
-            d_tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_double_array_fixed(_buf)?,
-            fcn: _buf.read_u8()?,
+            common: self.parse()?,
+            gamma: self.parse()?,
+            tau: self.parse()?,
+            d_tau: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
+            fcn: self.parse()?,
         } )
     }
 }
@@ -2868,20 +2726,20 @@ pub struct MsgEphemerisGloDepD {
     pub iod: u8,
 }
 
-impl MsgEphemerisGloDepD {
+impl SbpParse<MsgEphemerisGloDepD> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGloDepD, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGloDepD> {
         Ok( MsgEphemerisGloDepD{
             sender_id: None,
-            common: EphemerisCommonContentDepB::parse(_buf)?,
-            gamma: _buf.read_f64::<LittleEndian>()?,
-            tau: _buf.read_f64::<LittleEndian>()?,
-            d_tau: _buf.read_f64::<LittleEndian>()?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_double_array_fixed(_buf)?,
-            fcn: _buf.read_u8()?,
-            iod: _buf.read_u8()?,
+            common: self.parse()?,
+            gamma: self.parse()?,
+            tau: self.parse()?,
+            d_tau: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
+            fcn: self.parse()?,
+            iod: self.parse()?,
         } )
     }
 }
@@ -2998,34 +2856,34 @@ pub struct MsgEphemerisGPS {
     pub iodc: u16,
 }
 
-impl MsgEphemerisGPS {
+impl SbpParse<MsgEphemerisGPS> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPS, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGPS> {
         Ok( MsgEphemerisGPS{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            tgd: _buf.read_f32::<LittleEndian>()?,
-            c_rs: _buf.read_f32::<LittleEndian>()?,
-            c_rc: _buf.read_f32::<LittleEndian>()?,
-            c_uc: _buf.read_f32::<LittleEndian>()?,
-            c_us: _buf.read_f32::<LittleEndian>()?,
-            c_ic: _buf.read_f32::<LittleEndian>()?,
-            c_is: _buf.read_f32::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f32::<LittleEndian>()?,
-            af1: _buf.read_f32::<LittleEndian>()?,
-            af2: _buf.read_f32::<LittleEndian>()?,
-            toc: GPSTimeSec::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
+            common: self.parse()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
         } )
     }
 }
@@ -3170,34 +3028,34 @@ pub struct MsgEphemerisGPSDepE {
     pub iodc: u16,
 }
 
-impl MsgEphemerisGPSDepE {
+impl SbpParse<MsgEphemerisGPSDepE> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPSDepE, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGPSDepE> {
         Ok( MsgEphemerisGPSDepE{
             sender_id: None,
-            common: EphemerisCommonContentDepA::parse(_buf)?,
-            tgd: _buf.read_f64::<LittleEndian>()?,
-            c_rs: _buf.read_f64::<LittleEndian>()?,
-            c_rc: _buf.read_f64::<LittleEndian>()?,
-            c_uc: _buf.read_f64::<LittleEndian>()?,
-            c_us: _buf.read_f64::<LittleEndian>()?,
-            c_ic: _buf.read_f64::<LittleEndian>()?,
-            c_is: _buf.read_f64::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f64::<LittleEndian>()?,
-            toc: GPSTimeDep::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
+            common: self.parse()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
         } )
     }
 }
@@ -3339,34 +3197,34 @@ pub struct MsgEphemerisGPSDepF {
     pub iodc: u16,
 }
 
-impl MsgEphemerisGPSDepF {
+impl SbpParse<MsgEphemerisGPSDepF> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisGPSDepF, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisGPSDepF> {
         Ok( MsgEphemerisGPSDepF{
             sender_id: None,
-            common: EphemerisCommonContentDepB::parse(_buf)?,
-            tgd: _buf.read_f64::<LittleEndian>()?,
-            c_rs: _buf.read_f64::<LittleEndian>()?,
-            c_rc: _buf.read_f64::<LittleEndian>()?,
-            c_uc: _buf.read_f64::<LittleEndian>()?,
-            c_us: _buf.read_f64::<LittleEndian>()?,
-            c_ic: _buf.read_f64::<LittleEndian>()?,
-            c_is: _buf.read_f64::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f64::<LittleEndian>()?,
-            af1: _buf.read_f64::<LittleEndian>()?,
-            af2: _buf.read_f64::<LittleEndian>()?,
-            toc: GPSTimeSec::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
+            common: self.parse()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
         } )
     }
 }
@@ -3509,34 +3367,34 @@ pub struct MsgEphemerisQzss {
     pub iodc: u16,
 }
 
-impl MsgEphemerisQzss {
+impl SbpParse<MsgEphemerisQzss> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisQzss, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisQzss> {
         Ok( MsgEphemerisQzss{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            tgd: _buf.read_f32::<LittleEndian>()?,
-            c_rs: _buf.read_f32::<LittleEndian>()?,
-            c_rc: _buf.read_f32::<LittleEndian>()?,
-            c_uc: _buf.read_f32::<LittleEndian>()?,
-            c_us: _buf.read_f32::<LittleEndian>()?,
-            c_ic: _buf.read_f32::<LittleEndian>()?,
-            c_is: _buf.read_f32::<LittleEndian>()?,
-            dn: _buf.read_f64::<LittleEndian>()?,
-            m0: _buf.read_f64::<LittleEndian>()?,
-            ecc: _buf.read_f64::<LittleEndian>()?,
-            sqrta: _buf.read_f64::<LittleEndian>()?,
-            omega0: _buf.read_f64::<LittleEndian>()?,
-            omegadot: _buf.read_f64::<LittleEndian>()?,
-            w: _buf.read_f64::<LittleEndian>()?,
-            inc: _buf.read_f64::<LittleEndian>()?,
-            inc_dot: _buf.read_f64::<LittleEndian>()?,
-            af0: _buf.read_f32::<LittleEndian>()?,
-            af1: _buf.read_f32::<LittleEndian>()?,
-            af2: _buf.read_f32::<LittleEndian>()?,
-            toc: GPSTimeSec::parse(_buf)?,
-            iode: _buf.read_u8()?,
-            iodc: _buf.read_u16::<LittleEndian>()?,
+            common: self.parse()?,
+            tgd: self.parse()?,
+            c_rs: self.parse()?,
+            c_rc: self.parse()?,
+            c_uc: self.parse()?,
+            c_us: self.parse()?,
+            c_ic: self.parse()?,
+            c_is: self.parse()?,
+            dn: self.parse()?,
+            m0: self.parse()?,
+            ecc: self.parse()?,
+            sqrta: self.parse()?,
+            omega0: self.parse()?,
+            omegadot: self.parse()?,
+            w: self.parse()?,
+            inc: self.parse()?,
+            inc_dot: self.parse()?,
+            af0: self.parse()?,
+            af1: self.parse()?,
+            af2: self.parse()?,
+            toc: self.parse()?,
+            iode: self.parse()?,
+            iodc: self.parse()?,
         } )
     }
 }
@@ -3635,17 +3493,17 @@ pub struct MsgEphemerisSbas {
     pub a_gf1: f32,
 }
 
-impl MsgEphemerisSbas {
+impl SbpParse<MsgEphemerisSbas> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbas, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisSbas> {
         Ok( MsgEphemerisSbas{
             sender_id: None,
-            common: EphemerisCommonContent::parse(_buf)?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_float_array_fixed(_buf)?,
-            acc: crate::parser::read_float_array_fixed(_buf)?,
-            a_gf0: _buf.read_f32::<LittleEndian>()?,
-            a_gf1: _buf.read_f32::<LittleEndian>()?,
+            common: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
+            a_gf0: self.parse()?,
+            a_gf1: self.parse()?,
         } )
     }
 }
@@ -3710,17 +3568,17 @@ pub struct MsgEphemerisSbasDepA {
     pub a_gf1: f64,
 }
 
-impl MsgEphemerisSbasDepA {
+impl SbpParse<MsgEphemerisSbasDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbasDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisSbasDepA> {
         Ok( MsgEphemerisSbasDepA{
             sender_id: None,
-            common: EphemerisCommonContentDepA::parse(_buf)?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_double_array_fixed(_buf)?,
-            a_gf0: _buf.read_f64::<LittleEndian>()?,
-            a_gf1: _buf.read_f64::<LittleEndian>()?,
+            common: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
+            a_gf0: self.parse()?,
+            a_gf1: self.parse()?,
         } )
     }
 }
@@ -3790,17 +3648,17 @@ pub struct MsgEphemerisSbasDepB {
     pub a_gf1: f64,
 }
 
-impl MsgEphemerisSbasDepB {
+impl SbpParse<MsgEphemerisSbasDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgEphemerisSbasDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgEphemerisSbasDepB> {
         Ok( MsgEphemerisSbasDepB{
             sender_id: None,
-            common: EphemerisCommonContentDepB::parse(_buf)?,
-            pos: crate::parser::read_double_array_fixed(_buf)?,
-            vel: crate::parser::read_double_array_fixed(_buf)?,
-            acc: crate::parser::read_double_array_fixed(_buf)?,
-            a_gf0: _buf.read_f64::<LittleEndian>()?,
-            a_gf1: _buf.read_f64::<LittleEndian>()?,
+            common: self.parse()?,
+            pos: self.parse()?,
+            vel: self.parse()?,
+            acc: self.parse()?,
+            a_gf0: self.parse()?,
+            a_gf1: self.parse()?,
         } )
     }
 }
@@ -3870,16 +3728,16 @@ pub struct MsgGloBiases {
     pub l2p_bias: i16,
 }
 
-impl MsgGloBiases {
+impl SbpParse<MsgGloBiases> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGloBiases, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGloBiases> {
         Ok( MsgGloBiases{
             sender_id: None,
-            mask: _buf.read_u8()?,
-            l1ca_bias: _buf.read_i16::<LittleEndian>()?,
-            l1p_bias: _buf.read_i16::<LittleEndian>()?,
-            l2ca_bias: _buf.read_i16::<LittleEndian>()?,
-            l2p_bias: _buf.read_i16::<LittleEndian>()?,
+            mask: self.parse()?,
+            l1ca_bias: self.parse()?,
+            l1p_bias: self.parse()?,
+            l2ca_bias: self.parse()?,
+            l2p_bias: self.parse()?,
         } )
     }
 }
@@ -3934,13 +3792,13 @@ pub struct MsgGnssCapb {
     pub gc: GnssCapb,
 }
 
-impl MsgGnssCapb {
+impl SbpParse<MsgGnssCapb> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGnssCapb, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGnssCapb> {
         Ok( MsgGnssCapb{
             sender_id: None,
-            t_nmct: GPSTimeSec::parse(_buf)?,
-            gc: GnssCapb::parse(_buf)?,
+            t_nmct: self.parse()?,
+            gc: self.parse()?,
         } )
     }
 }
@@ -3999,17 +3857,17 @@ pub struct MsgGroupDelay {
     pub isc_l2c: i16,
 }
 
-impl MsgGroupDelay {
+impl SbpParse<MsgGroupDelay> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelay, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGroupDelay> {
         Ok( MsgGroupDelay{
             sender_id: None,
-            t_op: GPSTimeSec::parse(_buf)?,
-            sid: GnssSignal::parse(_buf)?,
-            valid: _buf.read_u8()?,
-            tgd: _buf.read_i16::<LittleEndian>()?,
-            isc_l1ca: _buf.read_i16::<LittleEndian>()?,
-            isc_l2c: _buf.read_i16::<LittleEndian>()?,
+            t_op: self.parse()?,
+            sid: self.parse()?,
+            valid: self.parse()?,
+            tgd: self.parse()?,
+            isc_l1ca: self.parse()?,
+            isc_l2c: self.parse()?,
         } )
     }
 }
@@ -4076,17 +3934,17 @@ pub struct MsgGroupDelayDepA {
     pub isc_l2c: i16,
 }
 
-impl MsgGroupDelayDepA {
+impl SbpParse<MsgGroupDelayDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelayDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGroupDelayDepA> {
         Ok( MsgGroupDelayDepA{
             sender_id: None,
-            t_op: GPSTimeDep::parse(_buf)?,
-            prn: _buf.read_u8()?,
-            valid: _buf.read_u8()?,
-            tgd: _buf.read_i16::<LittleEndian>()?,
-            isc_l1ca: _buf.read_i16::<LittleEndian>()?,
-            isc_l2c: _buf.read_i16::<LittleEndian>()?,
+            t_op: self.parse()?,
+            prn: self.parse()?,
+            valid: self.parse()?,
+            tgd: self.parse()?,
+            isc_l1ca: self.parse()?,
+            isc_l2c: self.parse()?,
         } )
     }
 }
@@ -4153,17 +4011,17 @@ pub struct MsgGroupDelayDepB {
     pub isc_l2c: i16,
 }
 
-impl MsgGroupDelayDepB {
+impl SbpParse<MsgGroupDelayDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupDelayDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGroupDelayDepB> {
         Ok( MsgGroupDelayDepB{
             sender_id: None,
-            t_op: GPSTimeSec::parse(_buf)?,
-            sid: GnssSignalDep::parse(_buf)?,
-            valid: _buf.read_u8()?,
-            tgd: _buf.read_i16::<LittleEndian>()?,
-            isc_l1ca: _buf.read_i16::<LittleEndian>()?,
-            isc_l2c: _buf.read_i16::<LittleEndian>()?,
+            t_op: self.parse()?,
+            sid: self.parse()?,
+            valid: self.parse()?,
+            tgd: self.parse()?,
+            isc_l1ca: self.parse()?,
+            isc_l2c: self.parse()?,
         } )
     }
 }
@@ -4232,20 +4090,20 @@ pub struct MsgIono {
     pub b3: f64,
 }
 
-impl MsgIono {
+impl SbpParse<MsgIono> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgIono, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgIono> {
         Ok( MsgIono{
             sender_id: None,
-            t_nmct: GPSTimeSec::parse(_buf)?,
-            a0: _buf.read_f64::<LittleEndian>()?,
-            a1: _buf.read_f64::<LittleEndian>()?,
-            a2: _buf.read_f64::<LittleEndian>()?,
-            a3: _buf.read_f64::<LittleEndian>()?,
-            b0: _buf.read_f64::<LittleEndian>()?,
-            b1: _buf.read_f64::<LittleEndian>()?,
-            b2: _buf.read_f64::<LittleEndian>()?,
-            b3: _buf.read_f64::<LittleEndian>()?,
+            t_nmct: self.parse()?,
+            a0: self.parse()?,
+            a1: self.parse()?,
+            a2: self.parse()?,
+            a3: self.parse()?,
+            b0: self.parse()?,
+            b1: self.parse()?,
+            b2: self.parse()?,
+            b3: self.parse()?,
         } )
     }
 }
@@ -4318,13 +4176,13 @@ pub struct MsgObs {
     pub obs: Vec<PackedObsContent>,
 }
 
-impl MsgObs {
+impl SbpParse<MsgObs> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObs, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgObs> {
         Ok( MsgObs{
             sender_id: None,
-            header: ObservationHeader::parse(_buf)?,
-            obs: PackedObsContent::parse_array(_buf)?,
+            header: self.parse()?,
+            obs: self.parse()?,
         } )
     }
 }
@@ -4377,13 +4235,13 @@ pub struct MsgObsDepA {
     pub obs: Vec<PackedObsContentDepA>,
 }
 
-impl MsgObsDepA {
+impl SbpParse<MsgObsDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgObsDepA> {
         Ok( MsgObsDepA{
             sender_id: None,
-            header: ObservationHeaderDep::parse(_buf)?,
-            obs: PackedObsContentDepA::parse_array(_buf)?,
+            header: self.parse()?,
+            obs: self.parse()?,
         } )
     }
 }
@@ -4441,13 +4299,13 @@ pub struct MsgObsDepB {
     pub obs: Vec<PackedObsContentDepB>,
 }
 
-impl MsgObsDepB {
+impl SbpParse<MsgObsDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgObsDepB> {
         Ok( MsgObsDepB{
             sender_id: None,
-            header: ObservationHeaderDep::parse(_buf)?,
-            obs: PackedObsContentDepB::parse_array(_buf)?,
+            header: self.parse()?,
+            obs: self.parse()?,
         } )
     }
 }
@@ -4506,13 +4364,13 @@ pub struct MsgObsDepC {
     pub obs: Vec<PackedObsContentDepC>,
 }
 
-impl MsgObsDepC {
+impl SbpParse<MsgObsDepC> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgObsDepC, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgObsDepC> {
         Ok( MsgObsDepC{
             sender_id: None,
-            header: ObservationHeaderDep::parse(_buf)?,
-            obs: PackedObsContentDepC::parse_array(_buf)?,
+            header: self.parse()?,
+            obs: self.parse()?,
         } )
     }
 }
@@ -4565,13 +4423,13 @@ pub struct MsgOsr {
     pub obs: Vec<PackedOsrContent>,
 }
 
-impl MsgOsr {
+impl SbpParse<MsgOsr> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOsr, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgOsr> {
         Ok( MsgOsr{
             sender_id: None,
-            header: ObservationHeader::parse(_buf)?,
-            obs: PackedOsrContent::parse_array(_buf)?,
+            header: self.parse()?,
+            obs: self.parse()?,
         } )
     }
 }
@@ -4623,12 +4481,12 @@ pub struct MsgSvAzEl {
     pub azel: Vec<SvAzEl>,
 }
 
-impl MsgSvAzEl {
+impl SbpParse<MsgSvAzEl> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSvAzEl, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSvAzEl> {
         Ok( MsgSvAzEl{
             sender_id: None,
-            azel: SvAzEl::parse_array(_buf)?,
+            azel: self.parse()?,
         } )
     }
 }
@@ -4679,13 +4537,13 @@ pub struct MsgSvConfigurationGPSDep {
     pub l2c_mask: u32,
 }
 
-impl MsgSvConfigurationGPSDep {
+impl SbpParse<MsgSvConfigurationGPSDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSvConfigurationGPSDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSvConfigurationGPSDep> {
         Ok( MsgSvConfigurationGPSDep{
             sender_id: None,
-            t_nmct: GPSTimeSec::parse(_buf)?,
-            l2c_mask: _buf.read_u32::<LittleEndian>()?,
+            t_nmct: self.parse()?,
+            l2c_mask: self.parse()?,
         } )
     }
 }
@@ -4738,30 +4596,13 @@ pub struct ObservationHeader {
     pub n_obs: u8,
 }
 
-impl ObservationHeader {
+impl SbpParse<ObservationHeader> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<ObservationHeader, crate::Error> {
+    fn parse(&mut self) -> crate::Result<ObservationHeader> {
         Ok( ObservationHeader{
-            t: GPSTime::parse(_buf)?,
-            n_obs: _buf.read_u8()?,
+            t: self.parse()?,
+            n_obs: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<ObservationHeader>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(ObservationHeader::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[ObservationHeader; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(ObservationHeader::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -4795,30 +4636,13 @@ pub struct ObservationHeaderDep {
     pub n_obs: u8,
 }
 
-impl ObservationHeaderDep {
+impl SbpParse<ObservationHeaderDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<ObservationHeaderDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<ObservationHeaderDep> {
         Ok( ObservationHeaderDep{
-            t: GPSTimeDep::parse(_buf)?,
-            n_obs: _buf.read_u8()?,
+            t: self.parse()?,
+            n_obs: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<ObservationHeaderDep>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(ObservationHeaderDep::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[ObservationHeaderDep; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(ObservationHeaderDep::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -4874,35 +4698,18 @@ pub struct PackedObsContent {
     pub sid: GnssSignal,
 }
 
-impl PackedObsContent {
+impl SbpParse<PackedObsContent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<PackedObsContent> {
         Ok( PackedObsContent{
-            P: _buf.read_u32::<LittleEndian>()?,
-            L: CarrierPhase::parse(_buf)?,
-            D: Doppler::parse(_buf)?,
-            cn0: _buf.read_u8()?,
-            lock: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
-            sid: GnssSignal::parse(_buf)?,
+            P: self.parse()?,
+            L: self.parse()?,
+            D: self.parse()?,
+            cn0: self.parse()?,
+            lock: self.parse()?,
+            flags: self.parse()?,
+            sid: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContent>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(PackedObsContent::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[PackedObsContent; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(PackedObsContent::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -4953,33 +4760,16 @@ pub struct PackedObsContentDepA {
     pub prn: u8,
 }
 
-impl PackedObsContentDepA {
+impl SbpParse<PackedObsContentDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<PackedObsContentDepA> {
         Ok( PackedObsContentDepA{
-            P: _buf.read_u32::<LittleEndian>()?,
-            L: CarrierPhaseDepA::parse(_buf)?,
-            cn0: _buf.read_u8()?,
-            lock: _buf.read_u16::<LittleEndian>()?,
-            prn: _buf.read_u8()?,
+            P: self.parse()?,
+            L: self.parse()?,
+            cn0: self.parse()?,
+            lock: self.parse()?,
+            prn: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(PackedObsContentDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[PackedObsContentDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(PackedObsContentDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5027,33 +4817,16 @@ pub struct PackedObsContentDepB {
     pub sid: GnssSignalDep,
 }
 
-impl PackedObsContentDepB {
+impl SbpParse<PackedObsContentDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<PackedObsContentDepB> {
         Ok( PackedObsContentDepB{
-            P: _buf.read_u32::<LittleEndian>()?,
-            L: CarrierPhaseDepA::parse(_buf)?,
-            cn0: _buf.read_u8()?,
-            lock: _buf.read_u16::<LittleEndian>()?,
-            sid: GnssSignalDep::parse(_buf)?,
+            P: self.parse()?,
+            L: self.parse()?,
+            cn0: self.parse()?,
+            lock: self.parse()?,
+            sid: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepB>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(PackedObsContentDepB::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[PackedObsContentDepB; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(PackedObsContentDepB::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5102,33 +4875,16 @@ pub struct PackedObsContentDepC {
     pub sid: GnssSignalDep,
 }
 
-impl PackedObsContentDepC {
+impl SbpParse<PackedObsContentDepC> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedObsContentDepC, crate::Error> {
+    fn parse(&mut self) -> crate::Result<PackedObsContentDepC> {
         Ok( PackedObsContentDepC{
-            P: _buf.read_u32::<LittleEndian>()?,
-            L: CarrierPhase::parse(_buf)?,
-            cn0: _buf.read_u8()?,
-            lock: _buf.read_u16::<LittleEndian>()?,
-            sid: GnssSignalDep::parse(_buf)?,
+            P: self.parse()?,
+            L: self.parse()?,
+            cn0: self.parse()?,
+            lock: self.parse()?,
+            sid: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedObsContentDepC>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(PackedObsContentDepC::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[PackedObsContentDepC; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(PackedObsContentDepC::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5184,36 +4940,19 @@ pub struct PackedOsrContent {
     pub range_std: u16,
 }
 
-impl PackedOsrContent {
+impl SbpParse<PackedOsrContent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<PackedOsrContent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<PackedOsrContent> {
         Ok( PackedOsrContent{
-            P: _buf.read_u32::<LittleEndian>()?,
-            L: CarrierPhase::parse(_buf)?,
-            lock: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
-            sid: GnssSignal::parse(_buf)?,
-            iono_std: _buf.read_u16::<LittleEndian>()?,
-            tropo_std: _buf.read_u16::<LittleEndian>()?,
-            range_std: _buf.read_u16::<LittleEndian>()?,
+            P: self.parse()?,
+            L: self.parse()?,
+            lock: self.parse()?,
+            flags: self.parse()?,
+            sid: self.parse()?,
+            iono_std: self.parse()?,
+            tropo_std: self.parse()?,
+            range_std: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PackedOsrContent>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(PackedOsrContent::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[PackedOsrContent; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(PackedOsrContent::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -5260,29 +4999,14 @@ pub struct SvAzEl {
     pub el: i8,
 }
 
-impl SvAzEl {
+impl SbpParse<SvAzEl> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<SvAzEl, crate::Error> {
+    fn parse(&mut self) -> crate::Result<SvAzEl> {
         Ok( SvAzEl{
-            sid: GnssSignal::parse(_buf)?,
-            az: _buf.read_u8()?,
-            el: _buf.read_i8()?,
+            sid: self.parse()?,
+            az: self.parse()?,
+            el: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SvAzEl>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(SvAzEl::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[SvAzEl; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(SvAzEl::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/orientation.rs
+++ b/rust/sbp/src/messages/orientation.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Orientation Messages
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/orientation.rs
+++ b/rust/sbp/src/messages/orientation.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Orientation Messages
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Vehicle Body Frame instantaneous angular rates
 ///
@@ -55,16 +49,16 @@ pub struct MsgAngularRate {
     pub flags: u8,
 }
 
-impl MsgAngularRate {
+impl SbpParse<MsgAngularRate> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAngularRate, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAngularRate> {
         Ok( MsgAngularRate{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -130,15 +124,15 @@ pub struct MsgBaselineHeading {
     pub flags: u8,
 }
 
-impl MsgBaselineHeading {
+impl SbpParse<MsgBaselineHeading> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgBaselineHeading, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgBaselineHeading> {
         Ok( MsgBaselineHeading{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            heading: _buf.read_u32::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            heading: self.parse()?,
+            n_sats: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -211,19 +205,19 @@ pub struct MsgOrientEuler {
     pub flags: u8,
 }
 
-impl MsgOrientEuler {
+impl SbpParse<MsgOrientEuler> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOrientEuler, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgOrientEuler> {
         Ok( MsgOrientEuler{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            roll: _buf.read_i32::<LittleEndian>()?,
-            pitch: _buf.read_i32::<LittleEndian>()?,
-            yaw: _buf.read_i32::<LittleEndian>()?,
-            roll_accuracy: _buf.read_f32::<LittleEndian>()?,
-            pitch_accuracy: _buf.read_f32::<LittleEndian>()?,
-            yaw_accuracy: _buf.read_f32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            roll: self.parse()?,
+            pitch: self.parse()?,
+            yaw: self.parse()?,
+            roll_accuracy: self.parse()?,
+            pitch_accuracy: self.parse()?,
+            yaw_accuracy: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -308,21 +302,21 @@ pub struct MsgOrientQuat {
     pub flags: u8,
 }
 
-impl MsgOrientQuat {
+impl SbpParse<MsgOrientQuat> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOrientQuat, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgOrientQuat> {
         Ok( MsgOrientQuat{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            w: _buf.read_i32::<LittleEndian>()?,
-            x: _buf.read_i32::<LittleEndian>()?,
-            y: _buf.read_i32::<LittleEndian>()?,
-            z: _buf.read_i32::<LittleEndian>()?,
-            w_accuracy: _buf.read_f32::<LittleEndian>()?,
-            x_accuracy: _buf.read_f32::<LittleEndian>()?,
-            y_accuracy: _buf.read_f32::<LittleEndian>()?,
-            z_accuracy: _buf.read_f32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            w: self.parse()?,
+            x: self.parse()?,
+            y: self.parse()?,
+            z: self.parse()?,
+            w_accuracy: self.parse()?,
+            x_accuracy: self.parse()?,
+            y_accuracy: self.parse()?,
+            z_accuracy: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/piksi.rs
+++ b/rust/sbp/src/messages/piksi.rs
@@ -17,6 +17,9 @@
 //! may no longer be used.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -67,12 +70,14 @@ impl Latency {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Latency>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[Latency; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(Latency::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -581,9 +586,9 @@ impl crate::serialize::SbpSerialize for MsgDeviceMonitor {
 pub struct MsgFrontEndGain {
     pub sender_id: Option<u16>,
     /// RF gain for each frontend channel
-    pub rf_gain: Vec<i8>,
+    pub rf_gain: [i8; 8],
     /// Intermediate frequency gain for each frontend channel
-    pub if_gain: Vec<i8>,
+    pub if_gain: [i8; 8],
 }
 
 impl MsgFrontEndGain {
@@ -591,8 +596,8 @@ impl MsgFrontEndGain {
     pub fn parse(_buf: &mut &[u8]) -> Result<MsgFrontEndGain, crate::Error> {
         Ok( MsgFrontEndGain{
             sender_id: None,
-            rf_gain: crate::parser::read_s8_array_limit(_buf, 8)?,
-            if_gain: crate::parser::read_s8_array_limit(_buf, 8)?,
+            rf_gain: crate::parser::read_s8_array_fixed(_buf)?,
+            if_gain: crate::parser::read_s8_array_fixed(_buf)?,
         } )
     }
 }
@@ -967,11 +972,11 @@ impl crate::serialize::SbpSerialize for MsgNetworkStateReq {
 pub struct MsgNetworkStateResp {
     pub sender_id: Option<u16>,
     /// IPv4 address (all zero when unavailable)
-    pub ipv4_address: Vec<u8>,
+    pub ipv4_address: [u8; 4],
     /// IPv4 netmask CIDR notation
     pub ipv4_mask_size: u8,
     /// IPv6 address (all zero when unavailable)
-    pub ipv6_address: Vec<u8>,
+    pub ipv6_address: [u8; 16],
     /// IPv6 netmask CIDR notation
     pub ipv6_mask_size: u8,
     /// Number of Rx bytes
@@ -989,9 +994,9 @@ impl MsgNetworkStateResp {
     pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateResp, crate::Error> {
         Ok( MsgNetworkStateResp{
             sender_id: None,
-            ipv4_address: crate::parser::read_u8_array_limit(_buf, 4)?,
+            ipv4_address: crate::parser::read_u8_array_fixed(_buf)?,
             ipv4_mask_size: _buf.read_u8()?,
-            ipv6_address: crate::parser::read_u8_array_limit(_buf, 16)?,
+            ipv6_address: crate::parser::read_u8_array_fixed(_buf)?,
             ipv6_mask_size: _buf.read_u8()?,
             rx_bytes: _buf.read_u32::<LittleEndian>()?,
             tx_bytes: _buf.read_u32::<LittleEndian>()?,
@@ -1682,12 +1687,14 @@ impl NetworkUsage {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<NetworkUsage>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[NetworkUsage; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(NetworkUsage::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1753,12 +1760,12 @@ impl Period {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<Period>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[Period; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(Period::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1825,12 +1832,14 @@ impl UARTChannel {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<UARTChannel>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[UARTChannel; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(UARTChannel::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/piksi.rs
+++ b/rust/sbp/src/messages/piksi.rs
@@ -17,18 +17,12 @@
 //! may no longer be used.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Receiver-to-base station latency
 ///
@@ -52,32 +46,15 @@ pub struct Latency {
     pub current: i32,
 }
 
-impl Latency {
+impl SbpParse<Latency> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<Latency, crate::Error> {
+    fn parse(&mut self) -> crate::Result<Latency> {
         Ok( Latency{
-            avg: _buf.read_i32::<LittleEndian>()?,
-            lmin: _buf.read_i32::<LittleEndian>()?,
-            lmax: _buf.read_i32::<LittleEndian>()?,
-            current: _buf.read_i32::<LittleEndian>()?,
+            avg: self.parse()?,
+            lmin: self.parse()?,
+            lmax: self.parse()?,
+            current: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Latency>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(Latency::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[Latency; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(Latency::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -112,9 +89,9 @@ pub struct MsgAlmanac {
     pub sender_id: Option<u16>,
 }
 
-impl MsgAlmanac {
+impl SbpParse<MsgAlmanac> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgAlmanac, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgAlmanac> {
         Ok( MsgAlmanac{
             sender_id: None,
         } )
@@ -167,14 +144,14 @@ pub struct MsgCellModemStatus {
     pub reserved: Vec<u8>,
 }
 
-impl MsgCellModemStatus {
+impl SbpParse<MsgCellModemStatus> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCellModemStatus, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCellModemStatus> {
         Ok( MsgCellModemStatus{
             sender_id: None,
-            signal_strength: _buf.read_i8()?,
-            signal_error_rate: _buf.read_f32::<LittleEndian>()?,
-            reserved: crate::parser::read_u8_array(_buf)?,
+            signal_strength: self.parse()?,
+            signal_error_rate: self.parse()?,
+            reserved: self.parse()?,
         } )
     }
 }
@@ -229,16 +206,16 @@ pub struct MsgCommandOutput {
     /// Sequence number
     pub sequence: u32,
     /// Line of standard output or standard error
-    pub line: SbpString,
+    pub line: UnboundedSbpString,
 }
 
-impl MsgCommandOutput {
+impl SbpParse<MsgCommandOutput> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandOutput, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCommandOutput> {
         Ok( MsgCommandOutput{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            line: crate::parser::read_string(_buf)?,
+            sequence: self.parse()?,
+            line: self.parse()?,
         } )
     }
 }
@@ -290,16 +267,16 @@ pub struct MsgCommandReq {
     /// Sequence number
     pub sequence: u32,
     /// Command line to execute
-    pub command: SbpString,
+    pub command: UnboundedSbpString,
 }
 
-impl MsgCommandReq {
+impl SbpParse<MsgCommandReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCommandReq> {
         Ok( MsgCommandReq{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            command: crate::parser::read_string(_buf)?,
+            sequence: self.parse()?,
+            command: self.parse()?,
         } )
     }
 }
@@ -353,13 +330,13 @@ pub struct MsgCommandResp {
     pub code: i32,
 }
 
-impl MsgCommandResp {
+impl SbpParse<MsgCommandResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCommandResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCommandResp> {
         Ok( MsgCommandResp{
             sender_id: None,
-            sequence: _buf.read_u32::<LittleEndian>()?,
-            code: _buf.read_i32::<LittleEndian>()?,
+            sequence: self.parse()?,
+            code: self.parse()?,
         } )
     }
 }
@@ -410,9 +387,9 @@ pub struct MsgCwResults {
     pub sender_id: Option<u16>,
 }
 
-impl MsgCwResults {
+impl SbpParse<MsgCwResults> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCwResults, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCwResults> {
         Ok( MsgCwResults{
             sender_id: None,
         } )
@@ -459,9 +436,9 @@ pub struct MsgCwStart {
     pub sender_id: Option<u16>,
 }
 
-impl MsgCwStart {
+impl SbpParse<MsgCwStart> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCwStart, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCwStart> {
         Ok( MsgCwStart{
             sender_id: None,
         } )
@@ -518,16 +495,16 @@ pub struct MsgDeviceMonitor {
     pub fe_temperature: i16,
 }
 
-impl MsgDeviceMonitor {
+impl SbpParse<MsgDeviceMonitor> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDeviceMonitor, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgDeviceMonitor> {
         Ok( MsgDeviceMonitor{
             sender_id: None,
-            dev_vin: _buf.read_i16::<LittleEndian>()?,
-            cpu_vint: _buf.read_i16::<LittleEndian>()?,
-            cpu_vaux: _buf.read_i16::<LittleEndian>()?,
-            cpu_temperature: _buf.read_i16::<LittleEndian>()?,
-            fe_temperature: _buf.read_i16::<LittleEndian>()?,
+            dev_vin: self.parse()?,
+            cpu_vint: self.parse()?,
+            cpu_vaux: self.parse()?,
+            cpu_temperature: self.parse()?,
+            fe_temperature: self.parse()?,
         } )
     }
 }
@@ -591,13 +568,13 @@ pub struct MsgFrontEndGain {
     pub if_gain: [i8; 8],
 }
 
-impl MsgFrontEndGain {
+impl SbpParse<MsgFrontEndGain> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgFrontEndGain, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgFrontEndGain> {
         Ok( MsgFrontEndGain{
             sender_id: None,
-            rf_gain: crate::parser::read_s8_array_fixed(_buf)?,
-            if_gain: crate::parser::read_s8_array_fixed(_buf)?,
+            rf_gain: self.parse()?,
+            if_gain: self.parse()?,
         } )
     }
 }
@@ -651,12 +628,12 @@ pub struct MsgIarState {
     pub num_hyps: u32,
 }
 
-impl MsgIarState {
+impl SbpParse<MsgIarState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgIarState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgIarState> {
         Ok( MsgIarState{
             sender_id: None,
-            num_hyps: _buf.read_u32::<LittleEndian>()?,
+            num_hyps: self.parse()?,
         } )
     }
 }
@@ -703,9 +680,9 @@ pub struct MsgInitBaseDep {
     pub sender_id: Option<u16>,
 }
 
-impl MsgInitBaseDep {
+impl SbpParse<MsgInitBaseDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInitBaseDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgInitBaseDep> {
         Ok( MsgInitBaseDep{
             sender_id: None,
         } )
@@ -755,13 +732,13 @@ pub struct MsgMaskSatellite {
     pub sid: GnssSignal,
 }
 
-impl MsgMaskSatellite {
+impl SbpParse<MsgMaskSatellite> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMaskSatellite, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgMaskSatellite> {
         Ok( MsgMaskSatellite{
             sender_id: None,
-            mask: _buf.read_u8()?,
-            sid: GnssSignal::parse(_buf)?,
+            mask: self.parse()?,
+            sid: self.parse()?,
         } )
     }
 }
@@ -814,13 +791,13 @@ pub struct MsgMaskSatelliteDep {
     pub sid: GnssSignalDep,
 }
 
-impl MsgMaskSatelliteDep {
+impl SbpParse<MsgMaskSatelliteDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMaskSatelliteDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgMaskSatelliteDep> {
         Ok( MsgMaskSatelliteDep{
             sender_id: None,
-            mask: _buf.read_u8()?,
-            sid: GnssSignalDep::parse(_buf)?,
+            mask: self.parse()?,
+            sid: self.parse()?,
         } )
     }
 }
@@ -871,12 +848,12 @@ pub struct MsgNetworkBandwidthUsage {
     pub interfaces: Vec<NetworkUsage>,
 }
 
-impl MsgNetworkBandwidthUsage {
+impl SbpParse<MsgNetworkBandwidthUsage> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkBandwidthUsage, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgNetworkBandwidthUsage> {
         Ok( MsgNetworkBandwidthUsage{
             sender_id: None,
-            interfaces: NetworkUsage::parse_array(_buf)?,
+            interfaces: self.parse()?,
         } )
     }
 }
@@ -924,9 +901,9 @@ pub struct MsgNetworkStateReq {
     pub sender_id: Option<u16>,
 }
 
-impl MsgNetworkStateReq {
+impl SbpParse<MsgNetworkStateReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgNetworkStateReq> {
         Ok( MsgNetworkStateReq{
             sender_id: None,
         } )
@@ -984,24 +961,24 @@ pub struct MsgNetworkStateResp {
     /// Number of Tx bytes
     pub tx_bytes: u32,
     /// Interface Name
-    pub interface_name: SbpString,
+    pub interface_name: BoundedSbpString<16>,
     /// Interface flags from SIOCGIFFLAGS
     pub flags: u32,
 }
 
-impl MsgNetworkStateResp {
+impl SbpParse<MsgNetworkStateResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgNetworkStateResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgNetworkStateResp> {
         Ok( MsgNetworkStateResp{
             sender_id: None,
-            ipv4_address: crate::parser::read_u8_array_fixed(_buf)?,
-            ipv4_mask_size: _buf.read_u8()?,
-            ipv6_address: crate::parser::read_u8_array_fixed(_buf)?,
-            ipv6_mask_size: _buf.read_u8()?,
-            rx_bytes: _buf.read_u32::<LittleEndian>()?,
-            tx_bytes: _buf.read_u32::<LittleEndian>()?,
-            interface_name: crate::parser::read_string_limit(_buf, 16)?,
-            flags: _buf.read_u32::<LittleEndian>()?,
+            ipv4_address: self.parse()?,
+            ipv4_mask_size: self.parse()?,
+            ipv6_address: self.parse()?,
+            ipv6_mask_size: self.parse()?,
+            rx_bytes: self.parse()?,
+            tx_bytes: self.parse()?,
+            interface_name: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1065,12 +1042,12 @@ pub struct MsgReset {
     pub flags: u32,
 }
 
-impl MsgReset {
+impl SbpParse<MsgReset> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgReset, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgReset> {
         Ok( MsgReset{
             sender_id: None,
-            flags: _buf.read_u32::<LittleEndian>()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -1118,9 +1095,9 @@ pub struct MsgResetDep {
     pub sender_id: Option<u16>,
 }
 
-impl MsgResetDep {
+impl SbpParse<MsgResetDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgResetDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgResetDep> {
         Ok( MsgResetDep{
             sender_id: None,
         } )
@@ -1168,12 +1145,12 @@ pub struct MsgResetFilters {
     pub filter: u8,
 }
 
-impl MsgResetFilters {
+impl SbpParse<MsgResetFilters> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgResetFilters, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgResetFilters> {
         Ok( MsgResetFilters{
             sender_id: None,
-            filter: _buf.read_u8()?,
+            filter: self.parse()?,
         } )
     }
 }
@@ -1221,9 +1198,9 @@ pub struct MsgSetTime {
     pub sender_id: Option<u16>,
 }
 
-impl MsgSetTime {
+impl SbpParse<MsgSetTime> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSetTime, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSetTime> {
         Ok( MsgSetTime{
             sender_id: None,
         } )
@@ -1282,18 +1259,18 @@ pub struct MsgSpecan {
     pub amplitude_value: Vec<u8>,
 }
 
-impl MsgSpecan {
+impl SbpParse<MsgSpecan> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSpecan, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSpecan> {
         Ok( MsgSpecan{
             sender_id: None,
-            channel_tag: _buf.read_u16::<LittleEndian>()?,
-            t: GPSTime::parse(_buf)?,
-            freq_ref: _buf.read_f32::<LittleEndian>()?,
-            freq_step: _buf.read_f32::<LittleEndian>()?,
-            amplitude_ref: _buf.read_f32::<LittleEndian>()?,
-            amplitude_unit: _buf.read_f32::<LittleEndian>()?,
-            amplitude_value: crate::parser::read_u8_array(_buf)?,
+            channel_tag: self.parse()?,
+            t: self.parse()?,
+            freq_ref: self.parse()?,
+            freq_step: self.parse()?,
+            amplitude_ref: self.parse()?,
+            amplitude_unit: self.parse()?,
+            amplitude_value: self.parse()?,
         } )
     }
 }
@@ -1366,18 +1343,18 @@ pub struct MsgSpecanDep {
     pub amplitude_value: Vec<u8>,
 }
 
-impl MsgSpecanDep {
+impl SbpParse<MsgSpecanDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSpecanDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSpecanDep> {
         Ok( MsgSpecanDep{
             sender_id: None,
-            channel_tag: _buf.read_u16::<LittleEndian>()?,
-            t: GPSTimeDep::parse(_buf)?,
-            freq_ref: _buf.read_f32::<LittleEndian>()?,
-            freq_step: _buf.read_f32::<LittleEndian>()?,
-            amplitude_ref: _buf.read_f32::<LittleEndian>()?,
-            amplitude_unit: _buf.read_f32::<LittleEndian>()?,
-            amplitude_value: crate::parser::read_u8_array(_buf)?,
+            channel_tag: self.parse()?,
+            t: self.parse()?,
+            freq_ref: self.parse()?,
+            freq_step: self.parse()?,
+            amplitude_ref: self.parse()?,
+            amplitude_unit: self.parse()?,
+            amplitude_value: self.parse()?,
         } )
     }
 }
@@ -1437,7 +1414,7 @@ impl crate::serialize::SbpSerialize for MsgSpecanDep {
 pub struct MsgThreadState {
     pub sender_id: Option<u16>,
     /// Thread name (NULL terminated)
-    pub name: SbpString,
+    pub name: BoundedSbpString<20>,
     /// Percentage cpu use for this thread. Values range from 0 - 1000 and needs
     /// to be renormalized to 100
     pub cpu: u16,
@@ -1445,14 +1422,14 @@ pub struct MsgThreadState {
     pub stack_free: u32,
 }
 
-impl MsgThreadState {
+impl SbpParse<MsgThreadState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgThreadState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgThreadState> {
         Ok( MsgThreadState{
             sender_id: None,
-            name: crate::parser::read_string_limit(_buf, 20)?,
-            cpu: _buf.read_u16::<LittleEndian>()?,
-            stack_free: _buf.read_u32::<LittleEndian>()?,
+            name: self.parse()?,
+            cpu: self.parse()?,
+            stack_free: self.parse()?,
         } )
     }
 }
@@ -1521,16 +1498,16 @@ pub struct MsgUartState {
     pub obs_period: Period,
 }
 
-impl MsgUartState {
+impl SbpParse<MsgUartState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUartState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgUartState> {
         Ok( MsgUartState{
             sender_id: None,
-            uart_a: UARTChannel::parse(_buf)?,
-            uart_b: UARTChannel::parse(_buf)?,
-            uart_ftdi: UARTChannel::parse(_buf)?,
-            latency: Latency::parse(_buf)?,
-            obs_period: Period::parse(_buf)?,
+            uart_a: self.parse()?,
+            uart_b: self.parse()?,
+            uart_ftdi: self.parse()?,
+            latency: self.parse()?,
+            obs_period: self.parse()?,
         } )
     }
 }
@@ -1593,15 +1570,15 @@ pub struct MsgUartStateDepa {
     pub latency: Latency,
 }
 
-impl MsgUartStateDepa {
+impl SbpParse<MsgUartStateDepa> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUartStateDepa, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgUartStateDepa> {
         Ok( MsgUartStateDepa{
             sender_id: None,
-            uart_a: UARTChannel::parse(_buf)?,
-            uart_b: UARTChannel::parse(_buf)?,
-            uart_ftdi: UARTChannel::parse(_buf)?,
-            latency: Latency::parse(_buf)?,
+            uart_a: self.parse()?,
+            uart_b: self.parse()?,
+            uart_ftdi: self.parse()?,
+            latency: self.parse()?,
         } )
     }
 }
@@ -1665,36 +1642,19 @@ pub struct NetworkUsage {
     /// Number of bytes received within period
     pub tx_bytes: u32,
     /// Interface Name
-    pub interface_name: SbpString,
+    pub interface_name: BoundedSbpString<16>,
 }
 
-impl NetworkUsage {
+impl SbpParse<NetworkUsage> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<NetworkUsage, crate::Error> {
+    fn parse(&mut self) -> crate::Result<NetworkUsage> {
         Ok( NetworkUsage{
-            duration: _buf.read_u64::<LittleEndian>()?,
-            total_bytes: _buf.read_u64::<LittleEndian>()?,
-            rx_bytes: _buf.read_u32::<LittleEndian>()?,
-            tx_bytes: _buf.read_u32::<LittleEndian>()?,
-            interface_name: crate::parser::read_string_limit(_buf, 16)?,
+            duration: self.parse()?,
+            total_bytes: self.parse()?,
+            rx_bytes: self.parse()?,
+            tx_bytes: self.parse()?,
+            interface_name: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<NetworkUsage>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(NetworkUsage::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[NetworkUsage; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(NetworkUsage::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1742,30 +1702,15 @@ pub struct Period {
     pub current: i32,
 }
 
-impl Period {
+impl SbpParse<Period> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<Period, crate::Error> {
+    fn parse(&mut self) -> crate::Result<Period> {
         Ok( Period{
-            avg: _buf.read_i32::<LittleEndian>()?,
-            pmin: _buf.read_i32::<LittleEndian>()?,
-            pmax: _buf.read_i32::<LittleEndian>()?,
-            current: _buf.read_i32::<LittleEndian>()?,
+            avg: self.parse()?,
+            pmin: self.parse()?,
+            pmax: self.parse()?,
+            current: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<Period>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(Period::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[Period; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(Period::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1812,34 +1757,17 @@ pub struct UARTChannel {
     pub rx_buffer_level: u8,
 }
 
-impl UARTChannel {
+impl SbpParse<UARTChannel> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<UARTChannel, crate::Error> {
+    fn parse(&mut self) -> crate::Result<UARTChannel> {
         Ok( UARTChannel{
-            tx_throughput: _buf.read_f32::<LittleEndian>()?,
-            rx_throughput: _buf.read_f32::<LittleEndian>()?,
-            crc_error_count: _buf.read_u16::<LittleEndian>()?,
-            io_error_count: _buf.read_u16::<LittleEndian>()?,
-            tx_buffer_level: _buf.read_u8()?,
-            rx_buffer_level: _buf.read_u8()?,
+            tx_throughput: self.parse()?,
+            rx_throughput: self.parse()?,
+            crc_error_count: self.parse()?,
+            io_error_count: self.parse()?,
+            tx_buffer_level: self.parse()?,
+            rx_buffer_level: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<UARTChannel>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(UARTChannel::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[UARTChannel; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(UARTChannel::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/sbas.rs
+++ b/rust/sbp/src/messages/sbas.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! SBAS data
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -41,7 +44,7 @@ pub struct MsgSbasRaw {
     /// SBAS message type (0-63)
     pub message_type: u8,
     /// Raw SBAS data field of 212 bits (last byte padded with zeros).
-    pub data: Vec<u8>,
+    pub data: [u8; 27],
 }
 
 impl MsgSbasRaw {
@@ -52,7 +55,7 @@ impl MsgSbasRaw {
             sid: GnssSignal::parse(_buf)?,
             tow: _buf.read_u32::<LittleEndian>()?,
             message_type: _buf.read_u8()?,
-            data: crate::parser::read_u8_array_limit(_buf, 27)?,
+            data: crate::parser::read_u8_array_fixed(_buf)?,
         } )
     }
 }

--- a/rust/sbp/src/messages/sbas.rs
+++ b/rust/sbp/src/messages/sbas.rs
@@ -14,18 +14,12 @@
 //****************************************************************************/
 //! SBAS data
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Raw SBAS data
 ///
@@ -47,15 +41,15 @@ pub struct MsgSbasRaw {
     pub data: [u8; 27],
 }
 
-impl MsgSbasRaw {
+impl SbpParse<MsgSbasRaw> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSbasRaw, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSbasRaw> {
         Ok( MsgSbasRaw{
             sender_id: None,
-            sid: GnssSignal::parse(_buf)?,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            message_type: _buf.read_u8()?,
-            data: crate::parser::read_u8_array_fixed(_buf)?,
+            sid: self.parse()?,
+            tow: self.parse()?,
+            message_type: self.parse()?,
+            data: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/settings.rs
+++ b/rust/sbp/src/messages/settings.rs
@@ -40,6 +40,9 @@
 //! reference and example.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/settings.rs
+++ b/rust/sbp/src/messages/settings.rs
@@ -40,17 +40,11 @@
 //! reference and example.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Finished reading settings (host <= device)
 ///
@@ -63,9 +57,9 @@ pub struct MsgSettingsReadByIndexDone {
     pub sender_id: Option<u16>,
 }
 
-impl MsgSettingsReadByIndexDone {
+impl SbpParse<MsgSettingsReadByIndexDone> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexDone, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsReadByIndexDone> {
         Ok( MsgSettingsReadByIndexDone{
             sender_id: None,
         } )
@@ -115,12 +109,12 @@ pub struct MsgSettingsReadByIndexReq {
     pub index: u16,
 }
 
-impl MsgSettingsReadByIndexReq {
+impl SbpParse<MsgSettingsReadByIndexReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsReadByIndexReq> {
         Ok( MsgSettingsReadByIndexReq{
             sender_id: None,
-            index: _buf.read_u16::<LittleEndian>()?,
+            index: self.parse()?,
         } )
     }
 }
@@ -179,16 +173,16 @@ pub struct MsgSettingsReadByIndexResp {
     pub index: u16,
     /// A NULL-terminated and delimited string with contents
     /// "SECTION_SETTING\0SETTING\0VALUE\0FORMAT_TYPE\0"
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsReadByIndexResp {
+impl SbpParse<MsgSettingsReadByIndexResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadByIndexResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsReadByIndexResp> {
         Ok( MsgSettingsReadByIndexResp{
             sender_id: None,
-            index: _buf.read_u16::<LittleEndian>()?,
-            setting: crate::parser::read_string(_buf)?,
+            index: self.parse()?,
+            setting: self.parse()?,
         } )
     }
 }
@@ -244,15 +238,15 @@ pub struct MsgSettingsReadReq {
     pub sender_id: Option<u16>,
     /// A NULL-terminated and NULL-delimited string with contents
     /// "SECTION_SETTING\0SETTING\0"
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsReadReq {
+impl SbpParse<MsgSettingsReadReq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadReq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsReadReq> {
         Ok( MsgSettingsReadReq{
             sender_id: None,
-            setting: crate::parser::read_string(_buf)?,
+            setting: self.parse()?,
         } )
     }
 }
@@ -305,15 +299,15 @@ pub struct MsgSettingsReadResp {
     pub sender_id: Option<u16>,
     /// A NULL-terminated and NULL-delimited string with contents
     /// "SECTION_SETTING\0SETTING\0VALUE\0"
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsReadResp {
+impl SbpParse<MsgSettingsReadResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsReadResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsReadResp> {
         Ok( MsgSettingsReadResp{
             sender_id: None,
-            setting: crate::parser::read_string(_buf)?,
+            setting: self.parse()?,
         } )
     }
 }
@@ -362,15 +356,15 @@ pub struct MsgSettingsRegister {
     pub sender_id: Option<u16>,
     /// A NULL-terminated and delimited string with contents
     /// "SECTION_SETTING\0SETTING\0VALUE".
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsRegister {
+impl SbpParse<MsgSettingsRegister> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsRegister, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsRegister> {
         Ok( MsgSettingsRegister{
             sender_id: None,
-            setting: crate::parser::read_string(_buf)?,
+            setting: self.parse()?,
         } )
     }
 }
@@ -423,16 +417,16 @@ pub struct MsgSettingsRegisterResp {
     /// A NULL-terminated and delimited string with contents
     /// "SECTION_SETTING\0SETTING\0VALUE". The meaning of value is defined
     /// according to the status field.
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsRegisterResp {
+impl SbpParse<MsgSettingsRegisterResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsRegisterResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsRegisterResp> {
         Ok( MsgSettingsRegisterResp{
             sender_id: None,
-            status: _buf.read_u8()?,
-            setting: crate::parser::read_string(_buf)?,
+            status: self.parse()?,
+            setting: self.parse()?,
         } )
     }
 }
@@ -482,9 +476,9 @@ pub struct MsgSettingsSave {
     pub sender_id: Option<u16>,
 }
 
-impl MsgSettingsSave {
+impl SbpParse<MsgSettingsSave> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsSave, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsSave> {
         Ok( MsgSettingsSave{
             sender_id: None,
         } )
@@ -535,15 +529,15 @@ pub struct MsgSettingsWrite {
     pub sender_id: Option<u16>,
     /// A NULL-terminated and NULL-delimited string with contents
     /// "SECTION_SETTING\0SETTING\0VALUE\0"
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsWrite {
+impl SbpParse<MsgSettingsWrite> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsWrite, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsWrite> {
         Ok( MsgSettingsWrite{
             sender_id: None,
-            setting: crate::parser::read_string(_buf)?,
+            setting: self.parse()?,
         } )
     }
 }
@@ -598,16 +592,16 @@ pub struct MsgSettingsWriteResp {
     pub status: u8,
     /// A NULL-terminated and delimited string with contents
     /// "SECTION_SETTING\0SETTING\0VALUE\0"
-    pub setting: SbpString,
+    pub setting: UnboundedSbpString,
 }
 
-impl MsgSettingsWriteResp {
+impl SbpParse<MsgSettingsWriteResp> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSettingsWriteResp, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSettingsWriteResp> {
         Ok( MsgSettingsWriteResp{
             sender_id: None,
-            status: _buf.read_u8()?,
-            setting: crate::parser::read_string(_buf)?,
+            status: self.parse()?,
+            setting: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/solution_meta.rs
+++ b/rust/sbp/src/messages/solution_meta.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Standardized Metadata messages for Fuzed Solution from Swift Navigation devices.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -51,15 +54,14 @@ impl GNSSInputType {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<GNSSInputType>, crate::Error> {
+    ) -> Result<[GNSSInputType; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GNSSInputType::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -104,12 +106,14 @@ impl IMUInputType {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<IMUInputType>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[IMUInputType; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(IMUInputType::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -354,12 +358,14 @@ impl OdoInputType {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<OdoInputType>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[OdoInputType; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(OdoInputType::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -411,15 +417,14 @@ impl SolutionInputType {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<SolutionInputType>, crate::Error> {
+    ) -> Result<[SolutionInputType; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(SolutionInputType::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/solution_meta.rs
+++ b/rust/sbp/src/messages/solution_meta.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Standardized Metadata messages for Fuzed Solution from Swift Navigation devices.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Instruments the physical type of GNSS sensor input to the fuzed solution.
 ///
@@ -39,29 +33,12 @@ pub struct GNSSInputType {
     pub flags: u8,
 }
 
-impl GNSSInputType {
+impl SbpParse<GNSSInputType> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GNSSInputType, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GNSSInputType> {
         Ok( GNSSInputType{
-            flags: _buf.read_u8()?,
+            flags: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GNSSInputType>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GNSSInputType::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GNSSInputType; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GNSSInputType::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -91,29 +68,12 @@ pub struct IMUInputType {
     pub flags: u8,
 }
 
-impl IMUInputType {
+impl SbpParse<IMUInputType> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<IMUInputType, crate::Error> {
+    fn parse(&mut self) -> crate::Result<IMUInputType> {
         Ok( IMUInputType{
-            flags: _buf.read_u8()?,
+            flags: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<IMUInputType>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(IMUInputType::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[IMUInputType; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(IMUInputType::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -168,18 +128,18 @@ pub struct MsgSolnMeta {
     pub sol_in: Vec<SolutionInputType>,
 }
 
-impl MsgSolnMeta {
+impl SbpParse<MsgSolnMeta> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSolnMeta, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSolnMeta> {
         Ok( MsgSolnMeta{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            pdop: _buf.read_u16::<LittleEndian>()?,
-            hdop: _buf.read_u16::<LittleEndian>()?,
-            vdop: _buf.read_u16::<LittleEndian>()?,
-            age_corrections: _buf.read_u16::<LittleEndian>()?,
-            age_gnss: _buf.read_u32::<LittleEndian>()?,
-            sol_in: SolutionInputType::parse_array(_buf)?,
+            tow: self.parse()?,
+            pdop: self.parse()?,
+            hdop: self.parse()?,
+            vdop: self.parse()?,
+            age_corrections: self.parse()?,
+            age_gnss: self.parse()?,
+            sol_in: self.parse()?,
         } )
     }
 }
@@ -265,20 +225,20 @@ pub struct MsgSolnMetaDepA {
     pub sol_in: Vec<SolutionInputType>,
 }
 
-impl MsgSolnMetaDepA {
+impl SbpParse<MsgSolnMetaDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSolnMetaDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSolnMetaDepA> {
         Ok( MsgSolnMetaDepA{
             sender_id: None,
-            pdop: _buf.read_u16::<LittleEndian>()?,
-            hdop: _buf.read_u16::<LittleEndian>()?,
-            vdop: _buf.read_u16::<LittleEndian>()?,
-            n_sats: _buf.read_u8()?,
-            age_corrections: _buf.read_u16::<LittleEndian>()?,
-            alignment_status: _buf.read_u8()?,
-            last_used_gnss_pos_tow: _buf.read_u32::<LittleEndian>()?,
-            last_used_gnss_vel_tow: _buf.read_u32::<LittleEndian>()?,
-            sol_in: SolutionInputType::parse_array(_buf)?,
+            pdop: self.parse()?,
+            hdop: self.parse()?,
+            vdop: self.parse()?,
+            n_sats: self.parse()?,
+            age_corrections: self.parse()?,
+            alignment_status: self.parse()?,
+            last_used_gnss_pos_tow: self.parse()?,
+            last_used_gnss_vel_tow: self.parse()?,
+            sol_in: self.parse()?,
         } )
     }
 }
@@ -343,29 +303,12 @@ pub struct OdoInputType {
     pub flags: u8,
 }
 
-impl OdoInputType {
+impl SbpParse<OdoInputType> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<OdoInputType, crate::Error> {
+    fn parse(&mut self) -> crate::Result<OdoInputType> {
         Ok( OdoInputType{
-            flags: _buf.read_u8()?,
+            flags: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<OdoInputType>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(OdoInputType::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[OdoInputType; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(OdoInputType::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -401,30 +344,13 @@ pub struct SolutionInputType {
     pub flags: u8,
 }
 
-impl SolutionInputType {
+impl SbpParse<SolutionInputType> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<SolutionInputType, crate::Error> {
+    fn parse(&mut self) -> crate::Result<SolutionInputType> {
         Ok( SolutionInputType{
-            sensor_type: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
+            sensor_type: self.parse()?,
+            flags: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<SolutionInputType>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(SolutionInputType::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[SolutionInputType; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(SolutionInputType::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -14,18 +14,12 @@
 //****************************************************************************/
 //! Precise State Space Representation (SSR) corrections format
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// SSR code biases corrections for a particular satellite.
 ///
@@ -42,30 +36,13 @@ pub struct CodeBiasesContent {
     pub value: i16,
 }
 
-impl CodeBiasesContent {
+impl SbpParse<CodeBiasesContent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<CodeBiasesContent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<CodeBiasesContent> {
         Ok( CodeBiasesContent{
-            code: _buf.read_u8()?,
-            value: _buf.read_i16::<LittleEndian>()?,
+            code: self.parse()?,
+            value: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<CodeBiasesContent>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(CodeBiasesContent::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[CodeBiasesContent; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(CodeBiasesContent::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -109,34 +86,17 @@ pub struct GridDefinitionHeaderDepA {
     pub seq_num: u8,
 }
 
-impl GridDefinitionHeaderDepA {
+impl SbpParse<GridDefinitionHeaderDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GridDefinitionHeaderDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GridDefinitionHeaderDepA> {
         Ok( GridDefinitionHeaderDepA{
-            region_size_inverse: _buf.read_u8()?,
-            area_width: _buf.read_u16::<LittleEndian>()?,
-            lat_nw_corner_enc: _buf.read_u16::<LittleEndian>()?,
-            lon_nw_corner_enc: _buf.read_u16::<LittleEndian>()?,
-            num_msgs: _buf.read_u8()?,
-            seq_num: _buf.read_u8()?,
+            region_size_inverse: self.parse()?,
+            area_width: self.parse()?,
+            lat_nw_corner_enc: self.parse()?,
+            lon_nw_corner_enc: self.parse()?,
+            num_msgs: self.parse()?,
+            seq_num: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridDefinitionHeaderDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GridDefinitionHeaderDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GridDefinitionHeaderDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GridDefinitionHeaderDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -180,31 +140,14 @@ pub struct GridElement {
     pub stec_residuals: Vec<STECResidual>,
 }
 
-impl GridElement {
+impl SbpParse<GridElement> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GridElement, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GridElement> {
         Ok( GridElement{
-            index: _buf.read_u16::<LittleEndian>()?,
-            tropo_delay_correction: TroposphericDelayCorrection::parse(_buf)?,
-            stec_residuals: STECResidual::parse_array(_buf)?,
+            index: self.parse()?,
+            tropo_delay_correction: self.parse()?,
+            stec_residuals: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridElement>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GridElement::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GridElement; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GridElement::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -242,31 +185,14 @@ pub struct GridElementNoStd {
     pub stec_residuals: Vec<STECResidualNoStd>,
 }
 
-impl GridElementNoStd {
+impl SbpParse<GridElementNoStd> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GridElementNoStd, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GridElementNoStd> {
         Ok( GridElementNoStd{
-            index: _buf.read_u16::<LittleEndian>()?,
-            tropo_delay_correction: TroposphericDelayCorrectionNoStd::parse(_buf)?,
-            stec_residuals: STECResidualNoStd::parse_array(_buf)?,
+            index: self.parse()?,
+            tropo_delay_correction: self.parse()?,
+            stec_residuals: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GridElementNoStd>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GridElementNoStd::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GridElementNoStd; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GridElementNoStd::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -317,36 +243,19 @@ pub struct GriddedCorrectionHeader {
     pub tropo_quality_indicator: u8,
 }
 
-impl GriddedCorrectionHeader {
+impl SbpParse<GriddedCorrectionHeader> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GriddedCorrectionHeader, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GriddedCorrectionHeader> {
         Ok( GriddedCorrectionHeader{
-            tile_set_id: _buf.read_u16::<LittleEndian>()?,
-            tile_id: _buf.read_u16::<LittleEndian>()?,
-            time: GPSTimeSec::parse(_buf)?,
-            num_msgs: _buf.read_u16::<LittleEndian>()?,
-            seq_num: _buf.read_u16::<LittleEndian>()?,
-            update_interval: _buf.read_u8()?,
-            iod_atmo: _buf.read_u8()?,
-            tropo_quality_indicator: _buf.read_u8()?,
+            tile_set_id: self.parse()?,
+            tile_id: self.parse()?,
+            time: self.parse()?,
+            num_msgs: self.parse()?,
+            seq_num: self.parse()?,
+            update_interval: self.parse()?,
+            iod_atmo: self.parse()?,
+            tropo_quality_indicator: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GriddedCorrectionHeader>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GriddedCorrectionHeader::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GriddedCorrectionHeader; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GriddedCorrectionHeader::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -403,34 +312,17 @@ pub struct GriddedCorrectionHeaderDepA {
     pub tropo_quality_indicator: u8,
 }
 
-impl GriddedCorrectionHeaderDepA {
+impl SbpParse<GriddedCorrectionHeaderDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<GriddedCorrectionHeaderDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<GriddedCorrectionHeaderDepA> {
         Ok( GriddedCorrectionHeaderDepA{
-            time: GPSTimeSec::parse(_buf)?,
-            num_msgs: _buf.read_u16::<LittleEndian>()?,
-            seq_num: _buf.read_u16::<LittleEndian>()?,
-            update_interval: _buf.read_u8()?,
-            iod_atmo: _buf.read_u8()?,
-            tropo_quality_indicator: _buf.read_u8()?,
+            time: self.parse()?,
+            num_msgs: self.parse()?,
+            seq_num: self.parse()?,
+            update_interval: self.parse()?,
+            iod_atmo: self.parse()?,
+            tropo_quality_indicator: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<GriddedCorrectionHeaderDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(GriddedCorrectionHeaderDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[GriddedCorrectionHeaderDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(GriddedCorrectionHeaderDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -483,16 +375,16 @@ pub struct MsgSsrCodeBiases {
     pub biases: Vec<CodeBiasesContent>,
 }
 
-impl MsgSsrCodeBiases {
+impl SbpParse<MsgSsrCodeBiases> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrCodeBiases, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrCodeBiases> {
         Ok( MsgSsrCodeBiases{
             sender_id: None,
-            time: GPSTimeSec::parse(_buf)?,
-            sid: GnssSignal::parse(_buf)?,
-            update_interval: _buf.read_u8()?,
-            iod_ssr: _buf.read_u8()?,
-            biases: CodeBiasesContent::parse_array(_buf)?,
+            time: self.parse()?,
+            sid: self.parse()?,
+            update_interval: self.parse()?,
+            iod_ssr: self.parse()?,
+            biases: self.parse()?,
         } )
     }
 }
@@ -553,13 +445,13 @@ pub struct MsgSsrGriddedCorrection {
     pub element: GridElement,
 }
 
-impl MsgSsrGriddedCorrection {
+impl SbpParse<MsgSsrGriddedCorrection> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGriddedCorrection, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrGriddedCorrection> {
         Ok( MsgSsrGriddedCorrection{
             sender_id: None,
-            header: GriddedCorrectionHeader::parse(_buf)?,
-            element: GridElement::parse(_buf)?,
+            header: self.parse()?,
+            element: self.parse()?,
         } )
     }
 }
@@ -609,13 +501,13 @@ pub struct MsgSsrGriddedCorrectionDepA {
     pub element: GridElement,
 }
 
-impl MsgSsrGriddedCorrectionDepA {
+impl SbpParse<MsgSsrGriddedCorrectionDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGriddedCorrectionDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrGriddedCorrectionDepA> {
         Ok( MsgSsrGriddedCorrectionDepA{
             sender_id: None,
-            header: GriddedCorrectionHeaderDepA::parse(_buf)?,
-            element: GridElement::parse(_buf)?,
+            header: self.parse()?,
+            element: self.parse()?,
         } )
     }
 }
@@ -664,13 +556,13 @@ pub struct MsgSsrGriddedCorrectionNoStdDepA {
     pub element: GridElementNoStd,
 }
 
-impl MsgSsrGriddedCorrectionNoStdDepA {
+impl SbpParse<MsgSsrGriddedCorrectionNoStdDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGriddedCorrectionNoStdDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrGriddedCorrectionNoStdDepA> {
         Ok( MsgSsrGriddedCorrectionNoStdDepA{
             sender_id: None,
-            header: GriddedCorrectionHeaderDepA::parse(_buf)?,
-            element: GridElementNoStd::parse(_buf)?,
+            header: self.parse()?,
+            element: self.parse()?,
         } )
     }
 }
@@ -722,13 +614,13 @@ pub struct MsgSsrGridDefinitionDepA {
     pub rle_list: Vec<u8>,
 }
 
-impl MsgSsrGridDefinitionDepA {
+impl SbpParse<MsgSsrGridDefinitionDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrGridDefinitionDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrGridDefinitionDepA> {
         Ok( MsgSsrGridDefinitionDepA{
             sender_id: None,
-            header: GridDefinitionHeaderDepA::parse(_buf)?,
-            rle_list: crate::parser::read_u8_array(_buf)?,
+            header: self.parse()?,
+            rle_list: self.parse()?,
         } )
     }
 }
@@ -810,25 +702,25 @@ pub struct MsgSsrOrbitClock {
     pub c2: i32,
 }
 
-impl MsgSsrOrbitClock {
+impl SbpParse<MsgSsrOrbitClock> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrOrbitClock, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrOrbitClock> {
         Ok( MsgSsrOrbitClock{
             sender_id: None,
-            time: GPSTimeSec::parse(_buf)?,
-            sid: GnssSignal::parse(_buf)?,
-            update_interval: _buf.read_u8()?,
-            iod_ssr: _buf.read_u8()?,
-            iod: _buf.read_u32::<LittleEndian>()?,
-            radial: _buf.read_i32::<LittleEndian>()?,
-            along: _buf.read_i32::<LittleEndian>()?,
-            cross: _buf.read_i32::<LittleEndian>()?,
-            dot_radial: _buf.read_i32::<LittleEndian>()?,
-            dot_along: _buf.read_i32::<LittleEndian>()?,
-            dot_cross: _buf.read_i32::<LittleEndian>()?,
-            c0: _buf.read_i32::<LittleEndian>()?,
-            c1: _buf.read_i32::<LittleEndian>()?,
-            c2: _buf.read_i32::<LittleEndian>()?,
+            time: self.parse()?,
+            sid: self.parse()?,
+            update_interval: self.parse()?,
+            iod_ssr: self.parse()?,
+            iod: self.parse()?,
+            radial: self.parse()?,
+            along: self.parse()?,
+            cross: self.parse()?,
+            dot_radial: self.parse()?,
+            dot_along: self.parse()?,
+            dot_cross: self.parse()?,
+            c0: self.parse()?,
+            c1: self.parse()?,
+            c2: self.parse()?,
         } )
     }
 }
@@ -927,25 +819,25 @@ pub struct MsgSsrOrbitClockDepA {
     pub c2: i32,
 }
 
-impl MsgSsrOrbitClockDepA {
+impl SbpParse<MsgSsrOrbitClockDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrOrbitClockDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrOrbitClockDepA> {
         Ok( MsgSsrOrbitClockDepA{
             sender_id: None,
-            time: GPSTimeSec::parse(_buf)?,
-            sid: GnssSignal::parse(_buf)?,
-            update_interval: _buf.read_u8()?,
-            iod_ssr: _buf.read_u8()?,
-            iod: _buf.read_u8()?,
-            radial: _buf.read_i32::<LittleEndian>()?,
-            along: _buf.read_i32::<LittleEndian>()?,
-            cross: _buf.read_i32::<LittleEndian>()?,
-            dot_radial: _buf.read_i32::<LittleEndian>()?,
-            dot_along: _buf.read_i32::<LittleEndian>()?,
-            dot_cross: _buf.read_i32::<LittleEndian>()?,
-            c0: _buf.read_i32::<LittleEndian>()?,
-            c1: _buf.read_i32::<LittleEndian>()?,
-            c2: _buf.read_i32::<LittleEndian>()?,
+            time: self.parse()?,
+            sid: self.parse()?,
+            update_interval: self.parse()?,
+            iod_ssr: self.parse()?,
+            iod: self.parse()?,
+            radial: self.parse()?,
+            along: self.parse()?,
+            cross: self.parse()?,
+            dot_radial: self.parse()?,
+            dot_along: self.parse()?,
+            dot_cross: self.parse()?,
+            c0: self.parse()?,
+            c1: self.parse()?,
+            c2: self.parse()?,
         } )
     }
 }
@@ -1043,20 +935,20 @@ pub struct MsgSsrPhaseBiases {
     pub biases: Vec<PhaseBiasesContent>,
 }
 
-impl MsgSsrPhaseBiases {
+impl SbpParse<MsgSsrPhaseBiases> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrPhaseBiases, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrPhaseBiases> {
         Ok( MsgSsrPhaseBiases{
             sender_id: None,
-            time: GPSTimeSec::parse(_buf)?,
-            sid: GnssSignal::parse(_buf)?,
-            update_interval: _buf.read_u8()?,
-            iod_ssr: _buf.read_u8()?,
-            dispersive_bias: _buf.read_u8()?,
-            mw_consistency: _buf.read_u8()?,
-            yaw: _buf.read_u16::<LittleEndian>()?,
-            yaw_rate: _buf.read_i8()?,
-            biases: PhaseBiasesContent::parse_array(_buf)?,
+            time: self.parse()?,
+            sid: self.parse()?,
+            update_interval: self.parse()?,
+            iod_ssr: self.parse()?,
+            dispersive_bias: self.parse()?,
+            mw_consistency: self.parse()?,
+            yaw: self.parse()?,
+            yaw_rate: self.parse()?,
+            biases: self.parse()?,
         } )
     }
 }
@@ -1128,13 +1020,13 @@ pub struct MsgSsrStecCorrection {
     pub stec_sat_list: Vec<STECSatElement>,
 }
 
-impl MsgSsrStecCorrection {
+impl SbpParse<MsgSsrStecCorrection> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrStecCorrection, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrStecCorrection> {
         Ok( MsgSsrStecCorrection{
             sender_id: None,
-            header: STECHeader::parse(_buf)?,
-            stec_sat_list: STECSatElement::parse_array(_buf)?,
+            header: self.parse()?,
+            stec_sat_list: self.parse()?,
         } )
     }
 }
@@ -1183,13 +1075,13 @@ pub struct MsgSsrStecCorrectionDepA {
     pub stec_sat_list: Vec<STECSatElement>,
 }
 
-impl MsgSsrStecCorrectionDepA {
+impl SbpParse<MsgSsrStecCorrectionDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrStecCorrectionDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrStecCorrectionDepA> {
         Ok( MsgSsrStecCorrectionDepA{
             sender_id: None,
-            header: STECHeaderDepA::parse(_buf)?,
-            stec_sat_list: STECSatElement::parse_array(_buf)?,
+            header: self.parse()?,
+            stec_sat_list: self.parse()?,
         } )
     }
 }
@@ -1283,20 +1175,20 @@ pub struct MsgSsrTileDefinition {
     pub bitmask: u64,
 }
 
-impl MsgSsrTileDefinition {
+impl SbpParse<MsgSsrTileDefinition> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgSsrTileDefinition, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgSsrTileDefinition> {
         Ok( MsgSsrTileDefinition{
             sender_id: None,
-            tile_set_id: _buf.read_u16::<LittleEndian>()?,
-            tile_id: _buf.read_u16::<LittleEndian>()?,
-            corner_nw_lat: _buf.read_i16::<LittleEndian>()?,
-            corner_nw_lon: _buf.read_i16::<LittleEndian>()?,
-            spacing_lat: _buf.read_u16::<LittleEndian>()?,
-            spacing_lon: _buf.read_u16::<LittleEndian>()?,
-            rows: _buf.read_u16::<LittleEndian>()?,
-            cols: _buf.read_u16::<LittleEndian>()?,
-            bitmask: _buf.read_u64::<LittleEndian>()?,
+            tile_set_id: self.parse()?,
+            tile_id: self.parse()?,
+            corner_nw_lat: self.parse()?,
+            corner_nw_lon: self.parse()?,
+            spacing_lat: self.parse()?,
+            spacing_lon: self.parse()?,
+            rows: self.parse()?,
+            cols: self.parse()?,
+            bitmask: self.parse()?,
         } )
     }
 }
@@ -1370,33 +1262,16 @@ pub struct PhaseBiasesContent {
     pub bias: i32,
 }
 
-impl PhaseBiasesContent {
+impl SbpParse<PhaseBiasesContent> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<PhaseBiasesContent, crate::Error> {
+    fn parse(&mut self) -> crate::Result<PhaseBiasesContent> {
         Ok( PhaseBiasesContent{
-            code: _buf.read_u8()?,
-            integer_indicator: _buf.read_u8()?,
-            widelane_integer_indicator: _buf.read_u8()?,
-            discontinuity_counter: _buf.read_u8()?,
-            bias: _buf.read_i32::<LittleEndian>()?,
+            code: self.parse()?,
+            integer_indicator: self.parse()?,
+            widelane_integer_indicator: self.parse()?,
+            discontinuity_counter: self.parse()?,
+            bias: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<PhaseBiasesContent>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(PhaseBiasesContent::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[PhaseBiasesContent; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(PhaseBiasesContent::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1448,35 +1323,18 @@ pub struct STECHeader {
     pub iod_atmo: u8,
 }
 
-impl STECHeader {
+impl SbpParse<STECHeader> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECHeader, crate::Error> {
+    fn parse(&mut self) -> crate::Result<STECHeader> {
         Ok( STECHeader{
-            tile_set_id: _buf.read_u16::<LittleEndian>()?,
-            tile_id: _buf.read_u16::<LittleEndian>()?,
-            time: GPSTimeSec::parse(_buf)?,
-            num_msgs: _buf.read_u8()?,
-            seq_num: _buf.read_u8()?,
-            update_interval: _buf.read_u8()?,
-            iod_atmo: _buf.read_u8()?,
+            tile_set_id: self.parse()?,
+            tile_id: self.parse()?,
+            time: self.parse()?,
+            num_msgs: self.parse()?,
+            seq_num: self.parse()?,
+            update_interval: self.parse()?,
+            iod_atmo: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECHeader>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(STECHeader::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[STECHeader; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(STECHeader::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1528,33 +1386,16 @@ pub struct STECHeaderDepA {
     pub iod_atmo: u8,
 }
 
-impl STECHeaderDepA {
+impl SbpParse<STECHeaderDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECHeaderDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<STECHeaderDepA> {
         Ok( STECHeaderDepA{
-            time: GPSTimeSec::parse(_buf)?,
-            num_msgs: _buf.read_u8()?,
-            seq_num: _buf.read_u8()?,
-            update_interval: _buf.read_u8()?,
-            iod_atmo: _buf.read_u8()?,
+            time: self.parse()?,
+            num_msgs: self.parse()?,
+            seq_num: self.parse()?,
+            update_interval: self.parse()?,
+            iod_atmo: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECHeaderDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(STECHeaderDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[STECHeaderDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(STECHeaderDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1596,31 +1437,14 @@ pub struct STECResidual {
     pub stddev: u8,
 }
 
-impl STECResidual {
+impl SbpParse<STECResidual> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECResidual, crate::Error> {
+    fn parse(&mut self) -> crate::Result<STECResidual> {
         Ok( STECResidual{
-            sv_id: SvId::parse(_buf)?,
-            residual: _buf.read_i16::<LittleEndian>()?,
-            stddev: _buf.read_u8()?,
+            sv_id: self.parse()?,
+            residual: self.parse()?,
+            stddev: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECResidual>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(STECResidual::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[STECResidual; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(STECResidual::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1655,30 +1479,13 @@ pub struct STECResidualNoStd {
     pub residual: i16,
 }
 
-impl STECResidualNoStd {
+impl SbpParse<STECResidualNoStd> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECResidualNoStd, crate::Error> {
+    fn parse(&mut self) -> crate::Result<STECResidualNoStd> {
         Ok( STECResidualNoStd{
-            sv_id: SvId::parse(_buf)?,
-            residual: _buf.read_i16::<LittleEndian>()?,
+            sv_id: self.parse()?,
+            residual: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECResidualNoStd>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(STECResidualNoStd::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[STECResidualNoStd; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(STECResidualNoStd::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1714,31 +1521,14 @@ pub struct STECSatElement {
     pub stec_coeff: [i16; 4],
 }
 
-impl STECSatElement {
+impl SbpParse<STECSatElement> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<STECSatElement, crate::Error> {
+    fn parse(&mut self) -> crate::Result<STECSatElement> {
         Ok( STECSatElement{
-            sv_id: SvId::parse(_buf)?,
-            stec_quality_indicator: _buf.read_u8()?,
-            stec_coeff: crate::parser::read_s16_array_fixed(_buf)?,
+            sv_id: self.parse()?,
+            stec_quality_indicator: self.parse()?,
+            stec_coeff: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECSatElement>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(STECSatElement::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[STECSatElement; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(STECSatElement::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1776,31 +1566,14 @@ pub struct TroposphericDelayCorrection {
     pub stddev: u8,
 }
 
-impl TroposphericDelayCorrection {
+impl SbpParse<TroposphericDelayCorrection> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TroposphericDelayCorrection, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TroposphericDelayCorrection> {
         Ok( TroposphericDelayCorrection{
-            hydro: _buf.read_i16::<LittleEndian>()?,
-            wet: _buf.read_i8()?,
-            stddev: _buf.read_u8()?,
+            hydro: self.parse()?,
+            wet: self.parse()?,
+            stddev: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TroposphericDelayCorrection>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TroposphericDelayCorrection::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TroposphericDelayCorrection; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TroposphericDelayCorrection::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1835,32 +1608,13 @@ pub struct TroposphericDelayCorrectionNoStd {
     pub wet: i8,
 }
 
-impl TroposphericDelayCorrectionNoStd {
+impl SbpParse<TroposphericDelayCorrectionNoStd> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TroposphericDelayCorrectionNoStd, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TroposphericDelayCorrectionNoStd> {
         Ok( TroposphericDelayCorrectionNoStd{
-            hydro: _buf.read_i16::<LittleEndian>()?,
-            wet: _buf.read_i8()?,
+            hydro: self.parse()?,
+            wet: self.parse()?,
         } )
-    }
-    pub fn parse_array(
-        buf: &mut &[u8],
-    ) -> Result<Vec<TroposphericDelayCorrectionNoStd>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TroposphericDelayCorrectionNoStd::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TroposphericDelayCorrectionNoStd; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TroposphericDelayCorrectionNoStd::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Precise State Space Representation (SSR) corrections format
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -55,15 +58,14 @@ impl CodeBiasesContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<CodeBiasesContent>, crate::Error> {
+    ) -> Result<[CodeBiasesContent; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(CodeBiasesContent::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -127,15 +129,14 @@ impl GridDefinitionHeaderDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<GridDefinitionHeaderDepA>, crate::Error> {
+    ) -> Result<[GridDefinitionHeaderDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GridDefinitionHeaderDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -196,12 +197,14 @@ impl GridElement {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<GridElement>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[GridElement; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GridElement::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -256,15 +259,14 @@ impl GridElementNoStd {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<GridElementNoStd>, crate::Error> {
+    ) -> Result<[GridElementNoStd; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GridElementNoStd::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -337,15 +339,14 @@ impl GriddedCorrectionHeader {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<GriddedCorrectionHeader>, crate::Error> {
+    ) -> Result<[GriddedCorrectionHeader; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GriddedCorrectionHeader::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -422,15 +423,14 @@ impl GriddedCorrectionHeaderDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<GriddedCorrectionHeaderDepA>, crate::Error> {
+    ) -> Result<[GriddedCorrectionHeaderDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(GriddedCorrectionHeaderDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1389,15 +1389,14 @@ impl PhaseBiasesContent {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<PhaseBiasesContent>, crate::Error> {
+    ) -> Result<[PhaseBiasesContent; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(PhaseBiasesContent::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1470,12 +1469,14 @@ impl STECHeader {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECHeader>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[STECHeader; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(STECHeader::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1546,15 +1547,14 @@ impl STECHeaderDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<STECHeaderDepA>, crate::Error> {
+    ) -> Result<[STECHeaderDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(STECHeaderDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1613,12 +1613,14 @@ impl STECResidual {
         Ok(v)
     }
 
-    pub fn parse_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<STECResidual>, crate::Error> {
+    pub fn parse_array_fixed<const N: usize>(
+        buf: &mut &[u8],
+    ) -> Result<[STECResidual; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(STECResidual::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1669,15 +1671,14 @@ impl STECResidualNoStd {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<STECResidualNoStd>, crate::Error> {
+    ) -> Result<[STECResidualNoStd; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(STECResidualNoStd::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1710,7 +1711,7 @@ pub struct STECSatElement {
     /// in units of TECU instead of m.
     pub stec_quality_indicator: u8,
     /// Coefficents of the STEC polynomial in the order of C00, C01, C10, C11
-    pub stec_coeff: Vec<i16>,
+    pub stec_coeff: [i16; 4],
 }
 
 impl STECSatElement {
@@ -1719,7 +1720,7 @@ impl STECSatElement {
         Ok( STECSatElement{
             sv_id: SvId::parse(_buf)?,
             stec_quality_indicator: _buf.read_u8()?,
-            stec_coeff: crate::parser::read_s16_array_limit(_buf, 4)?,
+            stec_coeff: crate::parser::read_s16_array_fixed(_buf)?,
         } )
     }
     pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<STECSatElement>, crate::Error> {
@@ -1730,15 +1731,14 @@ impl STECSatElement {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<STECSatElement>, crate::Error> {
+    ) -> Result<[STECSatElement; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(STECSatElement::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1793,15 +1793,14 @@ impl TroposphericDelayCorrection {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TroposphericDelayCorrection>, crate::Error> {
+    ) -> Result<[TroposphericDelayCorrection; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TroposphericDelayCorrection::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1854,15 +1853,14 @@ impl TroposphericDelayCorrectionNoStd {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TroposphericDelayCorrectionNoStd>, crate::Error> {
+    ) -> Result<[TroposphericDelayCorrectionNoStd; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TroposphericDelayCorrectionNoStd::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/system.rs
+++ b/rust/sbp/src/messages/system.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Standardized system messages from Swift Navigation devices.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Experimental telemetry message
 ///
@@ -41,16 +35,16 @@ pub struct MsgCsacTelemetry {
     /// defined.
     pub id: u8,
     /// Comma separated list of values as defined by the index
-    pub telemetry: SbpString,
+    pub telemetry: UnboundedSbpString,
 }
 
-impl MsgCsacTelemetry {
+impl SbpParse<MsgCsacTelemetry> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCsacTelemetry, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCsacTelemetry> {
         Ok( MsgCsacTelemetry{
             sender_id: None,
-            id: _buf.read_u8()?,
-            telemetry: crate::parser::read_string(_buf)?,
+            id: self.parse()?,
+            telemetry: self.parse()?,
         } )
     }
 }
@@ -103,16 +97,16 @@ pub struct MsgCsacTelemetryLabels {
     /// defined.
     pub id: u8,
     /// Comma separated list of telemetry field values
-    pub telemetry_labels: SbpString,
+    pub telemetry_labels: UnboundedSbpString,
 }
 
-impl MsgCsacTelemetryLabels {
+impl SbpParse<MsgCsacTelemetryLabels> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgCsacTelemetryLabels, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgCsacTelemetryLabels> {
         Ok( MsgCsacTelemetryLabels{
             sender_id: None,
-            id: _buf.read_u8()?,
-            telemetry_labels: crate::parser::read_string(_buf)?,
+            id: self.parse()?,
+            telemetry_labels: self.parse()?,
         } )
     }
 }
@@ -168,18 +162,18 @@ pub struct MsgDgnssStatus {
     /// Number of signals from base station
     pub num_signals: u8,
     /// Corrections source string
-    pub source: SbpString,
+    pub source: UnboundedSbpString,
 }
 
-impl MsgDgnssStatus {
+impl SbpParse<MsgDgnssStatus> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgDgnssStatus, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgDgnssStatus> {
         Ok( MsgDgnssStatus{
             sender_id: None,
-            flags: _buf.read_u8()?,
-            latency: _buf.read_u16::<LittleEndian>()?,
-            num_signals: _buf.read_u8()?,
-            source: crate::parser::read_string(_buf)?,
+            flags: self.parse()?,
+            latency: self.parse()?,
+            num_signals: self.parse()?,
+            source: self.parse()?,
         } )
     }
 }
@@ -242,15 +236,15 @@ pub struct MsgGnssTimeOffset {
     pub flags: u8,
 }
 
-impl MsgGnssTimeOffset {
+impl SbpParse<MsgGnssTimeOffset> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGnssTimeOffset, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGnssTimeOffset> {
         Ok( MsgGnssTimeOffset{
             sender_id: None,
-            weeks: _buf.read_i16::<LittleEndian>()?,
-            milliseconds: _buf.read_i32::<LittleEndian>()?,
-            microseconds: _buf.read_i16::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            weeks: self.parse()?,
+            milliseconds: self.parse()?,
+            microseconds: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -313,15 +307,15 @@ pub struct MsgGroupMeta {
     pub group_msgs: Vec<u16>,
 }
 
-impl MsgGroupMeta {
+impl SbpParse<MsgGroupMeta> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgGroupMeta, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgGroupMeta> {
         Ok( MsgGroupMeta{
             sender_id: None,
-            group_id: _buf.read_u8()?,
-            flags: _buf.read_u8()?,
-            n_group_msgs: _buf.read_u8()?,
-            group_msgs: crate::parser::read_u16_array(_buf)?,
+            group_id: self.parse()?,
+            flags: self.parse()?,
+            n_group_msgs: self.parse()?,
+            group_msgs: self.parse()?,
         } )
     }
 }
@@ -385,12 +379,12 @@ pub struct MsgHeartbeat {
     pub flags: u32,
 }
 
-impl MsgHeartbeat {
+impl SbpParse<MsgHeartbeat> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgHeartbeat, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgHeartbeat> {
         Ok( MsgHeartbeat{
             sender_id: None,
-            flags: _buf.read_u32::<LittleEndian>()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -440,12 +434,12 @@ pub struct MsgInsStatus {
     pub flags: u32,
 }
 
-impl MsgInsStatus {
+impl SbpParse<MsgInsStatus> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInsStatus, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgInsStatus> {
         Ok( MsgInsStatus{
             sender_id: None,
-            flags: _buf.read_u32::<LittleEndian>()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -507,18 +501,18 @@ pub struct MsgInsUpdates {
     pub zerovel: u8,
 }
 
-impl MsgInsUpdates {
+impl SbpParse<MsgInsUpdates> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgInsUpdates, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgInsUpdates> {
         Ok( MsgInsUpdates{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            gnsspos: _buf.read_u8()?,
-            gnssvel: _buf.read_u8()?,
-            wheelticks: _buf.read_u8()?,
-            speed: _buf.read_u8()?,
-            nhc: _buf.read_u8()?,
-            zerovel: _buf.read_u8()?,
+            tow: self.parse()?,
+            gnsspos: self.parse()?,
+            gnssvel: self.parse()?,
+            wheelticks: self.parse()?,
+            speed: self.parse()?,
+            nhc: self.parse()?,
+            zerovel: self.parse()?,
         } )
     }
 }
@@ -586,14 +580,14 @@ pub struct MsgStartup {
     pub reserved: u16,
 }
 
-impl MsgStartup {
+impl SbpParse<MsgStartup> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgStartup, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgStartup> {
         Ok( MsgStartup{
             sender_id: None,
-            cause: _buf.read_u8()?,
-            startup_type: _buf.read_u8()?,
-            reserved: _buf.read_u16::<LittleEndian>()?,
+            cause: self.parse()?,
+            startup_type: self.parse()?,
+            reserved: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/system.rs
+++ b/rust/sbp/src/messages/system.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Standardized system messages from Swift Navigation devices.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/tracking.rs
+++ b/rust/sbp/src/messages/tracking.rs
@@ -15,18 +15,12 @@
 //! Satellite code and carrier-phase tracking messages from the device.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 use super::gnss::*;
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Measurement Engine signal tracking channel states
 ///
@@ -43,12 +37,12 @@ pub struct MsgMeasurementState {
     pub states: Vec<MeasurementState>,
 }
 
-impl MsgMeasurementState {
+impl SbpParse<MsgMeasurementState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgMeasurementState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgMeasurementState> {
         Ok( MsgMeasurementState{
             sender_id: None,
-            states: MeasurementState::parse_array(_buf)?,
+            states: self.parse()?,
         } )
     }
 }
@@ -102,14 +96,14 @@ pub struct MsgTrackingIq {
     pub corrs: [TrackingChannelCorrelation; 3],
 }
 
-impl MsgTrackingIq {
+impl SbpParse<MsgTrackingIq> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIq, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingIq> {
         Ok( MsgTrackingIq{
             sender_id: None,
-            channel: _buf.read_u8()?,
-            sid: GnssSignal::parse(_buf)?,
-            corrs: TrackingChannelCorrelation::parse_array_fixed(_buf)?,
+            channel: self.parse()?,
+            sid: self.parse()?,
+            corrs: self.parse()?,
         } )
     }
 }
@@ -166,14 +160,14 @@ pub struct MsgTrackingIqDepA {
     pub corrs: [TrackingChannelCorrelationDep; 3],
 }
 
-impl MsgTrackingIqDepA {
+impl SbpParse<MsgTrackingIqDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIqDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingIqDepA> {
         Ok( MsgTrackingIqDepA{
             sender_id: None,
-            channel: _buf.read_u8()?,
-            sid: GnssSignalDep::parse(_buf)?,
-            corrs: TrackingChannelCorrelationDep::parse_array_fixed(_buf)?,
+            channel: self.parse()?,
+            sid: self.parse()?,
+            corrs: self.parse()?,
         } )
     }
 }
@@ -231,14 +225,14 @@ pub struct MsgTrackingIqDepB {
     pub corrs: [TrackingChannelCorrelationDep; 3],
 }
 
-impl MsgTrackingIqDepB {
+impl SbpParse<MsgTrackingIqDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingIqDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingIqDepB> {
         Ok( MsgTrackingIqDepB{
             sender_id: None,
-            channel: _buf.read_u8()?,
-            sid: GnssSignal::parse(_buf)?,
-            corrs: TrackingChannelCorrelationDep::parse_array_fixed(_buf)?,
+            channel: self.parse()?,
+            sid: self.parse()?,
+            corrs: self.parse()?,
         } )
     }
 }
@@ -293,12 +287,12 @@ pub struct MsgTrackingState {
     pub states: Vec<TrackingChannelState>,
 }
 
-impl MsgTrackingState {
+impl SbpParse<MsgTrackingState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingState> {
         Ok( MsgTrackingState{
             sender_id: None,
-            states: TrackingChannelState::parse_array(_buf)?,
+            states: self.parse()?,
         } )
     }
 }
@@ -347,12 +341,12 @@ pub struct MsgTrackingStateDepA {
     pub states: Vec<TrackingChannelStateDepA>,
 }
 
-impl MsgTrackingStateDepA {
+impl SbpParse<MsgTrackingStateDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingStateDepA> {
         Ok( MsgTrackingStateDepA{
             sender_id: None,
-            states: TrackingChannelStateDepA::parse_array(_buf)?,
+            states: self.parse()?,
         } )
     }
 }
@@ -401,12 +395,12 @@ pub struct MsgTrackingStateDepB {
     pub states: Vec<TrackingChannelStateDepB>,
 }
 
-impl MsgTrackingStateDepB {
+impl SbpParse<MsgTrackingStateDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingStateDepB> {
         Ok( MsgTrackingStateDepB{
             sender_id: None,
-            states: TrackingChannelStateDepB::parse_array(_buf)?,
+            states: self.parse()?,
         } )
     }
 }
@@ -501,32 +495,32 @@ pub struct MsgTrackingStateDetailedDep {
     pub misc_flags: u8,
 }
 
-impl MsgTrackingStateDetailedDep {
+impl SbpParse<MsgTrackingStateDetailedDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDetailedDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingStateDetailedDep> {
         Ok( MsgTrackingStateDetailedDep{
             sender_id: None,
-            recv_time: _buf.read_u64::<LittleEndian>()?,
-            tot: GPSTimeDep::parse(_buf)?,
-            P: _buf.read_u32::<LittleEndian>()?,
-            P_std: _buf.read_u16::<LittleEndian>()?,
-            L: CarrierPhase::parse(_buf)?,
-            cn0: _buf.read_u8()?,
-            lock: _buf.read_u16::<LittleEndian>()?,
-            sid: GnssSignalDep::parse(_buf)?,
-            doppler: _buf.read_i32::<LittleEndian>()?,
-            doppler_std: _buf.read_u16::<LittleEndian>()?,
-            uptime: _buf.read_u32::<LittleEndian>()?,
-            clock_offset: _buf.read_i16::<LittleEndian>()?,
-            clock_drift: _buf.read_i16::<LittleEndian>()?,
-            corr_spacing: _buf.read_u16::<LittleEndian>()?,
-            acceleration: _buf.read_i8()?,
-            sync_flags: _buf.read_u8()?,
-            tow_flags: _buf.read_u8()?,
-            track_flags: _buf.read_u8()?,
-            nav_flags: _buf.read_u8()?,
-            pset_flags: _buf.read_u8()?,
-            misc_flags: _buf.read_u8()?,
+            recv_time: self.parse()?,
+            tot: self.parse()?,
+            P: self.parse()?,
+            P_std: self.parse()?,
+            L: self.parse()?,
+            cn0: self.parse()?,
+            lock: self.parse()?,
+            sid: self.parse()?,
+            doppler: self.parse()?,
+            doppler_std: self.parse()?,
+            uptime: self.parse()?,
+            clock_offset: self.parse()?,
+            clock_drift: self.parse()?,
+            corr_spacing: self.parse()?,
+            acceleration: self.parse()?,
+            sync_flags: self.parse()?,
+            tow_flags: self.parse()?,
+            track_flags: self.parse()?,
+            nav_flags: self.parse()?,
+            pset_flags: self.parse()?,
+            misc_flags: self.parse()?,
         } )
     }
 }
@@ -662,32 +656,32 @@ pub struct MsgTrackingStateDetailedDepA {
     pub misc_flags: u8,
 }
 
-impl MsgTrackingStateDetailedDepA {
+impl SbpParse<MsgTrackingStateDetailedDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgTrackingStateDetailedDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgTrackingStateDetailedDepA> {
         Ok( MsgTrackingStateDetailedDepA{
             sender_id: None,
-            recv_time: _buf.read_u64::<LittleEndian>()?,
-            tot: GPSTime::parse(_buf)?,
-            P: _buf.read_u32::<LittleEndian>()?,
-            P_std: _buf.read_u16::<LittleEndian>()?,
-            L: CarrierPhase::parse(_buf)?,
-            cn0: _buf.read_u8()?,
-            lock: _buf.read_u16::<LittleEndian>()?,
-            sid: GnssSignal::parse(_buf)?,
-            doppler: _buf.read_i32::<LittleEndian>()?,
-            doppler_std: _buf.read_u16::<LittleEndian>()?,
-            uptime: _buf.read_u32::<LittleEndian>()?,
-            clock_offset: _buf.read_i16::<LittleEndian>()?,
-            clock_drift: _buf.read_i16::<LittleEndian>()?,
-            corr_spacing: _buf.read_u16::<LittleEndian>()?,
-            acceleration: _buf.read_i8()?,
-            sync_flags: _buf.read_u8()?,
-            tow_flags: _buf.read_u8()?,
-            track_flags: _buf.read_u8()?,
-            nav_flags: _buf.read_u8()?,
-            pset_flags: _buf.read_u8()?,
-            misc_flags: _buf.read_u8()?,
+            recv_time: self.parse()?,
+            tot: self.parse()?,
+            P: self.parse()?,
+            P_std: self.parse()?,
+            L: self.parse()?,
+            cn0: self.parse()?,
+            lock: self.parse()?,
+            sid: self.parse()?,
+            doppler: self.parse()?,
+            doppler_std: self.parse()?,
+            uptime: self.parse()?,
+            clock_offset: self.parse()?,
+            clock_drift: self.parse()?,
+            corr_spacing: self.parse()?,
+            acceleration: self.parse()?,
+            sync_flags: self.parse()?,
+            tow_flags: self.parse()?,
+            track_flags: self.parse()?,
+            nav_flags: self.parse()?,
+            pset_flags: self.parse()?,
+            misc_flags: self.parse()?,
         } )
     }
 }
@@ -782,30 +776,13 @@ pub struct MeasurementState {
     pub cn0: u8,
 }
 
-impl MeasurementState {
+impl SbpParse<MeasurementState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MeasurementState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MeasurementState> {
         Ok( MeasurementState{
-            mesid: GnssSignal::parse(_buf)?,
-            cn0: _buf.read_u8()?,
+            mesid: self.parse()?,
+            cn0: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<MeasurementState>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(MeasurementState::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[MeasurementState; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(MeasurementState::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -838,30 +815,13 @@ pub struct TrackingChannelCorrelation {
     pub Q: i16,
 }
 
-impl TrackingChannelCorrelation {
+impl SbpParse<TrackingChannelCorrelation> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelCorrelation, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TrackingChannelCorrelation> {
         Ok( TrackingChannelCorrelation{
-            I: _buf.read_i16::<LittleEndian>()?,
-            Q: _buf.read_i16::<LittleEndian>()?,
+            I: self.parse()?,
+            Q: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelCorrelation>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TrackingChannelCorrelation::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TrackingChannelCorrelation; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TrackingChannelCorrelation::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -894,32 +854,13 @@ pub struct TrackingChannelCorrelationDep {
     pub Q: i32,
 }
 
-impl TrackingChannelCorrelationDep {
+impl SbpParse<TrackingChannelCorrelationDep> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelCorrelationDep, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TrackingChannelCorrelationDep> {
         Ok( TrackingChannelCorrelationDep{
-            I: _buf.read_i32::<LittleEndian>()?,
-            Q: _buf.read_i32::<LittleEndian>()?,
+            I: self.parse()?,
+            Q: self.parse()?,
         } )
-    }
-    pub fn parse_array(
-        buf: &mut &[u8],
-    ) -> Result<Vec<TrackingChannelCorrelationDep>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TrackingChannelCorrelationDep::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TrackingChannelCorrelationDep; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TrackingChannelCorrelationDep::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -955,31 +896,14 @@ pub struct TrackingChannelState {
     pub cn0: u8,
 }
 
-impl TrackingChannelState {
+impl SbpParse<TrackingChannelState> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelState, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TrackingChannelState> {
         Ok( TrackingChannelState{
-            sid: GnssSignal::parse(_buf)?,
-            fcn: _buf.read_u8()?,
-            cn0: _buf.read_u8()?,
+            sid: self.parse()?,
+            fcn: self.parse()?,
+            cn0: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelState>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TrackingChannelState::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TrackingChannelState; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TrackingChannelState::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1016,31 +940,14 @@ pub struct TrackingChannelStateDepA {
     pub cn0: f32,
 }
 
-impl TrackingChannelStateDepA {
+impl SbpParse<TrackingChannelStateDepA> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelStateDepA, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TrackingChannelStateDepA> {
         Ok( TrackingChannelStateDepA{
-            state: _buf.read_u8()?,
-            prn: _buf.read_u8()?,
-            cn0: _buf.read_f32::<LittleEndian>()?,
+            state: self.parse()?,
+            prn: self.parse()?,
+            cn0: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelStateDepA>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TrackingChannelStateDepA::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TrackingChannelStateDepA; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TrackingChannelStateDepA::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1077,31 +984,14 @@ pub struct TrackingChannelStateDepB {
     pub cn0: f32,
 }
 
-impl TrackingChannelStateDepB {
+impl SbpParse<TrackingChannelStateDepB> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<TrackingChannelStateDepB, crate::Error> {
+    fn parse(&mut self) -> crate::Result<TrackingChannelStateDepB> {
         Ok( TrackingChannelStateDepB{
-            state: _buf.read_u8()?,
-            sid: GnssSignalDep::parse(_buf)?,
-            cn0: _buf.read_f32::<LittleEndian>()?,
+            state: self.parse()?,
+            sid: self.parse()?,
+            cn0: self.parse()?,
         } )
-    }
-    pub fn parse_array(buf: &mut &[u8]) -> Result<Vec<TrackingChannelStateDepB>, crate::Error> {
-        let mut v = Vec::new();
-        while buf.len() > 0 {
-            v.push(TrackingChannelStateDepB::parse(buf)?);
-        }
-        Ok(v)
-    }
-
-    pub fn parse_array_fixed<const N: usize>(
-        buf: &mut &[u8],
-    ) -> Result<[TrackingChannelStateDepB; N], crate::Error> {
-        let mut v = Vec::new();
-        for _ in 0..N {
-            v.push(TrackingChannelStateDepB::parse(buf)?);
-        }
-        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/tracking.rs
+++ b/rust/sbp/src/messages/tracking.rs
@@ -15,6 +15,9 @@
 //! Satellite code and carrier-phase tracking messages from the device.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};
@@ -96,7 +99,7 @@ pub struct MsgTrackingIq {
     /// GNSS signal identifier
     pub sid: GnssSignal,
     /// Early, Prompt and Late correlations
-    pub corrs: Vec<TrackingChannelCorrelation>,
+    pub corrs: [TrackingChannelCorrelation; 3],
 }
 
 impl MsgTrackingIq {
@@ -106,7 +109,7 @@ impl MsgTrackingIq {
             sender_id: None,
             channel: _buf.read_u8()?,
             sid: GnssSignal::parse(_buf)?,
-            corrs: TrackingChannelCorrelation::parse_array_limit(_buf, 3)?,
+            corrs: TrackingChannelCorrelation::parse_array_fixed(_buf)?,
         } )
     }
 }
@@ -160,7 +163,7 @@ pub struct MsgTrackingIqDepA {
     /// GNSS signal identifier
     pub sid: GnssSignalDep,
     /// Early, Prompt and Late correlations
-    pub corrs: Vec<TrackingChannelCorrelationDep>,
+    pub corrs: [TrackingChannelCorrelationDep; 3],
 }
 
 impl MsgTrackingIqDepA {
@@ -170,7 +173,7 @@ impl MsgTrackingIqDepA {
             sender_id: None,
             channel: _buf.read_u8()?,
             sid: GnssSignalDep::parse(_buf)?,
-            corrs: TrackingChannelCorrelationDep::parse_array_limit(_buf, 3)?,
+            corrs: TrackingChannelCorrelationDep::parse_array_fixed(_buf)?,
         } )
     }
 }
@@ -225,7 +228,7 @@ pub struct MsgTrackingIqDepB {
     /// GNSS signal identifier
     pub sid: GnssSignal,
     /// Early, Prompt and Late correlations
-    pub corrs: Vec<TrackingChannelCorrelationDep>,
+    pub corrs: [TrackingChannelCorrelationDep; 3],
 }
 
 impl MsgTrackingIqDepB {
@@ -235,7 +238,7 @@ impl MsgTrackingIqDepB {
             sender_id: None,
             channel: _buf.read_u8()?,
             sid: GnssSignal::parse(_buf)?,
-            corrs: TrackingChannelCorrelationDep::parse_array_limit(_buf, 3)?,
+            corrs: TrackingChannelCorrelationDep::parse_array_fixed(_buf)?,
         } )
     }
 }
@@ -795,15 +798,14 @@ impl MeasurementState {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<MeasurementState>, crate::Error> {
+    ) -> Result<[MeasurementState; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(MeasurementState::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -852,15 +854,14 @@ impl TrackingChannelCorrelation {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TrackingChannelCorrelation>, crate::Error> {
+    ) -> Result<[TrackingChannelCorrelation; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TrackingChannelCorrelation::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -911,15 +912,14 @@ impl TrackingChannelCorrelationDep {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TrackingChannelCorrelationDep>, crate::Error> {
+    ) -> Result<[TrackingChannelCorrelationDep; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TrackingChannelCorrelationDep::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -972,15 +972,14 @@ impl TrackingChannelState {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TrackingChannelState>, crate::Error> {
+    ) -> Result<[TrackingChannelState; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TrackingChannelState::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1034,15 +1033,14 @@ impl TrackingChannelStateDepA {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TrackingChannelStateDepA>, crate::Error> {
+    ) -> Result<[TrackingChannelStateDepA; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TrackingChannelStateDepA::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 
@@ -1096,15 +1094,14 @@ impl TrackingChannelStateDepB {
         Ok(v)
     }
 
-    pub fn parse_array_limit(
+    pub fn parse_array_fixed<const N: usize>(
         buf: &mut &[u8],
-        n: usize,
-    ) -> Result<Vec<TrackingChannelStateDepB>, crate::Error> {
+    ) -> Result<[TrackingChannelStateDepB; N], crate::Error> {
         let mut v = Vec::new();
-        for _ in 0..n {
+        for _ in 0..N {
             v.push(TrackingChannelStateDepB::parse(buf)?);
         }
-        Ok(v)
+        v.try_into().map_err(|_| crate::Error::ParseError)
     }
 }
 

--- a/rust/sbp/src/messages/user.rs
+++ b/rust/sbp/src/messages/user.rs
@@ -15,17 +15,11 @@
 //! Messages reserved for use by the user.
 //!
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// User data
 ///
@@ -41,12 +35,12 @@ pub struct MsgUserData {
     pub contents: Vec<u8>,
 }
 
-impl MsgUserData {
+impl SbpParse<MsgUserData> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgUserData, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgUserData> {
         Ok( MsgUserData{
             sender_id: None,
-            contents: crate::parser::read_u8_array(_buf)?,
+            contents: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/user.rs
+++ b/rust/sbp/src/messages/user.rs
@@ -15,6 +15,9 @@
 //! Messages reserved for use by the user.
 //!
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -14,17 +14,11 @@
 //****************************************************************************/
 //! Messages from a vehicle.
 
-#[allow(unused_imports)]
-use std::convert::TryInto;
-
-extern crate byteorder;
-#[allow(unused_imports)]
-use self::byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "sbp_serde")]
 use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
-use crate::SbpString;
+use crate::{parser::SbpParse, BoundedSbpString, UnboundedSbpString};
 
 /// Vehicle forward (x-axis) velocity
 ///
@@ -52,14 +46,14 @@ pub struct MsgOdometry {
     pub flags: u8,
 }
 
-impl MsgOdometry {
+impl SbpParse<MsgOdometry> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgOdometry, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgOdometry> {
         Ok( MsgOdometry{
             sender_id: None,
-            tow: _buf.read_u32::<LittleEndian>()?,
-            velocity: _buf.read_i32::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
+            tow: self.parse()?,
+            velocity: self.parse()?,
+            flags: self.parse()?,
         } )
     }
 }
@@ -132,15 +126,15 @@ pub struct MsgWheeltick {
     pub ticks: i32,
 }
 
-impl MsgWheeltick {
+impl SbpParse<MsgWheeltick> for &[u8] {
     #[rustfmt::skip]
-    pub fn parse(_buf: &mut &[u8]) -> Result<MsgWheeltick, crate::Error> {
+    fn parse(&mut self) -> crate::Result<MsgWheeltick> {
         Ok( MsgWheeltick{
             sender_id: None,
-            time: _buf.read_u64::<LittleEndian>()?,
-            flags: _buf.read_u8()?,
-            source: _buf.read_u8()?,
-            ticks: _buf.read_i32::<LittleEndian>()?,
+            time: self.parse()?,
+            flags: self.parse()?,
+            source: self.parse()?,
+            ticks: self.parse()?,
         } )
     }
 }

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -14,6 +14,9 @@
 //****************************************************************************/
 //! Messages from a vehicle.
 
+#[allow(unused_imports)]
+use std::convert::TryInto;
+
 extern crate byteorder;
 #[allow(unused_imports)]
 use self::byteorder::{LittleEndian, ReadBytesExt};

--- a/rust/sbp/src/parser/mod.rs
+++ b/rust/sbp/src/parser/mod.rs
@@ -10,8 +10,9 @@ use self::nom::multi::length_data;
 use self::nom::number::complete::{le_u16, le_u8};
 use self::nom::sequence::tuple;
 use crate::messages::SBP;
-use crate::Result;
 use crate::SbpString;
+use crate::{Error, Result};
+use std::convert::TryInto;
 use std::io::{BufReader, Read};
 
 const MSG_HEADER_LEN: usize = 1 /*preamble*/ + 2 /*msg_type*/ + 2 /*sender_id*/ + 1 /*len*/;
@@ -257,50 +258,50 @@ pub(crate) fn read_u8_array(buf: &mut &[u8]) -> Result<Vec<u8>> {
     Ok(buf.to_vec())
 }
 
-pub(crate) fn read_u8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u8>> {
+pub(crate) fn read_u8_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[u8; N]> {
     let mut v = Vec::new();
-    for _ in 0..n {
+    for _ in 0..N {
         v.push(buf.read_u8()?);
     }
-    Ok(v)
+    v.try_into().map_err(|_| Error::ParseError)
 }
 
-pub(crate) fn read_s8_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i8>> {
+pub(crate) fn read_s8_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[i8; N]> {
     let mut v = Vec::new();
-    for _ in 0..n {
+    for _ in 0..N {
         v.push(buf.read_i8()?);
     }
-    Ok(v)
+    v.try_into().map_err(|_| Error::ParseError)
 }
 
-pub(crate) fn read_s16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<i16>> {
+pub(crate) fn read_s16_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[i16; N]> {
     let mut v = Vec::new();
-    for _ in 0..n {
+    for _ in 0..N {
         v.push(buf.read_i16::<LittleEndian>()?);
     }
-    Ok(v)
+    v.try_into().map_err(|_| Error::ParseError)
 }
 
-pub(crate) fn read_u16_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<u16>> {
+pub(crate) fn read_u16_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[u16; N]> {
     let mut v = Vec::new();
-    for _ in 0..n {
+    for _ in 0..N {
         v.push(buf.read_u16::<LittleEndian>()?);
     }
-    Ok(v)
+    v.try_into().map_err(|_| Error::ParseError)
 }
 
-pub(crate) fn read_float_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f32>> {
+pub(crate) fn read_float_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[f32; N]> {
     let mut v = Vec::new();
-    for _ in 0..n {
+    for _ in 0..N {
         v.push(buf.read_f32::<LittleEndian>()?);
     }
-    Ok(v)
+    v.try_into().map_err(|_| Error::ParseError)
 }
 
-pub(crate) fn read_double_array_limit(buf: &mut &[u8], n: usize) -> Result<Vec<f64>> {
+pub(crate) fn read_double_array_fixed<const N: usize>(buf: &mut &[u8]) -> Result<[f64; N]> {
     let mut v = Vec::new();
-    for _ in 0..n {
+    for _ in 0..N {
         v.push(buf.read_f64::<LittleEndian>()?);
     }
-    Ok(v)
+    v.try_into().map_err(|_| Error::ParseError)
 }

--- a/rust/sbp/src/serialize.rs
+++ b/rust/sbp/src/serialize.rs
@@ -107,13 +107,13 @@ impl SbpSerialize for f64 {
     }
 }
 
-impl SbpSerialize for SbpString {
+impl<T: SbpString> SbpSerialize for T {
     fn append_to_sbp_buffer(&self, buf: &mut Vec<u8>) {
         buf.extend(self.as_bytes());
     }
 
     fn sbp_size(&self) -> usize {
-        self.0.len()
+        self.as_bytes().len()
     }
 }
 

--- a/rust/sbp/src/serialize.rs
+++ b/rust/sbp/src/serialize.rs
@@ -117,18 +117,32 @@ impl SbpSerialize for SbpString {
     }
 }
 
-impl<T: SbpSerialize> SbpSerialize for Vec<T> {
+impl<T: SbpSerialize> SbpSerialize for &'_ [T] {
     fn append_to_sbp_buffer(&self, buf: &mut Vec<u8>) {
-        for item in self.into_iter() {
-            item.append_to_sbp_buffer(buf);
-        }
+        self.iter().for_each(|item| item.append_to_sbp_buffer(buf));
     }
 
     fn sbp_size(&self) -> usize {
-        let mut total = 0;
-        for item in self.iter() {
-            total += item.sbp_size();
-        }
-        total
+        self.iter().map(|item| item.sbp_size()).sum()
+    }
+}
+
+impl<T: SbpSerialize> SbpSerialize for Vec<T> {
+    fn append_to_sbp_buffer(&self, buf: &mut Vec<u8>) {
+        self.as_slice().append_to_sbp_buffer(buf)
+    }
+
+    fn sbp_size(&self) -> usize {
+        self.as_slice().sbp_size()
+    }
+}
+
+impl<T: SbpSerialize, const SIZE: usize> SbpSerialize for [T; SIZE] {
+    fn append_to_sbp_buffer(&self, buf: &mut Vec<u8>) {
+        self.as_ref().append_to_sbp_buffer(buf)
+    }
+
+    fn sbp_size(&self) -> usize {
+        self.as_ref().sbp_size()
     }
 }


### PR DESCRIPTION
This is a speculative PR that takes advantage of const generics available in the nightly rust compiler. We might want to consider this (or a similar) change once const generics are stable. This PR is split into two levels of changes with the second completely reworking the first. I'd suggest reviewing the changes in isolation treating the first change as a conservative modification and the second and a more intrusive refactor. We can drop the second set of changes if they are not of interest.

The first change modifies the rust code generator to use fixed size arrays in the message types when the message definition includes a known size. It also changes the existing functions to read fixed size arrays to be generic over array sizes instead of taking array size at runtime. Due to the complexity with our string handling code this change does not modify handling of fixed length strings.

The second change is a much wider refactor of our type parsing code in an attempt to reduce the amount of code that the SBP generator needs to generate. It adds a generic trait called `SbpParse` for parsing types out of something. We implement this trait for all the basic types and for each message, reading out of a `&[u8]`. We also have a generic implementation for parsing a `Vec<T>` or `[T; N]` for any `T` which can be parsed. Due to the trait definition we need to have separate types for fixed length strings and unbounded length strings so there can be two different parsing implementations. With the introduction of two string types a trait is added to give them a common interface. All of this has the end result of having to only generate a single `parse` function for each message type and remove the `parse_array` and `parse_array_limit` functions from the generated code.