### PR TITLE
[INFRA-444] gradle.build: Support Gradle 7

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    compile 'org.scream3r:jssc:2.8.0'
-    compile 'org.json:json:20131018'
+    implementation 'org.scream3r:jssc:2.8.0'
+    implementation 'org.json:json:20131018'
 }
 
 sourceSets {


### PR DESCRIPTION
Use of `compile` is not supported by Gradle 7.
Use implementation instead.