### PR TITLE
docker: add clang for rust build [INFRA-477]

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Run make all inside image
         # javascript fails due to permissions
         # rust fails due to missing stdbool.h
-        run: docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest sudo --preserve-env=PATH,RUSTUP_HOME,CARGO_HOME,NVM_DIR,NODE_PATH make c python gen-javascript java docs haskell protobuf gen-rust jsonschema quicktype
+        run: docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest sudo --preserve-env=PATH,RUSTUP_HOME,CARGO_HOME,NVM_DIR,NODE_PATH make c python gen-javascript java docs haskell protobuf gen-rust jsonschema quicktype rust

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Run make all inside image
         # javascript fails due to permissions
         # rust fails due to missing stdbool.h
-        run: docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest sudo --preserve-env=PATH,RUSTUP_HOME,CARGO_HOME,NVM_DIR,NODE_PATH make c python gen-javascript java docs haskell protobuf gen-rust jsonschema quicktype rust
+        run: docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest sudo --preserve-env=PATH,RUSTUP_HOME,CARGO_HOME,NVM_DIR,NODE_PATH make c python gen-javascript java docs haskell protobuf rust jsonschema quicktype

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN \
       build-essential \
       pandoc \
       llvm \
+      clang \
       gradle \
       texlive-science \
       texlive-fonts-extra \
@@ -48,8 +49,7 @@ RUN \
       uuid-dev \
       libgmp-dev \
       zlib1g-dev \
-      clang-format-6.0 \
-      clang
+      clang-format-6.0
 
 RUN add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN \
       uuid-dev \
       libgmp-dev \
       zlib1g-dev \
-      clang-format-6.0
+      clang-format-6.0 \
+      clang
 
 RUN add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -35,8 +35,7 @@ thiserror = "1.0"
 
 [dependencies.swiftnav-rs]
 git = "https://github.com/swift-nav/swiftnav-rs"
-#tag = "v0.5.1"
-branch = "silverjam/build-rs-install-fixup"
+tag = "v0.5.1"
 optional = true
 
 [dependencies.serde]

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0"
 
 [dependencies.swiftnav-rs]
 git = "https://github.com/swift-nav/swiftnav-rs"
-tag = "v0.5.0"
+tag = "v0.5.1"
 optional = true
 
 [dependencies.serde]

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -35,7 +35,8 @@ thiserror = "1.0"
 
 [dependencies.swiftnav-rs]
 git = "https://github.com/swift-nav/swiftnav-rs"
-tag = "v0.5.1"
+#tag = "v0.5.1"
+branch = "silverjam/build-rs-install-fixup"
 optional = true
 
 [dependencies.serde]


### PR DESCRIPTION
Dependent on https://github.com/swift-nav/swiftnav-rs/pull/51 but will allow us to run `cargo test --verbose --all-features --all-targets` inside the docker image.

In order to build all the Rust targets we need clang to build the swiftnav-rs  dependency.  This is apparently a transitive dependency of bindgen.