### PR TITLE
Clarify units used in MSG_LINUX_SYS_STATE message

### DIFF
--- a/spec/yaml/swiftnav/sbp/linux.yaml
+++ b/spec/yaml/swiftnav/sbp/linux.yaml
@@ -256,7 +256,7 @@ definitions:
            desc: the PID of the process
        - pcpu:
            type: u8
-           desc: percent of cpu used, expressed as a fraction of 256
+           desc: percent of CPU used, expressed as a fraction of 256
        - time:
            type: u32
            desc: timestamp of message, refer to flags field for how to interpret
@@ -327,10 +327,10 @@ definitions:
            desc: total system memory, in MiB
        - pcpu:
            type: u8
-           desc: percent of total cpu currently utilized
+           desc: percent of CPU used, expressed as a fraction of 256
        - pmem:
            type: u8
-           desc: percent of total memory currently utilized
+           desc: percent of memory used, expressed as a fraction of 256
        - procs_starting:
            type: u16
            desc: number of processes that started during collection phase


### PR DESCRIPTION
The documentation for MSG_LINUX_SYS_STATE says that the `pcpu` and `pmem` fields are percentages, however, from looking at test results and the code (https://github.com/swift-nav/piksi_apps/blob/master/app/resource_monitor/query_sys_state.c#L371) it is expressed as a fraction of 256 (i.e. equivalent to the MSG_LINUX_CPU_STATE and MSG_LINUX_MEM_STATE messages).