### PR TITLE
Default to unbuffered output [INFRA-426]

### DIFF
--- a/generator/sbpg/targets/resources/sbp2json-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp2json-cargo.toml
@@ -16,7 +16,6 @@ path = "../sbp"
 features = ["json"]
 
 [dependencies]
-atty = "0.2"
 dencode = "0.1"
 env_logger = "0.8"
 serde_json = "1.0"

--- a/rust/sbp2json/Cargo.toml
+++ b/rust/sbp2json/Cargo.toml
@@ -16,7 +16,6 @@ path = "../sbp"
 features = ["json"]
 
 [dependencies]
-atty = "0.2"
 dencode = "0.1"
 env_logger = "0.8"
 serde_json = "1.0"

--- a/rust/sbp2json/src/bin/json2json.rs
+++ b/rust/sbp2json/src/bin/json2json.rs
@@ -25,9 +25,9 @@ struct Options {
     #[structopt(long = "float-compat")]
     float_compat: bool,
 
-    /// Flush output on every message
-    #[structopt(long = "unbuffered")]
-    unbuffered: bool,
+    /// Buffer output before flushing
+    #[structopt(short, long)]
+    buffered: bool,
 }
 
 fn main() -> sbp::Result<()> {
@@ -42,11 +42,9 @@ fn main() -> sbp::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
 
-    let unbuffered = atty::is(atty::Stream::Stdout) || options.unbuffered;
-
     if options.float_compat {
-        json2json(stdin, stdout, HaskellishFloatFormatter {}, unbuffered)
+        json2json(stdin, stdout, HaskellishFloatFormatter {}, options.buffered)
     } else {
-        json2json(stdin, stdout, CompactFormatter {}, unbuffered)
+        json2json(stdin, stdout, CompactFormatter {}, options.buffered)
     }
 }

--- a/rust/sbp2json/src/bin/json2sbp.rs
+++ b/rust/sbp2json/src/bin/json2sbp.rs
@@ -20,9 +20,9 @@ struct Options {
     #[structopt(long)]
     debug: bool,
 
-    /// Flush output on every message
-    #[structopt(long = "unbuffered")]
-    unbuffered: bool,
+    /// Buffer output before flushing
+    #[structopt(short, long)]
+    buffered: bool,
 }
 
 fn main() -> sbp::Result<()> {
@@ -37,7 +37,5 @@ fn main() -> sbp::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
 
-    let unbuffered = atty::is(atty::Stream::Stdout) || options.unbuffered;
-
-    json2sbp(stdin, stdout, unbuffered)
+    json2sbp(stdin, stdout, options.buffered)
 }

--- a/rust/sbp2json/src/bin/sbp2json.rs
+++ b/rust/sbp2json/src/bin/sbp2json.rs
@@ -29,9 +29,9 @@ pub struct Options {
     #[structopt(short = "d", long)]
     debug: bool,
 
-    /// Flush output on every message
-    #[structopt(long = "unbuffered")]
-    unbuffered: bool,
+    /// Buffer output before flushing
+    #[structopt(short, long)]
+    buffered: bool,
 }
 
 fn main() -> sbp::Result<()> {
@@ -46,11 +46,9 @@ fn main() -> sbp::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
 
-    let unbuffered = atty::is(atty::Stream::Stdout) || options.unbuffered;
-
     if options.float_compat {
-        sbp2json(stdin, stdout, HaskellishFloatFormatter {}, unbuffered)
+        sbp2json(stdin, stdout, HaskellishFloatFormatter {}, options.buffered)
     } else {
-        sbp2json(stdin, stdout, CompactFormatter {}, unbuffered)
+        sbp2json(stdin, stdout, CompactFormatter {}, options.buffered)
     }
 }

--- a/rust/sbp2json/src/lib.rs
+++ b/rust/sbp2json/src/lib.rs
@@ -11,7 +11,7 @@ use sbp::{
     Error, Result,
 };
 
-pub fn json2sbp<R, W>(input: R, output: W, unbuffered: bool) -> Result<()>
+pub fn json2sbp<R, W>(input: R, output: W, buffered: bool) -> Result<()>
 where
     R: Read,
     W: Write,
@@ -19,7 +19,7 @@ where
     let source = FramedRead::new(input, JsonDecoder::new());
     let sink = FramedWrite::new(output, SbpEncoder::new());
 
-    maybe_send_unbuffered(source, sink, unbuffered)?;
+    maybe_send_buffered(source, sink, buffered)?;
 
     Ok(())
 }
@@ -33,12 +33,12 @@ where
     let source = FramedRead::new(input, Json2JsonDecoder {});
     let sink = FramedWrite::new(output, Json2JsonEncoder::new(formatter));
 
-    maybe_send_unbuffered(source, sink, unbufferd)?;
+    maybe_send_buffered(source, sink, unbufferd)?;
 
     Ok(())
 }
 
-pub fn sbp2json<R, W, F>(input: R, output: W, formatter: F, unbuffered: bool) -> Result<()>
+pub fn sbp2json<R, W, F>(input: R, output: W, formatter: F, buffered: bool) -> Result<()>
 where
     R: Read,
     W: Write,
@@ -47,15 +47,15 @@ where
     let source = FramedRead::new(input, SbpDecoder {});
     let sink = FramedWrite::new(output, JsonEncoder::new(formatter));
 
-    maybe_send_unbuffered(source, sink, unbuffered)?;
+    maybe_send_buffered(source, sink, buffered)?;
 
     Ok(())
 }
 
-fn maybe_send_unbuffered<R, W, D, E>(
+fn maybe_send_buffered<R, W, D, E>(
     mut source: FramedRead<R, D>,
     mut sink: FramedWrite<W, E>,
-    unbuffered: bool,
+    buffered: bool,
 ) -> Result<()>
 where
     R: Read,
@@ -63,12 +63,12 @@ where
     D: Decoder<Item = E::Item, Error = Error>,
     E: Encoder<Error = Error>,
 {
-    if unbuffered {
+    if buffered {
+        sink.send_all(source)?;
+    } else {
         while let Some(msg) = source.next() {
             sink.send(msg?)?;
         }
-    } else {
-        sink.send_all(source)?;
     }
 
     Ok(())


### PR DESCRIPTION
A less fancy approach where the tools always use unbuffered output unless you specify `-b/--buffered`.

The performance doesn't get that much worse, so it this is more usable this just might be the better approach 

```
(base) {13:41}~/projects/libsbp:steve/unbuffered ✗ ➭ hyperfine -L buffered --buffered, "sbp2json {buffered} <test_data/benchmark.sbp >/dev/null"
Benchmark #1: sbp2json --buffered <test_data/benchmark.sbp >/dev/null
  Time (mean ± σ):     504.4 ms ±  32.6 ms    [User: 502.2 ms, System: 2.3 ms]
  Range (min … max):   465.2 ms … 570.9 ms    10 runs
 
Benchmark #2: sbp2json  <test_data/benchmark.sbp >/dev/null
  Time (mean ± σ):     532.1 ms ±   8.4 ms    [User: 512.9 ms, System: 19.3 ms]
  Range (min … max):   523.9 ms … 549.5 ms    10 runs
 
Summary
  'sbp2json --buffered <test_data/benchmark.sbp >/dev/null' ran
    1.05 ± 0.07 times faster than 'sbp2json  <test_data/benchmark.sbp >/dev/null'

```