### PR TITLE
[ESD-2012] Don't cast function pointers to void*

### DIFF
--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -81,6 +81,10 @@ typedef void (*sbp_msg_callback_t)(u16 sender_id, u8 len, u8 msg[],
 typedef void (*sbp_frame_callback_t)(u16 sender_id, u16 msg_type,
                                      u8 payload_len, u8 payload[],
                                      u16 frame_len, u8 frame[], void *context);
+typedef union {
+  sbp_msg_callback_t msg;
+  sbp_frame_callback_t frame;
+} sbp_callback_t;
 
 /** SBP callback type enum:
  * SBP_PAYLOAD_CALLBACK are the original callbacks in libsbp without framing
@@ -104,9 +108,9 @@ typedef enum sbp_cb_type sbp_cb_type;
  *       and sbp_register_frame_callback().
  */
 typedef struct sbp_msg_callbacks_node {
-  u16 msg_type;  /**< Message ID associated with callback. */
-  void *cb;      /**< Pointer to callback function. */
-  void *context; /**< Pointer to a context */
+  u16 msg_type;      /**< Message ID associated with callback. */
+  sbp_callback_t cb; /**< Pointer to callback function. */
+  void *context;     /**< Pointer to a context */
   struct sbp_msg_callbacks_node *next; /**< Pointer to next node in list. */
   sbp_cb_type cb_type; /**< Enum that holds the type of callback. */
 } sbp_msg_callbacks_node_t;


### PR DESCRIPTION
Harvard architectures keep code and data in separate blocks of memory that can potentially have different address sizes. Therefore it is dangerous to assume that a function pointer can be cast to `void*` and back again. C/C++ disallow this practice although many compilers do support it.

libsbp uses a `void*` member in the state struct to hold the callback pointer which can be one of 2 types - `sbp_msg_callback_t` or `sbp_frame_callback_t`. When the callback is registered a function pointer is passed in of the correct type to the register function but it is cast to void* during the process of adding the callbacks node to the list. When a frame is processed the void* pointer is cast back to the correct function pointer type and invoked.

This PR alters the way that callback pointers are stored in the SBP state object so the type is never lost and we don't use undefined behaviour of casting function pointers to a data pointer type.