### PR TITLE
additional generated work

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -7,12 +7,6 @@ on:
     tags:
       - "*"
   pull_request:
-    paths:
-      - "generator/**"
-      - "spec/**"
-      - "c/test/**"
-      - "java/test/**"
-      - "rust/sbp/tests/**"
 jobs:
   generation:
     name: Generated artifacts

--- a/c/include/libsbp/new/sbp_msg.h
+++ b/c/include/libsbp/new/sbp_msg.h
@@ -52,42 +52,40 @@ extern "C" {
 struct sbp_state;
 
 typedef union {
-  sbp_msg_tracking_state_detailed_dep_a_t tracking_state_detailed_dep_a;
-  sbp_msg_tracking_state_detailed_dep_t tracking_state_detailed_dep;
-  sbp_msg_tracking_state_t tracking_state;
-  sbp_msg_measurement_state_t measurement_state;
-  sbp_msg_tracking_iq_t tracking_iq;
-  sbp_msg_tracking_iq_dep_b_t tracking_iq_dep_b;
-  sbp_msg_tracking_iq_dep_a_t tracking_iq_dep_a;
-  sbp_msg_tracking_state_dep_a_t tracking_state_dep_a;
-  sbp_msg_tracking_state_dep_b_t tracking_state_dep_b;
-  sbp_msg_settings_save_t settings_save;
-  sbp_msg_settings_write_t settings_write;
-  sbp_msg_settings_write_resp_t settings_write_resp;
-  sbp_msg_settings_read_req_t settings_read_req;
-  sbp_msg_settings_read_resp_t settings_read_resp;
-  sbp_msg_settings_read_by_index_req_t settings_read_by_index_req;
-  sbp_msg_settings_read_by_index_resp_t settings_read_by_index_resp;
-  sbp_msg_settings_read_by_index_done_t settings_read_by_index_done;
-  sbp_msg_settings_register_t settings_register;
-  sbp_msg_settings_register_resp_t settings_register_resp;
-  sbp_msg_ssr_orbit_clock_t ssr_orbit_clock;
-  sbp_msg_ssr_code_biases_t ssr_code_biases;
-  sbp_msg_ssr_phase_biases_t ssr_phase_biases;
-  sbp_msg_ssr_stec_correction_t ssr_stec_correction;
-  sbp_msg_ssr_gridded_correction_t ssr_gridded_correction;
-  sbp_msg_ssr_tile_definition_t ssr_tile_definition;
-  sbp_msg_ssr_satellite_apc_t ssr_satellite_apc;
-  sbp_msg_ssr_orbit_clock_dep_a_t ssr_orbit_clock_dep_a;
-  sbp_msg_ssr_stec_correction_dep_a_t ssr_stec_correction_dep_a;
-  sbp_msg_ssr_gridded_correction_no_std_dep_a_t
-      ssr_gridded_correction_no_std_dep_a;
-  sbp_msg_ssr_gridded_correction_dep_a_t ssr_gridded_correction_dep_a;
-  sbp_msg_ssr_grid_definition_dep_a_t ssr_grid_definition_dep_a;
+  sbp_msg_acq_result_t acq_result;
+  sbp_msg_acq_result_dep_c_t acq_result_dep_c;
+  sbp_msg_acq_result_dep_b_t acq_result_dep_b;
+  sbp_msg_acq_result_dep_a_t acq_result_dep_a;
+  sbp_msg_acq_sv_profile_t acq_sv_profile;
+  sbp_msg_acq_sv_profile_dep_t acq_sv_profile_dep;
+  sbp_msg_bootloader_handshake_req_t bootloader_handshake_req;
+  sbp_msg_bootloader_handshake_resp_t bootloader_handshake_resp;
+  sbp_msg_bootloader_jump_to_app_t bootloader_jump_to_app;
+  sbp_msg_nap_device_dna_req_t nap_device_dna_req;
+  sbp_msg_nap_device_dna_resp_t nap_device_dna_resp;
+  sbp_msg_bootloader_handshake_dep_a_t bootloader_handshake_dep_a;
   sbp_msg_ext_event_t ext_event;
-  sbp_msg_odometry_t odometry;
-  sbp_msg_wheeltick_t wheeltick;
-  sbp_msg_user_data_t user_data;
+  sbp_msg_fileio_read_req_t fileio_read_req;
+  sbp_msg_fileio_read_resp_t fileio_read_resp;
+  sbp_msg_fileio_read_dir_req_t fileio_read_dir_req;
+  sbp_msg_fileio_read_dir_resp_t fileio_read_dir_resp;
+  sbp_msg_fileio_remove_t fileio_remove;
+  sbp_msg_fileio_write_req_t fileio_write_req;
+  sbp_msg_fileio_write_resp_t fileio_write_resp;
+  sbp_msg_fileio_config_req_t fileio_config_req;
+  sbp_msg_fileio_config_resp_t fileio_config_resp;
+  sbp_msg_flash_program_t flash_program;
+  sbp_msg_flash_done_t flash_done;
+  sbp_msg_flash_read_req_t flash_read_req;
+  sbp_msg_flash_read_resp_t flash_read_resp;
+  sbp_msg_flash_erase_t flash_erase;
+  sbp_msg_stm_flash_lock_sector_t stm_flash_lock_sector;
+  sbp_msg_stm_flash_unlock_sector_t stm_flash_unlock_sector;
+  sbp_msg_stm_unique_id_req_t stm_unique_id_req;
+  sbp_msg_stm_unique_id_resp_t stm_unique_id_resp;
+  sbp_msg_m25_flash_write_status_t m25_flash_write_status;
+  sbp_msg_imu_raw_t imu_raw;
+  sbp_msg_imu_aux_t imu_aux;
   sbp_msg_linux_cpu_state_dep_a_t linux_cpu_state_dep_a;
   sbp_msg_linux_mem_state_dep_a_t linux_mem_state_dep_a;
   sbp_msg_linux_sys_state_dep_a_t linux_sys_state_dep_a;
@@ -99,6 +97,10 @@ typedef union {
   sbp_msg_linux_cpu_state_t linux_cpu_state;
   sbp_msg_linux_mem_state_t linux_mem_state;
   sbp_msg_linux_sys_state_t linux_sys_state;
+  sbp_msg_log_t log;
+  sbp_msg_fwd_t fwd;
+  sbp_msg_print_dep_t print_dep;
+  sbp_msg_mag_raw_t mag_raw;
   sbp_msg_gps_time_t gps_time;
   sbp_msg_gps_time_gnss_t gps_time_gnss;
   sbp_msg_utc_time_t utc_time;
@@ -135,35 +137,7 @@ typedef union {
   sbp_msg_baseline_heading_dep_a_t baseline_heading_dep_a;
   sbp_msg_protection_level_dep_a_t protection_level_dep_a;
   sbp_msg_protection_level_t protection_level;
-  sbp_msg_fileio_read_req_t fileio_read_req;
-  sbp_msg_fileio_read_resp_t fileio_read_resp;
-  sbp_msg_fileio_read_dir_req_t fileio_read_dir_req;
-  sbp_msg_fileio_read_dir_resp_t fileio_read_dir_resp;
-  sbp_msg_fileio_remove_t fileio_remove;
-  sbp_msg_fileio_write_req_t fileio_write_req;
-  sbp_msg_fileio_write_resp_t fileio_write_resp;
-  sbp_msg_fileio_config_req_t fileio_config_req;
-  sbp_msg_fileio_config_resp_t fileio_config_resp;
-  sbp_msg_log_t log;
-  sbp_msg_fwd_t fwd;
-  sbp_msg_print_dep_t print_dep;
-  sbp_msg_bootloader_handshake_req_t bootloader_handshake_req;
-  sbp_msg_bootloader_handshake_resp_t bootloader_handshake_resp;
-  sbp_msg_bootloader_jump_to_app_t bootloader_jump_to_app;
-  sbp_msg_nap_device_dna_req_t nap_device_dna_req;
-  sbp_msg_nap_device_dna_resp_t nap_device_dna_resp;
-  sbp_msg_bootloader_handshake_dep_a_t bootloader_handshake_dep_a;
-  sbp_msg_startup_t startup;
-  sbp_msg_dgnss_status_t dgnss_status;
-  sbp_msg_heartbeat_t heartbeat;
-  sbp_msg_status_report_t status_report;
-  sbp_msg_ins_status_t ins_status;
-  sbp_msg_csac_telemetry_t csac_telemetry;
-  sbp_msg_csac_telemetry_labels_t csac_telemetry_labels;
-  sbp_msg_ins_updates_t ins_updates;
-  sbp_msg_gnss_time_offset_t gnss_time_offset;
-  sbp_msg_pps_time_t pps_time;
-  sbp_msg_group_meta_t group_meta;
+  sbp_msg_ndb_event_t ndb_event;
   sbp_msg_obs_t obs;
   sbp_msg_base_pos_llh_t base_pos_llh;
   sbp_msg_base_pos_ecef_t base_pos_ecef;
@@ -202,7 +176,10 @@ typedef union {
   sbp_msg_glo_biases_t glo_biases;
   sbp_msg_sv_az_el_t sv_az_el;
   sbp_msg_osr_t osr;
-  sbp_msg_sbas_raw_t sbas_raw;
+  sbp_msg_baseline_heading_t baseline_heading;
+  sbp_msg_orient_quat_t orient_quat;
+  sbp_msg_orient_euler_t orient_euler;
+  sbp_msg_angular_rate_t angular_rate;
   sbp_msg_almanac_t almanac;
   sbp_msg_set_time_t set_time;
   sbp_msg_reset_t reset;
@@ -228,141 +205,160 @@ typedef union {
   sbp_msg_specan_dep_t specan_dep;
   sbp_msg_specan_t specan;
   sbp_msg_front_end_gain_t front_end_gain;
-  sbp_msg_flash_program_t flash_program;
-  sbp_msg_flash_done_t flash_done;
-  sbp_msg_flash_read_req_t flash_read_req;
-  sbp_msg_flash_read_resp_t flash_read_resp;
-  sbp_msg_flash_erase_t flash_erase;
-  sbp_msg_stm_flash_lock_sector_t stm_flash_lock_sector;
-  sbp_msg_stm_flash_unlock_sector_t stm_flash_unlock_sector;
-  sbp_msg_stm_unique_id_req_t stm_unique_id_req;
-  sbp_msg_stm_unique_id_resp_t stm_unique_id_resp;
-  sbp_msg_m25_flash_write_status_t m25_flash_write_status;
-  sbp_msg_imu_raw_t imu_raw;
-  sbp_msg_imu_aux_t imu_aux;
-  sbp_msg_ndb_event_t ndb_event;
-  sbp_msg_acq_result_t acq_result;
-  sbp_msg_acq_result_dep_c_t acq_result_dep_c;
-  sbp_msg_acq_result_dep_b_t acq_result_dep_b;
-  sbp_msg_acq_result_dep_a_t acq_result_dep_a;
-  sbp_msg_acq_sv_profile_t acq_sv_profile;
-  sbp_msg_acq_sv_profile_dep_t acq_sv_profile_dep;
+  sbp_msg_sbas_raw_t sbas_raw;
+  sbp_msg_settings_save_t settings_save;
+  sbp_msg_settings_write_t settings_write;
+  sbp_msg_settings_write_resp_t settings_write_resp;
+  sbp_msg_settings_read_req_t settings_read_req;
+  sbp_msg_settings_read_resp_t settings_read_resp;
+  sbp_msg_settings_read_by_index_req_t settings_read_by_index_req;
+  sbp_msg_settings_read_by_index_resp_t settings_read_by_index_resp;
+  sbp_msg_settings_read_by_index_done_t settings_read_by_index_done;
+  sbp_msg_settings_register_t settings_register;
+  sbp_msg_settings_register_resp_t settings_register_resp;
   sbp_msg_soln_meta_dep_a_t soln_meta_dep_a;
   sbp_msg_soln_meta_t soln_meta;
-  sbp_msg_baseline_heading_t baseline_heading;
-  sbp_msg_orient_quat_t orient_quat;
-  sbp_msg_orient_euler_t orient_euler;
-  sbp_msg_angular_rate_t angular_rate;
-  sbp_msg_mag_raw_t mag_raw;
+  sbp_msg_ssr_orbit_clock_t ssr_orbit_clock;
+  sbp_msg_ssr_code_biases_t ssr_code_biases;
+  sbp_msg_ssr_phase_biases_t ssr_phase_biases;
+  sbp_msg_ssr_stec_correction_t ssr_stec_correction;
+  sbp_msg_ssr_gridded_correction_t ssr_gridded_correction;
+  sbp_msg_ssr_tile_definition_t ssr_tile_definition;
+  sbp_msg_ssr_satellite_apc_t ssr_satellite_apc;
+  sbp_msg_ssr_orbit_clock_dep_a_t ssr_orbit_clock_dep_a;
+  sbp_msg_ssr_stec_correction_dep_a_t ssr_stec_correction_dep_a;
+  sbp_msg_ssr_gridded_correction_no_std_dep_a_t
+      ssr_gridded_correction_no_std_dep_a;
+  sbp_msg_ssr_gridded_correction_dep_a_t ssr_gridded_correction_dep_a;
+  sbp_msg_ssr_grid_definition_dep_a_t ssr_grid_definition_dep_a;
+  sbp_msg_startup_t startup;
+  sbp_msg_dgnss_status_t dgnss_status;
+  sbp_msg_heartbeat_t heartbeat;
+  sbp_msg_status_report_t status_report;
+  sbp_msg_ins_status_t ins_status;
+  sbp_msg_csac_telemetry_t csac_telemetry;
+  sbp_msg_csac_telemetry_labels_t csac_telemetry_labels;
+  sbp_msg_ins_updates_t ins_updates;
+  sbp_msg_gnss_time_offset_t gnss_time_offset;
+  sbp_msg_pps_time_t pps_time;
+  sbp_msg_group_meta_t group_meta;
+  sbp_msg_tracking_state_detailed_dep_a_t tracking_state_detailed_dep_a;
+  sbp_msg_tracking_state_detailed_dep_t tracking_state_detailed_dep;
+  sbp_msg_tracking_state_t tracking_state;
+  sbp_msg_measurement_state_t measurement_state;
+  sbp_msg_tracking_iq_t tracking_iq;
+  sbp_msg_tracking_iq_dep_b_t tracking_iq_dep_b;
+  sbp_msg_tracking_iq_dep_a_t tracking_iq_dep_a;
+  sbp_msg_tracking_state_dep_a_t tracking_state_dep_a;
+  sbp_msg_tracking_state_dep_b_t tracking_state_dep_b;
+  sbp_msg_user_data_t user_data;
+  sbp_msg_odometry_t odometry;
+  sbp_msg_wheeltick_t wheeltick;
 } sbp_msg_t;
 
 static inline s8 sbp_encode_msg(uint8_t *buf, uint8_t len, uint8_t *n_written,
                                 uint16_t msg_type, const sbp_msg_t *msg) {
   switch (msg_type) {
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
-      return sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(
-          buf, len, n_written, &msg->tracking_state_detailed_dep_a);
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
-      return sbp_encode_sbp_msg_tracking_state_detailed_dep_t(
-          buf, len, n_written, &msg->tracking_state_detailed_dep);
-    case SBP_MSG_TRACKING_STATE:
-      return sbp_encode_sbp_msg_tracking_state_t(buf, len, n_written,
-                                                 &msg->tracking_state);
-    case SBP_MSG_MEASUREMENT_STATE:
-      return sbp_encode_sbp_msg_measurement_state_t(buf, len, n_written,
-                                                    &msg->measurement_state);
-    case SBP_MSG_TRACKING_IQ:
-      return sbp_encode_sbp_msg_tracking_iq_t(buf, len, n_written,
-                                              &msg->tracking_iq);
-    case SBP_MSG_TRACKING_IQ_DEP_B:
-      return sbp_encode_sbp_msg_tracking_iq_dep_b_t(buf, len, n_written,
-                                                    &msg->tracking_iq_dep_b);
-    case SBP_MSG_TRACKING_IQ_DEP_A:
-      return sbp_encode_sbp_msg_tracking_iq_dep_a_t(buf, len, n_written,
-                                                    &msg->tracking_iq_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_A:
-      return sbp_encode_sbp_msg_tracking_state_dep_a_t(
-          buf, len, n_written, &msg->tracking_state_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_B:
-      return sbp_encode_sbp_msg_tracking_state_dep_b_t(
-          buf, len, n_written, &msg->tracking_state_dep_b);
-    case SBP_MSG_SETTINGS_SAVE:
-      return sbp_encode_sbp_msg_settings_save_t(buf, len, n_written,
-                                                &msg->settings_save);
-    case SBP_MSG_SETTINGS_WRITE:
-      return sbp_encode_sbp_msg_settings_write_t(buf, len, n_written,
-                                                 &msg->settings_write);
-    case SBP_MSG_SETTINGS_WRITE_RESP:
-      return sbp_encode_sbp_msg_settings_write_resp_t(
-          buf, len, n_written, &msg->settings_write_resp);
-    case SBP_MSG_SETTINGS_READ_REQ:
-      return sbp_encode_sbp_msg_settings_read_req_t(buf, len, n_written,
-                                                    &msg->settings_read_req);
-    case SBP_MSG_SETTINGS_READ_RESP:
-      return sbp_encode_sbp_msg_settings_read_resp_t(buf, len, n_written,
-                                                     &msg->settings_read_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
-      return sbp_encode_sbp_msg_settings_read_by_index_req_t(
-          buf, len, n_written, &msg->settings_read_by_index_req);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
-      return sbp_encode_sbp_msg_settings_read_by_index_resp_t(
-          buf, len, n_written, &msg->settings_read_by_index_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
-      return sbp_encode_sbp_msg_settings_read_by_index_done_t(
-          buf, len, n_written, &msg->settings_read_by_index_done);
-    case SBP_MSG_SETTINGS_REGISTER:
-      return sbp_encode_sbp_msg_settings_register_t(buf, len, n_written,
-                                                    &msg->settings_register);
-    case SBP_MSG_SETTINGS_REGISTER_RESP:
-      return sbp_encode_sbp_msg_settings_register_resp_t(
-          buf, len, n_written, &msg->settings_register_resp);
-    case SBP_MSG_SSR_ORBIT_CLOCK:
-      return sbp_encode_sbp_msg_ssr_orbit_clock_t(buf, len, n_written,
-                                                  &msg->ssr_orbit_clock);
-    case SBP_MSG_SSR_CODE_BIASES:
-      return sbp_encode_sbp_msg_ssr_code_biases_t(buf, len, n_written,
-                                                  &msg->ssr_code_biases);
-    case SBP_MSG_SSR_PHASE_BIASES:
-      return sbp_encode_sbp_msg_ssr_phase_biases_t(buf, len, n_written,
-                                                   &msg->ssr_phase_biases);
-    case SBP_MSG_SSR_STEC_CORRECTION:
-      return sbp_encode_sbp_msg_ssr_stec_correction_t(
-          buf, len, n_written, &msg->ssr_stec_correction);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION:
-      return sbp_encode_sbp_msg_ssr_gridded_correction_t(
-          buf, len, n_written, &msg->ssr_gridded_correction);
-    case SBP_MSG_SSR_TILE_DEFINITION:
-      return sbp_encode_sbp_msg_ssr_tile_definition_t(
-          buf, len, n_written, &msg->ssr_tile_definition);
-    case SBP_MSG_SSR_SATELLITE_APC:
-      return sbp_encode_sbp_msg_ssr_satellite_apc_t(buf, len, n_written,
-                                                    &msg->ssr_satellite_apc);
-    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
-      return sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(
-          buf, len, n_written, &msg->ssr_orbit_clock_dep_a);
-    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
-      return sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(
-          buf, len, n_written, &msg->ssr_stec_correction_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
-      return sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
-          buf, len, n_written, &msg->ssr_gridded_correction_no_std_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
-      return sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(
-          buf, len, n_written, &msg->ssr_gridded_correction_dep_a);
-    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
-      return sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(
-          buf, len, n_written, &msg->ssr_grid_definition_dep_a);
+    case SBP_MSG_ACQ_RESULT:
+      return sbp_encode_sbp_msg_acq_result_t(buf, len, n_written,
+                                             &msg->acq_result);
+    case SBP_MSG_ACQ_RESULT_DEP_C:
+      return sbp_encode_sbp_msg_acq_result_dep_c_t(buf, len, n_written,
+                                                   &msg->acq_result_dep_c);
+    case SBP_MSG_ACQ_RESULT_DEP_B:
+      return sbp_encode_sbp_msg_acq_result_dep_b_t(buf, len, n_written,
+                                                   &msg->acq_result_dep_b);
+    case SBP_MSG_ACQ_RESULT_DEP_A:
+      return sbp_encode_sbp_msg_acq_result_dep_a_t(buf, len, n_written,
+                                                   &msg->acq_result_dep_a);
+    case SBP_MSG_ACQ_SV_PROFILE:
+      return sbp_encode_sbp_msg_acq_sv_profile_t(buf, len, n_written,
+                                                 &msg->acq_sv_profile);
+    case SBP_MSG_ACQ_SV_PROFILE_DEP:
+      return sbp_encode_sbp_msg_acq_sv_profile_dep_t(buf, len, n_written,
+                                                     &msg->acq_sv_profile_dep);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
+      return sbp_encode_sbp_msg_bootloader_handshake_req_t(
+          buf, len, n_written, &msg->bootloader_handshake_req);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
+      return sbp_encode_sbp_msg_bootloader_handshake_resp_t(
+          buf, len, n_written, &msg->bootloader_handshake_resp);
+    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
+      return sbp_encode_sbp_msg_bootloader_jump_to_app_t(
+          buf, len, n_written, &msg->bootloader_jump_to_app);
+    case SBP_MSG_NAP_DEVICE_DNA_REQ:
+      return sbp_encode_sbp_msg_nap_device_dna_req_t(buf, len, n_written,
+                                                     &msg->nap_device_dna_req);
+    case SBP_MSG_NAP_DEVICE_DNA_RESP:
+      return sbp_encode_sbp_msg_nap_device_dna_resp_t(
+          buf, len, n_written, &msg->nap_device_dna_resp);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
+      return sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(
+          buf, len, n_written, &msg->bootloader_handshake_dep_a);
     case SBP_MSG_EXT_EVENT:
       return sbp_encode_sbp_msg_ext_event_t(buf, len, n_written,
                                             &msg->ext_event);
-    case SBP_MSG_ODOMETRY:
-      return sbp_encode_sbp_msg_odometry_t(buf, len, n_written, &msg->odometry);
-    case SBP_MSG_WHEELTICK:
-      return sbp_encode_sbp_msg_wheeltick_t(buf, len, n_written,
-                                            &msg->wheeltick);
-    case SBP_MSG_USER_DATA:
-      return sbp_encode_sbp_msg_user_data_t(buf, len, n_written,
-                                            &msg->user_data);
+    case SBP_MSG_FILEIO_READ_REQ:
+      return sbp_encode_sbp_msg_fileio_read_req_t(buf, len, n_written,
+                                                  &msg->fileio_read_req);
+    case SBP_MSG_FILEIO_READ_RESP:
+      return sbp_encode_sbp_msg_fileio_read_resp_t(buf, len, n_written,
+                                                   &msg->fileio_read_resp);
+    case SBP_MSG_FILEIO_READ_DIR_REQ:
+      return sbp_encode_sbp_msg_fileio_read_dir_req_t(
+          buf, len, n_written, &msg->fileio_read_dir_req);
+    case SBP_MSG_FILEIO_READ_DIR_RESP:
+      return sbp_encode_sbp_msg_fileio_read_dir_resp_t(
+          buf, len, n_written, &msg->fileio_read_dir_resp);
+    case SBP_MSG_FILEIO_REMOVE:
+      return sbp_encode_sbp_msg_fileio_remove_t(buf, len, n_written,
+                                                &msg->fileio_remove);
+    case SBP_MSG_FILEIO_WRITE_REQ:
+      return sbp_encode_sbp_msg_fileio_write_req_t(buf, len, n_written,
+                                                   &msg->fileio_write_req);
+    case SBP_MSG_FILEIO_WRITE_RESP:
+      return sbp_encode_sbp_msg_fileio_write_resp_t(buf, len, n_written,
+                                                    &msg->fileio_write_resp);
+    case SBP_MSG_FILEIO_CONFIG_REQ:
+      return sbp_encode_sbp_msg_fileio_config_req_t(buf, len, n_written,
+                                                    &msg->fileio_config_req);
+    case SBP_MSG_FILEIO_CONFIG_RESP:
+      return sbp_encode_sbp_msg_fileio_config_resp_t(buf, len, n_written,
+                                                     &msg->fileio_config_resp);
+    case SBP_MSG_FLASH_PROGRAM:
+      return sbp_encode_sbp_msg_flash_program_t(buf, len, n_written,
+                                                &msg->flash_program);
+    case SBP_MSG_FLASH_DONE:
+      return sbp_encode_sbp_msg_flash_done_t(buf, len, n_written,
+                                             &msg->flash_done);
+    case SBP_MSG_FLASH_READ_REQ:
+      return sbp_encode_sbp_msg_flash_read_req_t(buf, len, n_written,
+                                                 &msg->flash_read_req);
+    case SBP_MSG_FLASH_READ_RESP:
+      return sbp_encode_sbp_msg_flash_read_resp_t(buf, len, n_written,
+                                                  &msg->flash_read_resp);
+    case SBP_MSG_FLASH_ERASE:
+      return sbp_encode_sbp_msg_flash_erase_t(buf, len, n_written,
+                                              &msg->flash_erase);
+    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
+      return sbp_encode_sbp_msg_stm_flash_lock_sector_t(
+          buf, len, n_written, &msg->stm_flash_lock_sector);
+    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
+      return sbp_encode_sbp_msg_stm_flash_unlock_sector_t(
+          buf, len, n_written, &msg->stm_flash_unlock_sector);
+    case SBP_MSG_STM_UNIQUE_ID_REQ:
+      return sbp_encode_sbp_msg_stm_unique_id_req_t(buf, len, n_written,
+                                                    &msg->stm_unique_id_req);
+    case SBP_MSG_STM_UNIQUE_ID_RESP:
+      return sbp_encode_sbp_msg_stm_unique_id_resp_t(buf, len, n_written,
+                                                     &msg->stm_unique_id_resp);
+    case SBP_MSG_M25_FLASH_WRITE_STATUS:
+      return sbp_encode_sbp_msg_m25_flash_write_status_t(
+          buf, len, n_written, &msg->m25_flash_write_status);
+    case SBP_MSG_IMU_RAW:
+      return sbp_encode_sbp_msg_imu_raw_t(buf, len, n_written, &msg->imu_raw);
+    case SBP_MSG_IMU_AUX:
+      return sbp_encode_sbp_msg_imu_aux_t(buf, len, n_written, &msg->imu_aux);
     case SBP_MSG_LINUX_CPU_STATE_DEP_A:
       return sbp_encode_sbp_msg_linux_cpu_state_dep_a_t(
           buf, len, n_written, &msg->linux_cpu_state_dep_a);
@@ -396,6 +392,15 @@ static inline s8 sbp_encode_msg(uint8_t *buf, uint8_t len, uint8_t *n_written,
     case SBP_MSG_LINUX_SYS_STATE:
       return sbp_encode_sbp_msg_linux_sys_state_t(buf, len, n_written,
                                                   &msg->linux_sys_state);
+    case SBP_MSG_LOG:
+      return sbp_encode_sbp_msg_log_t(buf, len, n_written, &msg->log);
+    case SBP_MSG_FWD:
+      return sbp_encode_sbp_msg_fwd_t(buf, len, n_written, &msg->fwd);
+    case SBP_MSG_PRINT_DEP:
+      return sbp_encode_sbp_msg_print_dep_t(buf, len, n_written,
+                                            &msg->print_dep);
+    case SBP_MSG_MAG_RAW:
+      return sbp_encode_sbp_msg_mag_raw_t(buf, len, n_written, &msg->mag_raw);
     case SBP_MSG_GPS_TIME:
       return sbp_encode_sbp_msg_gps_time_t(buf, len, n_written, &msg->gps_time);
     case SBP_MSG_GPS_TIME_GNSS:
@@ -496,89 +501,9 @@ static inline s8 sbp_encode_msg(uint8_t *buf, uint8_t len, uint8_t *n_written,
     case SBP_MSG_PROTECTION_LEVEL:
       return sbp_encode_sbp_msg_protection_level_t(buf, len, n_written,
                                                    &msg->protection_level);
-    case SBP_MSG_FILEIO_READ_REQ:
-      return sbp_encode_sbp_msg_fileio_read_req_t(buf, len, n_written,
-                                                  &msg->fileio_read_req);
-    case SBP_MSG_FILEIO_READ_RESP:
-      return sbp_encode_sbp_msg_fileio_read_resp_t(buf, len, n_written,
-                                                   &msg->fileio_read_resp);
-    case SBP_MSG_FILEIO_READ_DIR_REQ:
-      return sbp_encode_sbp_msg_fileio_read_dir_req_t(
-          buf, len, n_written, &msg->fileio_read_dir_req);
-    case SBP_MSG_FILEIO_READ_DIR_RESP:
-      return sbp_encode_sbp_msg_fileio_read_dir_resp_t(
-          buf, len, n_written, &msg->fileio_read_dir_resp);
-    case SBP_MSG_FILEIO_REMOVE:
-      return sbp_encode_sbp_msg_fileio_remove_t(buf, len, n_written,
-                                                &msg->fileio_remove);
-    case SBP_MSG_FILEIO_WRITE_REQ:
-      return sbp_encode_sbp_msg_fileio_write_req_t(buf, len, n_written,
-                                                   &msg->fileio_write_req);
-    case SBP_MSG_FILEIO_WRITE_RESP:
-      return sbp_encode_sbp_msg_fileio_write_resp_t(buf, len, n_written,
-                                                    &msg->fileio_write_resp);
-    case SBP_MSG_FILEIO_CONFIG_REQ:
-      return sbp_encode_sbp_msg_fileio_config_req_t(buf, len, n_written,
-                                                    &msg->fileio_config_req);
-    case SBP_MSG_FILEIO_CONFIG_RESP:
-      return sbp_encode_sbp_msg_fileio_config_resp_t(buf, len, n_written,
-                                                     &msg->fileio_config_resp);
-    case SBP_MSG_LOG:
-      return sbp_encode_sbp_msg_log_t(buf, len, n_written, &msg->log);
-    case SBP_MSG_FWD:
-      return sbp_encode_sbp_msg_fwd_t(buf, len, n_written, &msg->fwd);
-    case SBP_MSG_PRINT_DEP:
-      return sbp_encode_sbp_msg_print_dep_t(buf, len, n_written,
-                                            &msg->print_dep);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
-      return sbp_encode_sbp_msg_bootloader_handshake_req_t(
-          buf, len, n_written, &msg->bootloader_handshake_req);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
-      return sbp_encode_sbp_msg_bootloader_handshake_resp_t(
-          buf, len, n_written, &msg->bootloader_handshake_resp);
-    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
-      return sbp_encode_sbp_msg_bootloader_jump_to_app_t(
-          buf, len, n_written, &msg->bootloader_jump_to_app);
-    case SBP_MSG_NAP_DEVICE_DNA_REQ:
-      return sbp_encode_sbp_msg_nap_device_dna_req_t(buf, len, n_written,
-                                                     &msg->nap_device_dna_req);
-    case SBP_MSG_NAP_DEVICE_DNA_RESP:
-      return sbp_encode_sbp_msg_nap_device_dna_resp_t(
-          buf, len, n_written, &msg->nap_device_dna_resp);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
-      return sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(
-          buf, len, n_written, &msg->bootloader_handshake_dep_a);
-    case SBP_MSG_STARTUP:
-      return sbp_encode_sbp_msg_startup_t(buf, len, n_written, &msg->startup);
-    case SBP_MSG_DGNSS_STATUS:
-      return sbp_encode_sbp_msg_dgnss_status_t(buf, len, n_written,
-                                               &msg->dgnss_status);
-    case SBP_MSG_HEARTBEAT:
-      return sbp_encode_sbp_msg_heartbeat_t(buf, len, n_written,
-                                            &msg->heartbeat);
-    case SBP_MSG_STATUS_REPORT:
-      return sbp_encode_sbp_msg_status_report_t(buf, len, n_written,
-                                                &msg->status_report);
-    case SBP_MSG_INS_STATUS:
-      return sbp_encode_sbp_msg_ins_status_t(buf, len, n_written,
-                                             &msg->ins_status);
-    case SBP_MSG_CSAC_TELEMETRY:
-      return sbp_encode_sbp_msg_csac_telemetry_t(buf, len, n_written,
-                                                 &msg->csac_telemetry);
-    case SBP_MSG_CSAC_TELEMETRY_LABELS:
-      return sbp_encode_sbp_msg_csac_telemetry_labels_t(
-          buf, len, n_written, &msg->csac_telemetry_labels);
-    case SBP_MSG_INS_UPDATES:
-      return sbp_encode_sbp_msg_ins_updates_t(buf, len, n_written,
-                                              &msg->ins_updates);
-    case SBP_MSG_GNSS_TIME_OFFSET:
-      return sbp_encode_sbp_msg_gnss_time_offset_t(buf, len, n_written,
-                                                   &msg->gnss_time_offset);
-    case SBP_MSG_PPS_TIME:
-      return sbp_encode_sbp_msg_pps_time_t(buf, len, n_written, &msg->pps_time);
-    case SBP_MSG_GROUP_META:
-      return sbp_encode_sbp_msg_group_meta_t(buf, len, n_written,
-                                             &msg->group_meta);
+    case SBP_MSG_NDB_EVENT:
+      return sbp_encode_sbp_msg_ndb_event_t(buf, len, n_written,
+                                            &msg->ndb_event);
     case SBP_MSG_OBS:
       return sbp_encode_sbp_msg_obs_t(buf, len, n_written, &msg->obs);
     case SBP_MSG_BASE_POS_LLH:
@@ -689,8 +614,18 @@ static inline s8 sbp_encode_msg(uint8_t *buf, uint8_t len, uint8_t *n_written,
       return sbp_encode_sbp_msg_sv_az_el_t(buf, len, n_written, &msg->sv_az_el);
     case SBP_MSG_OSR:
       return sbp_encode_sbp_msg_osr_t(buf, len, n_written, &msg->osr);
-    case SBP_MSG_SBAS_RAW:
-      return sbp_encode_sbp_msg_sbas_raw_t(buf, len, n_written, &msg->sbas_raw);
+    case SBP_MSG_BASELINE_HEADING:
+      return sbp_encode_sbp_msg_baseline_heading_t(buf, len, n_written,
+                                                   &msg->baseline_heading);
+    case SBP_MSG_ORIENT_QUAT:
+      return sbp_encode_sbp_msg_orient_quat_t(buf, len, n_written,
+                                              &msg->orient_quat);
+    case SBP_MSG_ORIENT_EULER:
+      return sbp_encode_sbp_msg_orient_euler_t(buf, len, n_written,
+                                               &msg->orient_euler);
+    case SBP_MSG_ANGULAR_RATE:
+      return sbp_encode_sbp_msg_angular_rate_t(buf, len, n_written,
+                                               &msg->angular_rate);
     case SBP_MSG_ALMANAC:
       return sbp_encode_sbp_msg_almanac_t(buf, len, n_written, &msg->almanac);
     case SBP_MSG_SET_TIME:
@@ -761,81 +696,146 @@ static inline s8 sbp_encode_msg(uint8_t *buf, uint8_t len, uint8_t *n_written,
     case SBP_MSG_FRONT_END_GAIN:
       return sbp_encode_sbp_msg_front_end_gain_t(buf, len, n_written,
                                                  &msg->front_end_gain);
-    case SBP_MSG_FLASH_PROGRAM:
-      return sbp_encode_sbp_msg_flash_program_t(buf, len, n_written,
-                                                &msg->flash_program);
-    case SBP_MSG_FLASH_DONE:
-      return sbp_encode_sbp_msg_flash_done_t(buf, len, n_written,
-                                             &msg->flash_done);
-    case SBP_MSG_FLASH_READ_REQ:
-      return sbp_encode_sbp_msg_flash_read_req_t(buf, len, n_written,
-                                                 &msg->flash_read_req);
-    case SBP_MSG_FLASH_READ_RESP:
-      return sbp_encode_sbp_msg_flash_read_resp_t(buf, len, n_written,
-                                                  &msg->flash_read_resp);
-    case SBP_MSG_FLASH_ERASE:
-      return sbp_encode_sbp_msg_flash_erase_t(buf, len, n_written,
-                                              &msg->flash_erase);
-    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
-      return sbp_encode_sbp_msg_stm_flash_lock_sector_t(
-          buf, len, n_written, &msg->stm_flash_lock_sector);
-    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
-      return sbp_encode_sbp_msg_stm_flash_unlock_sector_t(
-          buf, len, n_written, &msg->stm_flash_unlock_sector);
-    case SBP_MSG_STM_UNIQUE_ID_REQ:
-      return sbp_encode_sbp_msg_stm_unique_id_req_t(buf, len, n_written,
-                                                    &msg->stm_unique_id_req);
-    case SBP_MSG_STM_UNIQUE_ID_RESP:
-      return sbp_encode_sbp_msg_stm_unique_id_resp_t(buf, len, n_written,
-                                                     &msg->stm_unique_id_resp);
-    case SBP_MSG_M25_FLASH_WRITE_STATUS:
-      return sbp_encode_sbp_msg_m25_flash_write_status_t(
-          buf, len, n_written, &msg->m25_flash_write_status);
-    case SBP_MSG_IMU_RAW:
-      return sbp_encode_sbp_msg_imu_raw_t(buf, len, n_written, &msg->imu_raw);
-    case SBP_MSG_IMU_AUX:
-      return sbp_encode_sbp_msg_imu_aux_t(buf, len, n_written, &msg->imu_aux);
-    case SBP_MSG_NDB_EVENT:
-      return sbp_encode_sbp_msg_ndb_event_t(buf, len, n_written,
-                                            &msg->ndb_event);
-    case SBP_MSG_ACQ_RESULT:
-      return sbp_encode_sbp_msg_acq_result_t(buf, len, n_written,
-                                             &msg->acq_result);
-    case SBP_MSG_ACQ_RESULT_DEP_C:
-      return sbp_encode_sbp_msg_acq_result_dep_c_t(buf, len, n_written,
-                                                   &msg->acq_result_dep_c);
-    case SBP_MSG_ACQ_RESULT_DEP_B:
-      return sbp_encode_sbp_msg_acq_result_dep_b_t(buf, len, n_written,
-                                                   &msg->acq_result_dep_b);
-    case SBP_MSG_ACQ_RESULT_DEP_A:
-      return sbp_encode_sbp_msg_acq_result_dep_a_t(buf, len, n_written,
-                                                   &msg->acq_result_dep_a);
-    case SBP_MSG_ACQ_SV_PROFILE:
-      return sbp_encode_sbp_msg_acq_sv_profile_t(buf, len, n_written,
-                                                 &msg->acq_sv_profile);
-    case SBP_MSG_ACQ_SV_PROFILE_DEP:
-      return sbp_encode_sbp_msg_acq_sv_profile_dep_t(buf, len, n_written,
-                                                     &msg->acq_sv_profile_dep);
+    case SBP_MSG_SBAS_RAW:
+      return sbp_encode_sbp_msg_sbas_raw_t(buf, len, n_written, &msg->sbas_raw);
+    case SBP_MSG_SETTINGS_SAVE:
+      return sbp_encode_sbp_msg_settings_save_t(buf, len, n_written,
+                                                &msg->settings_save);
+    case SBP_MSG_SETTINGS_WRITE:
+      return sbp_encode_sbp_msg_settings_write_t(buf, len, n_written,
+                                                 &msg->settings_write);
+    case SBP_MSG_SETTINGS_WRITE_RESP:
+      return sbp_encode_sbp_msg_settings_write_resp_t(
+          buf, len, n_written, &msg->settings_write_resp);
+    case SBP_MSG_SETTINGS_READ_REQ:
+      return sbp_encode_sbp_msg_settings_read_req_t(buf, len, n_written,
+                                                    &msg->settings_read_req);
+    case SBP_MSG_SETTINGS_READ_RESP:
+      return sbp_encode_sbp_msg_settings_read_resp_t(buf, len, n_written,
+                                                     &msg->settings_read_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
+      return sbp_encode_sbp_msg_settings_read_by_index_req_t(
+          buf, len, n_written, &msg->settings_read_by_index_req);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
+      return sbp_encode_sbp_msg_settings_read_by_index_resp_t(
+          buf, len, n_written, &msg->settings_read_by_index_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
+      return sbp_encode_sbp_msg_settings_read_by_index_done_t(
+          buf, len, n_written, &msg->settings_read_by_index_done);
+    case SBP_MSG_SETTINGS_REGISTER:
+      return sbp_encode_sbp_msg_settings_register_t(buf, len, n_written,
+                                                    &msg->settings_register);
+    case SBP_MSG_SETTINGS_REGISTER_RESP:
+      return sbp_encode_sbp_msg_settings_register_resp_t(
+          buf, len, n_written, &msg->settings_register_resp);
     case SBP_MSG_SOLN_META_DEP_A:
       return sbp_encode_sbp_msg_soln_meta_dep_a_t(buf, len, n_written,
                                                   &msg->soln_meta_dep_a);
     case SBP_MSG_SOLN_META:
       return sbp_encode_sbp_msg_soln_meta_t(buf, len, n_written,
                                             &msg->soln_meta);
-    case SBP_MSG_BASELINE_HEADING:
-      return sbp_encode_sbp_msg_baseline_heading_t(buf, len, n_written,
-                                                   &msg->baseline_heading);
-    case SBP_MSG_ORIENT_QUAT:
-      return sbp_encode_sbp_msg_orient_quat_t(buf, len, n_written,
-                                              &msg->orient_quat);
-    case SBP_MSG_ORIENT_EULER:
-      return sbp_encode_sbp_msg_orient_euler_t(buf, len, n_written,
-                                               &msg->orient_euler);
-    case SBP_MSG_ANGULAR_RATE:
-      return sbp_encode_sbp_msg_angular_rate_t(buf, len, n_written,
-                                               &msg->angular_rate);
-    case SBP_MSG_MAG_RAW:
-      return sbp_encode_sbp_msg_mag_raw_t(buf, len, n_written, &msg->mag_raw);
+    case SBP_MSG_SSR_ORBIT_CLOCK:
+      return sbp_encode_sbp_msg_ssr_orbit_clock_t(buf, len, n_written,
+                                                  &msg->ssr_orbit_clock);
+    case SBP_MSG_SSR_CODE_BIASES:
+      return sbp_encode_sbp_msg_ssr_code_biases_t(buf, len, n_written,
+                                                  &msg->ssr_code_biases);
+    case SBP_MSG_SSR_PHASE_BIASES:
+      return sbp_encode_sbp_msg_ssr_phase_biases_t(buf, len, n_written,
+                                                   &msg->ssr_phase_biases);
+    case SBP_MSG_SSR_STEC_CORRECTION:
+      return sbp_encode_sbp_msg_ssr_stec_correction_t(
+          buf, len, n_written, &msg->ssr_stec_correction);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION:
+      return sbp_encode_sbp_msg_ssr_gridded_correction_t(
+          buf, len, n_written, &msg->ssr_gridded_correction);
+    case SBP_MSG_SSR_TILE_DEFINITION:
+      return sbp_encode_sbp_msg_ssr_tile_definition_t(
+          buf, len, n_written, &msg->ssr_tile_definition);
+    case SBP_MSG_SSR_SATELLITE_APC:
+      return sbp_encode_sbp_msg_ssr_satellite_apc_t(buf, len, n_written,
+                                                    &msg->ssr_satellite_apc);
+    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
+      return sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(
+          buf, len, n_written, &msg->ssr_orbit_clock_dep_a);
+    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
+      return sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(
+          buf, len, n_written, &msg->ssr_stec_correction_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
+      return sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+          buf, len, n_written, &msg->ssr_gridded_correction_no_std_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
+      return sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(
+          buf, len, n_written, &msg->ssr_gridded_correction_dep_a);
+    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
+      return sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(
+          buf, len, n_written, &msg->ssr_grid_definition_dep_a);
+    case SBP_MSG_STARTUP:
+      return sbp_encode_sbp_msg_startup_t(buf, len, n_written, &msg->startup);
+    case SBP_MSG_DGNSS_STATUS:
+      return sbp_encode_sbp_msg_dgnss_status_t(buf, len, n_written,
+                                               &msg->dgnss_status);
+    case SBP_MSG_HEARTBEAT:
+      return sbp_encode_sbp_msg_heartbeat_t(buf, len, n_written,
+                                            &msg->heartbeat);
+    case SBP_MSG_STATUS_REPORT:
+      return sbp_encode_sbp_msg_status_report_t(buf, len, n_written,
+                                                &msg->status_report);
+    case SBP_MSG_INS_STATUS:
+      return sbp_encode_sbp_msg_ins_status_t(buf, len, n_written,
+                                             &msg->ins_status);
+    case SBP_MSG_CSAC_TELEMETRY:
+      return sbp_encode_sbp_msg_csac_telemetry_t(buf, len, n_written,
+                                                 &msg->csac_telemetry);
+    case SBP_MSG_CSAC_TELEMETRY_LABELS:
+      return sbp_encode_sbp_msg_csac_telemetry_labels_t(
+          buf, len, n_written, &msg->csac_telemetry_labels);
+    case SBP_MSG_INS_UPDATES:
+      return sbp_encode_sbp_msg_ins_updates_t(buf, len, n_written,
+                                              &msg->ins_updates);
+    case SBP_MSG_GNSS_TIME_OFFSET:
+      return sbp_encode_sbp_msg_gnss_time_offset_t(buf, len, n_written,
+                                                   &msg->gnss_time_offset);
+    case SBP_MSG_PPS_TIME:
+      return sbp_encode_sbp_msg_pps_time_t(buf, len, n_written, &msg->pps_time);
+    case SBP_MSG_GROUP_META:
+      return sbp_encode_sbp_msg_group_meta_t(buf, len, n_written,
+                                             &msg->group_meta);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
+      return sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(
+          buf, len, n_written, &msg->tracking_state_detailed_dep_a);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
+      return sbp_encode_sbp_msg_tracking_state_detailed_dep_t(
+          buf, len, n_written, &msg->tracking_state_detailed_dep);
+    case SBP_MSG_TRACKING_STATE:
+      return sbp_encode_sbp_msg_tracking_state_t(buf, len, n_written,
+                                                 &msg->tracking_state);
+    case SBP_MSG_MEASUREMENT_STATE:
+      return sbp_encode_sbp_msg_measurement_state_t(buf, len, n_written,
+                                                    &msg->measurement_state);
+    case SBP_MSG_TRACKING_IQ:
+      return sbp_encode_sbp_msg_tracking_iq_t(buf, len, n_written,
+                                              &msg->tracking_iq);
+    case SBP_MSG_TRACKING_IQ_DEP_B:
+      return sbp_encode_sbp_msg_tracking_iq_dep_b_t(buf, len, n_written,
+                                                    &msg->tracking_iq_dep_b);
+    case SBP_MSG_TRACKING_IQ_DEP_A:
+      return sbp_encode_sbp_msg_tracking_iq_dep_a_t(buf, len, n_written,
+                                                    &msg->tracking_iq_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_A:
+      return sbp_encode_sbp_msg_tracking_state_dep_a_t(
+          buf, len, n_written, &msg->tracking_state_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_B:
+      return sbp_encode_sbp_msg_tracking_state_dep_b_t(
+          buf, len, n_written, &msg->tracking_state_dep_b);
+    case SBP_MSG_USER_DATA:
+      return sbp_encode_sbp_msg_user_data_t(buf, len, n_written,
+                                            &msg->user_data);
+    case SBP_MSG_ODOMETRY:
+      return sbp_encode_sbp_msg_odometry_t(buf, len, n_written, &msg->odometry);
+    case SBP_MSG_WHEELTICK:
+      return sbp_encode_sbp_msg_wheeltick_t(buf, len, n_written,
+                                            &msg->wheeltick);
     default:
       break;
   }
@@ -846,107 +846,105 @@ static inline s8 sbp_decode_msg(const uint8_t *buf, uint8_t len,
                                 uint8_t *n_read, uint16_t msg_type,
                                 sbp_msg_t *msg) {
   switch (msg_type) {
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
-      return sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(
-          buf, len, n_read, &msg->tracking_state_detailed_dep_a);
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
-      return sbp_decode_sbp_msg_tracking_state_detailed_dep_t(
-          buf, len, n_read, &msg->tracking_state_detailed_dep);
-    case SBP_MSG_TRACKING_STATE:
-      return sbp_decode_sbp_msg_tracking_state_t(buf, len, n_read,
-                                                 &msg->tracking_state);
-    case SBP_MSG_MEASUREMENT_STATE:
-      return sbp_decode_sbp_msg_measurement_state_t(buf, len, n_read,
-                                                    &msg->measurement_state);
-    case SBP_MSG_TRACKING_IQ:
-      return sbp_decode_sbp_msg_tracking_iq_t(buf, len, n_read,
-                                              &msg->tracking_iq);
-    case SBP_MSG_TRACKING_IQ_DEP_B:
-      return sbp_decode_sbp_msg_tracking_iq_dep_b_t(buf, len, n_read,
-                                                    &msg->tracking_iq_dep_b);
-    case SBP_MSG_TRACKING_IQ_DEP_A:
-      return sbp_decode_sbp_msg_tracking_iq_dep_a_t(buf, len, n_read,
-                                                    &msg->tracking_iq_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_A:
-      return sbp_decode_sbp_msg_tracking_state_dep_a_t(
-          buf, len, n_read, &msg->tracking_state_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_B:
-      return sbp_decode_sbp_msg_tracking_state_dep_b_t(
-          buf, len, n_read, &msg->tracking_state_dep_b);
-    case SBP_MSG_SETTINGS_SAVE:
-      return sbp_decode_sbp_msg_settings_save_t(buf, len, n_read,
-                                                &msg->settings_save);
-    case SBP_MSG_SETTINGS_WRITE:
-      return sbp_decode_sbp_msg_settings_write_t(buf, len, n_read,
-                                                 &msg->settings_write);
-    case SBP_MSG_SETTINGS_WRITE_RESP:
-      return sbp_decode_sbp_msg_settings_write_resp_t(
-          buf, len, n_read, &msg->settings_write_resp);
-    case SBP_MSG_SETTINGS_READ_REQ:
-      return sbp_decode_sbp_msg_settings_read_req_t(buf, len, n_read,
-                                                    &msg->settings_read_req);
-    case SBP_MSG_SETTINGS_READ_RESP:
-      return sbp_decode_sbp_msg_settings_read_resp_t(buf, len, n_read,
-                                                     &msg->settings_read_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
-      return sbp_decode_sbp_msg_settings_read_by_index_req_t(
-          buf, len, n_read, &msg->settings_read_by_index_req);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
-      return sbp_decode_sbp_msg_settings_read_by_index_resp_t(
-          buf, len, n_read, &msg->settings_read_by_index_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
-      return sbp_decode_sbp_msg_settings_read_by_index_done_t(
-          buf, len, n_read, &msg->settings_read_by_index_done);
-    case SBP_MSG_SETTINGS_REGISTER:
-      return sbp_decode_sbp_msg_settings_register_t(buf, len, n_read,
-                                                    &msg->settings_register);
-    case SBP_MSG_SETTINGS_REGISTER_RESP:
-      return sbp_decode_sbp_msg_settings_register_resp_t(
-          buf, len, n_read, &msg->settings_register_resp);
-    case SBP_MSG_SSR_ORBIT_CLOCK:
-      return sbp_decode_sbp_msg_ssr_orbit_clock_t(buf, len, n_read,
-                                                  &msg->ssr_orbit_clock);
-    case SBP_MSG_SSR_CODE_BIASES:
-      return sbp_decode_sbp_msg_ssr_code_biases_t(buf, len, n_read,
-                                                  &msg->ssr_code_biases);
-    case SBP_MSG_SSR_PHASE_BIASES:
-      return sbp_decode_sbp_msg_ssr_phase_biases_t(buf, len, n_read,
-                                                   &msg->ssr_phase_biases);
-    case SBP_MSG_SSR_STEC_CORRECTION:
-      return sbp_decode_sbp_msg_ssr_stec_correction_t(
-          buf, len, n_read, &msg->ssr_stec_correction);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION:
-      return sbp_decode_sbp_msg_ssr_gridded_correction_t(
-          buf, len, n_read, &msg->ssr_gridded_correction);
-    case SBP_MSG_SSR_TILE_DEFINITION:
-      return sbp_decode_sbp_msg_ssr_tile_definition_t(
-          buf, len, n_read, &msg->ssr_tile_definition);
-    case SBP_MSG_SSR_SATELLITE_APC:
-      return sbp_decode_sbp_msg_ssr_satellite_apc_t(buf, len, n_read,
-                                                    &msg->ssr_satellite_apc);
-    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
-      return sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(
-          buf, len, n_read, &msg->ssr_orbit_clock_dep_a);
-    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
-      return sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(
-          buf, len, n_read, &msg->ssr_stec_correction_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
-      return sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
-          buf, len, n_read, &msg->ssr_gridded_correction_no_std_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
-      return sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(
-          buf, len, n_read, &msg->ssr_gridded_correction_dep_a);
-    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
-      return sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(
-          buf, len, n_read, &msg->ssr_grid_definition_dep_a);
+    case SBP_MSG_ACQ_RESULT:
+      return sbp_decode_sbp_msg_acq_result_t(buf, len, n_read,
+                                             &msg->acq_result);
+    case SBP_MSG_ACQ_RESULT_DEP_C:
+      return sbp_decode_sbp_msg_acq_result_dep_c_t(buf, len, n_read,
+                                                   &msg->acq_result_dep_c);
+    case SBP_MSG_ACQ_RESULT_DEP_B:
+      return sbp_decode_sbp_msg_acq_result_dep_b_t(buf, len, n_read,
+                                                   &msg->acq_result_dep_b);
+    case SBP_MSG_ACQ_RESULT_DEP_A:
+      return sbp_decode_sbp_msg_acq_result_dep_a_t(buf, len, n_read,
+                                                   &msg->acq_result_dep_a);
+    case SBP_MSG_ACQ_SV_PROFILE:
+      return sbp_decode_sbp_msg_acq_sv_profile_t(buf, len, n_read,
+                                                 &msg->acq_sv_profile);
+    case SBP_MSG_ACQ_SV_PROFILE_DEP:
+      return sbp_decode_sbp_msg_acq_sv_profile_dep_t(buf, len, n_read,
+                                                     &msg->acq_sv_profile_dep);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
+      return sbp_decode_sbp_msg_bootloader_handshake_req_t(
+          buf, len, n_read, &msg->bootloader_handshake_req);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
+      return sbp_decode_sbp_msg_bootloader_handshake_resp_t(
+          buf, len, n_read, &msg->bootloader_handshake_resp);
+    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
+      return sbp_decode_sbp_msg_bootloader_jump_to_app_t(
+          buf, len, n_read, &msg->bootloader_jump_to_app);
+    case SBP_MSG_NAP_DEVICE_DNA_REQ:
+      return sbp_decode_sbp_msg_nap_device_dna_req_t(buf, len, n_read,
+                                                     &msg->nap_device_dna_req);
+    case SBP_MSG_NAP_DEVICE_DNA_RESP:
+      return sbp_decode_sbp_msg_nap_device_dna_resp_t(
+          buf, len, n_read, &msg->nap_device_dna_resp);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
+      return sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(
+          buf, len, n_read, &msg->bootloader_handshake_dep_a);
     case SBP_MSG_EXT_EVENT:
       return sbp_decode_sbp_msg_ext_event_t(buf, len, n_read, &msg->ext_event);
-    case SBP_MSG_ODOMETRY:
-      return sbp_decode_sbp_msg_odometry_t(buf, len, n_read, &msg->odometry);
-    case SBP_MSG_WHEELTICK:
-      return sbp_decode_sbp_msg_wheeltick_t(buf, len, n_read, &msg->wheeltick);
-    case SBP_MSG_USER_DATA:
-      return sbp_decode_sbp_msg_user_data_t(buf, len, n_read, &msg->user_data);
+    case SBP_MSG_FILEIO_READ_REQ:
+      return sbp_decode_sbp_msg_fileio_read_req_t(buf, len, n_read,
+                                                  &msg->fileio_read_req);
+    case SBP_MSG_FILEIO_READ_RESP:
+      return sbp_decode_sbp_msg_fileio_read_resp_t(buf, len, n_read,
+                                                   &msg->fileio_read_resp);
+    case SBP_MSG_FILEIO_READ_DIR_REQ:
+      return sbp_decode_sbp_msg_fileio_read_dir_req_t(
+          buf, len, n_read, &msg->fileio_read_dir_req);
+    case SBP_MSG_FILEIO_READ_DIR_RESP:
+      return sbp_decode_sbp_msg_fileio_read_dir_resp_t(
+          buf, len, n_read, &msg->fileio_read_dir_resp);
+    case SBP_MSG_FILEIO_REMOVE:
+      return sbp_decode_sbp_msg_fileio_remove_t(buf, len, n_read,
+                                                &msg->fileio_remove);
+    case SBP_MSG_FILEIO_WRITE_REQ:
+      return sbp_decode_sbp_msg_fileio_write_req_t(buf, len, n_read,
+                                                   &msg->fileio_write_req);
+    case SBP_MSG_FILEIO_WRITE_RESP:
+      return sbp_decode_sbp_msg_fileio_write_resp_t(buf, len, n_read,
+                                                    &msg->fileio_write_resp);
+    case SBP_MSG_FILEIO_CONFIG_REQ:
+      return sbp_decode_sbp_msg_fileio_config_req_t(buf, len, n_read,
+                                                    &msg->fileio_config_req);
+    case SBP_MSG_FILEIO_CONFIG_RESP:
+      return sbp_decode_sbp_msg_fileio_config_resp_t(buf, len, n_read,
+                                                     &msg->fileio_config_resp);
+    case SBP_MSG_FLASH_PROGRAM:
+      return sbp_decode_sbp_msg_flash_program_t(buf, len, n_read,
+                                                &msg->flash_program);
+    case SBP_MSG_FLASH_DONE:
+      return sbp_decode_sbp_msg_flash_done_t(buf, len, n_read,
+                                             &msg->flash_done);
+    case SBP_MSG_FLASH_READ_REQ:
+      return sbp_decode_sbp_msg_flash_read_req_t(buf, len, n_read,
+                                                 &msg->flash_read_req);
+    case SBP_MSG_FLASH_READ_RESP:
+      return sbp_decode_sbp_msg_flash_read_resp_t(buf, len, n_read,
+                                                  &msg->flash_read_resp);
+    case SBP_MSG_FLASH_ERASE:
+      return sbp_decode_sbp_msg_flash_erase_t(buf, len, n_read,
+                                              &msg->flash_erase);
+    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
+      return sbp_decode_sbp_msg_stm_flash_lock_sector_t(
+          buf, len, n_read, &msg->stm_flash_lock_sector);
+    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
+      return sbp_decode_sbp_msg_stm_flash_unlock_sector_t(
+          buf, len, n_read, &msg->stm_flash_unlock_sector);
+    case SBP_MSG_STM_UNIQUE_ID_REQ:
+      return sbp_decode_sbp_msg_stm_unique_id_req_t(buf, len, n_read,
+                                                    &msg->stm_unique_id_req);
+    case SBP_MSG_STM_UNIQUE_ID_RESP:
+      return sbp_decode_sbp_msg_stm_unique_id_resp_t(buf, len, n_read,
+                                                     &msg->stm_unique_id_resp);
+    case SBP_MSG_M25_FLASH_WRITE_STATUS:
+      return sbp_decode_sbp_msg_m25_flash_write_status_t(
+          buf, len, n_read, &msg->m25_flash_write_status);
+    case SBP_MSG_IMU_RAW:
+      return sbp_decode_sbp_msg_imu_raw_t(buf, len, n_read, &msg->imu_raw);
+    case SBP_MSG_IMU_AUX:
+      return sbp_decode_sbp_msg_imu_aux_t(buf, len, n_read, &msg->imu_aux);
     case SBP_MSG_LINUX_CPU_STATE_DEP_A:
       return sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(
           buf, len, n_read, &msg->linux_cpu_state_dep_a);
@@ -980,6 +978,14 @@ static inline s8 sbp_decode_msg(const uint8_t *buf, uint8_t len,
     case SBP_MSG_LINUX_SYS_STATE:
       return sbp_decode_sbp_msg_linux_sys_state_t(buf, len, n_read,
                                                   &msg->linux_sys_state);
+    case SBP_MSG_LOG:
+      return sbp_decode_sbp_msg_log_t(buf, len, n_read, &msg->log);
+    case SBP_MSG_FWD:
+      return sbp_decode_sbp_msg_fwd_t(buf, len, n_read, &msg->fwd);
+    case SBP_MSG_PRINT_DEP:
+      return sbp_decode_sbp_msg_print_dep_t(buf, len, n_read, &msg->print_dep);
+    case SBP_MSG_MAG_RAW:
+      return sbp_decode_sbp_msg_mag_raw_t(buf, len, n_read, &msg->mag_raw);
     case SBP_MSG_GPS_TIME:
       return sbp_decode_sbp_msg_gps_time_t(buf, len, n_read, &msg->gps_time);
     case SBP_MSG_GPS_TIME_GNSS:
@@ -1080,87 +1086,8 @@ static inline s8 sbp_decode_msg(const uint8_t *buf, uint8_t len,
     case SBP_MSG_PROTECTION_LEVEL:
       return sbp_decode_sbp_msg_protection_level_t(buf, len, n_read,
                                                    &msg->protection_level);
-    case SBP_MSG_FILEIO_READ_REQ:
-      return sbp_decode_sbp_msg_fileio_read_req_t(buf, len, n_read,
-                                                  &msg->fileio_read_req);
-    case SBP_MSG_FILEIO_READ_RESP:
-      return sbp_decode_sbp_msg_fileio_read_resp_t(buf, len, n_read,
-                                                   &msg->fileio_read_resp);
-    case SBP_MSG_FILEIO_READ_DIR_REQ:
-      return sbp_decode_sbp_msg_fileio_read_dir_req_t(
-          buf, len, n_read, &msg->fileio_read_dir_req);
-    case SBP_MSG_FILEIO_READ_DIR_RESP:
-      return sbp_decode_sbp_msg_fileio_read_dir_resp_t(
-          buf, len, n_read, &msg->fileio_read_dir_resp);
-    case SBP_MSG_FILEIO_REMOVE:
-      return sbp_decode_sbp_msg_fileio_remove_t(buf, len, n_read,
-                                                &msg->fileio_remove);
-    case SBP_MSG_FILEIO_WRITE_REQ:
-      return sbp_decode_sbp_msg_fileio_write_req_t(buf, len, n_read,
-                                                   &msg->fileio_write_req);
-    case SBP_MSG_FILEIO_WRITE_RESP:
-      return sbp_decode_sbp_msg_fileio_write_resp_t(buf, len, n_read,
-                                                    &msg->fileio_write_resp);
-    case SBP_MSG_FILEIO_CONFIG_REQ:
-      return sbp_decode_sbp_msg_fileio_config_req_t(buf, len, n_read,
-                                                    &msg->fileio_config_req);
-    case SBP_MSG_FILEIO_CONFIG_RESP:
-      return sbp_decode_sbp_msg_fileio_config_resp_t(buf, len, n_read,
-                                                     &msg->fileio_config_resp);
-    case SBP_MSG_LOG:
-      return sbp_decode_sbp_msg_log_t(buf, len, n_read, &msg->log);
-    case SBP_MSG_FWD:
-      return sbp_decode_sbp_msg_fwd_t(buf, len, n_read, &msg->fwd);
-    case SBP_MSG_PRINT_DEP:
-      return sbp_decode_sbp_msg_print_dep_t(buf, len, n_read, &msg->print_dep);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
-      return sbp_decode_sbp_msg_bootloader_handshake_req_t(
-          buf, len, n_read, &msg->bootloader_handshake_req);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
-      return sbp_decode_sbp_msg_bootloader_handshake_resp_t(
-          buf, len, n_read, &msg->bootloader_handshake_resp);
-    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
-      return sbp_decode_sbp_msg_bootloader_jump_to_app_t(
-          buf, len, n_read, &msg->bootloader_jump_to_app);
-    case SBP_MSG_NAP_DEVICE_DNA_REQ:
-      return sbp_decode_sbp_msg_nap_device_dna_req_t(buf, len, n_read,
-                                                     &msg->nap_device_dna_req);
-    case SBP_MSG_NAP_DEVICE_DNA_RESP:
-      return sbp_decode_sbp_msg_nap_device_dna_resp_t(
-          buf, len, n_read, &msg->nap_device_dna_resp);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
-      return sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(
-          buf, len, n_read, &msg->bootloader_handshake_dep_a);
-    case SBP_MSG_STARTUP:
-      return sbp_decode_sbp_msg_startup_t(buf, len, n_read, &msg->startup);
-    case SBP_MSG_DGNSS_STATUS:
-      return sbp_decode_sbp_msg_dgnss_status_t(buf, len, n_read,
-                                               &msg->dgnss_status);
-    case SBP_MSG_HEARTBEAT:
-      return sbp_decode_sbp_msg_heartbeat_t(buf, len, n_read, &msg->heartbeat);
-    case SBP_MSG_STATUS_REPORT:
-      return sbp_decode_sbp_msg_status_report_t(buf, len, n_read,
-                                                &msg->status_report);
-    case SBP_MSG_INS_STATUS:
-      return sbp_decode_sbp_msg_ins_status_t(buf, len, n_read,
-                                             &msg->ins_status);
-    case SBP_MSG_CSAC_TELEMETRY:
-      return sbp_decode_sbp_msg_csac_telemetry_t(buf, len, n_read,
-                                                 &msg->csac_telemetry);
-    case SBP_MSG_CSAC_TELEMETRY_LABELS:
-      return sbp_decode_sbp_msg_csac_telemetry_labels_t(
-          buf, len, n_read, &msg->csac_telemetry_labels);
-    case SBP_MSG_INS_UPDATES:
-      return sbp_decode_sbp_msg_ins_updates_t(buf, len, n_read,
-                                              &msg->ins_updates);
-    case SBP_MSG_GNSS_TIME_OFFSET:
-      return sbp_decode_sbp_msg_gnss_time_offset_t(buf, len, n_read,
-                                                   &msg->gnss_time_offset);
-    case SBP_MSG_PPS_TIME:
-      return sbp_decode_sbp_msg_pps_time_t(buf, len, n_read, &msg->pps_time);
-    case SBP_MSG_GROUP_META:
-      return sbp_decode_sbp_msg_group_meta_t(buf, len, n_read,
-                                             &msg->group_meta);
+    case SBP_MSG_NDB_EVENT:
+      return sbp_decode_sbp_msg_ndb_event_t(buf, len, n_read, &msg->ndb_event);
     case SBP_MSG_OBS:
       return sbp_decode_sbp_msg_obs_t(buf, len, n_read, &msg->obs);
     case SBP_MSG_BASE_POS_LLH:
@@ -1267,8 +1194,18 @@ static inline s8 sbp_decode_msg(const uint8_t *buf, uint8_t len,
       return sbp_decode_sbp_msg_sv_az_el_t(buf, len, n_read, &msg->sv_az_el);
     case SBP_MSG_OSR:
       return sbp_decode_sbp_msg_osr_t(buf, len, n_read, &msg->osr);
-    case SBP_MSG_SBAS_RAW:
-      return sbp_decode_sbp_msg_sbas_raw_t(buf, len, n_read, &msg->sbas_raw);
+    case SBP_MSG_BASELINE_HEADING:
+      return sbp_decode_sbp_msg_baseline_heading_t(buf, len, n_read,
+                                                   &msg->baseline_heading);
+    case SBP_MSG_ORIENT_QUAT:
+      return sbp_decode_sbp_msg_orient_quat_t(buf, len, n_read,
+                                              &msg->orient_quat);
+    case SBP_MSG_ORIENT_EULER:
+      return sbp_decode_sbp_msg_orient_euler_t(buf, len, n_read,
+                                               &msg->orient_euler);
+    case SBP_MSG_ANGULAR_RATE:
+      return sbp_decode_sbp_msg_angular_rate_t(buf, len, n_read,
+                                               &msg->angular_rate);
     case SBP_MSG_ALMANAC:
       return sbp_decode_sbp_msg_almanac_t(buf, len, n_read, &msg->almanac);
     case SBP_MSG_SET_TIME:
@@ -1337,79 +1274,142 @@ static inline s8 sbp_decode_msg(const uint8_t *buf, uint8_t len,
     case SBP_MSG_FRONT_END_GAIN:
       return sbp_decode_sbp_msg_front_end_gain_t(buf, len, n_read,
                                                  &msg->front_end_gain);
-    case SBP_MSG_FLASH_PROGRAM:
-      return sbp_decode_sbp_msg_flash_program_t(buf, len, n_read,
-                                                &msg->flash_program);
-    case SBP_MSG_FLASH_DONE:
-      return sbp_decode_sbp_msg_flash_done_t(buf, len, n_read,
-                                             &msg->flash_done);
-    case SBP_MSG_FLASH_READ_REQ:
-      return sbp_decode_sbp_msg_flash_read_req_t(buf, len, n_read,
-                                                 &msg->flash_read_req);
-    case SBP_MSG_FLASH_READ_RESP:
-      return sbp_decode_sbp_msg_flash_read_resp_t(buf, len, n_read,
-                                                  &msg->flash_read_resp);
-    case SBP_MSG_FLASH_ERASE:
-      return sbp_decode_sbp_msg_flash_erase_t(buf, len, n_read,
-                                              &msg->flash_erase);
-    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
-      return sbp_decode_sbp_msg_stm_flash_lock_sector_t(
-          buf, len, n_read, &msg->stm_flash_lock_sector);
-    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
-      return sbp_decode_sbp_msg_stm_flash_unlock_sector_t(
-          buf, len, n_read, &msg->stm_flash_unlock_sector);
-    case SBP_MSG_STM_UNIQUE_ID_REQ:
-      return sbp_decode_sbp_msg_stm_unique_id_req_t(buf, len, n_read,
-                                                    &msg->stm_unique_id_req);
-    case SBP_MSG_STM_UNIQUE_ID_RESP:
-      return sbp_decode_sbp_msg_stm_unique_id_resp_t(buf, len, n_read,
-                                                     &msg->stm_unique_id_resp);
-    case SBP_MSG_M25_FLASH_WRITE_STATUS:
-      return sbp_decode_sbp_msg_m25_flash_write_status_t(
-          buf, len, n_read, &msg->m25_flash_write_status);
-    case SBP_MSG_IMU_RAW:
-      return sbp_decode_sbp_msg_imu_raw_t(buf, len, n_read, &msg->imu_raw);
-    case SBP_MSG_IMU_AUX:
-      return sbp_decode_sbp_msg_imu_aux_t(buf, len, n_read, &msg->imu_aux);
-    case SBP_MSG_NDB_EVENT:
-      return sbp_decode_sbp_msg_ndb_event_t(buf, len, n_read, &msg->ndb_event);
-    case SBP_MSG_ACQ_RESULT:
-      return sbp_decode_sbp_msg_acq_result_t(buf, len, n_read,
-                                             &msg->acq_result);
-    case SBP_MSG_ACQ_RESULT_DEP_C:
-      return sbp_decode_sbp_msg_acq_result_dep_c_t(buf, len, n_read,
-                                                   &msg->acq_result_dep_c);
-    case SBP_MSG_ACQ_RESULT_DEP_B:
-      return sbp_decode_sbp_msg_acq_result_dep_b_t(buf, len, n_read,
-                                                   &msg->acq_result_dep_b);
-    case SBP_MSG_ACQ_RESULT_DEP_A:
-      return sbp_decode_sbp_msg_acq_result_dep_a_t(buf, len, n_read,
-                                                   &msg->acq_result_dep_a);
-    case SBP_MSG_ACQ_SV_PROFILE:
-      return sbp_decode_sbp_msg_acq_sv_profile_t(buf, len, n_read,
-                                                 &msg->acq_sv_profile);
-    case SBP_MSG_ACQ_SV_PROFILE_DEP:
-      return sbp_decode_sbp_msg_acq_sv_profile_dep_t(buf, len, n_read,
-                                                     &msg->acq_sv_profile_dep);
+    case SBP_MSG_SBAS_RAW:
+      return sbp_decode_sbp_msg_sbas_raw_t(buf, len, n_read, &msg->sbas_raw);
+    case SBP_MSG_SETTINGS_SAVE:
+      return sbp_decode_sbp_msg_settings_save_t(buf, len, n_read,
+                                                &msg->settings_save);
+    case SBP_MSG_SETTINGS_WRITE:
+      return sbp_decode_sbp_msg_settings_write_t(buf, len, n_read,
+                                                 &msg->settings_write);
+    case SBP_MSG_SETTINGS_WRITE_RESP:
+      return sbp_decode_sbp_msg_settings_write_resp_t(
+          buf, len, n_read, &msg->settings_write_resp);
+    case SBP_MSG_SETTINGS_READ_REQ:
+      return sbp_decode_sbp_msg_settings_read_req_t(buf, len, n_read,
+                                                    &msg->settings_read_req);
+    case SBP_MSG_SETTINGS_READ_RESP:
+      return sbp_decode_sbp_msg_settings_read_resp_t(buf, len, n_read,
+                                                     &msg->settings_read_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
+      return sbp_decode_sbp_msg_settings_read_by_index_req_t(
+          buf, len, n_read, &msg->settings_read_by_index_req);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
+      return sbp_decode_sbp_msg_settings_read_by_index_resp_t(
+          buf, len, n_read, &msg->settings_read_by_index_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
+      return sbp_decode_sbp_msg_settings_read_by_index_done_t(
+          buf, len, n_read, &msg->settings_read_by_index_done);
+    case SBP_MSG_SETTINGS_REGISTER:
+      return sbp_decode_sbp_msg_settings_register_t(buf, len, n_read,
+                                                    &msg->settings_register);
+    case SBP_MSG_SETTINGS_REGISTER_RESP:
+      return sbp_decode_sbp_msg_settings_register_resp_t(
+          buf, len, n_read, &msg->settings_register_resp);
     case SBP_MSG_SOLN_META_DEP_A:
       return sbp_decode_sbp_msg_soln_meta_dep_a_t(buf, len, n_read,
                                                   &msg->soln_meta_dep_a);
     case SBP_MSG_SOLN_META:
       return sbp_decode_sbp_msg_soln_meta_t(buf, len, n_read, &msg->soln_meta);
-    case SBP_MSG_BASELINE_HEADING:
-      return sbp_decode_sbp_msg_baseline_heading_t(buf, len, n_read,
-                                                   &msg->baseline_heading);
-    case SBP_MSG_ORIENT_QUAT:
-      return sbp_decode_sbp_msg_orient_quat_t(buf, len, n_read,
-                                              &msg->orient_quat);
-    case SBP_MSG_ORIENT_EULER:
-      return sbp_decode_sbp_msg_orient_euler_t(buf, len, n_read,
-                                               &msg->orient_euler);
-    case SBP_MSG_ANGULAR_RATE:
-      return sbp_decode_sbp_msg_angular_rate_t(buf, len, n_read,
-                                               &msg->angular_rate);
-    case SBP_MSG_MAG_RAW:
-      return sbp_decode_sbp_msg_mag_raw_t(buf, len, n_read, &msg->mag_raw);
+    case SBP_MSG_SSR_ORBIT_CLOCK:
+      return sbp_decode_sbp_msg_ssr_orbit_clock_t(buf, len, n_read,
+                                                  &msg->ssr_orbit_clock);
+    case SBP_MSG_SSR_CODE_BIASES:
+      return sbp_decode_sbp_msg_ssr_code_biases_t(buf, len, n_read,
+                                                  &msg->ssr_code_biases);
+    case SBP_MSG_SSR_PHASE_BIASES:
+      return sbp_decode_sbp_msg_ssr_phase_biases_t(buf, len, n_read,
+                                                   &msg->ssr_phase_biases);
+    case SBP_MSG_SSR_STEC_CORRECTION:
+      return sbp_decode_sbp_msg_ssr_stec_correction_t(
+          buf, len, n_read, &msg->ssr_stec_correction);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION:
+      return sbp_decode_sbp_msg_ssr_gridded_correction_t(
+          buf, len, n_read, &msg->ssr_gridded_correction);
+    case SBP_MSG_SSR_TILE_DEFINITION:
+      return sbp_decode_sbp_msg_ssr_tile_definition_t(
+          buf, len, n_read, &msg->ssr_tile_definition);
+    case SBP_MSG_SSR_SATELLITE_APC:
+      return sbp_decode_sbp_msg_ssr_satellite_apc_t(buf, len, n_read,
+                                                    &msg->ssr_satellite_apc);
+    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
+      return sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(
+          buf, len, n_read, &msg->ssr_orbit_clock_dep_a);
+    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
+      return sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(
+          buf, len, n_read, &msg->ssr_stec_correction_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
+      return sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+          buf, len, n_read, &msg->ssr_gridded_correction_no_std_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
+      return sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(
+          buf, len, n_read, &msg->ssr_gridded_correction_dep_a);
+    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
+      return sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(
+          buf, len, n_read, &msg->ssr_grid_definition_dep_a);
+    case SBP_MSG_STARTUP:
+      return sbp_decode_sbp_msg_startup_t(buf, len, n_read, &msg->startup);
+    case SBP_MSG_DGNSS_STATUS:
+      return sbp_decode_sbp_msg_dgnss_status_t(buf, len, n_read,
+                                               &msg->dgnss_status);
+    case SBP_MSG_HEARTBEAT:
+      return sbp_decode_sbp_msg_heartbeat_t(buf, len, n_read, &msg->heartbeat);
+    case SBP_MSG_STATUS_REPORT:
+      return sbp_decode_sbp_msg_status_report_t(buf, len, n_read,
+                                                &msg->status_report);
+    case SBP_MSG_INS_STATUS:
+      return sbp_decode_sbp_msg_ins_status_t(buf, len, n_read,
+                                             &msg->ins_status);
+    case SBP_MSG_CSAC_TELEMETRY:
+      return sbp_decode_sbp_msg_csac_telemetry_t(buf, len, n_read,
+                                                 &msg->csac_telemetry);
+    case SBP_MSG_CSAC_TELEMETRY_LABELS:
+      return sbp_decode_sbp_msg_csac_telemetry_labels_t(
+          buf, len, n_read, &msg->csac_telemetry_labels);
+    case SBP_MSG_INS_UPDATES:
+      return sbp_decode_sbp_msg_ins_updates_t(buf, len, n_read,
+                                              &msg->ins_updates);
+    case SBP_MSG_GNSS_TIME_OFFSET:
+      return sbp_decode_sbp_msg_gnss_time_offset_t(buf, len, n_read,
+                                                   &msg->gnss_time_offset);
+    case SBP_MSG_PPS_TIME:
+      return sbp_decode_sbp_msg_pps_time_t(buf, len, n_read, &msg->pps_time);
+    case SBP_MSG_GROUP_META:
+      return sbp_decode_sbp_msg_group_meta_t(buf, len, n_read,
+                                             &msg->group_meta);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
+      return sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(
+          buf, len, n_read, &msg->tracking_state_detailed_dep_a);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
+      return sbp_decode_sbp_msg_tracking_state_detailed_dep_t(
+          buf, len, n_read, &msg->tracking_state_detailed_dep);
+    case SBP_MSG_TRACKING_STATE:
+      return sbp_decode_sbp_msg_tracking_state_t(buf, len, n_read,
+                                                 &msg->tracking_state);
+    case SBP_MSG_MEASUREMENT_STATE:
+      return sbp_decode_sbp_msg_measurement_state_t(buf, len, n_read,
+                                                    &msg->measurement_state);
+    case SBP_MSG_TRACKING_IQ:
+      return sbp_decode_sbp_msg_tracking_iq_t(buf, len, n_read,
+                                              &msg->tracking_iq);
+    case SBP_MSG_TRACKING_IQ_DEP_B:
+      return sbp_decode_sbp_msg_tracking_iq_dep_b_t(buf, len, n_read,
+                                                    &msg->tracking_iq_dep_b);
+    case SBP_MSG_TRACKING_IQ_DEP_A:
+      return sbp_decode_sbp_msg_tracking_iq_dep_a_t(buf, len, n_read,
+                                                    &msg->tracking_iq_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_A:
+      return sbp_decode_sbp_msg_tracking_state_dep_a_t(
+          buf, len, n_read, &msg->tracking_state_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_B:
+      return sbp_decode_sbp_msg_tracking_state_dep_b_t(
+          buf, len, n_read, &msg->tracking_state_dep_b);
+    case SBP_MSG_USER_DATA:
+      return sbp_decode_sbp_msg_user_data_t(buf, len, n_read, &msg->user_data);
+    case SBP_MSG_ODOMETRY:
+      return sbp_decode_sbp_msg_odometry_t(buf, len, n_read, &msg->odometry);
+    case SBP_MSG_WHEELTICK:
+      return sbp_decode_sbp_msg_wheeltick_t(buf, len, n_read, &msg->wheeltick);
     default:
       break;
   }
@@ -1418,100 +1418,91 @@ static inline s8 sbp_decode_msg(const uint8_t *buf, uint8_t len,
 
 static inline size_t sbp_packed_size(uint16_t msg_type, const sbp_msg_t *msg) {
   switch (msg_type) {
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
-      return sbp_packed_size_sbp_msg_tracking_state_detailed_dep_a_t(
-          &msg->tracking_state_detailed_dep_a);
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
-      return sbp_packed_size_sbp_msg_tracking_state_detailed_dep_t(
-          &msg->tracking_state_detailed_dep);
-    case SBP_MSG_TRACKING_STATE:
-      return sbp_packed_size_sbp_msg_tracking_state_t(&msg->tracking_state);
-    case SBP_MSG_MEASUREMENT_STATE:
-      return sbp_packed_size_sbp_msg_measurement_state_t(
-          &msg->measurement_state);
-    case SBP_MSG_TRACKING_IQ:
-      return sbp_packed_size_sbp_msg_tracking_iq_t(&msg->tracking_iq);
-    case SBP_MSG_TRACKING_IQ_DEP_B:
-      return sbp_packed_size_sbp_msg_tracking_iq_dep_b_t(
-          &msg->tracking_iq_dep_b);
-    case SBP_MSG_TRACKING_IQ_DEP_A:
-      return sbp_packed_size_sbp_msg_tracking_iq_dep_a_t(
-          &msg->tracking_iq_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_A:
-      return sbp_packed_size_sbp_msg_tracking_state_dep_a_t(
-          &msg->tracking_state_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_B:
-      return sbp_packed_size_sbp_msg_tracking_state_dep_b_t(
-          &msg->tracking_state_dep_b);
-    case SBP_MSG_SETTINGS_SAVE:
-      return sbp_packed_size_sbp_msg_settings_save_t(&msg->settings_save);
-    case SBP_MSG_SETTINGS_WRITE:
-      return sbp_packed_size_sbp_msg_settings_write_t(&msg->settings_write);
-    case SBP_MSG_SETTINGS_WRITE_RESP:
-      return sbp_packed_size_sbp_msg_settings_write_resp_t(
-          &msg->settings_write_resp);
-    case SBP_MSG_SETTINGS_READ_REQ:
-      return sbp_packed_size_sbp_msg_settings_read_req_t(
-          &msg->settings_read_req);
-    case SBP_MSG_SETTINGS_READ_RESP:
-      return sbp_packed_size_sbp_msg_settings_read_resp_t(
-          &msg->settings_read_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
-      return sbp_packed_size_sbp_msg_settings_read_by_index_req_t(
-          &msg->settings_read_by_index_req);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
-      return sbp_packed_size_sbp_msg_settings_read_by_index_resp_t(
-          &msg->settings_read_by_index_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
-      return sbp_packed_size_sbp_msg_settings_read_by_index_done_t(
-          &msg->settings_read_by_index_done);
-    case SBP_MSG_SETTINGS_REGISTER:
-      return sbp_packed_size_sbp_msg_settings_register_t(
-          &msg->settings_register);
-    case SBP_MSG_SETTINGS_REGISTER_RESP:
-      return sbp_packed_size_sbp_msg_settings_register_resp_t(
-          &msg->settings_register_resp);
-    case SBP_MSG_SSR_ORBIT_CLOCK:
-      return sbp_packed_size_sbp_msg_ssr_orbit_clock_t(&msg->ssr_orbit_clock);
-    case SBP_MSG_SSR_CODE_BIASES:
-      return sbp_packed_size_sbp_msg_ssr_code_biases_t(&msg->ssr_code_biases);
-    case SBP_MSG_SSR_PHASE_BIASES:
-      return sbp_packed_size_sbp_msg_ssr_phase_biases_t(&msg->ssr_phase_biases);
-    case SBP_MSG_SSR_STEC_CORRECTION:
-      return sbp_packed_size_sbp_msg_ssr_stec_correction_t(
-          &msg->ssr_stec_correction);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION:
-      return sbp_packed_size_sbp_msg_ssr_gridded_correction_t(
-          &msg->ssr_gridded_correction);
-    case SBP_MSG_SSR_TILE_DEFINITION:
-      return sbp_packed_size_sbp_msg_ssr_tile_definition_t(
-          &msg->ssr_tile_definition);
-    case SBP_MSG_SSR_SATELLITE_APC:
-      return sbp_packed_size_sbp_msg_ssr_satellite_apc_t(
-          &msg->ssr_satellite_apc);
-    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
-      return sbp_packed_size_sbp_msg_ssr_orbit_clock_dep_a_t(
-          &msg->ssr_orbit_clock_dep_a);
-    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
-      return sbp_packed_size_sbp_msg_ssr_stec_correction_dep_a_t(
-          &msg->ssr_stec_correction_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
-      return sbp_packed_size_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
-          &msg->ssr_gridded_correction_no_std_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
-      return sbp_packed_size_sbp_msg_ssr_gridded_correction_dep_a_t(
-          &msg->ssr_gridded_correction_dep_a);
-    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
-      return sbp_packed_size_sbp_msg_ssr_grid_definition_dep_a_t(
-          &msg->ssr_grid_definition_dep_a);
+    case SBP_MSG_ACQ_RESULT:
+      return sbp_packed_size_sbp_msg_acq_result_t(&msg->acq_result);
+    case SBP_MSG_ACQ_RESULT_DEP_C:
+      return sbp_packed_size_sbp_msg_acq_result_dep_c_t(&msg->acq_result_dep_c);
+    case SBP_MSG_ACQ_RESULT_DEP_B:
+      return sbp_packed_size_sbp_msg_acq_result_dep_b_t(&msg->acq_result_dep_b);
+    case SBP_MSG_ACQ_RESULT_DEP_A:
+      return sbp_packed_size_sbp_msg_acq_result_dep_a_t(&msg->acq_result_dep_a);
+    case SBP_MSG_ACQ_SV_PROFILE:
+      return sbp_packed_size_sbp_msg_acq_sv_profile_t(&msg->acq_sv_profile);
+    case SBP_MSG_ACQ_SV_PROFILE_DEP:
+      return sbp_packed_size_sbp_msg_acq_sv_profile_dep_t(
+          &msg->acq_sv_profile_dep);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
+      return sbp_packed_size_sbp_msg_bootloader_handshake_req_t(
+          &msg->bootloader_handshake_req);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
+      return sbp_packed_size_sbp_msg_bootloader_handshake_resp_t(
+          &msg->bootloader_handshake_resp);
+    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
+      return sbp_packed_size_sbp_msg_bootloader_jump_to_app_t(
+          &msg->bootloader_jump_to_app);
+    case SBP_MSG_NAP_DEVICE_DNA_REQ:
+      return sbp_packed_size_sbp_msg_nap_device_dna_req_t(
+          &msg->nap_device_dna_req);
+    case SBP_MSG_NAP_DEVICE_DNA_RESP:
+      return sbp_packed_size_sbp_msg_nap_device_dna_resp_t(
+          &msg->nap_device_dna_resp);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
+      return sbp_packed_size_sbp_msg_bootloader_handshake_dep_a_t(
+          &msg->bootloader_handshake_dep_a);
     case SBP_MSG_EXT_EVENT:
       return sbp_packed_size_sbp_msg_ext_event_t(&msg->ext_event);
-    case SBP_MSG_ODOMETRY:
-      return sbp_packed_size_sbp_msg_odometry_t(&msg->odometry);
-    case SBP_MSG_WHEELTICK:
-      return sbp_packed_size_sbp_msg_wheeltick_t(&msg->wheeltick);
-    case SBP_MSG_USER_DATA:
-      return sbp_packed_size_sbp_msg_user_data_t(&msg->user_data);
+    case SBP_MSG_FILEIO_READ_REQ:
+      return sbp_packed_size_sbp_msg_fileio_read_req_t(&msg->fileio_read_req);
+    case SBP_MSG_FILEIO_READ_RESP:
+      return sbp_packed_size_sbp_msg_fileio_read_resp_t(&msg->fileio_read_resp);
+    case SBP_MSG_FILEIO_READ_DIR_REQ:
+      return sbp_packed_size_sbp_msg_fileio_read_dir_req_t(
+          &msg->fileio_read_dir_req);
+    case SBP_MSG_FILEIO_READ_DIR_RESP:
+      return sbp_packed_size_sbp_msg_fileio_read_dir_resp_t(
+          &msg->fileio_read_dir_resp);
+    case SBP_MSG_FILEIO_REMOVE:
+      return sbp_packed_size_sbp_msg_fileio_remove_t(&msg->fileio_remove);
+    case SBP_MSG_FILEIO_WRITE_REQ:
+      return sbp_packed_size_sbp_msg_fileio_write_req_t(&msg->fileio_write_req);
+    case SBP_MSG_FILEIO_WRITE_RESP:
+      return sbp_packed_size_sbp_msg_fileio_write_resp_t(
+          &msg->fileio_write_resp);
+    case SBP_MSG_FILEIO_CONFIG_REQ:
+      return sbp_packed_size_sbp_msg_fileio_config_req_t(
+          &msg->fileio_config_req);
+    case SBP_MSG_FILEIO_CONFIG_RESP:
+      return sbp_packed_size_sbp_msg_fileio_config_resp_t(
+          &msg->fileio_config_resp);
+    case SBP_MSG_FLASH_PROGRAM:
+      return sbp_packed_size_sbp_msg_flash_program_t(&msg->flash_program);
+    case SBP_MSG_FLASH_DONE:
+      return sbp_packed_size_sbp_msg_flash_done_t(&msg->flash_done);
+    case SBP_MSG_FLASH_READ_REQ:
+      return sbp_packed_size_sbp_msg_flash_read_req_t(&msg->flash_read_req);
+    case SBP_MSG_FLASH_READ_RESP:
+      return sbp_packed_size_sbp_msg_flash_read_resp_t(&msg->flash_read_resp);
+    case SBP_MSG_FLASH_ERASE:
+      return sbp_packed_size_sbp_msg_flash_erase_t(&msg->flash_erase);
+    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
+      return sbp_packed_size_sbp_msg_stm_flash_lock_sector_t(
+          &msg->stm_flash_lock_sector);
+    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
+      return sbp_packed_size_sbp_msg_stm_flash_unlock_sector_t(
+          &msg->stm_flash_unlock_sector);
+    case SBP_MSG_STM_UNIQUE_ID_REQ:
+      return sbp_packed_size_sbp_msg_stm_unique_id_req_t(
+          &msg->stm_unique_id_req);
+    case SBP_MSG_STM_UNIQUE_ID_RESP:
+      return sbp_packed_size_sbp_msg_stm_unique_id_resp_t(
+          &msg->stm_unique_id_resp);
+    case SBP_MSG_M25_FLASH_WRITE_STATUS:
+      return sbp_packed_size_sbp_msg_m25_flash_write_status_t(
+          &msg->m25_flash_write_status);
+    case SBP_MSG_IMU_RAW:
+      return sbp_packed_size_sbp_msg_imu_raw_t(&msg->imu_raw);
+    case SBP_MSG_IMU_AUX:
+      return sbp_packed_size_sbp_msg_imu_aux_t(&msg->imu_aux);
     case SBP_MSG_LINUX_CPU_STATE_DEP_A:
       return sbp_packed_size_sbp_msg_linux_cpu_state_dep_a_t(
           &msg->linux_cpu_state_dep_a);
@@ -1542,6 +1533,14 @@ static inline size_t sbp_packed_size(uint16_t msg_type, const sbp_msg_t *msg) {
       return sbp_packed_size_sbp_msg_linux_mem_state_t(&msg->linux_mem_state);
     case SBP_MSG_LINUX_SYS_STATE:
       return sbp_packed_size_sbp_msg_linux_sys_state_t(&msg->linux_sys_state);
+    case SBP_MSG_LOG:
+      return sbp_packed_size_sbp_msg_log_t(&msg->log);
+    case SBP_MSG_FWD:
+      return sbp_packed_size_sbp_msg_fwd_t(&msg->fwd);
+    case SBP_MSG_PRINT_DEP:
+      return sbp_packed_size_sbp_msg_print_dep_t(&msg->print_dep);
+    case SBP_MSG_MAG_RAW:
+      return sbp_packed_size_sbp_msg_mag_raw_t(&msg->mag_raw);
     case SBP_MSG_GPS_TIME:
       return sbp_packed_size_sbp_msg_gps_time_t(&msg->gps_time);
     case SBP_MSG_GPS_TIME_GNSS:
@@ -1620,76 +1619,8 @@ static inline size_t sbp_packed_size(uint16_t msg_type, const sbp_msg_t *msg) {
           &msg->protection_level_dep_a);
     case SBP_MSG_PROTECTION_LEVEL:
       return sbp_packed_size_sbp_msg_protection_level_t(&msg->protection_level);
-    case SBP_MSG_FILEIO_READ_REQ:
-      return sbp_packed_size_sbp_msg_fileio_read_req_t(&msg->fileio_read_req);
-    case SBP_MSG_FILEIO_READ_RESP:
-      return sbp_packed_size_sbp_msg_fileio_read_resp_t(&msg->fileio_read_resp);
-    case SBP_MSG_FILEIO_READ_DIR_REQ:
-      return sbp_packed_size_sbp_msg_fileio_read_dir_req_t(
-          &msg->fileio_read_dir_req);
-    case SBP_MSG_FILEIO_READ_DIR_RESP:
-      return sbp_packed_size_sbp_msg_fileio_read_dir_resp_t(
-          &msg->fileio_read_dir_resp);
-    case SBP_MSG_FILEIO_REMOVE:
-      return sbp_packed_size_sbp_msg_fileio_remove_t(&msg->fileio_remove);
-    case SBP_MSG_FILEIO_WRITE_REQ:
-      return sbp_packed_size_sbp_msg_fileio_write_req_t(&msg->fileio_write_req);
-    case SBP_MSG_FILEIO_WRITE_RESP:
-      return sbp_packed_size_sbp_msg_fileio_write_resp_t(
-          &msg->fileio_write_resp);
-    case SBP_MSG_FILEIO_CONFIG_REQ:
-      return sbp_packed_size_sbp_msg_fileio_config_req_t(
-          &msg->fileio_config_req);
-    case SBP_MSG_FILEIO_CONFIG_RESP:
-      return sbp_packed_size_sbp_msg_fileio_config_resp_t(
-          &msg->fileio_config_resp);
-    case SBP_MSG_LOG:
-      return sbp_packed_size_sbp_msg_log_t(&msg->log);
-    case SBP_MSG_FWD:
-      return sbp_packed_size_sbp_msg_fwd_t(&msg->fwd);
-    case SBP_MSG_PRINT_DEP:
-      return sbp_packed_size_sbp_msg_print_dep_t(&msg->print_dep);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
-      return sbp_packed_size_sbp_msg_bootloader_handshake_req_t(
-          &msg->bootloader_handshake_req);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
-      return sbp_packed_size_sbp_msg_bootloader_handshake_resp_t(
-          &msg->bootloader_handshake_resp);
-    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
-      return sbp_packed_size_sbp_msg_bootloader_jump_to_app_t(
-          &msg->bootloader_jump_to_app);
-    case SBP_MSG_NAP_DEVICE_DNA_REQ:
-      return sbp_packed_size_sbp_msg_nap_device_dna_req_t(
-          &msg->nap_device_dna_req);
-    case SBP_MSG_NAP_DEVICE_DNA_RESP:
-      return sbp_packed_size_sbp_msg_nap_device_dna_resp_t(
-          &msg->nap_device_dna_resp);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
-      return sbp_packed_size_sbp_msg_bootloader_handshake_dep_a_t(
-          &msg->bootloader_handshake_dep_a);
-    case SBP_MSG_STARTUP:
-      return sbp_packed_size_sbp_msg_startup_t(&msg->startup);
-    case SBP_MSG_DGNSS_STATUS:
-      return sbp_packed_size_sbp_msg_dgnss_status_t(&msg->dgnss_status);
-    case SBP_MSG_HEARTBEAT:
-      return sbp_packed_size_sbp_msg_heartbeat_t(&msg->heartbeat);
-    case SBP_MSG_STATUS_REPORT:
-      return sbp_packed_size_sbp_msg_status_report_t(&msg->status_report);
-    case SBP_MSG_INS_STATUS:
-      return sbp_packed_size_sbp_msg_ins_status_t(&msg->ins_status);
-    case SBP_MSG_CSAC_TELEMETRY:
-      return sbp_packed_size_sbp_msg_csac_telemetry_t(&msg->csac_telemetry);
-    case SBP_MSG_CSAC_TELEMETRY_LABELS:
-      return sbp_packed_size_sbp_msg_csac_telemetry_labels_t(
-          &msg->csac_telemetry_labels);
-    case SBP_MSG_INS_UPDATES:
-      return sbp_packed_size_sbp_msg_ins_updates_t(&msg->ins_updates);
-    case SBP_MSG_GNSS_TIME_OFFSET:
-      return sbp_packed_size_sbp_msg_gnss_time_offset_t(&msg->gnss_time_offset);
-    case SBP_MSG_PPS_TIME:
-      return sbp_packed_size_sbp_msg_pps_time_t(&msg->pps_time);
-    case SBP_MSG_GROUP_META:
-      return sbp_packed_size_sbp_msg_group_meta_t(&msg->group_meta);
+    case SBP_MSG_NDB_EVENT:
+      return sbp_packed_size_sbp_msg_ndb_event_t(&msg->ndb_event);
     case SBP_MSG_OBS:
       return sbp_packed_size_sbp_msg_obs_t(&msg->obs);
     case SBP_MSG_BASE_POS_LLH:
@@ -1778,8 +1709,14 @@ static inline size_t sbp_packed_size(uint16_t msg_type, const sbp_msg_t *msg) {
       return sbp_packed_size_sbp_msg_sv_az_el_t(&msg->sv_az_el);
     case SBP_MSG_OSR:
       return sbp_packed_size_sbp_msg_osr_t(&msg->osr);
-    case SBP_MSG_SBAS_RAW:
-      return sbp_packed_size_sbp_msg_sbas_raw_t(&msg->sbas_raw);
+    case SBP_MSG_BASELINE_HEADING:
+      return sbp_packed_size_sbp_msg_baseline_heading_t(&msg->baseline_heading);
+    case SBP_MSG_ORIENT_QUAT:
+      return sbp_packed_size_sbp_msg_orient_quat_t(&msg->orient_quat);
+    case SBP_MSG_ORIENT_EULER:
+      return sbp_packed_size_sbp_msg_orient_euler_t(&msg->orient_euler);
+    case SBP_MSG_ANGULAR_RATE:
+      return sbp_packed_size_sbp_msg_angular_rate_t(&msg->angular_rate);
     case SBP_MSG_ALMANAC:
       return sbp_packed_size_sbp_msg_almanac_t(&msg->almanac);
     case SBP_MSG_SET_TIME:
@@ -1835,64 +1772,127 @@ static inline size_t sbp_packed_size(uint16_t msg_type, const sbp_msg_t *msg) {
       return sbp_packed_size_sbp_msg_specan_t(&msg->specan);
     case SBP_MSG_FRONT_END_GAIN:
       return sbp_packed_size_sbp_msg_front_end_gain_t(&msg->front_end_gain);
-    case SBP_MSG_FLASH_PROGRAM:
-      return sbp_packed_size_sbp_msg_flash_program_t(&msg->flash_program);
-    case SBP_MSG_FLASH_DONE:
-      return sbp_packed_size_sbp_msg_flash_done_t(&msg->flash_done);
-    case SBP_MSG_FLASH_READ_REQ:
-      return sbp_packed_size_sbp_msg_flash_read_req_t(&msg->flash_read_req);
-    case SBP_MSG_FLASH_READ_RESP:
-      return sbp_packed_size_sbp_msg_flash_read_resp_t(&msg->flash_read_resp);
-    case SBP_MSG_FLASH_ERASE:
-      return sbp_packed_size_sbp_msg_flash_erase_t(&msg->flash_erase);
-    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
-      return sbp_packed_size_sbp_msg_stm_flash_lock_sector_t(
-          &msg->stm_flash_lock_sector);
-    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
-      return sbp_packed_size_sbp_msg_stm_flash_unlock_sector_t(
-          &msg->stm_flash_unlock_sector);
-    case SBP_MSG_STM_UNIQUE_ID_REQ:
-      return sbp_packed_size_sbp_msg_stm_unique_id_req_t(
-          &msg->stm_unique_id_req);
-    case SBP_MSG_STM_UNIQUE_ID_RESP:
-      return sbp_packed_size_sbp_msg_stm_unique_id_resp_t(
-          &msg->stm_unique_id_resp);
-    case SBP_MSG_M25_FLASH_WRITE_STATUS:
-      return sbp_packed_size_sbp_msg_m25_flash_write_status_t(
-          &msg->m25_flash_write_status);
-    case SBP_MSG_IMU_RAW:
-      return sbp_packed_size_sbp_msg_imu_raw_t(&msg->imu_raw);
-    case SBP_MSG_IMU_AUX:
-      return sbp_packed_size_sbp_msg_imu_aux_t(&msg->imu_aux);
-    case SBP_MSG_NDB_EVENT:
-      return sbp_packed_size_sbp_msg_ndb_event_t(&msg->ndb_event);
-    case SBP_MSG_ACQ_RESULT:
-      return sbp_packed_size_sbp_msg_acq_result_t(&msg->acq_result);
-    case SBP_MSG_ACQ_RESULT_DEP_C:
-      return sbp_packed_size_sbp_msg_acq_result_dep_c_t(&msg->acq_result_dep_c);
-    case SBP_MSG_ACQ_RESULT_DEP_B:
-      return sbp_packed_size_sbp_msg_acq_result_dep_b_t(&msg->acq_result_dep_b);
-    case SBP_MSG_ACQ_RESULT_DEP_A:
-      return sbp_packed_size_sbp_msg_acq_result_dep_a_t(&msg->acq_result_dep_a);
-    case SBP_MSG_ACQ_SV_PROFILE:
-      return sbp_packed_size_sbp_msg_acq_sv_profile_t(&msg->acq_sv_profile);
-    case SBP_MSG_ACQ_SV_PROFILE_DEP:
-      return sbp_packed_size_sbp_msg_acq_sv_profile_dep_t(
-          &msg->acq_sv_profile_dep);
+    case SBP_MSG_SBAS_RAW:
+      return sbp_packed_size_sbp_msg_sbas_raw_t(&msg->sbas_raw);
+    case SBP_MSG_SETTINGS_SAVE:
+      return sbp_packed_size_sbp_msg_settings_save_t(&msg->settings_save);
+    case SBP_MSG_SETTINGS_WRITE:
+      return sbp_packed_size_sbp_msg_settings_write_t(&msg->settings_write);
+    case SBP_MSG_SETTINGS_WRITE_RESP:
+      return sbp_packed_size_sbp_msg_settings_write_resp_t(
+          &msg->settings_write_resp);
+    case SBP_MSG_SETTINGS_READ_REQ:
+      return sbp_packed_size_sbp_msg_settings_read_req_t(
+          &msg->settings_read_req);
+    case SBP_MSG_SETTINGS_READ_RESP:
+      return sbp_packed_size_sbp_msg_settings_read_resp_t(
+          &msg->settings_read_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
+      return sbp_packed_size_sbp_msg_settings_read_by_index_req_t(
+          &msg->settings_read_by_index_req);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
+      return sbp_packed_size_sbp_msg_settings_read_by_index_resp_t(
+          &msg->settings_read_by_index_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
+      return sbp_packed_size_sbp_msg_settings_read_by_index_done_t(
+          &msg->settings_read_by_index_done);
+    case SBP_MSG_SETTINGS_REGISTER:
+      return sbp_packed_size_sbp_msg_settings_register_t(
+          &msg->settings_register);
+    case SBP_MSG_SETTINGS_REGISTER_RESP:
+      return sbp_packed_size_sbp_msg_settings_register_resp_t(
+          &msg->settings_register_resp);
     case SBP_MSG_SOLN_META_DEP_A:
       return sbp_packed_size_sbp_msg_soln_meta_dep_a_t(&msg->soln_meta_dep_a);
     case SBP_MSG_SOLN_META:
       return sbp_packed_size_sbp_msg_soln_meta_t(&msg->soln_meta);
-    case SBP_MSG_BASELINE_HEADING:
-      return sbp_packed_size_sbp_msg_baseline_heading_t(&msg->baseline_heading);
-    case SBP_MSG_ORIENT_QUAT:
-      return sbp_packed_size_sbp_msg_orient_quat_t(&msg->orient_quat);
-    case SBP_MSG_ORIENT_EULER:
-      return sbp_packed_size_sbp_msg_orient_euler_t(&msg->orient_euler);
-    case SBP_MSG_ANGULAR_RATE:
-      return sbp_packed_size_sbp_msg_angular_rate_t(&msg->angular_rate);
-    case SBP_MSG_MAG_RAW:
-      return sbp_packed_size_sbp_msg_mag_raw_t(&msg->mag_raw);
+    case SBP_MSG_SSR_ORBIT_CLOCK:
+      return sbp_packed_size_sbp_msg_ssr_orbit_clock_t(&msg->ssr_orbit_clock);
+    case SBP_MSG_SSR_CODE_BIASES:
+      return sbp_packed_size_sbp_msg_ssr_code_biases_t(&msg->ssr_code_biases);
+    case SBP_MSG_SSR_PHASE_BIASES:
+      return sbp_packed_size_sbp_msg_ssr_phase_biases_t(&msg->ssr_phase_biases);
+    case SBP_MSG_SSR_STEC_CORRECTION:
+      return sbp_packed_size_sbp_msg_ssr_stec_correction_t(
+          &msg->ssr_stec_correction);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION:
+      return sbp_packed_size_sbp_msg_ssr_gridded_correction_t(
+          &msg->ssr_gridded_correction);
+    case SBP_MSG_SSR_TILE_DEFINITION:
+      return sbp_packed_size_sbp_msg_ssr_tile_definition_t(
+          &msg->ssr_tile_definition);
+    case SBP_MSG_SSR_SATELLITE_APC:
+      return sbp_packed_size_sbp_msg_ssr_satellite_apc_t(
+          &msg->ssr_satellite_apc);
+    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
+      return sbp_packed_size_sbp_msg_ssr_orbit_clock_dep_a_t(
+          &msg->ssr_orbit_clock_dep_a);
+    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
+      return sbp_packed_size_sbp_msg_ssr_stec_correction_dep_a_t(
+          &msg->ssr_stec_correction_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
+      return sbp_packed_size_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+          &msg->ssr_gridded_correction_no_std_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
+      return sbp_packed_size_sbp_msg_ssr_gridded_correction_dep_a_t(
+          &msg->ssr_gridded_correction_dep_a);
+    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
+      return sbp_packed_size_sbp_msg_ssr_grid_definition_dep_a_t(
+          &msg->ssr_grid_definition_dep_a);
+    case SBP_MSG_STARTUP:
+      return sbp_packed_size_sbp_msg_startup_t(&msg->startup);
+    case SBP_MSG_DGNSS_STATUS:
+      return sbp_packed_size_sbp_msg_dgnss_status_t(&msg->dgnss_status);
+    case SBP_MSG_HEARTBEAT:
+      return sbp_packed_size_sbp_msg_heartbeat_t(&msg->heartbeat);
+    case SBP_MSG_STATUS_REPORT:
+      return sbp_packed_size_sbp_msg_status_report_t(&msg->status_report);
+    case SBP_MSG_INS_STATUS:
+      return sbp_packed_size_sbp_msg_ins_status_t(&msg->ins_status);
+    case SBP_MSG_CSAC_TELEMETRY:
+      return sbp_packed_size_sbp_msg_csac_telemetry_t(&msg->csac_telemetry);
+    case SBP_MSG_CSAC_TELEMETRY_LABELS:
+      return sbp_packed_size_sbp_msg_csac_telemetry_labels_t(
+          &msg->csac_telemetry_labels);
+    case SBP_MSG_INS_UPDATES:
+      return sbp_packed_size_sbp_msg_ins_updates_t(&msg->ins_updates);
+    case SBP_MSG_GNSS_TIME_OFFSET:
+      return sbp_packed_size_sbp_msg_gnss_time_offset_t(&msg->gnss_time_offset);
+    case SBP_MSG_PPS_TIME:
+      return sbp_packed_size_sbp_msg_pps_time_t(&msg->pps_time);
+    case SBP_MSG_GROUP_META:
+      return sbp_packed_size_sbp_msg_group_meta_t(&msg->group_meta);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
+      return sbp_packed_size_sbp_msg_tracking_state_detailed_dep_a_t(
+          &msg->tracking_state_detailed_dep_a);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
+      return sbp_packed_size_sbp_msg_tracking_state_detailed_dep_t(
+          &msg->tracking_state_detailed_dep);
+    case SBP_MSG_TRACKING_STATE:
+      return sbp_packed_size_sbp_msg_tracking_state_t(&msg->tracking_state);
+    case SBP_MSG_MEASUREMENT_STATE:
+      return sbp_packed_size_sbp_msg_measurement_state_t(
+          &msg->measurement_state);
+    case SBP_MSG_TRACKING_IQ:
+      return sbp_packed_size_sbp_msg_tracking_iq_t(&msg->tracking_iq);
+    case SBP_MSG_TRACKING_IQ_DEP_B:
+      return sbp_packed_size_sbp_msg_tracking_iq_dep_b_t(
+          &msg->tracking_iq_dep_b);
+    case SBP_MSG_TRACKING_IQ_DEP_A:
+      return sbp_packed_size_sbp_msg_tracking_iq_dep_a_t(
+          &msg->tracking_iq_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_A:
+      return sbp_packed_size_sbp_msg_tracking_state_dep_a_t(
+          &msg->tracking_state_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_B:
+      return sbp_packed_size_sbp_msg_tracking_state_dep_b_t(
+          &msg->tracking_state_dep_b);
+    case SBP_MSG_USER_DATA:
+      return sbp_packed_size_sbp_msg_user_data_t(&msg->user_data);
+    case SBP_MSG_ODOMETRY:
+      return sbp_packed_size_sbp_msg_odometry_t(&msg->odometry);
+    case SBP_MSG_WHEELTICK:
+      return sbp_packed_size_sbp_msg_wheeltick_t(&msg->wheeltick);
     default:
       break;
   }
@@ -1902,107 +1902,102 @@ static inline size_t sbp_packed_size(uint16_t msg_type, const sbp_msg_t *msg) {
 static inline int sbp_msg_cmp(uint16_t msg_type, const sbp_msg_t *a,
                               const sbp_msg_t *b) {
   switch (msg_type) {
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
-      return sbp_cmp_sbp_msg_tracking_state_detailed_dep_a_t(
-          &a->tracking_state_detailed_dep_a, &b->tracking_state_detailed_dep_a);
-    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
-      return sbp_cmp_sbp_msg_tracking_state_detailed_dep_t(
-          &a->tracking_state_detailed_dep, &b->tracking_state_detailed_dep);
-    case SBP_MSG_TRACKING_STATE:
-      return sbp_cmp_sbp_msg_tracking_state_t(&a->tracking_state,
-                                              &b->tracking_state);
-    case SBP_MSG_MEASUREMENT_STATE:
-      return sbp_cmp_sbp_msg_measurement_state_t(&a->measurement_state,
-                                                 &b->measurement_state);
-    case SBP_MSG_TRACKING_IQ:
-      return sbp_cmp_sbp_msg_tracking_iq_t(&a->tracking_iq, &b->tracking_iq);
-    case SBP_MSG_TRACKING_IQ_DEP_B:
-      return sbp_cmp_sbp_msg_tracking_iq_dep_b_t(&a->tracking_iq_dep_b,
-                                                 &b->tracking_iq_dep_b);
-    case SBP_MSG_TRACKING_IQ_DEP_A:
-      return sbp_cmp_sbp_msg_tracking_iq_dep_a_t(&a->tracking_iq_dep_a,
-                                                 &b->tracking_iq_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_A:
-      return sbp_cmp_sbp_msg_tracking_state_dep_a_t(&a->tracking_state_dep_a,
-                                                    &b->tracking_state_dep_a);
-    case SBP_MSG_TRACKING_STATE_DEP_B:
-      return sbp_cmp_sbp_msg_tracking_state_dep_b_t(&a->tracking_state_dep_b,
-                                                    &b->tracking_state_dep_b);
-    case SBP_MSG_SETTINGS_SAVE:
-      return sbp_cmp_sbp_msg_settings_save_t(&a->settings_save,
-                                             &b->settings_save);
-    case SBP_MSG_SETTINGS_WRITE:
-      return sbp_cmp_sbp_msg_settings_write_t(&a->settings_write,
-                                              &b->settings_write);
-    case SBP_MSG_SETTINGS_WRITE_RESP:
-      return sbp_cmp_sbp_msg_settings_write_resp_t(&a->settings_write_resp,
-                                                   &b->settings_write_resp);
-    case SBP_MSG_SETTINGS_READ_REQ:
-      return sbp_cmp_sbp_msg_settings_read_req_t(&a->settings_read_req,
-                                                 &b->settings_read_req);
-    case SBP_MSG_SETTINGS_READ_RESP:
-      return sbp_cmp_sbp_msg_settings_read_resp_t(&a->settings_read_resp,
-                                                  &b->settings_read_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
-      return sbp_cmp_sbp_msg_settings_read_by_index_req_t(
-          &a->settings_read_by_index_req, &b->settings_read_by_index_req);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
-      return sbp_cmp_sbp_msg_settings_read_by_index_resp_t(
-          &a->settings_read_by_index_resp, &b->settings_read_by_index_resp);
-    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
-      return sbp_cmp_sbp_msg_settings_read_by_index_done_t(
-          &a->settings_read_by_index_done, &b->settings_read_by_index_done);
-    case SBP_MSG_SETTINGS_REGISTER:
-      return sbp_cmp_sbp_msg_settings_register_t(&a->settings_register,
-                                                 &b->settings_register);
-    case SBP_MSG_SETTINGS_REGISTER_RESP:
-      return sbp_cmp_sbp_msg_settings_register_resp_t(
-          &a->settings_register_resp, &b->settings_register_resp);
-    case SBP_MSG_SSR_ORBIT_CLOCK:
-      return sbp_cmp_sbp_msg_ssr_orbit_clock_t(&a->ssr_orbit_clock,
-                                               &b->ssr_orbit_clock);
-    case SBP_MSG_SSR_CODE_BIASES:
-      return sbp_cmp_sbp_msg_ssr_code_biases_t(&a->ssr_code_biases,
-                                               &b->ssr_code_biases);
-    case SBP_MSG_SSR_PHASE_BIASES:
-      return sbp_cmp_sbp_msg_ssr_phase_biases_t(&a->ssr_phase_biases,
-                                                &b->ssr_phase_biases);
-    case SBP_MSG_SSR_STEC_CORRECTION:
-      return sbp_cmp_sbp_msg_ssr_stec_correction_t(&a->ssr_stec_correction,
-                                                   &b->ssr_stec_correction);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION:
-      return sbp_cmp_sbp_msg_ssr_gridded_correction_t(
-          &a->ssr_gridded_correction, &b->ssr_gridded_correction);
-    case SBP_MSG_SSR_TILE_DEFINITION:
-      return sbp_cmp_sbp_msg_ssr_tile_definition_t(&a->ssr_tile_definition,
-                                                   &b->ssr_tile_definition);
-    case SBP_MSG_SSR_SATELLITE_APC:
-      return sbp_cmp_sbp_msg_ssr_satellite_apc_t(&a->ssr_satellite_apc,
-                                                 &b->ssr_satellite_apc);
-    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
-      return sbp_cmp_sbp_msg_ssr_orbit_clock_dep_a_t(&a->ssr_orbit_clock_dep_a,
-                                                     &b->ssr_orbit_clock_dep_a);
-    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
-      return sbp_cmp_sbp_msg_ssr_stec_correction_dep_a_t(
-          &a->ssr_stec_correction_dep_a, &b->ssr_stec_correction_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
-      return sbp_cmp_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
-          &a->ssr_gridded_correction_no_std_dep_a,
-          &b->ssr_gridded_correction_no_std_dep_a);
-    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
-      return sbp_cmp_sbp_msg_ssr_gridded_correction_dep_a_t(
-          &a->ssr_gridded_correction_dep_a, &b->ssr_gridded_correction_dep_a);
-    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
-      return sbp_cmp_sbp_msg_ssr_grid_definition_dep_a_t(
-          &a->ssr_grid_definition_dep_a, &b->ssr_grid_definition_dep_a);
+    case SBP_MSG_ACQ_RESULT:
+      return sbp_cmp_sbp_msg_acq_result_t(&a->acq_result, &b->acq_result);
+    case SBP_MSG_ACQ_RESULT_DEP_C:
+      return sbp_cmp_sbp_msg_acq_result_dep_c_t(&a->acq_result_dep_c,
+                                                &b->acq_result_dep_c);
+    case SBP_MSG_ACQ_RESULT_DEP_B:
+      return sbp_cmp_sbp_msg_acq_result_dep_b_t(&a->acq_result_dep_b,
+                                                &b->acq_result_dep_b);
+    case SBP_MSG_ACQ_RESULT_DEP_A:
+      return sbp_cmp_sbp_msg_acq_result_dep_a_t(&a->acq_result_dep_a,
+                                                &b->acq_result_dep_a);
+    case SBP_MSG_ACQ_SV_PROFILE:
+      return sbp_cmp_sbp_msg_acq_sv_profile_t(&a->acq_sv_profile,
+                                              &b->acq_sv_profile);
+    case SBP_MSG_ACQ_SV_PROFILE_DEP:
+      return sbp_cmp_sbp_msg_acq_sv_profile_dep_t(&a->acq_sv_profile_dep,
+                                                  &b->acq_sv_profile_dep);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
+      return sbp_cmp_sbp_msg_bootloader_handshake_req_t(
+          &a->bootloader_handshake_req, &b->bootloader_handshake_req);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
+      return sbp_cmp_sbp_msg_bootloader_handshake_resp_t(
+          &a->bootloader_handshake_resp, &b->bootloader_handshake_resp);
+    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
+      return sbp_cmp_sbp_msg_bootloader_jump_to_app_t(
+          &a->bootloader_jump_to_app, &b->bootloader_jump_to_app);
+    case SBP_MSG_NAP_DEVICE_DNA_REQ:
+      return sbp_cmp_sbp_msg_nap_device_dna_req_t(&a->nap_device_dna_req,
+                                                  &b->nap_device_dna_req);
+    case SBP_MSG_NAP_DEVICE_DNA_RESP:
+      return sbp_cmp_sbp_msg_nap_device_dna_resp_t(&a->nap_device_dna_resp,
+                                                   &b->nap_device_dna_resp);
+    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
+      return sbp_cmp_sbp_msg_bootloader_handshake_dep_a_t(
+          &a->bootloader_handshake_dep_a, &b->bootloader_handshake_dep_a);
     case SBP_MSG_EXT_EVENT:
       return sbp_cmp_sbp_msg_ext_event_t(&a->ext_event, &b->ext_event);
-    case SBP_MSG_ODOMETRY:
-      return sbp_cmp_sbp_msg_odometry_t(&a->odometry, &b->odometry);
-    case SBP_MSG_WHEELTICK:
-      return sbp_cmp_sbp_msg_wheeltick_t(&a->wheeltick, &b->wheeltick);
-    case SBP_MSG_USER_DATA:
-      return sbp_cmp_sbp_msg_user_data_t(&a->user_data, &b->user_data);
+    case SBP_MSG_FILEIO_READ_REQ:
+      return sbp_cmp_sbp_msg_fileio_read_req_t(&a->fileio_read_req,
+                                               &b->fileio_read_req);
+    case SBP_MSG_FILEIO_READ_RESP:
+      return sbp_cmp_sbp_msg_fileio_read_resp_t(&a->fileio_read_resp,
+                                                &b->fileio_read_resp);
+    case SBP_MSG_FILEIO_READ_DIR_REQ:
+      return sbp_cmp_sbp_msg_fileio_read_dir_req_t(&a->fileio_read_dir_req,
+                                                   &b->fileio_read_dir_req);
+    case SBP_MSG_FILEIO_READ_DIR_RESP:
+      return sbp_cmp_sbp_msg_fileio_read_dir_resp_t(&a->fileio_read_dir_resp,
+                                                    &b->fileio_read_dir_resp);
+    case SBP_MSG_FILEIO_REMOVE:
+      return sbp_cmp_sbp_msg_fileio_remove_t(&a->fileio_remove,
+                                             &b->fileio_remove);
+    case SBP_MSG_FILEIO_WRITE_REQ:
+      return sbp_cmp_sbp_msg_fileio_write_req_t(&a->fileio_write_req,
+                                                &b->fileio_write_req);
+    case SBP_MSG_FILEIO_WRITE_RESP:
+      return sbp_cmp_sbp_msg_fileio_write_resp_t(&a->fileio_write_resp,
+                                                 &b->fileio_write_resp);
+    case SBP_MSG_FILEIO_CONFIG_REQ:
+      return sbp_cmp_sbp_msg_fileio_config_req_t(&a->fileio_config_req,
+                                                 &b->fileio_config_req);
+    case SBP_MSG_FILEIO_CONFIG_RESP:
+      return sbp_cmp_sbp_msg_fileio_config_resp_t(&a->fileio_config_resp,
+                                                  &b->fileio_config_resp);
+    case SBP_MSG_FLASH_PROGRAM:
+      return sbp_cmp_sbp_msg_flash_program_t(&a->flash_program,
+                                             &b->flash_program);
+    case SBP_MSG_FLASH_DONE:
+      return sbp_cmp_sbp_msg_flash_done_t(&a->flash_done, &b->flash_done);
+    case SBP_MSG_FLASH_READ_REQ:
+      return sbp_cmp_sbp_msg_flash_read_req_t(&a->flash_read_req,
+                                              &b->flash_read_req);
+    case SBP_MSG_FLASH_READ_RESP:
+      return sbp_cmp_sbp_msg_flash_read_resp_t(&a->flash_read_resp,
+                                               &b->flash_read_resp);
+    case SBP_MSG_FLASH_ERASE:
+      return sbp_cmp_sbp_msg_flash_erase_t(&a->flash_erase, &b->flash_erase);
+    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
+      return sbp_cmp_sbp_msg_stm_flash_lock_sector_t(&a->stm_flash_lock_sector,
+                                                     &b->stm_flash_lock_sector);
+    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
+      return sbp_cmp_sbp_msg_stm_flash_unlock_sector_t(
+          &a->stm_flash_unlock_sector, &b->stm_flash_unlock_sector);
+    case SBP_MSG_STM_UNIQUE_ID_REQ:
+      return sbp_cmp_sbp_msg_stm_unique_id_req_t(&a->stm_unique_id_req,
+                                                 &b->stm_unique_id_req);
+    case SBP_MSG_STM_UNIQUE_ID_RESP:
+      return sbp_cmp_sbp_msg_stm_unique_id_resp_t(&a->stm_unique_id_resp,
+                                                  &b->stm_unique_id_resp);
+    case SBP_MSG_M25_FLASH_WRITE_STATUS:
+      return sbp_cmp_sbp_msg_m25_flash_write_status_t(
+          &a->m25_flash_write_status, &b->m25_flash_write_status);
+    case SBP_MSG_IMU_RAW:
+      return sbp_cmp_sbp_msg_imu_raw_t(&a->imu_raw, &b->imu_raw);
+    case SBP_MSG_IMU_AUX:
+      return sbp_cmp_sbp_msg_imu_aux_t(&a->imu_aux, &b->imu_aux);
     case SBP_MSG_LINUX_CPU_STATE_DEP_A:
       return sbp_cmp_sbp_msg_linux_cpu_state_dep_a_t(&a->linux_cpu_state_dep_a,
                                                      &b->linux_cpu_state_dep_a);
@@ -2036,6 +2031,14 @@ static inline int sbp_msg_cmp(uint16_t msg_type, const sbp_msg_t *a,
     case SBP_MSG_LINUX_SYS_STATE:
       return sbp_cmp_sbp_msg_linux_sys_state_t(&a->linux_sys_state,
                                                &b->linux_sys_state);
+    case SBP_MSG_LOG:
+      return sbp_cmp_sbp_msg_log_t(&a->log, &b->log);
+    case SBP_MSG_FWD:
+      return sbp_cmp_sbp_msg_fwd_t(&a->fwd, &b->fwd);
+    case SBP_MSG_PRINT_DEP:
+      return sbp_cmp_sbp_msg_print_dep_t(&a->print_dep, &b->print_dep);
+    case SBP_MSG_MAG_RAW:
+      return sbp_cmp_sbp_msg_mag_raw_t(&a->mag_raw, &b->mag_raw);
     case SBP_MSG_GPS_TIME:
       return sbp_cmp_sbp_msg_gps_time_t(&a->gps_time, &b->gps_time);
     case SBP_MSG_GPS_TIME_GNSS:
@@ -2128,83 +2131,8 @@ static inline int sbp_msg_cmp(uint16_t msg_type, const sbp_msg_t *a,
     case SBP_MSG_PROTECTION_LEVEL:
       return sbp_cmp_sbp_msg_protection_level_t(&a->protection_level,
                                                 &b->protection_level);
-    case SBP_MSG_FILEIO_READ_REQ:
-      return sbp_cmp_sbp_msg_fileio_read_req_t(&a->fileio_read_req,
-                                               &b->fileio_read_req);
-    case SBP_MSG_FILEIO_READ_RESP:
-      return sbp_cmp_sbp_msg_fileio_read_resp_t(&a->fileio_read_resp,
-                                                &b->fileio_read_resp);
-    case SBP_MSG_FILEIO_READ_DIR_REQ:
-      return sbp_cmp_sbp_msg_fileio_read_dir_req_t(&a->fileio_read_dir_req,
-                                                   &b->fileio_read_dir_req);
-    case SBP_MSG_FILEIO_READ_DIR_RESP:
-      return sbp_cmp_sbp_msg_fileio_read_dir_resp_t(&a->fileio_read_dir_resp,
-                                                    &b->fileio_read_dir_resp);
-    case SBP_MSG_FILEIO_REMOVE:
-      return sbp_cmp_sbp_msg_fileio_remove_t(&a->fileio_remove,
-                                             &b->fileio_remove);
-    case SBP_MSG_FILEIO_WRITE_REQ:
-      return sbp_cmp_sbp_msg_fileio_write_req_t(&a->fileio_write_req,
-                                                &b->fileio_write_req);
-    case SBP_MSG_FILEIO_WRITE_RESP:
-      return sbp_cmp_sbp_msg_fileio_write_resp_t(&a->fileio_write_resp,
-                                                 &b->fileio_write_resp);
-    case SBP_MSG_FILEIO_CONFIG_REQ:
-      return sbp_cmp_sbp_msg_fileio_config_req_t(&a->fileio_config_req,
-                                                 &b->fileio_config_req);
-    case SBP_MSG_FILEIO_CONFIG_RESP:
-      return sbp_cmp_sbp_msg_fileio_config_resp_t(&a->fileio_config_resp,
-                                                  &b->fileio_config_resp);
-    case SBP_MSG_LOG:
-      return sbp_cmp_sbp_msg_log_t(&a->log, &b->log);
-    case SBP_MSG_FWD:
-      return sbp_cmp_sbp_msg_fwd_t(&a->fwd, &b->fwd);
-    case SBP_MSG_PRINT_DEP:
-      return sbp_cmp_sbp_msg_print_dep_t(&a->print_dep, &b->print_dep);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_REQ:
-      return sbp_cmp_sbp_msg_bootloader_handshake_req_t(
-          &a->bootloader_handshake_req, &b->bootloader_handshake_req);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_RESP:
-      return sbp_cmp_sbp_msg_bootloader_handshake_resp_t(
-          &a->bootloader_handshake_resp, &b->bootloader_handshake_resp);
-    case SBP_MSG_BOOTLOADER_JUMP_TO_APP:
-      return sbp_cmp_sbp_msg_bootloader_jump_to_app_t(
-          &a->bootloader_jump_to_app, &b->bootloader_jump_to_app);
-    case SBP_MSG_NAP_DEVICE_DNA_REQ:
-      return sbp_cmp_sbp_msg_nap_device_dna_req_t(&a->nap_device_dna_req,
-                                                  &b->nap_device_dna_req);
-    case SBP_MSG_NAP_DEVICE_DNA_RESP:
-      return sbp_cmp_sbp_msg_nap_device_dna_resp_t(&a->nap_device_dna_resp,
-                                                   &b->nap_device_dna_resp);
-    case SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A:
-      return sbp_cmp_sbp_msg_bootloader_handshake_dep_a_t(
-          &a->bootloader_handshake_dep_a, &b->bootloader_handshake_dep_a);
-    case SBP_MSG_STARTUP:
-      return sbp_cmp_sbp_msg_startup_t(&a->startup, &b->startup);
-    case SBP_MSG_DGNSS_STATUS:
-      return sbp_cmp_sbp_msg_dgnss_status_t(&a->dgnss_status, &b->dgnss_status);
-    case SBP_MSG_HEARTBEAT:
-      return sbp_cmp_sbp_msg_heartbeat_t(&a->heartbeat, &b->heartbeat);
-    case SBP_MSG_STATUS_REPORT:
-      return sbp_cmp_sbp_msg_status_report_t(&a->status_report,
-                                             &b->status_report);
-    case SBP_MSG_INS_STATUS:
-      return sbp_cmp_sbp_msg_ins_status_t(&a->ins_status, &b->ins_status);
-    case SBP_MSG_CSAC_TELEMETRY:
-      return sbp_cmp_sbp_msg_csac_telemetry_t(&a->csac_telemetry,
-                                              &b->csac_telemetry);
-    case SBP_MSG_CSAC_TELEMETRY_LABELS:
-      return sbp_cmp_sbp_msg_csac_telemetry_labels_t(&a->csac_telemetry_labels,
-                                                     &b->csac_telemetry_labels);
-    case SBP_MSG_INS_UPDATES:
-      return sbp_cmp_sbp_msg_ins_updates_t(&a->ins_updates, &b->ins_updates);
-    case SBP_MSG_GNSS_TIME_OFFSET:
-      return sbp_cmp_sbp_msg_gnss_time_offset_t(&a->gnss_time_offset,
-                                                &b->gnss_time_offset);
-    case SBP_MSG_PPS_TIME:
-      return sbp_cmp_sbp_msg_pps_time_t(&a->pps_time, &b->pps_time);
-    case SBP_MSG_GROUP_META:
-      return sbp_cmp_sbp_msg_group_meta_t(&a->group_meta, &b->group_meta);
+    case SBP_MSG_NDB_EVENT:
+      return sbp_cmp_sbp_msg_ndb_event_t(&a->ndb_event, &b->ndb_event);
     case SBP_MSG_OBS:
       return sbp_cmp_sbp_msg_obs_t(&a->obs, &b->obs);
     case SBP_MSG_BASE_POS_LLH:
@@ -2306,8 +2234,15 @@ static inline int sbp_msg_cmp(uint16_t msg_type, const sbp_msg_t *a,
       return sbp_cmp_sbp_msg_sv_az_el_t(&a->sv_az_el, &b->sv_az_el);
     case SBP_MSG_OSR:
       return sbp_cmp_sbp_msg_osr_t(&a->osr, &b->osr);
-    case SBP_MSG_SBAS_RAW:
-      return sbp_cmp_sbp_msg_sbas_raw_t(&a->sbas_raw, &b->sbas_raw);
+    case SBP_MSG_BASELINE_HEADING:
+      return sbp_cmp_sbp_msg_baseline_heading_t(&a->baseline_heading,
+                                                &b->baseline_heading);
+    case SBP_MSG_ORIENT_QUAT:
+      return sbp_cmp_sbp_msg_orient_quat_t(&a->orient_quat, &b->orient_quat);
+    case SBP_MSG_ORIENT_EULER:
+      return sbp_cmp_sbp_msg_orient_euler_t(&a->orient_euler, &b->orient_euler);
+    case SBP_MSG_ANGULAR_RATE:
+      return sbp_cmp_sbp_msg_angular_rate_t(&a->angular_rate, &b->angular_rate);
     case SBP_MSG_ALMANAC:
       return sbp_cmp_sbp_msg_almanac_t(&a->almanac, &b->almanac);
     case SBP_MSG_SET_TIME:
@@ -2370,73 +2305,138 @@ static inline int sbp_msg_cmp(uint16_t msg_type, const sbp_msg_t *a,
     case SBP_MSG_FRONT_END_GAIN:
       return sbp_cmp_sbp_msg_front_end_gain_t(&a->front_end_gain,
                                               &b->front_end_gain);
-    case SBP_MSG_FLASH_PROGRAM:
-      return sbp_cmp_sbp_msg_flash_program_t(&a->flash_program,
-                                             &b->flash_program);
-    case SBP_MSG_FLASH_DONE:
-      return sbp_cmp_sbp_msg_flash_done_t(&a->flash_done, &b->flash_done);
-    case SBP_MSG_FLASH_READ_REQ:
-      return sbp_cmp_sbp_msg_flash_read_req_t(&a->flash_read_req,
-                                              &b->flash_read_req);
-    case SBP_MSG_FLASH_READ_RESP:
-      return sbp_cmp_sbp_msg_flash_read_resp_t(&a->flash_read_resp,
-                                               &b->flash_read_resp);
-    case SBP_MSG_FLASH_ERASE:
-      return sbp_cmp_sbp_msg_flash_erase_t(&a->flash_erase, &b->flash_erase);
-    case SBP_MSG_STM_FLASH_LOCK_SECTOR:
-      return sbp_cmp_sbp_msg_stm_flash_lock_sector_t(&a->stm_flash_lock_sector,
-                                                     &b->stm_flash_lock_sector);
-    case SBP_MSG_STM_FLASH_UNLOCK_SECTOR:
-      return sbp_cmp_sbp_msg_stm_flash_unlock_sector_t(
-          &a->stm_flash_unlock_sector, &b->stm_flash_unlock_sector);
-    case SBP_MSG_STM_UNIQUE_ID_REQ:
-      return sbp_cmp_sbp_msg_stm_unique_id_req_t(&a->stm_unique_id_req,
-                                                 &b->stm_unique_id_req);
-    case SBP_MSG_STM_UNIQUE_ID_RESP:
-      return sbp_cmp_sbp_msg_stm_unique_id_resp_t(&a->stm_unique_id_resp,
-                                                  &b->stm_unique_id_resp);
-    case SBP_MSG_M25_FLASH_WRITE_STATUS:
-      return sbp_cmp_sbp_msg_m25_flash_write_status_t(
-          &a->m25_flash_write_status, &b->m25_flash_write_status);
-    case SBP_MSG_IMU_RAW:
-      return sbp_cmp_sbp_msg_imu_raw_t(&a->imu_raw, &b->imu_raw);
-    case SBP_MSG_IMU_AUX:
-      return sbp_cmp_sbp_msg_imu_aux_t(&a->imu_aux, &b->imu_aux);
-    case SBP_MSG_NDB_EVENT:
-      return sbp_cmp_sbp_msg_ndb_event_t(&a->ndb_event, &b->ndb_event);
-    case SBP_MSG_ACQ_RESULT:
-      return sbp_cmp_sbp_msg_acq_result_t(&a->acq_result, &b->acq_result);
-    case SBP_MSG_ACQ_RESULT_DEP_C:
-      return sbp_cmp_sbp_msg_acq_result_dep_c_t(&a->acq_result_dep_c,
-                                                &b->acq_result_dep_c);
-    case SBP_MSG_ACQ_RESULT_DEP_B:
-      return sbp_cmp_sbp_msg_acq_result_dep_b_t(&a->acq_result_dep_b,
-                                                &b->acq_result_dep_b);
-    case SBP_MSG_ACQ_RESULT_DEP_A:
-      return sbp_cmp_sbp_msg_acq_result_dep_a_t(&a->acq_result_dep_a,
-                                                &b->acq_result_dep_a);
-    case SBP_MSG_ACQ_SV_PROFILE:
-      return sbp_cmp_sbp_msg_acq_sv_profile_t(&a->acq_sv_profile,
-                                              &b->acq_sv_profile);
-    case SBP_MSG_ACQ_SV_PROFILE_DEP:
-      return sbp_cmp_sbp_msg_acq_sv_profile_dep_t(&a->acq_sv_profile_dep,
-                                                  &b->acq_sv_profile_dep);
+    case SBP_MSG_SBAS_RAW:
+      return sbp_cmp_sbp_msg_sbas_raw_t(&a->sbas_raw, &b->sbas_raw);
+    case SBP_MSG_SETTINGS_SAVE:
+      return sbp_cmp_sbp_msg_settings_save_t(&a->settings_save,
+                                             &b->settings_save);
+    case SBP_MSG_SETTINGS_WRITE:
+      return sbp_cmp_sbp_msg_settings_write_t(&a->settings_write,
+                                              &b->settings_write);
+    case SBP_MSG_SETTINGS_WRITE_RESP:
+      return sbp_cmp_sbp_msg_settings_write_resp_t(&a->settings_write_resp,
+                                                   &b->settings_write_resp);
+    case SBP_MSG_SETTINGS_READ_REQ:
+      return sbp_cmp_sbp_msg_settings_read_req_t(&a->settings_read_req,
+                                                 &b->settings_read_req);
+    case SBP_MSG_SETTINGS_READ_RESP:
+      return sbp_cmp_sbp_msg_settings_read_resp_t(&a->settings_read_resp,
+                                                  &b->settings_read_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_REQ:
+      return sbp_cmp_sbp_msg_settings_read_by_index_req_t(
+          &a->settings_read_by_index_req, &b->settings_read_by_index_req);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_RESP:
+      return sbp_cmp_sbp_msg_settings_read_by_index_resp_t(
+          &a->settings_read_by_index_resp, &b->settings_read_by_index_resp);
+    case SBP_MSG_SETTINGS_READ_BY_INDEX_DONE:
+      return sbp_cmp_sbp_msg_settings_read_by_index_done_t(
+          &a->settings_read_by_index_done, &b->settings_read_by_index_done);
+    case SBP_MSG_SETTINGS_REGISTER:
+      return sbp_cmp_sbp_msg_settings_register_t(&a->settings_register,
+                                                 &b->settings_register);
+    case SBP_MSG_SETTINGS_REGISTER_RESP:
+      return sbp_cmp_sbp_msg_settings_register_resp_t(
+          &a->settings_register_resp, &b->settings_register_resp);
     case SBP_MSG_SOLN_META_DEP_A:
       return sbp_cmp_sbp_msg_soln_meta_dep_a_t(&a->soln_meta_dep_a,
                                                &b->soln_meta_dep_a);
     case SBP_MSG_SOLN_META:
       return sbp_cmp_sbp_msg_soln_meta_t(&a->soln_meta, &b->soln_meta);
-    case SBP_MSG_BASELINE_HEADING:
-      return sbp_cmp_sbp_msg_baseline_heading_t(&a->baseline_heading,
-                                                &b->baseline_heading);
-    case SBP_MSG_ORIENT_QUAT:
-      return sbp_cmp_sbp_msg_orient_quat_t(&a->orient_quat, &b->orient_quat);
-    case SBP_MSG_ORIENT_EULER:
-      return sbp_cmp_sbp_msg_orient_euler_t(&a->orient_euler, &b->orient_euler);
-    case SBP_MSG_ANGULAR_RATE:
-      return sbp_cmp_sbp_msg_angular_rate_t(&a->angular_rate, &b->angular_rate);
-    case SBP_MSG_MAG_RAW:
-      return sbp_cmp_sbp_msg_mag_raw_t(&a->mag_raw, &b->mag_raw);
+    case SBP_MSG_SSR_ORBIT_CLOCK:
+      return sbp_cmp_sbp_msg_ssr_orbit_clock_t(&a->ssr_orbit_clock,
+                                               &b->ssr_orbit_clock);
+    case SBP_MSG_SSR_CODE_BIASES:
+      return sbp_cmp_sbp_msg_ssr_code_biases_t(&a->ssr_code_biases,
+                                               &b->ssr_code_biases);
+    case SBP_MSG_SSR_PHASE_BIASES:
+      return sbp_cmp_sbp_msg_ssr_phase_biases_t(&a->ssr_phase_biases,
+                                                &b->ssr_phase_biases);
+    case SBP_MSG_SSR_STEC_CORRECTION:
+      return sbp_cmp_sbp_msg_ssr_stec_correction_t(&a->ssr_stec_correction,
+                                                   &b->ssr_stec_correction);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION:
+      return sbp_cmp_sbp_msg_ssr_gridded_correction_t(
+          &a->ssr_gridded_correction, &b->ssr_gridded_correction);
+    case SBP_MSG_SSR_TILE_DEFINITION:
+      return sbp_cmp_sbp_msg_ssr_tile_definition_t(&a->ssr_tile_definition,
+                                                   &b->ssr_tile_definition);
+    case SBP_MSG_SSR_SATELLITE_APC:
+      return sbp_cmp_sbp_msg_ssr_satellite_apc_t(&a->ssr_satellite_apc,
+                                                 &b->ssr_satellite_apc);
+    case SBP_MSG_SSR_ORBIT_CLOCK_DEP_A:
+      return sbp_cmp_sbp_msg_ssr_orbit_clock_dep_a_t(&a->ssr_orbit_clock_dep_a,
+                                                     &b->ssr_orbit_clock_dep_a);
+    case SBP_MSG_SSR_STEC_CORRECTION_DEP_A:
+      return sbp_cmp_sbp_msg_ssr_stec_correction_dep_a_t(
+          &a->ssr_stec_correction_dep_a, &b->ssr_stec_correction_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A:
+      return sbp_cmp_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+          &a->ssr_gridded_correction_no_std_dep_a,
+          &b->ssr_gridded_correction_no_std_dep_a);
+    case SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A:
+      return sbp_cmp_sbp_msg_ssr_gridded_correction_dep_a_t(
+          &a->ssr_gridded_correction_dep_a, &b->ssr_gridded_correction_dep_a);
+    case SBP_MSG_SSR_GRID_DEFINITION_DEP_A:
+      return sbp_cmp_sbp_msg_ssr_grid_definition_dep_a_t(
+          &a->ssr_grid_definition_dep_a, &b->ssr_grid_definition_dep_a);
+    case SBP_MSG_STARTUP:
+      return sbp_cmp_sbp_msg_startup_t(&a->startup, &b->startup);
+    case SBP_MSG_DGNSS_STATUS:
+      return sbp_cmp_sbp_msg_dgnss_status_t(&a->dgnss_status, &b->dgnss_status);
+    case SBP_MSG_HEARTBEAT:
+      return sbp_cmp_sbp_msg_heartbeat_t(&a->heartbeat, &b->heartbeat);
+    case SBP_MSG_STATUS_REPORT:
+      return sbp_cmp_sbp_msg_status_report_t(&a->status_report,
+                                             &b->status_report);
+    case SBP_MSG_INS_STATUS:
+      return sbp_cmp_sbp_msg_ins_status_t(&a->ins_status, &b->ins_status);
+    case SBP_MSG_CSAC_TELEMETRY:
+      return sbp_cmp_sbp_msg_csac_telemetry_t(&a->csac_telemetry,
+                                              &b->csac_telemetry);
+    case SBP_MSG_CSAC_TELEMETRY_LABELS:
+      return sbp_cmp_sbp_msg_csac_telemetry_labels_t(&a->csac_telemetry_labels,
+                                                     &b->csac_telemetry_labels);
+    case SBP_MSG_INS_UPDATES:
+      return sbp_cmp_sbp_msg_ins_updates_t(&a->ins_updates, &b->ins_updates);
+    case SBP_MSG_GNSS_TIME_OFFSET:
+      return sbp_cmp_sbp_msg_gnss_time_offset_t(&a->gnss_time_offset,
+                                                &b->gnss_time_offset);
+    case SBP_MSG_PPS_TIME:
+      return sbp_cmp_sbp_msg_pps_time_t(&a->pps_time, &b->pps_time);
+    case SBP_MSG_GROUP_META:
+      return sbp_cmp_sbp_msg_group_meta_t(&a->group_meta, &b->group_meta);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP_A:
+      return sbp_cmp_sbp_msg_tracking_state_detailed_dep_a_t(
+          &a->tracking_state_detailed_dep_a, &b->tracking_state_detailed_dep_a);
+    case SBP_MSG_TRACKING_STATE_DETAILED_DEP:
+      return sbp_cmp_sbp_msg_tracking_state_detailed_dep_t(
+          &a->tracking_state_detailed_dep, &b->tracking_state_detailed_dep);
+    case SBP_MSG_TRACKING_STATE:
+      return sbp_cmp_sbp_msg_tracking_state_t(&a->tracking_state,
+                                              &b->tracking_state);
+    case SBP_MSG_MEASUREMENT_STATE:
+      return sbp_cmp_sbp_msg_measurement_state_t(&a->measurement_state,
+                                                 &b->measurement_state);
+    case SBP_MSG_TRACKING_IQ:
+      return sbp_cmp_sbp_msg_tracking_iq_t(&a->tracking_iq, &b->tracking_iq);
+    case SBP_MSG_TRACKING_IQ_DEP_B:
+      return sbp_cmp_sbp_msg_tracking_iq_dep_b_t(&a->tracking_iq_dep_b,
+                                                 &b->tracking_iq_dep_b);
+    case SBP_MSG_TRACKING_IQ_DEP_A:
+      return sbp_cmp_sbp_msg_tracking_iq_dep_a_t(&a->tracking_iq_dep_a,
+                                                 &b->tracking_iq_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_A:
+      return sbp_cmp_sbp_msg_tracking_state_dep_a_t(&a->tracking_state_dep_a,
+                                                    &b->tracking_state_dep_a);
+    case SBP_MSG_TRACKING_STATE_DEP_B:
+      return sbp_cmp_sbp_msg_tracking_state_dep_b_t(&a->tracking_state_dep_b,
+                                                    &b->tracking_state_dep_b);
+    case SBP_MSG_USER_DATA:
+      return sbp_cmp_sbp_msg_user_data_t(&a->user_data, &b->user_data);
+    case SBP_MSG_ODOMETRY:
+      return sbp_cmp_sbp_msg_odometry_t(&a->odometry, &b->odometry);
+    case SBP_MSG_WHEELTICK:
+      return sbp_cmp_sbp_msg_wheeltick_t(&a->wheeltick, &b->wheeltick);
     default:
       break;
   }

--- a/generator/sbpg/generator.py
+++ b/generator/sbpg/generator.py
@@ -185,13 +185,13 @@ def main():
       if args.c:
         import sbpg.targets.c as c
         c.render_version(output_dir, release)
-        parsed = [yaml.parse_spec(spec) for spec in file_index.values()]
+        parsed = [yaml.parse_spec(spec) for _, spec in file_index_items]
         legacy_c.render_traits(output_dir, parsed)
         c.render_traits(output_dir, parsed)
         c.render_headers(output_dir, parsed)
       elif args.c_sources:
         import sbpg.targets.c as c
-        parsed = [yaml.parse_spec(spec) for spec in file_index.values()]
+        parsed = [yaml.parse_spec(spec) for _, spec in file_index_items]
         c.render_sources(output_dir, parsed)
       elif args.python:
         py.render_version(output_dir, release)

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrection.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrection.java
@@ -40,8 +40,14 @@ public class MsgSsrGriddedCorrection extends SBPMessage {
     /** Header of a gridded correction message */
     public GriddedCorrectionHeader header;
     
-    /** Tropo and STEC residuals for the given grid point. */
-    public GridElement element;
+    /** Index of the grid point. */
+    public int index;
+    
+    /** Wet and hydrostatic vertical delays (mean, stddev). */
+    public TroposphericDelayCorrection tropo_delay_correction;
+    
+    /** STEC residuals for each satellite (mean, stddev). */
+    public STECResidual[] stec_residuals;
     
 
     public MsgSsrGriddedCorrection (int sender) { super(sender, TYPE); }
@@ -55,20 +61,26 @@ public class MsgSsrGriddedCorrection extends SBPMessage {
     protected void parse(Parser parser) throws SBPBinaryException {
         /* Parse fields from binary */
         header = new GriddedCorrectionHeader().parse(parser);
-        element = new GridElement().parse(parser);
+        index = parser.getU16();
+        tropo_delay_correction = new TroposphericDelayCorrection().parse(parser);
+        stec_residuals = parser.getArray(STECResidual.class);
     }
 
     @Override
     protected void build(Builder builder) {
         header.build(builder);
-        element.build(builder);
+        builder.putU16(index);
+        tropo_delay_correction.build(builder);
+        builder.putArray(stec_residuals);
     }
 
     @Override
     public JSONObject toJSON() {
         JSONObject obj = super.toJSON();
         obj.put("header", header.toJSON());
-        obj.put("element", element.toJSON());
+        obj.put("index", index);
+        obj.put("tropo_delay_correction", tropo_delay_correction.toJSON());
+        obj.put("stec_residuals", SBPStruct.toJSONArray(stec_residuals));
         return obj;
     }
 }

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionDepA.java
@@ -31,9 +31,14 @@ public class MsgSsrGriddedCorrectionDepA extends SBPMessage {
     /** Header of a Gridded Correction message */
     public GriddedCorrectionHeaderDepA header;
     
-    /** Tropo and STEC residuals for the given grid point (mean and standard
-      * deviation) */
-    public GridElement element;
+    /** Index of the grid point */
+    public int index;
+    
+    /** Wet and hydrostatic vertical delays (mean, stddev) */
+    public TroposphericDelayCorrection tropo_delay_correction;
+    
+    /** STEC residuals for each satellite (mean, stddev) */
+    public STECResidual[] stec_residuals;
     
 
     public MsgSsrGriddedCorrectionDepA (int sender) { super(sender, TYPE); }
@@ -47,20 +52,26 @@ public class MsgSsrGriddedCorrectionDepA extends SBPMessage {
     protected void parse(Parser parser) throws SBPBinaryException {
         /* Parse fields from binary */
         header = new GriddedCorrectionHeaderDepA().parse(parser);
-        element = new GridElement().parse(parser);
+        index = parser.getU16();
+        tropo_delay_correction = new TroposphericDelayCorrection().parse(parser);
+        stec_residuals = parser.getArray(STECResidual.class);
     }
 
     @Override
     protected void build(Builder builder) {
         header.build(builder);
-        element.build(builder);
+        builder.putU16(index);
+        tropo_delay_correction.build(builder);
+        builder.putArray(stec_residuals);
     }
 
     @Override
     public JSONObject toJSON() {
         JSONObject obj = super.toJSON();
         obj.put("header", header.toJSON());
-        obj.put("element", element.toJSON());
+        obj.put("index", index);
+        obj.put("tropo_delay_correction", tropo_delay_correction.toJSON());
+        obj.put("stec_residuals", SBPStruct.toJSONArray(stec_residuals));
         return obj;
     }
 }

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionNoStdDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionNoStdDepA.java
@@ -31,8 +31,14 @@ public class MsgSsrGriddedCorrectionNoStdDepA extends SBPMessage {
     /** Header of a Gridded Correction message */
     public GriddedCorrectionHeaderDepA header;
     
-    /** Tropo and STEC residuals for the given grid point */
-    public GridElementNoStd element;
+    /** Index of the grid point */
+    public int index;
+    
+    /** Wet and hydrostatic vertical delays */
+    public TroposphericDelayCorrectionNoStd tropo_delay_correction;
+    
+    /** STEC residuals for each satellite */
+    public STECResidualNoStd[] stec_residuals;
     
 
     public MsgSsrGriddedCorrectionNoStdDepA (int sender) { super(sender, TYPE); }
@@ -46,20 +52,26 @@ public class MsgSsrGriddedCorrectionNoStdDepA extends SBPMessage {
     protected void parse(Parser parser) throws SBPBinaryException {
         /* Parse fields from binary */
         header = new GriddedCorrectionHeaderDepA().parse(parser);
-        element = new GridElementNoStd().parse(parser);
+        index = parser.getU16();
+        tropo_delay_correction = new TroposphericDelayCorrectionNoStd().parse(parser);
+        stec_residuals = parser.getArray(STECResidualNoStd.class);
     }
 
     @Override
     protected void build(Builder builder) {
         header.build(builder);
-        element.build(builder);
+        builder.putU16(index);
+        tropo_delay_correction.build(builder);
+        builder.putArray(stec_residuals);
     }
 
     @Override
     public JSONObject toJSON() {
         JSONObject obj = super.toJSON();
         obj.put("header", header.toJSON());
-        obj.put("element", element.toJSON());
+        obj.put("index", index);
+        obj.put("tropo_delay_correction", tropo_delay_correction.toJSON());
+        obj.put("stec_residuals", SBPStruct.toJSONArray(stec_residuals));
         return obj;
     }
 }


### PR DESCRIPTION
This PR piggy backs on https://github.com/swift-nav/libsbp/pull/996. Seems like the `Generated artifacts` stage was failing because the Java and Rust generated files weren't up to date. Just introducing them into the commit didn't kick off the stage because the files themselves weren't in the list of file changes that would kick off the stage. I've suggested removing those files from the list, not sure if this was done to save $$$.