### PR TITLE
rust: support encoding borrowed messages 

### DIFF
--- a/generator/sbpg/targets/resources/sbp-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp-cargo.toml
@@ -56,8 +56,7 @@ version = "0.3"
 optional = true
 
 [dependencies.dencode]
-git = "https://github.com/swift-nav/dencode"
-branch = "steve/generic"
+version = "0.3.0"
 default-features = false
 
 [dev-dependencies]

--- a/generator/sbpg/targets/resources/sbp-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp-cargo.toml
@@ -56,7 +56,8 @@ version = "0.3"
 optional = true
 
 [dependencies.dencode]
-version = "0.1.0"
+git = "https://github.com/swift-nav/dencode"
+branch = "steve/generic"
 default-features = false
 
 [dev-dependencies]

--- a/generator/sbpg/targets/resources/sbp2json-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp2json-cargo.toml
@@ -16,10 +16,14 @@ path = "../sbp"
 features = ["json"]
 
 [dependencies]
-dencode = "0.1"
 env_logger = "0.8"
 serde_json = "1.0"
 structopt = "0.3"
+
+[dependencies.dencode]
+git = "https://github.com/swift-nav/dencode"
+branch = "steve/generic"
+default-features = false
 
 [target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.3"

--- a/generator/sbpg/targets/resources/sbp2json-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp2json-cargo.toml
@@ -21,8 +21,7 @@ serde_json = "1.0"
 structopt = "0.3"
 
 [dependencies.dencode]
-git = "https://github.com/swift-nav/dencode"
-branch = "steve/generic"
+version = "0.3.0"
 default-features = false
 
 [target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -56,8 +56,7 @@ version = "0.3"
 optional = true
 
 [dependencies.dencode]
-git = "https://github.com/swift-nav/dencode"
-branch = "steve/generic"
+version = "0.3.0"
 default-features = false
 
 [dev-dependencies]

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -56,7 +56,8 @@ version = "0.3"
 optional = true
 
 [dependencies.dencode]
-version = "0.1.0"
+git = "https://github.com/swift-nav/dencode"
+branch = "steve/generic"
 default-features = false
 
 [dev-dependencies]

--- a/rust/sbp/src/codec/json.rs
+++ b/rust/sbp/src/codec/json.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Borrow, collections::HashMap};
 
 use bytes::{Buf, BufMut, BytesMut};
-use dencode::{Decoder, Encoder};
+use dencode::{Decoder, Encoder, FramedWrite};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{ser::Formatter, Deserializer, Serializer, Value};
 
@@ -155,6 +155,10 @@ impl<F: Formatter + Clone> JsonEncoder<F> {
             payload_buf: String::with_capacity(BASE64_SBP_MAX_PAYLOAD_SIZE),
             formatter,
         }
+    }
+
+    pub fn framed<W>(writer: W, formatter: F) -> FramedWrite<W, Self> {
+        FramedWrite::new(writer, Self::new(formatter))
     }
 }
 

--- a/rust/sbp/src/codec/json.rs
+++ b/rust/sbp/src/codec/json.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Borrow, collections::HashMap};
 
 use bytes::{Buf, BufMut, BytesMut};
 use dencode::{Decoder, Encoder};
@@ -170,12 +170,12 @@ struct JsonOutput<'a> {
 impl<F, T> Encoder<T> for JsonEncoder<F>
 where
     F: Formatter + Clone,
-    T: AsRef<SBP>,
+    T: Borrow<SBP>,
 {
     type Error = Error;
 
     fn encode(&mut self, msg: T, dst: &mut BytesMut) -> Result<()> {
-        let msg = msg.as_ref();
+        let msg = msg.borrow();
         let formatter = self.formatter.clone();
         let common = get_common_fields(&mut self.payload_buf, &mut self.frame_buf, msg)?;
         let output = JsonOutput { common, msg };

--- a/rust/sbp/src/codec/mod.rs
+++ b/rust/sbp/src/codec/mod.rs
@@ -1,3 +1,5 @@
+pub use dencode;
+
 #[cfg(feature = "json")]
 pub mod json;
 pub mod sbp;

--- a/rust/sbp/src/codec/sbp.rs
+++ b/rust/sbp/src/codec/sbp.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use bytes::{Buf, BufMut, BytesMut};
-use dencode::{Decoder, Encoder, FramedRead};
+use dencode::{Decoder, Encoder, FramedRead, FramedWrite};
 
 use crate::{
     messages::{SBPMessage, SBP},
@@ -72,6 +72,10 @@ impl SbpEncoder {
         SbpEncoder {
             frame: Vec::with_capacity(MAX_FRAME_LENGTH),
         }
+    }
+
+    pub fn framed<W>(writer: W) -> FramedWrite<W, Self> {
+        FramedWrite::new(writer, Self::new())
     }
 }
 

--- a/rust/sbp/src/codec/sbp.rs
+++ b/rust/sbp/src/codec/sbp.rs
@@ -73,13 +73,15 @@ impl SbpEncoder {
     }
 }
 
-impl Encoder for SbpEncoder {
-    type Item = SBP;
+impl<T> Encoder<T> for SbpEncoder
+where
+    T: AsRef<SBP>,
+{
     type Error = Error;
 
-    fn encode(&mut self, msg: SBP, dst: &mut BytesMut) -> Result<()> {
+    fn encode(&mut self, msg: T, dst: &mut BytesMut) -> Result<()> {
         self.frame.clear();
-        match msg.write_frame(&mut self.frame) {
+        match msg.as_ref().write_frame(&mut self.frame) {
             Ok(_) => dst.put_slice(self.frame.as_slice()),
             Err(err) => log::error!("Error converting sbp message to frame: {}", err),
         }

--- a/rust/sbp/src/codec/sbp.rs
+++ b/rust/sbp/src/codec/sbp.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use bytes::{Buf, BufMut, BytesMut};
 use dencode::{Decoder, Encoder, FramedRead};
 
@@ -75,13 +77,13 @@ impl SbpEncoder {
 
 impl<T> Encoder<T> for SbpEncoder
 where
-    T: AsRef<SBP>,
+    T: Borrow<SBP>,
 {
     type Error = Error;
 
     fn encode(&mut self, msg: T, dst: &mut BytesMut) -> Result<()> {
         self.frame.clear();
-        match msg.as_ref().write_frame(&mut self.frame) {
+        match msg.borrow().write_frame(&mut self.frame) {
             Ok(_) => dst.put_slice(self.frame.as_slice()),
             Err(err) => log::error!("Error converting sbp message to frame: {}", err),
         }

--- a/rust/sbp2json/Cargo.toml
+++ b/rust/sbp2json/Cargo.toml
@@ -16,10 +16,14 @@ path = "../sbp"
 features = ["json"]
 
 [dependencies]
-dencode = "0.1"
 env_logger = "0.8"
 serde_json = "1.0"
 structopt = "0.3"
+
+[dependencies.dencode]
+git = "https://github.com/swift-nav/dencode"
+branch = "steve/generic"
+default-features = false
 
 [target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.3"

--- a/rust/sbp2json/Cargo.toml
+++ b/rust/sbp2json/Cargo.toml
@@ -21,8 +21,7 @@ serde_json = "1.0"
 structopt = "0.3"
 
 [dependencies.dencode]
-git = "https://github.com/swift-nav/dencode"
-branch = "steve/generic"
+version = "0.3.0"
 default-features = false
 
 [target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]

--- a/rust/sbp2json/src/lib.rs
+++ b/rust/sbp2json/src/lib.rs
@@ -61,7 +61,7 @@ where
     R: Read,
     W: Write,
     D: Decoder<Item = E::Item, Error = Error>,
-    E: Encoder<Error = Error>,
+    E: Encoder<E::Item, Error = Error>,
 {
     if buffered {
         sink.send_all(source)?;

--- a/rust/sbp2json/src/lib.rs
+++ b/rust/sbp2json/src/lib.rs
@@ -60,8 +60,8 @@ fn maybe_send_buffered<R, W, D, E>(
 where
     R: Read,
     W: Write,
-    D: Decoder<Item = E::Item, Error = Error>,
-    E: Encoder<E::Item, Error = Error>,
+    D: Decoder<Error = Error>,
+    E: Encoder<D::Item, Error = Error>,
 {
     if buffered {
         sink.send_all(source)?;

--- a/rust/sbp2json/src/lib.rs
+++ b/rust/sbp2json/src/lib.rs
@@ -17,7 +17,7 @@ where
     W: Write,
 {
     let source = FramedRead::new(input, JsonDecoder::new());
-    let sink = FramedWrite::new(output, SbpEncoder::new());
+    let sink = SbpEncoder::framed(output);
 
     maybe_send_buffered(source, sink, buffered)?;
 
@@ -45,7 +45,7 @@ where
     F: Formatter + Clone,
 {
     let source = FramedRead::new(input, SbpDecoder {});
-    let sink = FramedWrite::new(output, JsonEncoder::new(formatter));
+    let sink = JsonEncoder::framed(output, formatter);
 
     maybe_send_buffered(source, sink, buffered)?;
 


### PR DESCRIPTION
needs https://github.com/swift-nav/dencode/pull/2

Makes it so the encoders work with borrowed messages. Adds convenience functions to get a framed writer. Should we reexport dencode so people don't have to bring it in?