### PR TITLE
[ESD-2014] Process solution_meta in javascript bindings

### DIFF
--- a/javascript/sbp/msg.js
+++ b/javascript/sbp/msg.js
@@ -105,6 +105,7 @@ var sbpImports = {
   sbas: require('./sbas.js'),
   settings: require('./settings.js'),
   signal: require('./signal.js'),
+  solution_meta: require('./solution_meta'),
   ssr: require('./ssr.js'),
   system: require('./system.js'),
   tracking: require('./tracking.js'),

--- a/javascript/sbp/msg.js
+++ b/javascript/sbp/msg.js
@@ -105,7 +105,7 @@ var sbpImports = {
   sbas: require('./sbas.js'),
   settings: require('./settings.js'),
   signal: require('./signal.js'),
-  solution_meta: require('./solution_meta'),
+  solution_meta: require('./solution_meta.js'),
   ssr: require('./ssr.js'),
   system: require('./system.js'),
   tracking: require('./tracking.js'),


### PR DESCRIPTION
The solution_meta module isn't imported in the javascript bindings so it can't be processed. Import the module. Tests to follow in ESD-2013 tickets