### PR TITLE
Fix building of rust tools in Docker

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p $SCCACHE_DIR
 
 RUN \
       apt-get update \
-   && apt-get install -y libssl-dev pkg-config curl build-essential \
+   && apt-get install -y libssl-dev pkg-config curl build-essential make \
    && curl -sSL -o /tmp/sccache.tgz "${SCCACHE_URL}" \
    && mkdir /tmp/sccache \
    && tar --strip-components=1 -C /tmp/sccache -xzf /tmp/sccache.tgz \


### PR DESCRIPTION
Attempting to run `cargo install --git https://github.com/swift-nav/libsbp.git --bins` in this Docker image fails during compilation of jemalloc since `make` is not installed