### PR TITLE
rust: fix parsing of invalid sbp

### DIFF
--- a/rust/sbp/src/codec/sbp.rs
+++ b/rust/sbp/src/codec/sbp.rs
@@ -106,3 +106,19 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_nothing() {
+        let mut decoder = SbpDecoder::new();
+        let data = vec![0u8; 1000];
+        let mut bytes = BytesMut::from(&data[..]);
+
+        assert_eq!(bytes.len(), 1000);
+        assert!(matches!(decoder.decode(&mut bytes), Ok(None)));
+        assert!(bytes.is_empty());
+    }
+}

--- a/rust/sbp/src/parser.rs
+++ b/rust/sbp/src/parser.rs
@@ -134,8 +134,6 @@ pub mod frame {
     pub type Error<'a> = (&'a [u8], ErrorKind);
 
     pub fn parse(i: &[u8]) -> IResult<&[u8], Frame, Error> {
-        let (i, _) = bytes::streaming::take_while(is_not_preamble)(i)?;
-
         tuple((
             parse_preamble,
             parse_msg_type,
@@ -154,10 +152,6 @@ pub mod frame {
         crc.update(payload);
 
         crc.get() == *crc_in
-    }
-
-    fn is_not_preamble(b: u8) -> bool {
-        b != 0x55
     }
 
     fn parse_preamble(i: &[u8]) -> IResult<&[u8], &[u8], Error> {


### PR DESCRIPTION
Issue was the parser would hold onto data while it waited to see the preamble, this just drops that data

```
(base) {18:31}~/projects/libsbp:steve/parser-fix ✗ ➭ time ./target/release/sbp2json <13-175033.sbp
./target/release/sbp2json < 13-175033.sbp  0.19s user 0.03s system 99% cpu 0.221 total
```

