### PR TITLE
[ESD-1897] Add support for Greenhill compiler

### DIFF
--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -51,7 +51,7 @@ typedef uint64_t u64;
 #endif
 
 /* Set packing based upon toolchain */
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__) || defined(__ghs__)
 
 #define SBP_PACK_START /* Intentionally empty */
 #define SBP_PACK_END /* Intentionally empty */


### PR DESCRIPTION
Greenhill compiler has the same struct packing attribute as gcc but needs an extra preprocessor test to enable it. Currently causes a build error using Greenhill compiler.