### PR TITLE
Pin npm to version 6 in CI stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
         - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
         # Install node 8; from https://github.com/nodejs/nan/blob/master/.travis.yml
         - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 8
-        - npm install npm
+        - npm install npm@latest-6
         - mv node_modules npm
         - npm/.bin/npm --version
         - npm/.bin/npm install


### PR DESCRIPTION
See https://github.com/npm/cli/issues/2599

Specify npm@latest-6 during CI setup
