### PR TITLE
[ESD-2049] Tidy up generated source files

### DIFF
--- a/c/scripts/clang-format.sh
+++ b/c/scripts/clang-format.sh
@@ -5,9 +5,10 @@ set -e -x
 # as it is introduced as part of fixing the docs,
 # and clang-format-6 would otherwise cause regressions
 # in the Google style of hand-written code.
-GENERATED_HEADERS=$(grep -rl --include="*.h" "Automatically generated" include/libsbp/*)
+GENERATED_HEADERS=$(grep -rl --include="*.h" "Automatically generated" include/libsbp/* src/)
+GENERATED_C_SOURCES=$(grep -rl --include="*.c" "Automatically generated" src/)
 CLANG_FORMAT=clang-format-6.0
-$CLANG_FORMAT -i $GENERATED_HEADERS test/*.c test/*.h test/legacy/cpp/*.cc test/legacy/*.c test/auto* test/cpp/auto*
+$CLANG_FORMAT -i $GENERATED_HEADERS $GENERATED_C_SOURCES test/*.c test/*.h test/legacy/cpp/*.cc test/legacy/*.c test/auto* test/cpp/auto*
 
 # clang-format-6 adds whitespace to blank lines inside comments
 sed -i.bak 's/^  *$//' $GENERATED_HEADERS

--- a/c/src/include/libsbp/internal/new/acquisition.h
+++ b/c/src/include/libsbp/internal/new/acquisition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_ACQUISITION_PRIVATE_H
-#define LIBSBP_UNPACKED_ACQUISITION_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_ACQUISITION_H
+#define LIBSBP_INTERNAL_NEW_ACQUISITION_H
 
 #include <stdbool.h>
 
@@ -28,43 +28,163 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_acq_result_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_acq_result_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_acq_result_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_acq_result_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_acq_result_dep_c_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_acq_result_dep_c_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_acq_result_dep_c_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_acq_result_dep_c_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_acq_result_dep_b_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_acq_result_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_acq_result_dep_b_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_acq_result_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_acq_result_dep_a_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_acq_result_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_acq_result_dep_a_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_acq_result_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
                                  const sbp_acq_sv_profile_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_acq_sv_profile_t(sbp_decode_ctx_t *ctx,
                                  sbp_acq_sv_profile_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx,
                                      const sbp_acq_sv_profile_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx,
                                      sbp_acq_sv_profile_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_acq_sv_profile_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_acq_sv_profile_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_acq_sv_profile_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_acq_sv_profile_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_acq_sv_profile_dep_t *msg);
 

--- a/c/src/include/libsbp/internal/new/acquisition.h
+++ b/c/src/include/libsbp/internal/new/acquisition.h
@@ -1,42 +1,75 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/acquisition.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_ACQUISITION_PRIVATE_H
 #define LIBSBP_UNPACKED_ACQUISITION_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/acquisition.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/acquisition.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_acq_result_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_t *msg);
-bool decode_sbp_msg_acq_result_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_t *msg);
+bool encode_sbp_msg_acq_result_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_acq_result_t *msg);
+bool decode_sbp_msg_acq_result_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_acq_result_t *msg);
 
-bool encode_sbp_msg_acq_result_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_dep_c_t *msg);
-bool decode_sbp_msg_acq_result_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_dep_c_t *msg);
+bool encode_sbp_msg_acq_result_dep_c_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_acq_result_dep_c_t *msg);
+bool decode_sbp_msg_acq_result_dep_c_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_acq_result_dep_c_t *msg);
 
-bool encode_sbp_msg_acq_result_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_dep_b_t *msg);
-bool decode_sbp_msg_acq_result_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_dep_b_t *msg);
+bool encode_sbp_msg_acq_result_dep_b_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_acq_result_dep_b_t *msg);
+bool decode_sbp_msg_acq_result_dep_b_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_acq_result_dep_b_t *msg);
 
-bool encode_sbp_msg_acq_result_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_dep_a_t *msg);
-bool decode_sbp_msg_acq_result_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_dep_a_t *msg);
+bool encode_sbp_msg_acq_result_dep_a_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_acq_result_dep_a_t *msg);
+bool decode_sbp_msg_acq_result_dep_a_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_acq_result_dep_a_t *msg);
 
-bool encode_sbp_acq_sv_profile_t(sbp_encode_ctx_t *ctx, const sbp_acq_sv_profile_t *msg);
-bool decode_sbp_acq_sv_profile_t(sbp_decode_ctx_t *ctx, sbp_acq_sv_profile_t *msg);
+bool encode_sbp_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_acq_sv_profile_t *msg);
+bool decode_sbp_acq_sv_profile_t(sbp_decode_ctx_t *ctx,
+                                 sbp_acq_sv_profile_t *msg);
 
-bool encode_sbp_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx, const sbp_acq_sv_profile_dep_t *msg);
-bool decode_sbp_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx, sbp_acq_sv_profile_dep_t *msg);
+bool encode_sbp_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_acq_sv_profile_dep_t *msg);
+bool decode_sbp_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx,
+                                     sbp_acq_sv_profile_dep_t *msg);
 
-bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_t *msg);
-bool decode_sbp_msg_acq_sv_profile_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_sv_profile_t *msg);
+bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_acq_sv_profile_t *msg);
+bool decode_sbp_msg_acq_sv_profile_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_acq_sv_profile_t *msg);
 
-bool encode_sbp_msg_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg);
-bool decode_sbp_msg_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_sv_profile_dep_t *msg);
+bool encode_sbp_msg_acq_sv_profile_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg);
+bool decode_sbp_msg_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_acq_sv_profile_dep_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/bootload.h
+++ b/c/src/include/libsbp/internal/new/bootload.h
@@ -1,35 +1,64 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/bootload.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_BOOTLOAD_PRIVATE_H
 #define LIBSBP_UNPACKED_BOOTLOAD_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/bootload.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/bootload.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_bootloader_handshake_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_req_t *msg);
-bool decode_sbp_msg_bootloader_handshake_req_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_req_t *msg);
+bool encode_sbp_msg_bootloader_handshake_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_req_t *msg);
+bool decode_sbp_msg_bootloader_handshake_req_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_req_t *msg);
 
-bool encode_sbp_msg_bootloader_handshake_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_resp_t *msg);
-bool decode_sbp_msg_bootloader_handshake_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_resp_t *msg);
+bool encode_sbp_msg_bootloader_handshake_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_resp_t *msg);
+bool decode_sbp_msg_bootloader_handshake_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_resp_t *msg);
 
-bool encode_sbp_msg_bootloader_jump_to_app_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_jump_to_app_t *msg);
-bool decode_sbp_msg_bootloader_jump_to_app_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_jump_to_app_t *msg);
+bool encode_sbp_msg_bootloader_jump_to_app_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_jump_to_app_t *msg);
+bool decode_sbp_msg_bootloader_jump_to_app_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_jump_to_app_t *msg);
 
-bool encode_sbp_msg_nap_device_dna_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_req_t *msg);
-bool decode_sbp_msg_nap_device_dna_req_t(sbp_decode_ctx_t *ctx, sbp_msg_nap_device_dna_req_t *msg);
+bool encode_sbp_msg_nap_device_dna_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_req_t *msg);
+bool decode_sbp_msg_nap_device_dna_req_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_nap_device_dna_req_t *msg);
 
-bool encode_sbp_msg_nap_device_dna_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg);
-bool decode_sbp_msg_nap_device_dna_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_nap_device_dna_resp_t *msg);
+bool encode_sbp_msg_nap_device_dna_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg);
+bool decode_sbp_msg_nap_device_dna_resp_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_nap_device_dna_resp_t *msg);
 
-bool encode_sbp_msg_bootloader_handshake_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_dep_a_t *msg);
-bool decode_sbp_msg_bootloader_handshake_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_dep_a_t *msg);
+bool encode_sbp_msg_bootloader_handshake_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_dep_a_t *msg);
+bool decode_sbp_msg_bootloader_handshake_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_dep_a_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/bootload.h
+++ b/c/src/include/libsbp/internal/new/bootload.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_BOOTLOAD_PRIVATE_H
-#define LIBSBP_UNPACKED_BOOTLOAD_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_BOOTLOAD_H
+#define LIBSBP_INTERNAL_NEW_BOOTLOAD_H
 
 #include <stdbool.h>
 
@@ -27,33 +27,123 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_bootloader_handshake_req_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_bootloader_handshake_req_t(
     sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_bootloader_handshake_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_bootloader_handshake_resp_t(
     sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_bootloader_jump_to_app_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_jump_to_app_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_bootloader_jump_to_app_t(
     sbp_decode_ctx_t *ctx, sbp_msg_bootloader_jump_to_app_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_nap_device_dna_req_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_nap_device_dna_req_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_nap_device_dna_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_nap_device_dna_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_nap_device_dna_resp_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_nap_device_dna_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_bootloader_handshake_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_bootloader_handshake_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_dep_a_t *msg);
 

--- a/c/src/include/libsbp/internal/new/common.h
+++ b/c/src/include/libsbp/internal/new/common.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 #include <libsbp/common.h>
 
 #ifdef __cplusplus

--- a/c/src/include/libsbp/internal/new/ext_events.h
+++ b/c/src/include/libsbp/internal/new/ext_events.h
@@ -1,20 +1,39 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ext_events.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_EXT_EVENTS_PRIVATE_H
 #define LIBSBP_UNPACKED_EXT_EVENTS_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/ext_events.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/ext_events.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_ext_event_t(sbp_encode_ctx_t *ctx, const sbp_msg_ext_event_t *msg);
-bool decode_sbp_msg_ext_event_t(sbp_decode_ctx_t *ctx, sbp_msg_ext_event_t *msg);
+bool encode_sbp_msg_ext_event_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_ext_event_t *msg);
+bool decode_sbp_msg_ext_event_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_ext_event_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/ext_events.h
+++ b/c/src/include/libsbp/internal/new/ext_events.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_EXT_EVENTS_PRIVATE_H
-#define LIBSBP_UNPACKED_EXT_EVENTS_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_EXT_EVENTS_H
+#define LIBSBP_INTERNAL_NEW_EXT_EVENTS_H
 
 #include <stdbool.h>
 
@@ -27,8 +27,23 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ext_event_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_ext_event_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ext_event_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_ext_event_t *msg);
 

--- a/c/src/include/libsbp/internal/new/file_io.h
+++ b/c/src/include/libsbp/internal/new/file_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_FILE_IO_PRIVATE_H
-#define LIBSBP_UNPACKED_FILE_IO_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_FILE_IO_H
+#define LIBSBP_INTERNAL_NEW_FILE_IO_H
 
 #include <stdbool.h>
 
@@ -27,48 +27,183 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_read_req_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_fileio_read_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_read_req_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_fileio_read_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_fileio_read_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_read_resp_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_fileio_read_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_read_dir_req_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_read_dir_req_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_fileio_read_dir_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_read_dir_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_read_dir_resp_t(sbp_decode_ctx_t *ctx,
                                            sbp_msg_fileio_read_dir_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_remove_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_fileio_remove_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_remove_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_fileio_remove_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_fileio_write_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_write_req_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_fileio_write_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_write_resp_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_fileio_write_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_write_resp_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_fileio_write_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_config_req_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_fileio_config_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_config_req_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_fileio_config_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fileio_config_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fileio_config_resp_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_fileio_config_resp_t *msg);
 

--- a/c/src/include/libsbp/internal/new/file_io.h
+++ b/c/src/include/libsbp/internal/new/file_io.h
@@ -1,44 +1,79 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/file_io.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_FILE_IO_PRIVATE_H
 #define LIBSBP_UNPACKED_FILE_IO_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/file_io.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/file_io.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_fileio_read_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_req_t *msg);
-bool decode_sbp_msg_fileio_read_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_req_t *msg);
+bool encode_sbp_msg_fileio_read_req_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_fileio_read_req_t *msg);
+bool decode_sbp_msg_fileio_read_req_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_fileio_read_req_t *msg);
 
-bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_resp_t *msg);
-bool decode_sbp_msg_fileio_read_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_resp_t *msg);
+bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_fileio_read_resp_t *msg);
+bool decode_sbp_msg_fileio_read_resp_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_fileio_read_resp_t *msg);
 
-bool encode_sbp_msg_fileio_read_dir_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_req_t *msg);
-bool decode_sbp_msg_fileio_read_dir_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_dir_req_t *msg);
+bool encode_sbp_msg_fileio_read_dir_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_req_t *msg);
+bool decode_sbp_msg_fileio_read_dir_req_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_fileio_read_dir_req_t *msg);
 
-bool encode_sbp_msg_fileio_read_dir_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_resp_t *msg);
-bool decode_sbp_msg_fileio_read_dir_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_dir_resp_t *msg);
+bool encode_sbp_msg_fileio_read_dir_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_resp_t *msg);
+bool decode_sbp_msg_fileio_read_dir_resp_t(sbp_decode_ctx_t *ctx,
+                                           sbp_msg_fileio_read_dir_resp_t *msg);
 
-bool encode_sbp_msg_fileio_remove_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_remove_t *msg);
-bool decode_sbp_msg_fileio_remove_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_remove_t *msg);
+bool encode_sbp_msg_fileio_remove_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_fileio_remove_t *msg);
+bool decode_sbp_msg_fileio_remove_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_fileio_remove_t *msg);
 
-bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_write_req_t *msg);
-bool decode_sbp_msg_fileio_write_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_write_req_t *msg);
+bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_fileio_write_req_t *msg);
+bool decode_sbp_msg_fileio_write_req_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_fileio_write_req_t *msg);
 
-bool encode_sbp_msg_fileio_write_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_write_resp_t *msg);
-bool decode_sbp_msg_fileio_write_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_write_resp_t *msg);
+bool encode_sbp_msg_fileio_write_resp_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_fileio_write_resp_t *msg);
+bool decode_sbp_msg_fileio_write_resp_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_fileio_write_resp_t *msg);
 
-bool encode_sbp_msg_fileio_config_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_req_t *msg);
-bool decode_sbp_msg_fileio_config_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_config_req_t *msg);
+bool encode_sbp_msg_fileio_config_req_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_fileio_config_req_t *msg);
+bool decode_sbp_msg_fileio_config_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_fileio_config_req_t *msg);
 
-bool encode_sbp_msg_fileio_config_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_resp_t *msg);
-bool decode_sbp_msg_fileio_config_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_config_resp_t *msg);
+bool encode_sbp_msg_fileio_config_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_resp_t *msg);
+bool decode_sbp_msg_fileio_config_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_fileio_config_resp_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/flash.h
+++ b/c/src/include/libsbp/internal/new/flash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_FLASH_PRIVATE_H
-#define LIBSBP_UNPACKED_FLASH_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_FLASH_H
+#define LIBSBP_INTERNAL_NEW_FLASH_H
 
 #include <stdbool.h>
 
@@ -27,53 +27,203 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_flash_program_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_flash_program_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_flash_program_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_flash_done_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_flash_done_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_flash_done_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_flash_done_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_flash_read_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_flash_read_req_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_flash_read_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_flash_read_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_flash_read_resp_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_flash_read_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_flash_erase_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_flash_erase_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_flash_erase_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_flash_erase_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_stm_flash_lock_sector_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_lock_sector_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_stm_flash_lock_sector_t(
     sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_lock_sector_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_stm_flash_unlock_sector_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_unlock_sector_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_stm_flash_unlock_sector_t(
     sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_unlock_sector_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_stm_unique_id_req_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_stm_unique_id_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_stm_unique_id_req_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_stm_unique_id_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_stm_unique_id_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_stm_unique_id_resp_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_stm_unique_id_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_m25_flash_write_status_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_m25_flash_write_status_t(
     sbp_decode_ctx_t *ctx, sbp_msg_m25_flash_write_status_t *msg);
 

--- a/c/src/include/libsbp/internal/new/flash.h
+++ b/c/src/include/libsbp/internal/new/flash.h
@@ -1,47 +1,84 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/flash.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_FLASH_PRIVATE_H
 #define LIBSBP_UNPACKED_FLASH_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/flash.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/flash.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_program_t *msg);
-bool decode_sbp_msg_flash_program_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_program_t *msg);
+bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_flash_program_t *msg);
+bool decode_sbp_msg_flash_program_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_flash_program_t *msg);
 
-bool encode_sbp_msg_flash_done_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_done_t *msg);
-bool decode_sbp_msg_flash_done_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_done_t *msg);
+bool encode_sbp_msg_flash_done_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_flash_done_t *msg);
+bool decode_sbp_msg_flash_done_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_flash_done_t *msg);
 
-bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_read_req_t *msg);
-bool decode_sbp_msg_flash_read_req_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_read_req_t *msg);
+bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_flash_read_req_t *msg);
+bool decode_sbp_msg_flash_read_req_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_flash_read_req_t *msg);
 
-bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_read_resp_t *msg);
-bool decode_sbp_msg_flash_read_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_read_resp_t *msg);
+bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_flash_read_resp_t *msg);
+bool decode_sbp_msg_flash_read_resp_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_flash_read_resp_t *msg);
 
-bool encode_sbp_msg_flash_erase_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_erase_t *msg);
-bool decode_sbp_msg_flash_erase_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_erase_t *msg);
+bool encode_sbp_msg_flash_erase_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_flash_erase_t *msg);
+bool decode_sbp_msg_flash_erase_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_flash_erase_t *msg);
 
-bool encode_sbp_msg_stm_flash_lock_sector_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_lock_sector_t *msg);
-bool decode_sbp_msg_stm_flash_lock_sector_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_lock_sector_t *msg);
+bool encode_sbp_msg_stm_flash_lock_sector_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_lock_sector_t *msg);
+bool decode_sbp_msg_stm_flash_lock_sector_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_lock_sector_t *msg);
 
-bool encode_sbp_msg_stm_flash_unlock_sector_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_unlock_sector_t *msg);
-bool decode_sbp_msg_stm_flash_unlock_sector_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_unlock_sector_t *msg);
+bool encode_sbp_msg_stm_flash_unlock_sector_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_unlock_sector_t *msg);
+bool decode_sbp_msg_stm_flash_unlock_sector_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_unlock_sector_t *msg);
 
-bool encode_sbp_msg_stm_unique_id_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_req_t *msg);
-bool decode_sbp_msg_stm_unique_id_req_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_unique_id_req_t *msg);
+bool encode_sbp_msg_stm_unique_id_req_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_stm_unique_id_req_t *msg);
+bool decode_sbp_msg_stm_unique_id_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_stm_unique_id_req_t *msg);
 
-bool encode_sbp_msg_stm_unique_id_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg);
-bool decode_sbp_msg_stm_unique_id_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_unique_id_resp_t *msg);
+bool encode_sbp_msg_stm_unique_id_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg);
+bool decode_sbp_msg_stm_unique_id_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_stm_unique_id_resp_t *msg);
 
-bool encode_sbp_msg_m25_flash_write_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg);
-bool decode_sbp_msg_m25_flash_write_status_t(sbp_decode_ctx_t *ctx, sbp_msg_m25_flash_write_status_t *msg);
+bool encode_sbp_msg_m25_flash_write_status_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg);
+bool decode_sbp_msg_m25_flash_write_status_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_m25_flash_write_status_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/gnss.h
+++ b/c/src/include/libsbp/internal/new/gnss.h
@@ -1,38 +1,64 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/gnss.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_GNSS_PRIVATE_H
 #define LIBSBP_UNPACKED_GNSS_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/gnss.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/gnss.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_sbp_gnss_signal_t(sbp_encode_ctx_t *ctx, const sbp_sbp_gnss_signal_t *msg);
-bool decode_sbp_sbp_gnss_signal_t(sbp_decode_ctx_t *ctx, sbp_sbp_gnss_signal_t *msg);
+bool encode_sbp_sbp_gnss_signal_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_sbp_gnss_signal_t *msg);
+bool decode_sbp_sbp_gnss_signal_t(sbp_decode_ctx_t *ctx,
+                                  sbp_sbp_gnss_signal_t *msg);
 
 bool encode_sbp_sv_id_t(sbp_encode_ctx_t *ctx, const sbp_sv_id_t *msg);
 bool decode_sbp_sv_id_t(sbp_decode_ctx_t *ctx, sbp_sv_id_t *msg);
 
-bool encode_sbp_gnss_signal_dep_t(sbp_encode_ctx_t *ctx, const sbp_gnss_signal_dep_t *msg);
-bool decode_sbp_gnss_signal_dep_t(sbp_decode_ctx_t *ctx, sbp_gnss_signal_dep_t *msg);
+bool encode_sbp_gnss_signal_dep_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_gnss_signal_dep_t *msg);
+bool decode_sbp_gnss_signal_dep_t(sbp_decode_ctx_t *ctx,
+                                  sbp_gnss_signal_dep_t *msg);
 
-bool encode_sbp_gps_time_dep_t(sbp_encode_ctx_t *ctx, const sbp_gps_time_dep_t *msg);
+bool encode_sbp_gps_time_dep_t(sbp_encode_ctx_t *ctx,
+                               const sbp_gps_time_dep_t *msg);
 bool decode_sbp_gps_time_dep_t(sbp_decode_ctx_t *ctx, sbp_gps_time_dep_t *msg);
 
-bool encode_sbp_gps_time_sec_t(sbp_encode_ctx_t *ctx, const sbp_gps_time_sec_t *msg);
+bool encode_sbp_gps_time_sec_t(sbp_encode_ctx_t *ctx,
+                               const sbp_gps_time_sec_t *msg);
 bool decode_sbp_gps_time_sec_t(sbp_decode_ctx_t *ctx, sbp_gps_time_sec_t *msg);
 
-bool encode_sbp_sbp_gps_time_t(sbp_encode_ctx_t *ctx, const sbp_sbp_gps_time_t *msg);
+bool encode_sbp_sbp_gps_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_sbp_gps_time_t *msg);
 bool decode_sbp_sbp_gps_time_t(sbp_decode_ctx_t *ctx, sbp_sbp_gps_time_t *msg);
 
-bool encode_sbp_carrier_phase_t(sbp_encode_ctx_t *ctx, const sbp_carrier_phase_t *msg);
-bool decode_sbp_carrier_phase_t(sbp_decode_ctx_t *ctx, sbp_carrier_phase_t *msg);
+bool encode_sbp_carrier_phase_t(sbp_encode_ctx_t *ctx,
+                                const sbp_carrier_phase_t *msg);
+bool decode_sbp_carrier_phase_t(sbp_decode_ctx_t *ctx,
+                                sbp_carrier_phase_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/gnss.h
+++ b/c/src/include/libsbp/internal/new/gnss.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_GNSS_PRIVATE_H
-#define LIBSBP_UNPACKED_GNSS_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_GNSS_H
+#define LIBSBP_INTERNAL_NEW_GNSS_H
 
 #include <stdbool.h>
 
@@ -27,33 +27,138 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_sbp_gnss_signal_t(sbp_encode_ctx_t *ctx,
                                   const sbp_sbp_gnss_signal_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_sbp_gnss_signal_t(sbp_decode_ctx_t *ctx,
                                   sbp_sbp_gnss_signal_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_sv_id_t(sbp_encode_ctx_t *ctx, const sbp_sv_id_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_sv_id_t(sbp_decode_ctx_t *ctx, sbp_sv_id_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gnss_signal_dep_t(sbp_encode_ctx_t *ctx,
                                   const sbp_gnss_signal_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gnss_signal_dep_t(sbp_decode_ctx_t *ctx,
                                   sbp_gnss_signal_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gps_time_dep_t(sbp_encode_ctx_t *ctx,
                                const sbp_gps_time_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gps_time_dep_t(sbp_decode_ctx_t *ctx, sbp_gps_time_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gps_time_sec_t(sbp_encode_ctx_t *ctx,
                                const sbp_gps_time_sec_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gps_time_sec_t(sbp_decode_ctx_t *ctx, sbp_gps_time_sec_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_sbp_gps_time_t(sbp_encode_ctx_t *ctx,
                                const sbp_sbp_gps_time_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_sbp_gps_time_t(sbp_decode_ctx_t *ctx, sbp_sbp_gps_time_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_carrier_phase_t(sbp_encode_ctx_t *ctx,
                                 const sbp_carrier_phase_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_carrier_phase_t(sbp_decode_ctx_t *ctx,
                                 sbp_carrier_phase_t *msg);
 

--- a/c/src/include/libsbp/internal/new/imu.h
+++ b/c/src/include/libsbp/internal/new/imu.h
@@ -1,23 +1,42 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/imu.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_IMU_PRIVATE_H
 #define LIBSBP_UNPACKED_IMU_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/imu.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/imu.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_imu_raw_t(sbp_encode_ctx_t *ctx, const sbp_msg_imu_raw_t *msg);
+bool encode_sbp_msg_imu_raw_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_imu_raw_t *msg);
 bool decode_sbp_msg_imu_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_raw_t *msg);
 
-bool encode_sbp_msg_imu_aux_t(sbp_encode_ctx_t *ctx, const sbp_msg_imu_aux_t *msg);
+bool encode_sbp_msg_imu_aux_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_imu_aux_t *msg);
 bool decode_sbp_msg_imu_aux_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_aux_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/imu.h
+++ b/c/src/include/libsbp/internal/new/imu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_IMU_PRIVATE_H
-#define LIBSBP_UNPACKED_IMU_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_IMU_H
+#define LIBSBP_INTERNAL_NEW_IMU_H
 
 #include <stdbool.h>
 
@@ -27,12 +27,42 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_imu_raw_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_imu_raw_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_imu_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_raw_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_imu_aux_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_imu_aux_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_imu_aux_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_aux_t *msg);
 
 #ifdef __cplusplus

--- a/c/src/include/libsbp/internal/new/linux.h
+++ b/c/src/include/libsbp/internal/new/linux.h
@@ -1,50 +1,89 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/linux.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_LINUX_PRIVATE_H
 #define LIBSBP_UNPACKED_LINUX_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/linux.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/linux.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_linux_cpu_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_dep_a_t *msg);
-bool decode_sbp_msg_linux_cpu_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_dep_a_t *msg);
+bool encode_sbp_msg_linux_cpu_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_dep_a_t *msg);
+bool decode_sbp_msg_linux_cpu_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_dep_a_t *msg);
 
-bool encode_sbp_msg_linux_mem_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_dep_a_t *msg);
-bool decode_sbp_msg_linux_mem_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_dep_a_t *msg);
+bool encode_sbp_msg_linux_mem_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_dep_a_t *msg);
+bool decode_sbp_msg_linux_mem_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_dep_a_t *msg);
 
-bool encode_sbp_msg_linux_sys_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_dep_a_t *msg);
-bool decode_sbp_msg_linux_sys_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_dep_a_t *msg);
+bool encode_sbp_msg_linux_sys_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_dep_a_t *msg);
+bool decode_sbp_msg_linux_sys_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_dep_a_t *msg);
 
-bool encode_sbp_msg_linux_process_socket_counts_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_counts_t *msg);
-bool decode_sbp_msg_linux_process_socket_counts_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_counts_t *msg);
+bool encode_sbp_msg_linux_process_socket_counts_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_counts_t *msg);
+bool decode_sbp_msg_linux_process_socket_counts_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_counts_t *msg);
 
-bool encode_sbp_msg_linux_process_socket_queues_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_queues_t *msg);
-bool decode_sbp_msg_linux_process_socket_queues_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_queues_t *msg);
+bool encode_sbp_msg_linux_process_socket_queues_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_queues_t *msg);
+bool decode_sbp_msg_linux_process_socket_queues_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_queues_t *msg);
 
-bool encode_sbp_msg_linux_socket_usage_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_socket_usage_t *msg);
-bool decode_sbp_msg_linux_socket_usage_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_socket_usage_t *msg);
+bool encode_sbp_msg_linux_socket_usage_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_socket_usage_t *msg);
+bool decode_sbp_msg_linux_socket_usage_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_linux_socket_usage_t *msg);
 
-bool encode_sbp_msg_linux_process_fd_count_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_count_t *msg);
-bool decode_sbp_msg_linux_process_fd_count_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_count_t *msg);
+bool encode_sbp_msg_linux_process_fd_count_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_count_t *msg);
+bool decode_sbp_msg_linux_process_fd_count_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_count_t *msg);
 
-bool encode_sbp_msg_linux_process_fd_summary_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_summary_t *msg);
-bool decode_sbp_msg_linux_process_fd_summary_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_summary_t *msg);
+bool encode_sbp_msg_linux_process_fd_summary_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_summary_t *msg);
+bool decode_sbp_msg_linux_process_fd_summary_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_summary_t *msg);
 
-bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_t *msg);
-bool decode_sbp_msg_linux_cpu_state_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_t *msg);
+bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_linux_cpu_state_t *msg);
+bool decode_sbp_msg_linux_cpu_state_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_linux_cpu_state_t *msg);
 
-bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_t *msg);
-bool decode_sbp_msg_linux_mem_state_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_t *msg);
+bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_linux_mem_state_t *msg);
+bool decode_sbp_msg_linux_mem_state_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_linux_mem_state_t *msg);
 
-bool encode_sbp_msg_linux_sys_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_t *msg);
-bool decode_sbp_msg_linux_sys_state_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_t *msg);
+bool encode_sbp_msg_linux_sys_state_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_linux_sys_state_t *msg);
+bool decode_sbp_msg_linux_sys_state_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_linux_sys_state_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/linux.h
+++ b/c/src/include/libsbp/internal/new/linux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_LINUX_PRIVATE_H
-#define LIBSBP_UNPACKED_LINUX_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_LINUX_H
+#define LIBSBP_INTERNAL_NEW_LINUX_H
 
 #include <stdbool.h>
 
@@ -27,58 +27,223 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_cpu_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_cpu_state_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_mem_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_mem_state_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_sys_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_sys_state_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_process_socket_counts_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_counts_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_process_socket_counts_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_counts_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_process_socket_queues_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_queues_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_process_socket_queues_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_queues_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_socket_usage_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_socket_usage_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_socket_usage_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_linux_socket_usage_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_process_fd_count_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_count_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_process_fd_count_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_count_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_process_fd_summary_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_summary_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_process_fd_summary_t(
     sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_summary_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_linux_cpu_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_cpu_state_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_linux_cpu_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_linux_mem_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_mem_state_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_linux_mem_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_linux_sys_state_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_linux_sys_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_linux_sys_state_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_linux_sys_state_t *msg);
 

--- a/c/src/include/libsbp/internal/new/logging.h
+++ b/c/src/include/libsbp/internal/new/logging.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_LOGGING_PRIVATE_H
-#define LIBSBP_UNPACKED_LOGGING_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_LOGGING_H
+#define LIBSBP_INTERNAL_NEW_LOGGING_H
 
 #include <stdbool.h>
 
@@ -27,14 +27,59 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_log_t(sbp_encode_ctx_t *ctx, const sbp_msg_log_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_log_t(sbp_decode_ctx_t *ctx, sbp_msg_log_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_fwd_t(sbp_encode_ctx_t *ctx, const sbp_msg_fwd_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_fwd_t(sbp_decode_ctx_t *ctx, sbp_msg_fwd_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_print_dep_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_print_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_print_dep_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_print_dep_t *msg);
 

--- a/c/src/include/libsbp/internal/new/logging.h
+++ b/c/src/include/libsbp/internal/new/logging.h
@@ -1,13 +1,30 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/logging.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_LOGGING_PRIVATE_H
 #define LIBSBP_UNPACKED_LOGGING_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/logging.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/logging.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
 bool encode_sbp_msg_log_t(sbp_encode_ctx_t *ctx, const sbp_msg_log_t *msg);
@@ -16,11 +33,13 @@ bool decode_sbp_msg_log_t(sbp_decode_ctx_t *ctx, sbp_msg_log_t *msg);
 bool encode_sbp_msg_fwd_t(sbp_encode_ctx_t *ctx, const sbp_msg_fwd_t *msg);
 bool decode_sbp_msg_fwd_t(sbp_decode_ctx_t *ctx, sbp_msg_fwd_t *msg);
 
-bool encode_sbp_msg_print_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_print_dep_t *msg);
-bool decode_sbp_msg_print_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_print_dep_t *msg);
+bool encode_sbp_msg_print_dep_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_print_dep_t *msg);
+bool decode_sbp_msg_print_dep_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_print_dep_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/mag.h
+++ b/c/src/include/libsbp/internal/new/mag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_MAG_PRIVATE_H
-#define LIBSBP_UNPACKED_MAG_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_MAG_H
+#define LIBSBP_INTERNAL_NEW_MAG_H
 
 #include <stdbool.h>
 
@@ -27,8 +27,23 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_mag_raw_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_mag_raw_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_mag_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_mag_raw_t *msg);
 
 #ifdef __cplusplus

--- a/c/src/include/libsbp/internal/new/mag.h
+++ b/c/src/include/libsbp/internal/new/mag.h
@@ -1,20 +1,38 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/mag.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_MAG_PRIVATE_H
 #define LIBSBP_UNPACKED_MAG_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/mag.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/mag.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_mag_raw_t(sbp_encode_ctx_t *ctx, const sbp_msg_mag_raw_t *msg);
+bool encode_sbp_msg_mag_raw_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_mag_raw_t *msg);
 bool decode_sbp_msg_mag_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_mag_raw_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/navigation.h
+++ b/c/src/include/libsbp/internal/new/navigation.h
@@ -1,125 +1,205 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/navigation.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_NAVIGATION_PRIVATE_H
 #define LIBSBP_UNPACKED_NAVIGATION_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/navigation.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/navigation.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_gps_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_gps_time_t *msg);
+bool encode_sbp_msg_gps_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_gps_time_t *msg);
 bool decode_sbp_msg_gps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_t *msg);
 
-bool encode_sbp_msg_gps_time_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_gps_time_gnss_t *msg);
-bool decode_sbp_msg_gps_time_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_gnss_t *msg);
+bool encode_sbp_msg_gps_time_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_gps_time_gnss_t *msg);
+bool decode_sbp_msg_gps_time_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_gps_time_gnss_t *msg);
 
-bool encode_sbp_msg_utc_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_utc_time_t *msg);
+bool encode_sbp_msg_utc_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_utc_time_t *msg);
 bool decode_sbp_msg_utc_time_t(sbp_decode_ctx_t *ctx, sbp_msg_utc_time_t *msg);
 
-bool encode_sbp_msg_utc_time_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_utc_time_gnss_t *msg);
-bool decode_sbp_msg_utc_time_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_utc_time_gnss_t *msg);
+bool encode_sbp_msg_utc_time_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_utc_time_gnss_t *msg);
+bool decode_sbp_msg_utc_time_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_utc_time_gnss_t *msg);
 
 bool encode_sbp_msg_dops_t(sbp_encode_ctx_t *ctx, const sbp_msg_dops_t *msg);
 bool decode_sbp_msg_dops_t(sbp_decode_ctx_t *ctx, sbp_msg_dops_t *msg);
 
-bool encode_sbp_msg_pos_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_t *msg);
+bool encode_sbp_msg_pos_ecef_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_pos_ecef_t *msg);
 bool decode_sbp_msg_pos_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_t *msg);
 
-bool encode_sbp_msg_pos_ecef_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_cov_t *msg);
-bool decode_sbp_msg_pos_ecef_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_cov_t *msg);
+bool encode_sbp_msg_pos_ecef_cov_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_pos_ecef_cov_t *msg);
+bool decode_sbp_msg_pos_ecef_cov_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_pos_ecef_cov_t *msg);
 
-bool encode_sbp_msg_pos_llh_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_t *msg);
+bool encode_sbp_msg_pos_llh_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_pos_llh_t *msg);
 bool decode_sbp_msg_pos_llh_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_t *msg);
 
-bool encode_sbp_msg_pos_llh_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_cov_t *msg);
-bool decode_sbp_msg_pos_llh_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_cov_t *msg);
+bool encode_sbp_msg_pos_llh_cov_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_pos_llh_cov_t *msg);
+bool decode_sbp_msg_pos_llh_cov_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_pos_llh_cov_t *msg);
 
-bool encode_sbp_msg_baseline_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_t *msg);
-bool decode_sbp_msg_baseline_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ecef_t *msg);
+bool encode_sbp_msg_baseline_ecef_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_baseline_ecef_t *msg);
+bool decode_sbp_msg_baseline_ecef_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_baseline_ecef_t *msg);
 
-bool encode_sbp_msg_baseline_ned_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_t *msg);
-bool decode_sbp_msg_baseline_ned_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ned_t *msg);
+bool encode_sbp_msg_baseline_ned_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_baseline_ned_t *msg);
+bool decode_sbp_msg_baseline_ned_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_baseline_ned_t *msg);
 
-bool encode_sbp_msg_vel_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_t *msg);
+bool encode_sbp_msg_vel_ecef_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_vel_ecef_t *msg);
 bool decode_sbp_msg_vel_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_t *msg);
 
-bool encode_sbp_msg_vel_ecef_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_cov_t *msg);
-bool decode_sbp_msg_vel_ecef_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_cov_t *msg);
+bool encode_sbp_msg_vel_ecef_cov_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_vel_ecef_cov_t *msg);
+bool decode_sbp_msg_vel_ecef_cov_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_vel_ecef_cov_t *msg);
 
-bool encode_sbp_msg_vel_ned_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_t *msg);
+bool encode_sbp_msg_vel_ned_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_vel_ned_t *msg);
 bool decode_sbp_msg_vel_ned_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_t *msg);
 
-bool encode_sbp_msg_vel_ned_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_cov_t *msg);
-bool decode_sbp_msg_vel_ned_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_cov_t *msg);
+bool encode_sbp_msg_vel_ned_cov_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_vel_ned_cov_t *msg);
+bool decode_sbp_msg_vel_ned_cov_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_vel_ned_cov_t *msg);
 
-bool encode_sbp_msg_pos_ecef_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_gnss_t *msg);
-bool decode_sbp_msg_pos_ecef_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_gnss_t *msg);
+bool encode_sbp_msg_pos_ecef_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_pos_ecef_gnss_t *msg);
+bool decode_sbp_msg_pos_ecef_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_pos_ecef_gnss_t *msg);
 
-bool encode_sbp_msg_pos_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_cov_gnss_t *msg);
-bool decode_sbp_msg_pos_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_cov_gnss_t *msg);
+bool encode_sbp_msg_pos_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_pos_ecef_cov_gnss_t *msg);
+bool decode_sbp_msg_pos_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_pos_ecef_cov_gnss_t *msg);
 
-bool encode_sbp_msg_pos_llh_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_gnss_t *msg);
-bool decode_sbp_msg_pos_llh_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_gnss_t *msg);
+bool encode_sbp_msg_pos_llh_gnss_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_pos_llh_gnss_t *msg);
+bool decode_sbp_msg_pos_llh_gnss_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_pos_llh_gnss_t *msg);
 
-bool encode_sbp_msg_pos_llh_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_cov_gnss_t *msg);
-bool decode_sbp_msg_pos_llh_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_cov_gnss_t *msg);
+bool encode_sbp_msg_pos_llh_cov_gnss_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_pos_llh_cov_gnss_t *msg);
+bool decode_sbp_msg_pos_llh_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_pos_llh_cov_gnss_t *msg);
 
-bool encode_sbp_msg_vel_ecef_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_gnss_t *msg);
-bool decode_sbp_msg_vel_ecef_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_gnss_t *msg);
+bool encode_sbp_msg_vel_ecef_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_vel_ecef_gnss_t *msg);
+bool decode_sbp_msg_vel_ecef_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_vel_ecef_gnss_t *msg);
 
-bool encode_sbp_msg_vel_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_cov_gnss_t *msg);
-bool decode_sbp_msg_vel_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_cov_gnss_t *msg);
+bool encode_sbp_msg_vel_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_vel_ecef_cov_gnss_t *msg);
+bool decode_sbp_msg_vel_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_vel_ecef_cov_gnss_t *msg);
 
-bool encode_sbp_msg_vel_ned_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_gnss_t *msg);
-bool decode_sbp_msg_vel_ned_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_gnss_t *msg);
+bool encode_sbp_msg_vel_ned_gnss_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_vel_ned_gnss_t *msg);
+bool decode_sbp_msg_vel_ned_gnss_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_vel_ned_gnss_t *msg);
 
-bool encode_sbp_msg_vel_ned_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_cov_gnss_t *msg);
-bool decode_sbp_msg_vel_ned_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_cov_gnss_t *msg);
+bool encode_sbp_msg_vel_ned_cov_gnss_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_vel_ned_cov_gnss_t *msg);
+bool decode_sbp_msg_vel_ned_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_vel_ned_cov_gnss_t *msg);
 
-bool encode_sbp_msg_vel_body_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_body_t *msg);
+bool encode_sbp_msg_vel_body_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_vel_body_t *msg);
 bool decode_sbp_msg_vel_body_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_body_t *msg);
 
-bool encode_sbp_msg_age_corrections_t(sbp_encode_ctx_t *ctx, const sbp_msg_age_corrections_t *msg);
-bool decode_sbp_msg_age_corrections_t(sbp_decode_ctx_t *ctx, sbp_msg_age_corrections_t *msg);
+bool encode_sbp_msg_age_corrections_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_age_corrections_t *msg);
+bool decode_sbp_msg_age_corrections_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_age_corrections_t *msg);
 
-bool encode_sbp_msg_gps_time_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_gps_time_dep_a_t *msg);
-bool decode_sbp_msg_gps_time_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_dep_a_t *msg);
+bool encode_sbp_msg_gps_time_dep_a_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_gps_time_dep_a_t *msg);
+bool decode_sbp_msg_gps_time_dep_a_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_gps_time_dep_a_t *msg);
 
-bool encode_sbp_msg_dops_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_dops_dep_a_t *msg);
-bool decode_sbp_msg_dops_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_dops_dep_a_t *msg);
+bool encode_sbp_msg_dops_dep_a_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_dops_dep_a_t *msg);
+bool decode_sbp_msg_dops_dep_a_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_dops_dep_a_t *msg);
 
-bool encode_sbp_msg_pos_ecef_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_dep_a_t *msg);
-bool decode_sbp_msg_pos_ecef_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_dep_a_t *msg);
+bool encode_sbp_msg_pos_ecef_dep_a_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_pos_ecef_dep_a_t *msg);
+bool decode_sbp_msg_pos_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_pos_ecef_dep_a_t *msg);
 
-bool encode_sbp_msg_pos_llh_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_dep_a_t *msg);
-bool decode_sbp_msg_pos_llh_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_dep_a_t *msg);
+bool encode_sbp_msg_pos_llh_dep_a_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_pos_llh_dep_a_t *msg);
+bool decode_sbp_msg_pos_llh_dep_a_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_pos_llh_dep_a_t *msg);
 
-bool encode_sbp_msg_baseline_ecef_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_dep_a_t *msg);
-bool decode_sbp_msg_baseline_ecef_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ecef_dep_a_t *msg);
+bool encode_sbp_msg_baseline_ecef_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_dep_a_t *msg);
+bool decode_sbp_msg_baseline_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_baseline_ecef_dep_a_t *msg);
 
-bool encode_sbp_msg_baseline_ned_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_dep_a_t *msg);
-bool decode_sbp_msg_baseline_ned_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ned_dep_a_t *msg);
+bool encode_sbp_msg_baseline_ned_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_dep_a_t *msg);
+bool decode_sbp_msg_baseline_ned_dep_a_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_baseline_ned_dep_a_t *msg);
 
-bool encode_sbp_msg_vel_ecef_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_dep_a_t *msg);
-bool decode_sbp_msg_vel_ecef_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_dep_a_t *msg);
+bool encode_sbp_msg_vel_ecef_dep_a_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_vel_ecef_dep_a_t *msg);
+bool decode_sbp_msg_vel_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_vel_ecef_dep_a_t *msg);
 
-bool encode_sbp_msg_vel_ned_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_dep_a_t *msg);
-bool decode_sbp_msg_vel_ned_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_dep_a_t *msg);
+bool encode_sbp_msg_vel_ned_dep_a_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_vel_ned_dep_a_t *msg);
+bool decode_sbp_msg_vel_ned_dep_a_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_vel_ned_dep_a_t *msg);
 
-bool encode_sbp_msg_baseline_heading_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_dep_a_t *msg);
-bool decode_sbp_msg_baseline_heading_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_dep_a_t *msg);
+bool encode_sbp_msg_baseline_heading_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_dep_a_t *msg);
+bool decode_sbp_msg_baseline_heading_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_dep_a_t *msg);
 
-bool encode_sbp_msg_protection_level_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_dep_a_t *msg);
-bool decode_sbp_msg_protection_level_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_protection_level_dep_a_t *msg);
+bool encode_sbp_msg_protection_level_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_dep_a_t *msg);
+bool decode_sbp_msg_protection_level_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_protection_level_dep_a_t *msg);
 
-bool encode_sbp_msg_protection_level_t(sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_t *msg);
-bool decode_sbp_msg_protection_level_t(sbp_decode_ctx_t *ctx, sbp_msg_protection_level_t *msg);
+bool encode_sbp_msg_protection_level_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_protection_level_t *msg);
+bool decode_sbp_msg_protection_level_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_protection_level_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/navigation.h
+++ b/c/src/include/libsbp/internal/new/navigation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_NAVIGATION_PRIVATE_H
-#define LIBSBP_UNPACKED_NAVIGATION_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_NAVIGATION_H
+#define LIBSBP_INTERNAL_NEW_NAVIGATION_H
 
 #include <stdbool.h>
 
@@ -27,174 +27,714 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_gps_time_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_gps_time_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_gps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_gps_time_gnss_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_gps_time_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_gps_time_gnss_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_gps_time_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_utc_time_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_utc_time_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_utc_time_t(sbp_decode_ctx_t *ctx, sbp_msg_utc_time_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_utc_time_gnss_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_utc_time_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_utc_time_gnss_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_utc_time_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_dops_t(sbp_encode_ctx_t *ctx, const sbp_msg_dops_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_dops_t(sbp_decode_ctx_t *ctx, sbp_msg_dops_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_ecef_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_pos_ecef_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_ecef_cov_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_pos_ecef_cov_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_ecef_cov_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_pos_ecef_cov_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_llh_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_pos_llh_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_llh_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_llh_cov_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_pos_llh_cov_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_llh_cov_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_pos_llh_cov_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_baseline_ecef_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_baseline_ecef_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_baseline_ecef_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_baseline_ecef_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_baseline_ned_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_baseline_ned_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_baseline_ned_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_baseline_ned_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ecef_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_vel_ecef_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ecef_cov_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_vel_ecef_cov_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ecef_cov_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_vel_ecef_cov_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ned_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_vel_ned_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ned_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ned_cov_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_vel_ned_cov_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ned_cov_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_vel_ned_cov_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_ecef_gnss_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_pos_ecef_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_ecef_gnss_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_pos_ecef_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_pos_ecef_cov_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_pos_ecef_cov_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_llh_gnss_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_pos_llh_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_llh_gnss_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_pos_llh_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_llh_cov_gnss_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_pos_llh_cov_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_llh_cov_gnss_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_pos_llh_cov_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ecef_gnss_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_vel_ecef_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ecef_gnss_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_vel_ecef_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_vel_ecef_cov_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_vel_ecef_cov_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ned_gnss_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_vel_ned_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ned_gnss_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_vel_ned_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ned_cov_gnss_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_vel_ned_cov_gnss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ned_cov_gnss_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_vel_ned_cov_gnss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_body_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_vel_body_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_body_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_body_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_age_corrections_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_age_corrections_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_age_corrections_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_age_corrections_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_gps_time_dep_a_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_gps_time_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_gps_time_dep_a_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_gps_time_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_dops_dep_a_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_dops_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_dops_dep_a_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_dops_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_ecef_dep_a_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_pos_ecef_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_pos_ecef_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pos_llh_dep_a_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_pos_llh_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pos_llh_dep_a_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_pos_llh_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_baseline_ecef_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_baseline_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_baseline_ecef_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_baseline_ned_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_baseline_ned_dep_a_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_baseline_ned_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ecef_dep_a_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_vel_ecef_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_vel_ecef_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_vel_ned_dep_a_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_vel_ned_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_vel_ned_dep_a_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_vel_ned_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_baseline_heading_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_baseline_heading_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_protection_level_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_protection_level_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_protection_level_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_protection_level_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_protection_level_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_protection_level_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_protection_level_t *msg);
 

--- a/c/src/include/libsbp/internal/new/ndb.h
+++ b/c/src/include/libsbp/internal/new/ndb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_NDB_PRIVATE_H
-#define LIBSBP_UNPACKED_NDB_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_NDB_H
+#define LIBSBP_INTERNAL_NEW_NDB_H
 
 #include <stdbool.h>
 
@@ -28,8 +28,23 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ndb_event_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_ndb_event_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ndb_event_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_ndb_event_t *msg);
 

--- a/c/src/include/libsbp/internal/new/ndb.h
+++ b/c/src/include/libsbp/internal/new/ndb.h
@@ -1,21 +1,40 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ndb.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_NDB_PRIVATE_H
 #define LIBSBP_UNPACKED_NDB_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/ndb.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/ndb.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_ndb_event_t(sbp_encode_ctx_t *ctx, const sbp_msg_ndb_event_t *msg);
-bool decode_sbp_msg_ndb_event_t(sbp_decode_ctx_t *ctx, sbp_msg_ndb_event_t *msg);
+bool encode_sbp_msg_ndb_event_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_ndb_event_t *msg);
+bool decode_sbp_msg_ndb_event_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_ndb_event_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/observation.h
+++ b/c/src/include/libsbp/internal/new/observation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_OBSERVATION_PRIVATE_H
-#define LIBSBP_UNPACKED_OBSERVATION_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_OBSERVATION_H
+#define LIBSBP_INTERNAL_NEW_OBSERVATION_H
 
 #include <stdbool.h>
 
@@ -28,261 +28,1071 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_observation_header_t(sbp_encode_ctx_t *ctx,
                                      const sbp_observation_header_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_observation_header_t(sbp_decode_ctx_t *ctx,
                                      sbp_observation_header_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_doppler_t(sbp_encode_ctx_t *ctx, const sbp_doppler_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_doppler_t(sbp_decode_ctx_t *ctx, sbp_doppler_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_packed_obs_content_t(sbp_encode_ctx_t *ctx,
                                      const sbp_packed_obs_content_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_packed_obs_content_t(sbp_decode_ctx_t *ctx,
                                      sbp_packed_obs_content_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_packed_osr_content_t(sbp_encode_ctx_t *ctx,
                                      const sbp_packed_osr_content_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_packed_osr_content_t(sbp_decode_ctx_t *ctx,
                                      sbp_packed_osr_content_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_obs_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_obs_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_base_pos_llh_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_base_pos_llh_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_base_pos_llh_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_base_pos_llh_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_base_pos_ecef_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_base_pos_ecef_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_base_pos_ecef_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_base_pos_ecef_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_ephemeris_common_content_t(
     sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_ephemeris_common_content_t(sbp_decode_ctx_t *ctx,
                                            sbp_ephemeris_common_content_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_ephemeris_common_content_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_ephemeris_common_content_dep_b_t(
     sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_ephemeris_common_content_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_ephemeris_common_content_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_gps_dep_e_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_e_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_gps_dep_e_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_gps_dep_e_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_gps_dep_f_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_f_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_gps_dep_f_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_gps_dep_f_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_gps_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_ephemeris_gps_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_gps_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_ephemeris_gps_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_qzss_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_ephemeris_qzss_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_qzss_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_ephemeris_qzss_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_bds_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_ephemeris_bds_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_bds_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_ephemeris_bds_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_gal_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_gal_dep_a_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_gal_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_gal_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_ephemeris_gal_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_gal_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_ephemeris_gal_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_sbas_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_sbas_dep_a_t(sbp_decode_ctx_t *ctx,
                                            sbp_msg_ephemeris_sbas_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_glo_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_glo_dep_a_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_glo_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_sbas_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_sbas_dep_b_t(sbp_decode_ctx_t *ctx,
                                            sbp_msg_ephemeris_sbas_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_ephemeris_sbas_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_sbas_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_ephemeris_sbas_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_glo_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_glo_dep_b_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_glo_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_glo_dep_c_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_c_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_glo_dep_c_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_glo_dep_c_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_glo_dep_d_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_d_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_glo_dep_d_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ephemeris_glo_dep_d_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_ephemeris_glo_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_glo_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_ephemeris_glo_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_dep_d_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_ephemeris_dep_d_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_dep_d_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_ephemeris_dep_d_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_dep_a_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_ephemeris_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_dep_a_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_ephemeris_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_dep_b_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_ephemeris_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_dep_b_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_ephemeris_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ephemeris_dep_c_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_ephemeris_dep_c_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ephemeris_dep_c_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_ephemeris_dep_c_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_observation_header_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_observation_header_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_observation_header_dep_t(sbp_decode_ctx_t *ctx,
                                          sbp_observation_header_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_carrier_phase_dep_a_t(sbp_encode_ctx_t *ctx,
                                       const sbp_carrier_phase_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_carrier_phase_dep_a_t(sbp_decode_ctx_t *ctx,
                                       sbp_carrier_phase_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_packed_obs_content_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_packed_obs_content_dep_a_t(sbp_decode_ctx_t *ctx,
                                            sbp_packed_obs_content_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_packed_obs_content_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_packed_obs_content_dep_b_t(sbp_decode_ctx_t *ctx,
                                            sbp_packed_obs_content_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_packed_obs_content_dep_c_t(
     sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_c_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_packed_obs_content_dep_c_t(sbp_decode_ctx_t *ctx,
                                            sbp_packed_obs_content_dep_c_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_obs_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_obs_dep_a_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_obs_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_obs_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_obs_dep_b_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_obs_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_obs_dep_c_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_obs_dep_c_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_obs_dep_c_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_iono_t(sbp_encode_ctx_t *ctx, const sbp_msg_iono_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_iono_t(sbp_decode_ctx_t *ctx, sbp_msg_iono_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_sv_configuration_gps_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_sv_configuration_gps_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_sv_configuration_gps_dep_t(
     sbp_decode_ctx_t *ctx, sbp_msg_sv_configuration_gps_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gnss_capb_t(sbp_encode_ctx_t *ctx, const sbp_gnss_capb_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gnss_capb_t(sbp_decode_ctx_t *ctx, sbp_gnss_capb_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_gnss_capb_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_gnss_capb_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_gnss_capb_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_gnss_capb_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_group_delay_dep_a_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_group_delay_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_group_delay_dep_a_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_group_delay_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_group_delay_dep_b_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_group_delay_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_group_delay_dep_b_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_group_delay_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_group_delay_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_group_delay_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_group_delay_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_group_delay_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_almanac_common_content_t(
     sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_almanac_common_content_t(sbp_decode_ctx_t *ctx,
                                          sbp_almanac_common_content_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_almanac_common_content_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_almanac_common_content_dep_t(
     sbp_decode_ctx_t *ctx, sbp_almanac_common_content_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_almanac_gps_dep_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_almanac_gps_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_almanac_gps_dep_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_almanac_gps_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_almanac_gps_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_almanac_gps_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_almanac_gps_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_almanac_gps_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_almanac_glo_dep_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_almanac_glo_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_almanac_glo_dep_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_almanac_glo_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_almanac_glo_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_almanac_glo_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_almanac_glo_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_almanac_glo_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_glo_biases_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_glo_biases_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_glo_biases_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_glo_biases_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_sv_az_el_t(sbp_encode_ctx_t *ctx, const sbp_sv_az_el_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_sv_az_el_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_sv_az_el_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_msg_sv_az_el_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_osr_t(sbp_encode_ctx_t *ctx, const sbp_msg_osr_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_osr_t(sbp_decode_ctx_t *ctx, sbp_msg_osr_t *msg);
 
 #ifdef __cplusplus

--- a/c/src/include/libsbp/internal/new/observation.h
+++ b/c/src/include/libsbp/internal/new/observation.h
@@ -1,180 +1,292 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/observation.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_OBSERVATION_PRIVATE_H
 #define LIBSBP_UNPACKED_OBSERVATION_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/observation.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/observation.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_observation_header_t(sbp_encode_ctx_t *ctx, const sbp_observation_header_t *msg);
-bool decode_sbp_observation_header_t(sbp_decode_ctx_t *ctx, sbp_observation_header_t *msg);
+bool encode_sbp_observation_header_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_observation_header_t *msg);
+bool decode_sbp_observation_header_t(sbp_decode_ctx_t *ctx,
+                                     sbp_observation_header_t *msg);
 
 bool encode_sbp_doppler_t(sbp_encode_ctx_t *ctx, const sbp_doppler_t *msg);
 bool decode_sbp_doppler_t(sbp_decode_ctx_t *ctx, sbp_doppler_t *msg);
 
-bool encode_sbp_packed_obs_content_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_t *msg);
-bool decode_sbp_packed_obs_content_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_t *msg);
+bool encode_sbp_packed_obs_content_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_packed_obs_content_t *msg);
+bool decode_sbp_packed_obs_content_t(sbp_decode_ctx_t *ctx,
+                                     sbp_packed_obs_content_t *msg);
 
-bool encode_sbp_packed_osr_content_t(sbp_encode_ctx_t *ctx, const sbp_packed_osr_content_t *msg);
-bool decode_sbp_packed_osr_content_t(sbp_decode_ctx_t *ctx, sbp_packed_osr_content_t *msg);
+bool encode_sbp_packed_osr_content_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_packed_osr_content_t *msg);
+bool decode_sbp_packed_osr_content_t(sbp_decode_ctx_t *ctx,
+                                     sbp_packed_osr_content_t *msg);
 
 bool encode_sbp_msg_obs_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_t *msg);
 bool decode_sbp_msg_obs_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_t *msg);
 
-bool encode_sbp_msg_base_pos_llh_t(sbp_encode_ctx_t *ctx, const sbp_msg_base_pos_llh_t *msg);
-bool decode_sbp_msg_base_pos_llh_t(sbp_decode_ctx_t *ctx, sbp_msg_base_pos_llh_t *msg);
+bool encode_sbp_msg_base_pos_llh_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_base_pos_llh_t *msg);
+bool decode_sbp_msg_base_pos_llh_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_base_pos_llh_t *msg);
 
-bool encode_sbp_msg_base_pos_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_base_pos_ecef_t *msg);
-bool decode_sbp_msg_base_pos_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_base_pos_ecef_t *msg);
+bool encode_sbp_msg_base_pos_ecef_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_base_pos_ecef_t *msg);
+bool decode_sbp_msg_base_pos_ecef_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_base_pos_ecef_t *msg);
 
-bool encode_sbp_ephemeris_common_content_t(sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_t *msg);
-bool decode_sbp_ephemeris_common_content_t(sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_t *msg);
+bool encode_sbp_ephemeris_common_content_t(
+    sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_t *msg);
+bool decode_sbp_ephemeris_common_content_t(sbp_decode_ctx_t *ctx,
+                                           sbp_ephemeris_common_content_t *msg);
 
-bool encode_sbp_ephemeris_common_content_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_b_t *msg);
-bool decode_sbp_ephemeris_common_content_dep_b_t(sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_b_t *msg);
+bool encode_sbp_ephemeris_common_content_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_b_t *msg);
+bool decode_sbp_ephemeris_common_content_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_b_t *msg);
 
-bool encode_sbp_ephemeris_common_content_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_a_t *msg);
-bool decode_sbp_ephemeris_common_content_dep_a_t(sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_a_t *msg);
+bool encode_sbp_ephemeris_common_content_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_a_t *msg);
+bool decode_sbp_ephemeris_common_content_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_a_t *msg);
 
-bool encode_sbp_msg_ephemeris_gps_dep_e_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_e_t *msg);
-bool decode_sbp_msg_ephemeris_gps_dep_e_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gps_dep_e_t *msg);
+bool encode_sbp_msg_ephemeris_gps_dep_e_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_e_t *msg);
+bool decode_sbp_msg_ephemeris_gps_dep_e_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_gps_dep_e_t *msg);
 
-bool encode_sbp_msg_ephemeris_gps_dep_f_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_f_t *msg);
-bool decode_sbp_msg_ephemeris_gps_dep_f_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gps_dep_f_t *msg);
+bool encode_sbp_msg_ephemeris_gps_dep_f_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_f_t *msg);
+bool decode_sbp_msg_ephemeris_gps_dep_f_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_gps_dep_f_t *msg);
 
-bool encode_sbp_msg_ephemeris_gps_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_t *msg);
-bool decode_sbp_msg_ephemeris_gps_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gps_t *msg);
+bool encode_sbp_msg_ephemeris_gps_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_gps_t *msg);
+bool decode_sbp_msg_ephemeris_gps_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_gps_t *msg);
 
-bool encode_sbp_msg_ephemeris_qzss_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_qzss_t *msg);
-bool decode_sbp_msg_ephemeris_qzss_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_qzss_t *msg);
+bool encode_sbp_msg_ephemeris_qzss_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_ephemeris_qzss_t *msg);
+bool decode_sbp_msg_ephemeris_qzss_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_ephemeris_qzss_t *msg);
 
-bool encode_sbp_msg_ephemeris_bds_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_bds_t *msg);
-bool decode_sbp_msg_ephemeris_bds_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_bds_t *msg);
+bool encode_sbp_msg_ephemeris_bds_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_bds_t *msg);
+bool decode_sbp_msg_ephemeris_bds_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_bds_t *msg);
 
-bool encode_sbp_msg_ephemeris_gal_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_dep_a_t *msg);
-bool decode_sbp_msg_ephemeris_gal_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gal_dep_a_t *msg);
+bool encode_sbp_msg_ephemeris_gal_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_dep_a_t *msg);
+bool decode_sbp_msg_ephemeris_gal_dep_a_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_gal_dep_a_t *msg);
 
-bool encode_sbp_msg_ephemeris_gal_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_t *msg);
-bool decode_sbp_msg_ephemeris_gal_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gal_t *msg);
+bool encode_sbp_msg_ephemeris_gal_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_gal_t *msg);
+bool decode_sbp_msg_ephemeris_gal_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_gal_t *msg);
 
-bool encode_sbp_msg_ephemeris_sbas_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_a_t *msg);
-bool decode_sbp_msg_ephemeris_sbas_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_dep_a_t *msg);
+bool encode_sbp_msg_ephemeris_sbas_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_a_t *msg);
+bool decode_sbp_msg_ephemeris_sbas_dep_a_t(sbp_decode_ctx_t *ctx,
+                                           sbp_msg_ephemeris_sbas_dep_a_t *msg);
 
-bool encode_sbp_msg_ephemeris_glo_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_a_t *msg);
-bool decode_sbp_msg_ephemeris_glo_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_a_t *msg);
+bool encode_sbp_msg_ephemeris_glo_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_a_t *msg);
+bool decode_sbp_msg_ephemeris_glo_dep_a_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_a_t *msg);
 
-bool encode_sbp_msg_ephemeris_sbas_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_b_t *msg);
-bool decode_sbp_msg_ephemeris_sbas_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_dep_b_t *msg);
+bool encode_sbp_msg_ephemeris_sbas_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_b_t *msg);
+bool decode_sbp_msg_ephemeris_sbas_dep_b_t(sbp_decode_ctx_t *ctx,
+                                           sbp_msg_ephemeris_sbas_dep_b_t *msg);
 
-bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_t *msg);
-bool decode_sbp_msg_ephemeris_sbas_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_t *msg);
+bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_ephemeris_sbas_t *msg);
+bool decode_sbp_msg_ephemeris_sbas_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_ephemeris_sbas_t *msg);
 
-bool encode_sbp_msg_ephemeris_glo_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_b_t *msg);
-bool decode_sbp_msg_ephemeris_glo_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_b_t *msg);
+bool encode_sbp_msg_ephemeris_glo_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_b_t *msg);
+bool decode_sbp_msg_ephemeris_glo_dep_b_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_b_t *msg);
 
-bool encode_sbp_msg_ephemeris_glo_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_c_t *msg);
-bool decode_sbp_msg_ephemeris_glo_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_c_t *msg);
+bool encode_sbp_msg_ephemeris_glo_dep_c_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_c_t *msg);
+bool decode_sbp_msg_ephemeris_glo_dep_c_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_c_t *msg);
 
-bool encode_sbp_msg_ephemeris_glo_dep_d_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_d_t *msg);
-bool decode_sbp_msg_ephemeris_glo_dep_d_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_d_t *msg);
+bool encode_sbp_msg_ephemeris_glo_dep_d_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_d_t *msg);
+bool decode_sbp_msg_ephemeris_glo_dep_d_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_d_t *msg);
 
-bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_t *msg);
-bool decode_sbp_msg_ephemeris_glo_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_t *msg);
+bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_glo_t *msg);
+bool decode_sbp_msg_ephemeris_glo_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_glo_t *msg);
 
-bool encode_sbp_msg_ephemeris_dep_d_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_d_t *msg);
-bool decode_sbp_msg_ephemeris_dep_d_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_d_t *msg);
+bool encode_sbp_msg_ephemeris_dep_d_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_d_t *msg);
+bool decode_sbp_msg_ephemeris_dep_d_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_d_t *msg);
 
-bool encode_sbp_msg_ephemeris_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_a_t *msg);
-bool decode_sbp_msg_ephemeris_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_a_t *msg);
+bool encode_sbp_msg_ephemeris_dep_a_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_a_t *msg);
+bool decode_sbp_msg_ephemeris_dep_a_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_a_t *msg);
 
-bool encode_sbp_msg_ephemeris_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_b_t *msg);
-bool decode_sbp_msg_ephemeris_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_b_t *msg);
+bool encode_sbp_msg_ephemeris_dep_b_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_b_t *msg);
+bool decode_sbp_msg_ephemeris_dep_b_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_b_t *msg);
 
-bool encode_sbp_msg_ephemeris_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_c_t *msg);
-bool decode_sbp_msg_ephemeris_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_c_t *msg);
+bool encode_sbp_msg_ephemeris_dep_c_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_c_t *msg);
+bool decode_sbp_msg_ephemeris_dep_c_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_c_t *msg);
 
-bool encode_sbp_observation_header_dep_t(sbp_encode_ctx_t *ctx, const sbp_observation_header_dep_t *msg);
-bool decode_sbp_observation_header_dep_t(sbp_decode_ctx_t *ctx, sbp_observation_header_dep_t *msg);
+bool encode_sbp_observation_header_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_observation_header_dep_t *msg);
+bool decode_sbp_observation_header_dep_t(sbp_decode_ctx_t *ctx,
+                                         sbp_observation_header_dep_t *msg);
 
-bool encode_sbp_carrier_phase_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_carrier_phase_dep_a_t *msg);
-bool decode_sbp_carrier_phase_dep_a_t(sbp_decode_ctx_t *ctx, sbp_carrier_phase_dep_a_t *msg);
+bool encode_sbp_carrier_phase_dep_a_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_carrier_phase_dep_a_t *msg);
+bool decode_sbp_carrier_phase_dep_a_t(sbp_decode_ctx_t *ctx,
+                                      sbp_carrier_phase_dep_a_t *msg);
 
-bool encode_sbp_packed_obs_content_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_a_t *msg);
-bool decode_sbp_packed_obs_content_dep_a_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_a_t *msg);
+bool encode_sbp_packed_obs_content_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_a_t *msg);
+bool decode_sbp_packed_obs_content_dep_a_t(sbp_decode_ctx_t *ctx,
+                                           sbp_packed_obs_content_dep_a_t *msg);
 
-bool encode_sbp_packed_obs_content_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_b_t *msg);
-bool decode_sbp_packed_obs_content_dep_b_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_b_t *msg);
+bool encode_sbp_packed_obs_content_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_b_t *msg);
+bool decode_sbp_packed_obs_content_dep_b_t(sbp_decode_ctx_t *ctx,
+                                           sbp_packed_obs_content_dep_b_t *msg);
 
-bool encode_sbp_packed_obs_content_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_c_t *msg);
-bool decode_sbp_packed_obs_content_dep_c_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_c_t *msg);
+bool encode_sbp_packed_obs_content_dep_c_t(
+    sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_c_t *msg);
+bool decode_sbp_packed_obs_content_dep_c_t(sbp_decode_ctx_t *ctx,
+                                           sbp_packed_obs_content_dep_c_t *msg);
 
-bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_dep_a_t *msg);
-bool decode_sbp_msg_obs_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_dep_a_t *msg);
+bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_obs_dep_a_t *msg);
+bool decode_sbp_msg_obs_dep_a_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_obs_dep_a_t *msg);
 
-bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_dep_b_t *msg);
-bool decode_sbp_msg_obs_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_dep_b_t *msg);
+bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_obs_dep_b_t *msg);
+bool decode_sbp_msg_obs_dep_b_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_obs_dep_b_t *msg);
 
-bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_dep_c_t *msg);
-bool decode_sbp_msg_obs_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_dep_c_t *msg);
+bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_obs_dep_c_t *msg);
+bool decode_sbp_msg_obs_dep_c_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_obs_dep_c_t *msg);
 
 bool encode_sbp_msg_iono_t(sbp_encode_ctx_t *ctx, const sbp_msg_iono_t *msg);
 bool decode_sbp_msg_iono_t(sbp_decode_ctx_t *ctx, sbp_msg_iono_t *msg);
 
-bool encode_sbp_msg_sv_configuration_gps_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_sv_configuration_gps_dep_t *msg);
-bool decode_sbp_msg_sv_configuration_gps_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_sv_configuration_gps_dep_t *msg);
+bool encode_sbp_msg_sv_configuration_gps_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_sv_configuration_gps_dep_t *msg);
+bool decode_sbp_msg_sv_configuration_gps_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_sv_configuration_gps_dep_t *msg);
 
 bool encode_sbp_gnss_capb_t(sbp_encode_ctx_t *ctx, const sbp_gnss_capb_t *msg);
 bool decode_sbp_gnss_capb_t(sbp_decode_ctx_t *ctx, sbp_gnss_capb_t *msg);
 
-bool encode_sbp_msg_gnss_capb_t(sbp_encode_ctx_t *ctx, const sbp_msg_gnss_capb_t *msg);
-bool decode_sbp_msg_gnss_capb_t(sbp_decode_ctx_t *ctx, sbp_msg_gnss_capb_t *msg);
+bool encode_sbp_msg_gnss_capb_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_gnss_capb_t *msg);
+bool decode_sbp_msg_gnss_capb_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_gnss_capb_t *msg);
 
-bool encode_sbp_msg_group_delay_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_dep_a_t *msg);
-bool decode_sbp_msg_group_delay_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_group_delay_dep_a_t *msg);
+bool encode_sbp_msg_group_delay_dep_a_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_group_delay_dep_a_t *msg);
+bool decode_sbp_msg_group_delay_dep_a_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_group_delay_dep_a_t *msg);
 
-bool encode_sbp_msg_group_delay_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_dep_b_t *msg);
-bool decode_sbp_msg_group_delay_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_group_delay_dep_b_t *msg);
+bool encode_sbp_msg_group_delay_dep_b_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_group_delay_dep_b_t *msg);
+bool decode_sbp_msg_group_delay_dep_b_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_group_delay_dep_b_t *msg);
 
-bool encode_sbp_msg_group_delay_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_t *msg);
-bool decode_sbp_msg_group_delay_t(sbp_decode_ctx_t *ctx, sbp_msg_group_delay_t *msg);
+bool encode_sbp_msg_group_delay_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_group_delay_t *msg);
+bool decode_sbp_msg_group_delay_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_group_delay_t *msg);
 
-bool encode_sbp_almanac_common_content_t(sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_t *msg);
-bool decode_sbp_almanac_common_content_t(sbp_decode_ctx_t *ctx, sbp_almanac_common_content_t *msg);
+bool encode_sbp_almanac_common_content_t(
+    sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_t *msg);
+bool decode_sbp_almanac_common_content_t(sbp_decode_ctx_t *ctx,
+                                         sbp_almanac_common_content_t *msg);
 
-bool encode_sbp_almanac_common_content_dep_t(sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_dep_t *msg);
-bool decode_sbp_almanac_common_content_dep_t(sbp_decode_ctx_t *ctx, sbp_almanac_common_content_dep_t *msg);
+bool encode_sbp_almanac_common_content_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_dep_t *msg);
+bool decode_sbp_almanac_common_content_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_almanac_common_content_dep_t *msg);
 
-bool encode_sbp_msg_almanac_gps_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_gps_dep_t *msg);
-bool decode_sbp_msg_almanac_gps_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_gps_dep_t *msg);
+bool encode_sbp_msg_almanac_gps_dep_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_almanac_gps_dep_t *msg);
+bool decode_sbp_msg_almanac_gps_dep_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_almanac_gps_dep_t *msg);
 
-bool encode_sbp_msg_almanac_gps_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_gps_t *msg);
-bool decode_sbp_msg_almanac_gps_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_gps_t *msg);
+bool encode_sbp_msg_almanac_gps_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_almanac_gps_t *msg);
+bool decode_sbp_msg_almanac_gps_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_almanac_gps_t *msg);
 
-bool encode_sbp_msg_almanac_glo_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_glo_dep_t *msg);
-bool decode_sbp_msg_almanac_glo_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_glo_dep_t *msg);
+bool encode_sbp_msg_almanac_glo_dep_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_almanac_glo_dep_t *msg);
+bool decode_sbp_msg_almanac_glo_dep_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_almanac_glo_dep_t *msg);
 
-bool encode_sbp_msg_almanac_glo_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_glo_t *msg);
-bool decode_sbp_msg_almanac_glo_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_glo_t *msg);
+bool encode_sbp_msg_almanac_glo_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_almanac_glo_t *msg);
+bool decode_sbp_msg_almanac_glo_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_almanac_glo_t *msg);
 
-bool encode_sbp_msg_glo_biases_t(sbp_encode_ctx_t *ctx, const sbp_msg_glo_biases_t *msg);
-bool decode_sbp_msg_glo_biases_t(sbp_decode_ctx_t *ctx, sbp_msg_glo_biases_t *msg);
+bool encode_sbp_msg_glo_biases_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_glo_biases_t *msg);
+bool decode_sbp_msg_glo_biases_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_glo_biases_t *msg);
 
 bool encode_sbp_sv_az_el_t(sbp_encode_ctx_t *ctx, const sbp_sv_az_el_t *msg);
 bool decode_sbp_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_sv_az_el_t *msg);
 
-bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx, const sbp_msg_sv_az_el_t *msg);
+bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_sv_az_el_t *msg);
 bool decode_sbp_msg_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_msg_sv_az_el_t *msg);
 
 bool encode_sbp_msg_osr_t(sbp_encode_ctx_t *ctx, const sbp_msg_osr_t *msg);
 bool decode_sbp_msg_osr_t(sbp_decode_ctx_t *ctx, sbp_msg_osr_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/orientation.h
+++ b/c/src/include/libsbp/internal/new/orientation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_ORIENTATION_PRIVATE_H
-#define LIBSBP_UNPACKED_ORIENTATION_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_ORIENTATION_H
+#define LIBSBP_INTERNAL_NEW_ORIENTATION_H
 
 #include <stdbool.h>
 
@@ -27,23 +27,83 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_baseline_heading_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_baseline_heading_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_baseline_heading_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_baseline_heading_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_orient_quat_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_orient_quat_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_orient_quat_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_orient_quat_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_orient_euler_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_orient_euler_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_orient_euler_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_orient_euler_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_angular_rate_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_angular_rate_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_angular_rate_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_angular_rate_t *msg);
 

--- a/c/src/include/libsbp/internal/new/orientation.h
+++ b/c/src/include/libsbp/internal/new/orientation.h
@@ -1,29 +1,54 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/orientation.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_ORIENTATION_PRIVATE_H
 #define LIBSBP_UNPACKED_ORIENTATION_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/orientation.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/orientation.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_baseline_heading_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_t *msg);
-bool decode_sbp_msg_baseline_heading_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_t *msg);
+bool encode_sbp_msg_baseline_heading_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_baseline_heading_t *msg);
+bool decode_sbp_msg_baseline_heading_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_baseline_heading_t *msg);
 
-bool encode_sbp_msg_orient_quat_t(sbp_encode_ctx_t *ctx, const sbp_msg_orient_quat_t *msg);
-bool decode_sbp_msg_orient_quat_t(sbp_decode_ctx_t *ctx, sbp_msg_orient_quat_t *msg);
+bool encode_sbp_msg_orient_quat_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_orient_quat_t *msg);
+bool decode_sbp_msg_orient_quat_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_orient_quat_t *msg);
 
-bool encode_sbp_msg_orient_euler_t(sbp_encode_ctx_t *ctx, const sbp_msg_orient_euler_t *msg);
-bool decode_sbp_msg_orient_euler_t(sbp_decode_ctx_t *ctx, sbp_msg_orient_euler_t *msg);
+bool encode_sbp_msg_orient_euler_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_orient_euler_t *msg);
+bool decode_sbp_msg_orient_euler_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_orient_euler_t *msg);
 
-bool encode_sbp_msg_angular_rate_t(sbp_encode_ctx_t *ctx, const sbp_msg_angular_rate_t *msg);
-bool decode_sbp_msg_angular_rate_t(sbp_decode_ctx_t *ctx, sbp_msg_angular_rate_t *msg);
+bool encode_sbp_msg_angular_rate_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_angular_rate_t *msg);
+bool decode_sbp_msg_angular_rate_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_angular_rate_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/piksi.h
+++ b/c/src/include/libsbp/internal/new/piksi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_PIKSI_PRIVATE_H
-#define LIBSBP_UNPACKED_PIKSI_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_PIKSI_H
+#define LIBSBP_INTERNAL_NEW_PIKSI_H
 
 #include <stdbool.h>
 
@@ -28,137 +28,572 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_almanac_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_almanac_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_almanac_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_set_time_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_set_time_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_set_time_t(sbp_decode_ctx_t *ctx, sbp_msg_set_time_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_reset_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_reset_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_reset_dep_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_reset_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_reset_dep_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_reset_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_cw_results_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_cw_results_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_cw_results_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_cw_results_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_cw_start_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_cw_start_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_cw_start_t(sbp_decode_ctx_t *ctx, sbp_msg_cw_start_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_reset_filters_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_reset_filters_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_reset_filters_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_reset_filters_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_init_base_dep_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_init_base_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_init_base_dep_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_init_base_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_thread_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_thread_state_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_thread_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_uart_channel_t(sbp_encode_ctx_t *ctx,
                                const sbp_uart_channel_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_uart_channel_t(sbp_decode_ctx_t *ctx, sbp_uart_channel_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_period_t(sbp_encode_ctx_t *ctx, const sbp_period_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_period_t(sbp_decode_ctx_t *ctx, sbp_period_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_latency_t(sbp_encode_ctx_t *ctx, const sbp_latency_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_latency_t(sbp_decode_ctx_t *ctx, sbp_latency_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_uart_state_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_uart_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_uart_state_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_uart_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_uart_state_depa_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_uart_state_depa_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_uart_state_depa_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_uart_state_depa_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_iar_state_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_iar_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_iar_state_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_iar_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_mask_satellite_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_mask_satellite_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_mask_satellite_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_mask_satellite_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_mask_satellite_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_mask_satellite_dep_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_mask_satellite_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_device_monitor_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_device_monitor_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_device_monitor_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_device_monitor_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_command_req_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_command_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_command_req_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_command_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_command_resp_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_command_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_command_resp_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_command_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_command_output_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_command_output_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_command_output_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_command_output_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_network_state_req_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_network_state_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_network_state_req_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_network_state_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_network_state_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_network_state_resp_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_network_state_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx,
                                 const sbp_network_usage_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_network_usage_t(sbp_decode_ctx_t *ctx,
                                 sbp_network_usage_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_network_bandwidth_usage_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_network_bandwidth_usage_t(
     sbp_decode_ctx_t *ctx, sbp_msg_network_bandwidth_usage_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_cell_modem_status_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_cell_modem_status_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_cell_modem_status_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_cell_modem_status_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_specan_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_specan_dep_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_specan_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx,
                              const sbp_msg_specan_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_specan_t(sbp_decode_ctx_t *ctx, sbp_msg_specan_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_front_end_gain_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_front_end_gain_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_front_end_gain_t *msg);
 

--- a/c/src/include/libsbp/internal/new/piksi.h
+++ b/c/src/include/libsbp/internal/new/piksi.h
@@ -1,44 +1,75 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/piksi.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_PIKSI_PRIVATE_H
 #define LIBSBP_UNPACKED_PIKSI_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/piksi.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/piksi.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_almanac_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_t *msg);
+bool encode_sbp_msg_almanac_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_almanac_t *msg);
 bool decode_sbp_msg_almanac_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_t *msg);
 
-bool encode_sbp_msg_set_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_set_time_t *msg);
+bool encode_sbp_msg_set_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_set_time_t *msg);
 bool decode_sbp_msg_set_time_t(sbp_decode_ctx_t *ctx, sbp_msg_set_time_t *msg);
 
 bool encode_sbp_msg_reset_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_t *msg);
 bool decode_sbp_msg_reset_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_t *msg);
 
-bool encode_sbp_msg_reset_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_dep_t *msg);
-bool decode_sbp_msg_reset_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_dep_t *msg);
+bool encode_sbp_msg_reset_dep_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_reset_dep_t *msg);
+bool decode_sbp_msg_reset_dep_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_reset_dep_t *msg);
 
-bool encode_sbp_msg_cw_results_t(sbp_encode_ctx_t *ctx, const sbp_msg_cw_results_t *msg);
-bool decode_sbp_msg_cw_results_t(sbp_decode_ctx_t *ctx, sbp_msg_cw_results_t *msg);
+bool encode_sbp_msg_cw_results_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_cw_results_t *msg);
+bool decode_sbp_msg_cw_results_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_cw_results_t *msg);
 
-bool encode_sbp_msg_cw_start_t(sbp_encode_ctx_t *ctx, const sbp_msg_cw_start_t *msg);
+bool encode_sbp_msg_cw_start_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_cw_start_t *msg);
 bool decode_sbp_msg_cw_start_t(sbp_decode_ctx_t *ctx, sbp_msg_cw_start_t *msg);
 
-bool encode_sbp_msg_reset_filters_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_filters_t *msg);
-bool decode_sbp_msg_reset_filters_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_filters_t *msg);
+bool encode_sbp_msg_reset_filters_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_reset_filters_t *msg);
+bool decode_sbp_msg_reset_filters_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_reset_filters_t *msg);
 
-bool encode_sbp_msg_init_base_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_init_base_dep_t *msg);
-bool decode_sbp_msg_init_base_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_init_base_dep_t *msg);
+bool encode_sbp_msg_init_base_dep_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_init_base_dep_t *msg);
+bool decode_sbp_msg_init_base_dep_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_init_base_dep_t *msg);
 
-bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_thread_state_t *msg);
-bool decode_sbp_msg_thread_state_t(sbp_decode_ctx_t *ctx, sbp_msg_thread_state_t *msg);
+bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_thread_state_t *msg);
+bool decode_sbp_msg_thread_state_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_thread_state_t *msg);
 
-bool encode_sbp_uart_channel_t(sbp_encode_ctx_t *ctx, const sbp_uart_channel_t *msg);
+bool encode_sbp_uart_channel_t(sbp_encode_ctx_t *ctx,
+                               const sbp_uart_channel_t *msg);
 bool decode_sbp_uart_channel_t(sbp_decode_ctx_t *ctx, sbp_uart_channel_t *msg);
 
 bool encode_sbp_period_t(sbp_encode_ctx_t *ctx, const sbp_period_t *msg);
@@ -47,59 +78,92 @@ bool decode_sbp_period_t(sbp_decode_ctx_t *ctx, sbp_period_t *msg);
 bool encode_sbp_latency_t(sbp_encode_ctx_t *ctx, const sbp_latency_t *msg);
 bool decode_sbp_latency_t(sbp_decode_ctx_t *ctx, sbp_latency_t *msg);
 
-bool encode_sbp_msg_uart_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_uart_state_t *msg);
-bool decode_sbp_msg_uart_state_t(sbp_decode_ctx_t *ctx, sbp_msg_uart_state_t *msg);
+bool encode_sbp_msg_uart_state_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_uart_state_t *msg);
+bool decode_sbp_msg_uart_state_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_uart_state_t *msg);
 
-bool encode_sbp_msg_uart_state_depa_t(sbp_encode_ctx_t *ctx, const sbp_msg_uart_state_depa_t *msg);
-bool decode_sbp_msg_uart_state_depa_t(sbp_decode_ctx_t *ctx, sbp_msg_uart_state_depa_t *msg);
+bool encode_sbp_msg_uart_state_depa_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_uart_state_depa_t *msg);
+bool decode_sbp_msg_uart_state_depa_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_uart_state_depa_t *msg);
 
-bool encode_sbp_msg_iar_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_iar_state_t *msg);
-bool decode_sbp_msg_iar_state_t(sbp_decode_ctx_t *ctx, sbp_msg_iar_state_t *msg);
+bool encode_sbp_msg_iar_state_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_iar_state_t *msg);
+bool decode_sbp_msg_iar_state_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_iar_state_t *msg);
 
-bool encode_sbp_msg_mask_satellite_t(sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_t *msg);
-bool decode_sbp_msg_mask_satellite_t(sbp_decode_ctx_t *ctx, sbp_msg_mask_satellite_t *msg);
+bool encode_sbp_msg_mask_satellite_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_mask_satellite_t *msg);
+bool decode_sbp_msg_mask_satellite_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_mask_satellite_t *msg);
 
-bool encode_sbp_msg_mask_satellite_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_dep_t *msg);
-bool decode_sbp_msg_mask_satellite_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_mask_satellite_dep_t *msg);
+bool encode_sbp_msg_mask_satellite_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_dep_t *msg);
+bool decode_sbp_msg_mask_satellite_dep_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_mask_satellite_dep_t *msg);
 
-bool encode_sbp_msg_device_monitor_t(sbp_encode_ctx_t *ctx, const sbp_msg_device_monitor_t *msg);
-bool decode_sbp_msg_device_monitor_t(sbp_decode_ctx_t *ctx, sbp_msg_device_monitor_t *msg);
+bool encode_sbp_msg_device_monitor_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_device_monitor_t *msg);
+bool decode_sbp_msg_device_monitor_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_device_monitor_t *msg);
 
-bool encode_sbp_msg_command_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_command_req_t *msg);
-bool decode_sbp_msg_command_req_t(sbp_decode_ctx_t *ctx, sbp_msg_command_req_t *msg);
+bool encode_sbp_msg_command_req_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_command_req_t *msg);
+bool decode_sbp_msg_command_req_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_command_req_t *msg);
 
-bool encode_sbp_msg_command_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_command_resp_t *msg);
-bool decode_sbp_msg_command_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_command_resp_t *msg);
+bool encode_sbp_msg_command_resp_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_command_resp_t *msg);
+bool decode_sbp_msg_command_resp_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_command_resp_t *msg);
 
-bool encode_sbp_msg_command_output_t(sbp_encode_ctx_t *ctx, const sbp_msg_command_output_t *msg);
-bool decode_sbp_msg_command_output_t(sbp_decode_ctx_t *ctx, sbp_msg_command_output_t *msg);
+bool encode_sbp_msg_command_output_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_command_output_t *msg);
+bool decode_sbp_msg_command_output_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_command_output_t *msg);
 
-bool encode_sbp_msg_network_state_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_network_state_req_t *msg);
-bool decode_sbp_msg_network_state_req_t(sbp_decode_ctx_t *ctx, sbp_msg_network_state_req_t *msg);
+bool encode_sbp_msg_network_state_req_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_network_state_req_t *msg);
+bool decode_sbp_msg_network_state_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_network_state_req_t *msg);
 
-bool encode_sbp_msg_network_state_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg);
-bool decode_sbp_msg_network_state_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_network_state_resp_t *msg);
+bool encode_sbp_msg_network_state_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg);
+bool decode_sbp_msg_network_state_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_network_state_resp_t *msg);
 
-bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx, const sbp_network_usage_t *msg);
-bool decode_sbp_network_usage_t(sbp_decode_ctx_t *ctx, sbp_network_usage_t *msg);
+bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx,
+                                const sbp_network_usage_t *msg);
+bool decode_sbp_network_usage_t(sbp_decode_ctx_t *ctx,
+                                sbp_network_usage_t *msg);
 
-bool encode_sbp_msg_network_bandwidth_usage_t(sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg);
-bool decode_sbp_msg_network_bandwidth_usage_t(sbp_decode_ctx_t *ctx, sbp_msg_network_bandwidth_usage_t *msg);
+bool encode_sbp_msg_network_bandwidth_usage_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg);
+bool decode_sbp_msg_network_bandwidth_usage_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_network_bandwidth_usage_t *msg);
 
-bool encode_sbp_msg_cell_modem_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_cell_modem_status_t *msg);
-bool decode_sbp_msg_cell_modem_status_t(sbp_decode_ctx_t *ctx, sbp_msg_cell_modem_status_t *msg);
+bool encode_sbp_msg_cell_modem_status_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_cell_modem_status_t *msg);
+bool decode_sbp_msg_cell_modem_status_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_cell_modem_status_t *msg);
 
-bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_specan_dep_t *msg);
-bool decode_sbp_msg_specan_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_specan_dep_t *msg);
+bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_specan_dep_t *msg);
+bool decode_sbp_msg_specan_dep_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_specan_dep_t *msg);
 
-bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx, const sbp_msg_specan_t *msg);
+bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx,
+                             const sbp_msg_specan_t *msg);
 bool decode_sbp_msg_specan_t(sbp_decode_ctx_t *ctx, sbp_msg_specan_t *msg);
 
-bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx, const sbp_msg_front_end_gain_t *msg);
-bool decode_sbp_msg_front_end_gain_t(sbp_decode_ctx_t *ctx, sbp_msg_front_end_gain_t *msg);
+bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_front_end_gain_t *msg);
+bool decode_sbp_msg_front_end_gain_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_front_end_gain_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/sbas.h
+++ b/c/src/include/libsbp/internal/new/sbas.h
@@ -1,21 +1,39 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/sbas.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_SBAS_PRIVATE_H
 #define LIBSBP_UNPACKED_SBAS_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/sbas.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/sbas.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx, const sbp_msg_sbas_raw_t *msg);
+bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_sbas_raw_t *msg);
 bool decode_sbp_msg_sbas_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_sbas_raw_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/sbas.h
+++ b/c/src/include/libsbp/internal/new/sbas.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_SBAS_PRIVATE_H
-#define LIBSBP_UNPACKED_SBAS_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_SBAS_H
+#define LIBSBP_INTERNAL_NEW_SBAS_H
 
 #include <stdbool.h>
 
@@ -28,8 +28,23 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_sbas_raw_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_sbas_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_sbas_raw_t *msg);
 
 #ifdef __cplusplus

--- a/c/src/include/libsbp/internal/new/settings.h
+++ b/c/src/include/libsbp/internal/new/settings.h
@@ -1,47 +1,84 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/settings.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_SETTINGS_PRIVATE_H
 #define LIBSBP_UNPACKED_SETTINGS_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/settings.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/settings.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_settings_save_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_save_t *msg);
-bool decode_sbp_msg_settings_save_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_save_t *msg);
+bool encode_sbp_msg_settings_save_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_settings_save_t *msg);
+bool decode_sbp_msg_settings_save_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_settings_save_t *msg);
 
-bool encode_sbp_msg_settings_write_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_t *msg);
-bool decode_sbp_msg_settings_write_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_write_t *msg);
+bool encode_sbp_msg_settings_write_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_settings_write_t *msg);
+bool decode_sbp_msg_settings_write_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_settings_write_t *msg);
 
-bool encode_sbp_msg_settings_write_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_resp_t *msg);
-bool decode_sbp_msg_settings_write_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_write_resp_t *msg);
+bool encode_sbp_msg_settings_write_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_resp_t *msg);
+bool decode_sbp_msg_settings_write_resp_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_settings_write_resp_t *msg);
 
-bool encode_sbp_msg_settings_read_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_req_t *msg);
-bool decode_sbp_msg_settings_read_req_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_req_t *msg);
+bool encode_sbp_msg_settings_read_req_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_settings_read_req_t *msg);
+bool decode_sbp_msg_settings_read_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_settings_read_req_t *msg);
 
-bool encode_sbp_msg_settings_read_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_resp_t *msg);
-bool decode_sbp_msg_settings_read_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_resp_t *msg);
+bool encode_sbp_msg_settings_read_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_resp_t *msg);
+bool decode_sbp_msg_settings_read_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_settings_read_resp_t *msg);
 
-bool encode_sbp_msg_settings_read_by_index_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_req_t *msg);
-bool decode_sbp_msg_settings_read_by_index_req_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_req_t *msg);
+bool encode_sbp_msg_settings_read_by_index_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_req_t *msg);
+bool decode_sbp_msg_settings_read_by_index_req_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_req_t *msg);
 
-bool encode_sbp_msg_settings_read_by_index_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_resp_t *msg);
-bool decode_sbp_msg_settings_read_by_index_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_resp_t *msg);
+bool encode_sbp_msg_settings_read_by_index_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_resp_t *msg);
+bool decode_sbp_msg_settings_read_by_index_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_resp_t *msg);
 
-bool encode_sbp_msg_settings_read_by_index_done_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_done_t *msg);
-bool decode_sbp_msg_settings_read_by_index_done_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_done_t *msg);
+bool encode_sbp_msg_settings_read_by_index_done_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_done_t *msg);
+bool decode_sbp_msg_settings_read_by_index_done_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_done_t *msg);
 
-bool encode_sbp_msg_settings_register_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_t *msg);
-bool decode_sbp_msg_settings_register_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_register_t *msg);
+bool encode_sbp_msg_settings_register_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_settings_register_t *msg);
+bool decode_sbp_msg_settings_register_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_settings_register_t *msg);
 
-bool encode_sbp_msg_settings_register_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_resp_t *msg);
-bool decode_sbp_msg_settings_register_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_register_resp_t *msg);
+bool encode_sbp_msg_settings_register_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_resp_t *msg);
+bool decode_sbp_msg_settings_register_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_register_resp_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/settings.h
+++ b/c/src/include/libsbp/internal/new/settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_SETTINGS_PRIVATE_H
-#define LIBSBP_UNPACKED_SETTINGS_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_SETTINGS_H
+#define LIBSBP_INTERNAL_NEW_SETTINGS_H
 
 #include <stdbool.h>
 
@@ -27,53 +27,203 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_save_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_settings_save_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_save_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_settings_save_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_write_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_settings_write_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_write_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_settings_write_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_write_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_write_resp_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_settings_write_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_read_req_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_settings_read_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_read_req_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_settings_read_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_read_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_read_resp_t(sbp_decode_ctx_t *ctx,
                                          sbp_msg_settings_read_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_read_by_index_req_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_req_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_read_by_index_req_t(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_req_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_read_by_index_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_read_by_index_resp_t(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_resp_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_read_by_index_done_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_done_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_read_by_index_done_t(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_done_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_register_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_settings_register_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_register_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_settings_register_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_settings_register_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_resp_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_settings_register_resp_t(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_register_resp_t *msg);
 

--- a/c/src/include/libsbp/internal/new/solution_meta.h
+++ b/c/src/include/libsbp/internal/new/solution_meta.h
@@ -1,35 +1,64 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/solution_meta.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_SOLUTION_META_PRIVATE_H
 #define LIBSBP_UNPACKED_SOLUTION_META_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/solution_meta.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/solution_meta.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_solution_input_type_t(sbp_encode_ctx_t *ctx, const sbp_solution_input_type_t *msg);
-bool decode_sbp_solution_input_type_t(sbp_decode_ctx_t *ctx, sbp_solution_input_type_t *msg);
+bool encode_sbp_solution_input_type_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_solution_input_type_t *msg);
+bool decode_sbp_solution_input_type_t(sbp_decode_ctx_t *ctx,
+                                      sbp_solution_input_type_t *msg);
 
-bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_soln_meta_dep_a_t *msg);
-bool decode_sbp_msg_soln_meta_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_soln_meta_dep_a_t *msg);
+bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_soln_meta_dep_a_t *msg);
+bool decode_sbp_msg_soln_meta_dep_a_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_soln_meta_dep_a_t *msg);
 
-bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx, const sbp_msg_soln_meta_t *msg);
-bool decode_sbp_msg_soln_meta_t(sbp_decode_ctx_t *ctx, sbp_msg_soln_meta_t *msg);
+bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_soln_meta_t *msg);
+bool decode_sbp_msg_soln_meta_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_soln_meta_t *msg);
 
-bool encode_sbp_gnss_input_type_t(sbp_encode_ctx_t *ctx, const sbp_gnss_input_type_t *msg);
-bool decode_sbp_gnss_input_type_t(sbp_decode_ctx_t *ctx, sbp_gnss_input_type_t *msg);
+bool encode_sbp_gnss_input_type_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_gnss_input_type_t *msg);
+bool decode_sbp_gnss_input_type_t(sbp_decode_ctx_t *ctx,
+                                  sbp_gnss_input_type_t *msg);
 
-bool encode_sbp_imu_input_type_t(sbp_encode_ctx_t *ctx, const sbp_imu_input_type_t *msg);
-bool decode_sbp_imu_input_type_t(sbp_decode_ctx_t *ctx, sbp_imu_input_type_t *msg);
+bool encode_sbp_imu_input_type_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_imu_input_type_t *msg);
+bool decode_sbp_imu_input_type_t(sbp_decode_ctx_t *ctx,
+                                 sbp_imu_input_type_t *msg);
 
-bool encode_sbp_odo_input_type_t(sbp_encode_ctx_t *ctx, const sbp_odo_input_type_t *msg);
-bool decode_sbp_odo_input_type_t(sbp_decode_ctx_t *ctx, sbp_odo_input_type_t *msg);
+bool encode_sbp_odo_input_type_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_odo_input_type_t *msg);
+bool decode_sbp_odo_input_type_t(sbp_decode_ctx_t *ctx,
+                                 sbp_odo_input_type_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/solution_meta.h
+++ b/c/src/include/libsbp/internal/new/solution_meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_SOLUTION_META_PRIVATE_H
-#define LIBSBP_UNPACKED_SOLUTION_META_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_SOLUTION_META_H
+#define LIBSBP_INTERNAL_NEW_SOLUTION_META_H
 
 #include <stdbool.h>
 
@@ -27,33 +27,123 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_solution_input_type_t(sbp_encode_ctx_t *ctx,
                                       const sbp_solution_input_type_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_solution_input_type_t(sbp_decode_ctx_t *ctx,
                                       sbp_solution_input_type_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_soln_meta_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_soln_meta_dep_a_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_soln_meta_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_soln_meta_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_soln_meta_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_soln_meta_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gnss_input_type_t(sbp_encode_ctx_t *ctx,
                                   const sbp_gnss_input_type_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gnss_input_type_t(sbp_decode_ctx_t *ctx,
                                   sbp_gnss_input_type_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_imu_input_type_t(sbp_encode_ctx_t *ctx,
                                  const sbp_imu_input_type_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_imu_input_type_t(sbp_decode_ctx_t *ctx,
                                  sbp_imu_input_type_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_odo_input_type_t(sbp_encode_ctx_t *ctx,
                                  const sbp_odo_input_type_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_odo_input_type_t(sbp_decode_ctx_t *ctx,
                                  sbp_odo_input_type_t *msg);
 

--- a/c/src/include/libsbp/internal/new/ssr.h
+++ b/c/src/include/libsbp/internal/new/ssr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_SSR_PRIVATE_H
-#define LIBSBP_UNPACKED_SSR_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_SSR_H
+#define LIBSBP_INTERNAL_NEW_SSR_H
 
 #include <stdbool.h>
 
@@ -28,129 +28,504 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_code_biases_content_t(sbp_encode_ctx_t *ctx,
                                       const sbp_code_biases_content_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_code_biases_content_t(sbp_decode_ctx_t *ctx,
                                       sbp_code_biases_content_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_phase_biases_content_t(sbp_encode_ctx_t *ctx,
                                        const sbp_phase_biases_content_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_phase_biases_content_t(sbp_decode_ctx_t *ctx,
                                        sbp_phase_biases_content_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_stec_header_t(sbp_encode_ctx_t *ctx,
                               const sbp_stec_header_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_stec_header_t(sbp_decode_ctx_t *ctx, sbp_stec_header_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gridded_correction_header_t(
     sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gridded_correction_header_t(
     sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx,
                                    const sbp_stec_sat_element_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_stec_sat_element_t(sbp_decode_ctx_t *ctx,
                                    sbp_stec_sat_element_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tropospheric_delay_correction_no_std_t(
     sbp_encode_ctx_t *ctx,
     const sbp_tropospheric_delay_correction_no_std_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tropospheric_delay_correction_no_std_t(
     sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_no_std_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tropospheric_delay_correction_t(
     sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tropospheric_delay_correction_t(
     sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_stec_residual_no_std_t(sbp_encode_ctx_t *ctx,
                                        const sbp_stec_residual_no_std_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_stec_residual_no_std_t(sbp_decode_ctx_t *ctx,
                                        sbp_stec_residual_no_std_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_stec_residual_t(sbp_encode_ctx_t *ctx,
                                 const sbp_stec_residual_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_stec_residual_t(sbp_decode_ctx_t *ctx,
                                 sbp_stec_residual_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_orbit_clock_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_ssr_orbit_clock_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_orbit_clock_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_ssr_orbit_clock_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx,
                                       const sbp_msg_ssr_code_biases_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_code_biases_t(sbp_decode_ctx_t *ctx,
                                       sbp_msg_ssr_code_biases_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_ssr_phase_biases_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_phase_biases_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_ssr_phase_biases_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_stec_correction_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_stec_correction_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ssr_stec_correction_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_gridded_correction_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_gridded_correction_t(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_tile_definition_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_tile_definition_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_tile_definition_t(sbp_decode_ctx_t *ctx,
                                           sbp_msg_ssr_tile_definition_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx,
                                 const sbp_satellite_apc_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_satellite_apc_t(sbp_decode_ctx_t *ctx,
                                 sbp_satellite_apc_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_satellite_apc_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_ssr_satellite_apc_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_satellite_apc_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_ssr_satellite_apc_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_orbit_clock_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_orbit_clock_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_stec_header_dep_a_t(sbp_encode_ctx_t *ctx,
                                     const sbp_stec_header_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_stec_header_dep_a_t(sbp_decode_ctx_t *ctx,
                                     sbp_stec_header_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_gridded_correction_header_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_gridded_correction_header_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_grid_definition_header_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_grid_definition_header_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_grid_definition_header_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_grid_definition_header_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_stec_correction_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_stec_correction_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
     sbp_encode_ctx_t *ctx,
     const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_gridded_correction_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ssr_grid_definition_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_grid_definition_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ssr_grid_definition_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_grid_definition_dep_a_t *msg);
 

--- a/c/src/include/libsbp/internal/new/ssr.h
+++ b/c/src/include/libsbp/internal/new/ssr.h
@@ -1,93 +1,161 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ssr.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_SSR_PRIVATE_H
 #define LIBSBP_UNPACKED_SSR_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/ssr.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/ssr.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_code_biases_content_t(sbp_encode_ctx_t *ctx, const sbp_code_biases_content_t *msg);
-bool decode_sbp_code_biases_content_t(sbp_decode_ctx_t *ctx, sbp_code_biases_content_t *msg);
+bool encode_sbp_code_biases_content_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_code_biases_content_t *msg);
+bool decode_sbp_code_biases_content_t(sbp_decode_ctx_t *ctx,
+                                      sbp_code_biases_content_t *msg);
 
-bool encode_sbp_phase_biases_content_t(sbp_encode_ctx_t *ctx, const sbp_phase_biases_content_t *msg);
-bool decode_sbp_phase_biases_content_t(sbp_decode_ctx_t *ctx, sbp_phase_biases_content_t *msg);
+bool encode_sbp_phase_biases_content_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_phase_biases_content_t *msg);
+bool decode_sbp_phase_biases_content_t(sbp_decode_ctx_t *ctx,
+                                       sbp_phase_biases_content_t *msg);
 
-bool encode_sbp_stec_header_t(sbp_encode_ctx_t *ctx, const sbp_stec_header_t *msg);
+bool encode_sbp_stec_header_t(sbp_encode_ctx_t *ctx,
+                              const sbp_stec_header_t *msg);
 bool decode_sbp_stec_header_t(sbp_decode_ctx_t *ctx, sbp_stec_header_t *msg);
 
-bool encode_sbp_gridded_correction_header_t(sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_t *msg);
-bool decode_sbp_gridded_correction_header_t(sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_t *msg);
+bool encode_sbp_gridded_correction_header_t(
+    sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_t *msg);
+bool decode_sbp_gridded_correction_header_t(
+    sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_t *msg);
 
-bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx, const sbp_stec_sat_element_t *msg);
-bool decode_sbp_stec_sat_element_t(sbp_decode_ctx_t *ctx, sbp_stec_sat_element_t *msg);
+bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_stec_sat_element_t *msg);
+bool decode_sbp_stec_sat_element_t(sbp_decode_ctx_t *ctx,
+                                   sbp_stec_sat_element_t *msg);
 
-bool encode_sbp_tropospheric_delay_correction_no_std_t(sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_no_std_t *msg);
-bool decode_sbp_tropospheric_delay_correction_no_std_t(sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_no_std_t *msg);
+bool encode_sbp_tropospheric_delay_correction_no_std_t(
+    sbp_encode_ctx_t *ctx,
+    const sbp_tropospheric_delay_correction_no_std_t *msg);
+bool decode_sbp_tropospheric_delay_correction_no_std_t(
+    sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_no_std_t *msg);
 
-bool encode_sbp_tropospheric_delay_correction_t(sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_t *msg);
-bool decode_sbp_tropospheric_delay_correction_t(sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_t *msg);
+bool encode_sbp_tropospheric_delay_correction_t(
+    sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_t *msg);
+bool decode_sbp_tropospheric_delay_correction_t(
+    sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_t *msg);
 
-bool encode_sbp_stec_residual_no_std_t(sbp_encode_ctx_t *ctx, const sbp_stec_residual_no_std_t *msg);
-bool decode_sbp_stec_residual_no_std_t(sbp_decode_ctx_t *ctx, sbp_stec_residual_no_std_t *msg);
+bool encode_sbp_stec_residual_no_std_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_stec_residual_no_std_t *msg);
+bool decode_sbp_stec_residual_no_std_t(sbp_decode_ctx_t *ctx,
+                                       sbp_stec_residual_no_std_t *msg);
 
-bool encode_sbp_stec_residual_t(sbp_encode_ctx_t *ctx, const sbp_stec_residual_t *msg);
-bool decode_sbp_stec_residual_t(sbp_decode_ctx_t *ctx, sbp_stec_residual_t *msg);
+bool encode_sbp_stec_residual_t(sbp_encode_ctx_t *ctx,
+                                const sbp_stec_residual_t *msg);
+bool decode_sbp_stec_residual_t(sbp_decode_ctx_t *ctx,
+                                sbp_stec_residual_t *msg);
 
-bool encode_sbp_msg_ssr_orbit_clock_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_t *msg);
-bool decode_sbp_msg_ssr_orbit_clock_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_t *msg);
+bool encode_sbp_msg_ssr_orbit_clock_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ssr_orbit_clock_t *msg);
+bool decode_sbp_msg_ssr_orbit_clock_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ssr_orbit_clock_t *msg);
 
-bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_code_biases_t *msg);
-bool decode_sbp_msg_ssr_code_biases_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_code_biases_t *msg);
+bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ssr_code_biases_t *msg);
+bool decode_sbp_msg_ssr_code_biases_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ssr_code_biases_t *msg);
 
-bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_phase_biases_t *msg);
-bool decode_sbp_msg_ssr_phase_biases_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_phase_biases_t *msg);
+bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_ssr_phase_biases_t *msg);
+bool decode_sbp_msg_ssr_phase_biases_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_ssr_phase_biases_t *msg);
 
-bool encode_sbp_msg_ssr_stec_correction_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_t *msg);
-bool decode_sbp_msg_ssr_stec_correction_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_t *msg);
+bool encode_sbp_msg_ssr_stec_correction_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_t *msg);
+bool decode_sbp_msg_ssr_stec_correction_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ssr_stec_correction_t *msg);
 
-bool encode_sbp_msg_ssr_gridded_correction_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_t *msg);
-bool decode_sbp_msg_ssr_gridded_correction_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_t *msg);
+bool encode_sbp_msg_ssr_gridded_correction_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_t *msg);
+bool decode_sbp_msg_ssr_gridded_correction_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_t *msg);
 
-bool encode_sbp_msg_ssr_tile_definition_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_tile_definition_t *msg);
-bool decode_sbp_msg_ssr_tile_definition_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_tile_definition_t *msg);
+bool encode_sbp_msg_ssr_tile_definition_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_tile_definition_t *msg);
+bool decode_sbp_msg_ssr_tile_definition_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ssr_tile_definition_t *msg);
 
-bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx, const sbp_satellite_apc_t *msg);
-bool decode_sbp_satellite_apc_t(sbp_decode_ctx_t *ctx, sbp_satellite_apc_t *msg);
+bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx,
+                                const sbp_satellite_apc_t *msg);
+bool decode_sbp_satellite_apc_t(sbp_decode_ctx_t *ctx,
+                                sbp_satellite_apc_t *msg);
 
-bool encode_sbp_msg_ssr_satellite_apc_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_satellite_apc_t *msg);
-bool decode_sbp_msg_ssr_satellite_apc_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_satellite_apc_t *msg);
+bool encode_sbp_msg_ssr_satellite_apc_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_ssr_satellite_apc_t *msg);
+bool decode_sbp_msg_ssr_satellite_apc_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_ssr_satellite_apc_t *msg);
 
-bool encode_sbp_msg_ssr_orbit_clock_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_dep_a_t *msg);
-bool decode_sbp_msg_ssr_orbit_clock_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_dep_a_t *msg);
+bool encode_sbp_msg_ssr_orbit_clock_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_dep_a_t *msg);
+bool decode_sbp_msg_ssr_orbit_clock_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_dep_a_t *msg);
 
-bool encode_sbp_stec_header_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_stec_header_dep_a_t *msg);
-bool decode_sbp_stec_header_dep_a_t(sbp_decode_ctx_t *ctx, sbp_stec_header_dep_a_t *msg);
+bool encode_sbp_stec_header_dep_a_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_stec_header_dep_a_t *msg);
+bool decode_sbp_stec_header_dep_a_t(sbp_decode_ctx_t *ctx,
+                                    sbp_stec_header_dep_a_t *msg);
 
-bool encode_sbp_gridded_correction_header_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_dep_a_t *msg);
-bool decode_sbp_gridded_correction_header_dep_a_t(sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_dep_a_t *msg);
+bool encode_sbp_gridded_correction_header_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_dep_a_t *msg);
+bool decode_sbp_gridded_correction_header_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_dep_a_t *msg);
 
-bool encode_sbp_grid_definition_header_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_grid_definition_header_dep_a_t *msg);
-bool decode_sbp_grid_definition_header_dep_a_t(sbp_decode_ctx_t *ctx, sbp_grid_definition_header_dep_a_t *msg);
+bool encode_sbp_grid_definition_header_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_grid_definition_header_dep_a_t *msg);
+bool decode_sbp_grid_definition_header_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_grid_definition_header_dep_a_t *msg);
 
-bool encode_sbp_msg_ssr_stec_correction_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_dep_a_t *msg);
-bool decode_sbp_msg_ssr_stec_correction_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_dep_a_t *msg);
+bool encode_sbp_msg_ssr_stec_correction_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_dep_a_t *msg);
+bool decode_sbp_msg_ssr_stec_correction_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_dep_a_t *msg);
 
-bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg);
-bool decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg);
+bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    sbp_encode_ctx_t *ctx,
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg);
+bool decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg);
 
-bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_a_t *msg);
-bool decode_sbp_msg_ssr_gridded_correction_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_a_t *msg);
+bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_a_t *msg);
+bool decode_sbp_msg_ssr_gridded_correction_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_a_t *msg);
 
-bool encode_sbp_msg_ssr_grid_definition_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_grid_definition_dep_a_t *msg);
-bool decode_sbp_msg_ssr_grid_definition_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_grid_definition_dep_a_t *msg);
+bool encode_sbp_msg_ssr_grid_definition_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_grid_definition_dep_a_t *msg);
+bool decode_sbp_msg_ssr_grid_definition_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_grid_definition_dep_a_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/system.h
+++ b/c/src/include/libsbp/internal/new/system.h
@@ -1,53 +1,92 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/system.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_SYSTEM_PRIVATE_H
 #define LIBSBP_UNPACKED_SYSTEM_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/system.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/system.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_startup_t(sbp_encode_ctx_t *ctx, const sbp_msg_startup_t *msg);
+bool encode_sbp_msg_startup_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_startup_t *msg);
 bool decode_sbp_msg_startup_t(sbp_decode_ctx_t *ctx, sbp_msg_startup_t *msg);
 
-bool encode_sbp_msg_dgnss_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_dgnss_status_t *msg);
-bool decode_sbp_msg_dgnss_status_t(sbp_decode_ctx_t *ctx, sbp_msg_dgnss_status_t *msg);
+bool encode_sbp_msg_dgnss_status_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_dgnss_status_t *msg);
+bool decode_sbp_msg_dgnss_status_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_dgnss_status_t *msg);
 
-bool encode_sbp_msg_heartbeat_t(sbp_encode_ctx_t *ctx, const sbp_msg_heartbeat_t *msg);
-bool decode_sbp_msg_heartbeat_t(sbp_decode_ctx_t *ctx, sbp_msg_heartbeat_t *msg);
+bool encode_sbp_msg_heartbeat_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_heartbeat_t *msg);
+bool decode_sbp_msg_heartbeat_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_heartbeat_t *msg);
 
-bool encode_sbp_sub_system_report_t(sbp_encode_ctx_t *ctx, const sbp_sub_system_report_t *msg);
-bool decode_sbp_sub_system_report_t(sbp_decode_ctx_t *ctx, sbp_sub_system_report_t *msg);
+bool encode_sbp_sub_system_report_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_sub_system_report_t *msg);
+bool decode_sbp_sub_system_report_t(sbp_decode_ctx_t *ctx,
+                                    sbp_sub_system_report_t *msg);
 
-bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx, const sbp_msg_status_report_t *msg);
-bool decode_sbp_msg_status_report_t(sbp_decode_ctx_t *ctx, sbp_msg_status_report_t *msg);
+bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_status_report_t *msg);
+bool decode_sbp_msg_status_report_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_status_report_t *msg);
 
-bool encode_sbp_msg_ins_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_ins_status_t *msg);
-bool decode_sbp_msg_ins_status_t(sbp_decode_ctx_t *ctx, sbp_msg_ins_status_t *msg);
+bool encode_sbp_msg_ins_status_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_ins_status_t *msg);
+bool decode_sbp_msg_ins_status_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_ins_status_t *msg);
 
-bool encode_sbp_msg_csac_telemetry_t(sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_t *msg);
-bool decode_sbp_msg_csac_telemetry_t(sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_t *msg);
+bool encode_sbp_msg_csac_telemetry_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_csac_telemetry_t *msg);
+bool decode_sbp_msg_csac_telemetry_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_csac_telemetry_t *msg);
 
-bool encode_sbp_msg_csac_telemetry_labels_t(sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_labels_t *msg);
-bool decode_sbp_msg_csac_telemetry_labels_t(sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_labels_t *msg);
+bool encode_sbp_msg_csac_telemetry_labels_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_labels_t *msg);
+bool decode_sbp_msg_csac_telemetry_labels_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_labels_t *msg);
 
-bool encode_sbp_msg_ins_updates_t(sbp_encode_ctx_t *ctx, const sbp_msg_ins_updates_t *msg);
-bool decode_sbp_msg_ins_updates_t(sbp_decode_ctx_t *ctx, sbp_msg_ins_updates_t *msg);
+bool encode_sbp_msg_ins_updates_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_ins_updates_t *msg);
+bool decode_sbp_msg_ins_updates_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_ins_updates_t *msg);
 
-bool encode_sbp_msg_gnss_time_offset_t(sbp_encode_ctx_t *ctx, const sbp_msg_gnss_time_offset_t *msg);
-bool decode_sbp_msg_gnss_time_offset_t(sbp_decode_ctx_t *ctx, sbp_msg_gnss_time_offset_t *msg);
+bool encode_sbp_msg_gnss_time_offset_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_gnss_time_offset_t *msg);
+bool decode_sbp_msg_gnss_time_offset_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_gnss_time_offset_t *msg);
 
-bool encode_sbp_msg_pps_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_pps_time_t *msg);
+bool encode_sbp_msg_pps_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_pps_time_t *msg);
 bool decode_sbp_msg_pps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_pps_time_t *msg);
 
-bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_meta_t *msg);
-bool decode_sbp_msg_group_meta_t(sbp_decode_ctx_t *ctx, sbp_msg_group_meta_t *msg);
+bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_group_meta_t *msg);
+bool decode_sbp_msg_group_meta_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_group_meta_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/system.h
+++ b/c/src/include/libsbp/internal/new/system.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_SYSTEM_PRIVATE_H
-#define LIBSBP_UNPACKED_SYSTEM_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_SYSTEM_H
+#define LIBSBP_INTERNAL_NEW_SYSTEM_H
 
 #include <stdbool.h>
 
@@ -27,61 +27,241 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_startup_t(sbp_encode_ctx_t *ctx,
                               const sbp_msg_startup_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_startup_t(sbp_decode_ctx_t *ctx, sbp_msg_startup_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_dgnss_status_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_dgnss_status_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_dgnss_status_t(sbp_decode_ctx_t *ctx,
                                    sbp_msg_dgnss_status_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_heartbeat_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_heartbeat_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_heartbeat_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_heartbeat_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_sub_system_report_t(sbp_encode_ctx_t *ctx,
                                     const sbp_sub_system_report_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_sub_system_report_t(sbp_decode_ctx_t *ctx,
                                     sbp_sub_system_report_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx,
                                     const sbp_msg_status_report_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_status_report_t(sbp_decode_ctx_t *ctx,
                                     sbp_msg_status_report_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ins_status_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_ins_status_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ins_status_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_ins_status_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_csac_telemetry_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_csac_telemetry_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_csac_telemetry_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_csac_telemetry_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_csac_telemetry_labels_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_labels_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_csac_telemetry_labels_t(
     sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_labels_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_ins_updates_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_ins_updates_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_ins_updates_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_ins_updates_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_gnss_time_offset_t(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_gnss_time_offset_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_gnss_time_offset_t(sbp_decode_ctx_t *ctx,
                                        sbp_msg_gnss_time_offset_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_pps_time_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_pps_time_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_pps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_pps_time_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx,
                                  const sbp_msg_group_meta_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_group_meta_t(sbp_decode_ctx_t *ctx,
                                  sbp_msg_group_meta_t *msg);
 

--- a/c/src/include/libsbp/internal/new/tracking.h
+++ b/c/src/include/libsbp/internal/new/tracking.h
@@ -1,63 +1,110 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/tracking.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_TRACKING_PRIVATE_H
 #define LIBSBP_UNPACKED_TRACKING_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/tracking.h>
 #include <libsbp/internal/new/common.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/new/tracking.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_tracking_state_detailed_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_a_t *msg);
-bool decode_sbp_msg_tracking_state_detailed_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_a_t *msg);
+bool encode_sbp_msg_tracking_state_detailed_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_a_t *msg);
+bool decode_sbp_msg_tracking_state_detailed_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_a_t *msg);
 
-bool encode_sbp_msg_tracking_state_detailed_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_t *msg);
-bool decode_sbp_msg_tracking_state_detailed_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_t *msg);
+bool encode_sbp_msg_tracking_state_detailed_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_t *msg);
+bool decode_sbp_msg_tracking_state_detailed_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_t *msg);
 
-bool encode_sbp_tracking_channel_state_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_t *msg);
-bool decode_sbp_tracking_channel_state_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_t *msg);
+bool encode_sbp_tracking_channel_state_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_t *msg);
+bool decode_sbp_tracking_channel_state_t(sbp_decode_ctx_t *ctx,
+                                         sbp_tracking_channel_state_t *msg);
 
-bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_t *msg);
-bool decode_sbp_msg_tracking_state_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_t *msg);
+bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_tracking_state_t *msg);
+bool decode_sbp_msg_tracking_state_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_tracking_state_t *msg);
 
-bool encode_sbp_measurement_state_t(sbp_encode_ctx_t *ctx, const sbp_measurement_state_t *msg);
-bool decode_sbp_measurement_state_t(sbp_decode_ctx_t *ctx, sbp_measurement_state_t *msg);
+bool encode_sbp_measurement_state_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_measurement_state_t *msg);
+bool decode_sbp_measurement_state_t(sbp_decode_ctx_t *ctx,
+                                    sbp_measurement_state_t *msg);
 
-bool encode_sbp_msg_measurement_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_measurement_state_t *msg);
-bool decode_sbp_msg_measurement_state_t(sbp_decode_ctx_t *ctx, sbp_msg_measurement_state_t *msg);
+bool encode_sbp_msg_measurement_state_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_measurement_state_t *msg);
+bool decode_sbp_msg_measurement_state_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_measurement_state_t *msg);
 
-bool encode_sbp_tracking_channel_correlation_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_t *msg);
-bool decode_sbp_tracking_channel_correlation_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_t *msg);
+bool encode_sbp_tracking_channel_correlation_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_t *msg);
+bool decode_sbp_tracking_channel_correlation_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_t *msg);
 
-bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_t *msg);
-bool decode_sbp_msg_tracking_iq_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_iq_t *msg);
+bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_tracking_iq_t *msg);
+bool decode_sbp_msg_tracking_iq_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_tracking_iq_t *msg);
 
-bool encode_sbp_tracking_channel_correlation_dep_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_dep_t *msg);
-bool decode_sbp_tracking_channel_correlation_dep_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_dep_t *msg);
+bool encode_sbp_tracking_channel_correlation_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_dep_t *msg);
+bool decode_sbp_tracking_channel_correlation_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_dep_t *msg);
 
-bool encode_sbp_msg_tracking_iq_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_dep_b_t *msg);
-bool decode_sbp_msg_tracking_iq_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_iq_dep_b_t *msg);
+bool encode_sbp_msg_tracking_iq_dep_b_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_tracking_iq_dep_b_t *msg);
+bool decode_sbp_msg_tracking_iq_dep_b_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_tracking_iq_dep_b_t *msg);
 
-bool encode_sbp_msg_tracking_iq_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_dep_a_t *msg);
-bool decode_sbp_msg_tracking_iq_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_iq_dep_a_t *msg);
+bool encode_sbp_msg_tracking_iq_dep_a_t(sbp_encode_ctx_t *ctx,
+                                        const sbp_msg_tracking_iq_dep_a_t *msg);
+bool decode_sbp_msg_tracking_iq_dep_a_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_tracking_iq_dep_a_t *msg);
 
-bool encode_sbp_tracking_channel_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_a_t *msg);
-bool decode_sbp_tracking_channel_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_a_t *msg);
+bool encode_sbp_tracking_channel_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_a_t *msg);
+bool decode_sbp_tracking_channel_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_a_t *msg);
 
-bool encode_sbp_msg_tracking_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg);
-bool decode_sbp_msg_tracking_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_a_t *msg);
+bool encode_sbp_msg_tracking_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg);
+bool decode_sbp_msg_tracking_state_dep_a_t(sbp_decode_ctx_t *ctx,
+                                           sbp_msg_tracking_state_dep_a_t *msg);
 
-bool encode_sbp_tracking_channel_state_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_b_t *msg);
-bool decode_sbp_tracking_channel_state_dep_b_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_b_t *msg);
+bool encode_sbp_tracking_channel_state_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_b_t *msg);
+bool decode_sbp_tracking_channel_state_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_b_t *msg);
 
-bool encode_sbp_msg_tracking_state_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg);
-bool decode_sbp_msg_tracking_state_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_b_t *msg);
+bool encode_sbp_msg_tracking_state_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg);
+bool decode_sbp_msg_tracking_state_dep_b_t(sbp_decode_ctx_t *ctx,
+                                           sbp_msg_tracking_state_dep_b_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/tracking.h
+++ b/c/src/include/libsbp/internal/new/tracking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_TRACKING_PRIVATE_H
-#define LIBSBP_UNPACKED_TRACKING_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_TRACKING_H
+#define LIBSBP_INTERNAL_NEW_TRACKING_H
 
 #include <stdbool.h>
 
@@ -28,78 +28,303 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_state_detailed_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_state_detailed_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_state_detailed_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_state_detailed_dep_t(
     sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tracking_channel_state_t(
     sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tracking_channel_state_t(sbp_decode_ctx_t *ctx,
                                          sbp_tracking_channel_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_tracking_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_state_t(sbp_decode_ctx_t *ctx,
                                      sbp_msg_tracking_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_measurement_state_t(sbp_encode_ctx_t *ctx,
                                     const sbp_measurement_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_measurement_state_t(sbp_decode_ctx_t *ctx,
                                     sbp_measurement_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_measurement_state_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_measurement_state_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_measurement_state_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_measurement_state_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tracking_channel_correlation_t(
     sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tracking_channel_correlation_t(
     sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx,
                                   const sbp_msg_tracking_iq_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_iq_t(sbp_decode_ctx_t *ctx,
                                   sbp_msg_tracking_iq_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tracking_channel_correlation_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tracking_channel_correlation_dep_t(
     sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_dep_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_iq_dep_b_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_tracking_iq_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_iq_dep_b_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_tracking_iq_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_iq_dep_a_t(sbp_encode_ctx_t *ctx,
                                         const sbp_msg_tracking_iq_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_iq_dep_a_t(sbp_decode_ctx_t *ctx,
                                         sbp_msg_tracking_iq_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tracking_channel_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tracking_channel_state_dep_a_t(
     sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_state_dep_a_t(sbp_decode_ctx_t *ctx,
                                            sbp_msg_tracking_state_dep_a_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_tracking_channel_state_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_tracking_channel_state_dep_b_t(
     sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_b_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_tracking_state_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_tracking_state_dep_b_t(sbp_decode_ctx_t *ctx,
                                            sbp_msg_tracking_state_dep_b_t *msg);
 

--- a/c/src/include/libsbp/internal/new/user.h
+++ b/c/src/include/libsbp/internal/new/user.h
@@ -1,20 +1,39 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/user.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_USER_PRIVATE_H
 #define LIBSBP_UNPACKED_USER_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/user.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/user.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx, const sbp_msg_user_data_t *msg);
-bool decode_sbp_msg_user_data_t(sbp_decode_ctx_t *ctx, sbp_msg_user_data_t *msg);
+bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_user_data_t *msg);
+bool decode_sbp_msg_user_data_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_user_data_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/include/libsbp/internal/new/user.h
+++ b/c/src/include/libsbp/internal/new/user.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_USER_PRIVATE_H
-#define LIBSBP_UNPACKED_USER_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_USER_H
+#define LIBSBP_INTERNAL_NEW_USER_H
 
 #include <stdbool.h>
 
@@ -27,8 +27,23 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_user_data_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_user_data_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_user_data_t *msg);
 

--- a/c/src/include/libsbp/internal/new/vehicle.h
+++ b/c/src/include/libsbp/internal/new/vehicle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_VEHICLE_PRIVATE_H
-#define LIBSBP_UNPACKED_VEHICLE_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_VEHICLE_H
+#define LIBSBP_INTERNAL_NEW_VEHICLE_H
 
 #include <stdbool.h>
 
@@ -27,12 +27,42 @@
 extern "C" {
 #endif
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_odometry_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_odometry_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_odometry_t(sbp_decode_ctx_t *ctx, sbp_msg_odometry_t *msg);
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_sbp_msg_wheeltick_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_wheeltick_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_sbp_msg_wheeltick_t(sbp_decode_ctx_t *ctx,
                                 sbp_msg_wheeltick_t *msg);
 

--- a/c/src/include/libsbp/internal/new/vehicle.h
+++ b/c/src/include/libsbp/internal/new/vehicle.h
@@ -1,23 +1,43 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/vehicle.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_VEHICLE_PRIVATE_H
 #define LIBSBP_UNPACKED_VEHICLE_PRIVATE_H
 
 #include <stdbool.h>
 
-#include <libsbp/new/vehicle.h>
 #include <libsbp/internal/new/common.h>
+#include <libsbp/new/vehicle.h>
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
-bool encode_sbp_msg_odometry_t(sbp_encode_ctx_t *ctx, const sbp_msg_odometry_t *msg);
+bool encode_sbp_msg_odometry_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_odometry_t *msg);
 bool decode_sbp_msg_odometry_t(sbp_decode_ctx_t *ctx, sbp_msg_odometry_t *msg);
 
-bool encode_sbp_msg_wheeltick_t(sbp_encode_ctx_t *ctx, const sbp_msg_wheeltick_t *msg);
-bool decode_sbp_msg_wheeltick_t(sbp_decode_ctx_t *ctx, sbp_msg_wheeltick_t *msg);
+bool encode_sbp_msg_wheeltick_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_wheeltick_t *msg);
+bool decode_sbp_msg_wheeltick_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_wheeltick_t *msg);
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/c/src/new/acquisition.c
+++ b/c/src/new/acquisition.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/acquisition.yaml
  * with generate.py. Please do not hand edit!
@@ -101,6 +89,7 @@ s8 sbp_decode_sbp_msg_acq_result_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_acq_result_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_acq_result_t *msg,
                                  sbp_write_fn_t write) {
@@ -216,6 +205,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_c_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_acq_result_dep_c_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_acq_result_dep_c_t *msg,
                                        sbp_write_fn_t write) {
@@ -331,6 +321,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_b_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_acq_result_dep_b_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_acq_result_dep_b_t *msg,
                                        sbp_write_fn_t write) {
@@ -446,6 +437,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_acq_result_dep_a_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_acq_result_dep_a_t *msg,
                                        sbp_write_fn_t write) {
@@ -890,7 +882,7 @@ size_t sbp_packed_size_sbp_msg_acq_sv_profile_t(
 
 bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_acq_sv_profile_t *msg) {
-  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_acq_sv_profile; i++) {
     if (!encode_sbp_acq_sv_profile_t(ctx, &msg->acq_sv_profile[i])) {
       return false;
     }
@@ -942,6 +934,7 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_acq_sv_profile_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_acq_sv_profile_t *msg,
                                      sbp_write_fn_t write) {
@@ -961,7 +954,7 @@ int sbp_cmp_sbp_msg_acq_sv_profile_t(const sbp_msg_acq_sv_profile_t *a,
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_acq_sv_profile, &b->n_acq_sv_profile);
-  for (uint8_t i = 0; i < a->n_acq_sv_profile && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_acq_sv_profile; i++) {
     ret = sbp_cmp_sbp_acq_sv_profile_t(&a->acq_sv_profile[i],
                                        &b->acq_sv_profile[i]);
   }
@@ -982,7 +975,7 @@ size_t sbp_packed_size_sbp_msg_acq_sv_profile_dep_t(
 
 bool encode_sbp_msg_acq_sv_profile_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg) {
-  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_acq_sv_profile; i++) {
     if (!encode_sbp_acq_sv_profile_dep_t(ctx, &msg->acq_sv_profile[i])) {
       return false;
     }
@@ -1034,6 +1027,7 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_acq_sv_profile_dep_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_dep_t *msg,
     sbp_write_fn_t write) {
@@ -1054,7 +1048,7 @@ int sbp_cmp_sbp_msg_acq_sv_profile_dep_t(
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_acq_sv_profile, &b->n_acq_sv_profile);
-  for (uint8_t i = 0; i < a->n_acq_sv_profile && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_acq_sv_profile; i++) {
     ret = sbp_cmp_sbp_acq_sv_profile_dep_t(&a->acq_sv_profile[i],
                                            &b->acq_sv_profile[i]);
   }

--- a/c/src/new/acquisition.c
+++ b/c/src/new/acquisition.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
-#include <libsbp/internal/new/common.h>
-#include <libsbp/new/acquisition.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/acquisition.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/acquisition.h>
+#include <libsbp/internal/new/common.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/acquisition.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_acq_result_t(const sbp_msg_acq_result_t *msg) {
   size_t packed_size = 0;
@@ -20,16 +37,26 @@ size_t sbp_packed_size_sbp_msg_acq_result_t(const sbp_msg_acq_result_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_acq_result_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_t *msg)
-{
-  if (!encode_float(ctx, &msg->cn0)) { return false; }
-  if (!encode_float(ctx, &msg->cp)) { return false; }
-  if (!encode_float(ctx, &msg->cf)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_msg_acq_result_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_acq_result_t *msg) {
+  if (!encode_float(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_acq_result_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_acq_result_t *msg) {
+s8 sbp_encode_sbp_msg_acq_result_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_acq_result_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -43,16 +70,25 @@ s8 sbp_encode_sbp_msg_acq_result_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_acq_result_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_t *msg)
-{
-  if (!decode_float(ctx, &msg->cn0)) { return false; }
-  if (!decode_float(ctx, &msg->cp)) { return false; }
-  if (!decode_float(ctx, &msg->cf)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_acq_result_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_acq_result_t *msg) {
+  if (!decode_float(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_acq_result_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_acq_result_t *msg) {
+s8 sbp_decode_sbp_msg_acq_result_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_acq_result_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -65,33 +101,48 @@ s8 sbp_decode_sbp_msg_acq_result_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_acq_result_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_acq_result_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_acq_result_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_acq_result_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_acq_result_t(const sbp_msg_acq_result_t *a, const sbp_msg_acq_result_t *b) {
+int sbp_cmp_sbp_msg_acq_result_t(const sbp_msg_acq_result_t *a,
+                                 const sbp_msg_acq_result_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_float(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cp, &b->cp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cf, &b->cf);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_acq_result_dep_c_t(const sbp_msg_acq_result_dep_c_t *msg) {
+size_t sbp_packed_size_sbp_msg_acq_result_dep_c_t(
+    const sbp_msg_acq_result_dep_c_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_float(&msg->cn0);
   packed_size += sbp_packed_size_float(&msg->cp);
@@ -100,16 +151,26 @@ size_t sbp_packed_size_sbp_msg_acq_result_dep_c_t(const sbp_msg_acq_result_dep_c
   return packed_size;
 }
 
-bool encode_sbp_msg_acq_result_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_dep_c_t *msg)
-{
-  if (!encode_float(ctx, &msg->cn0)) { return false; }
-  if (!encode_float(ctx, &msg->cp)) { return false; }
-  if (!encode_float(ctx, &msg->cf)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_msg_acq_result_dep_c_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_acq_result_dep_c_t *msg) {
+  if (!encode_float(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_acq_result_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_acq_result_dep_c_t *msg) {
+s8 sbp_encode_sbp_msg_acq_result_dep_c_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_acq_result_dep_c_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -123,16 +184,26 @@ s8 sbp_encode_sbp_msg_acq_result_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_acq_result_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_dep_c_t *msg)
-{
-  if (!decode_float(ctx, &msg->cn0)) { return false; }
-  if (!decode_float(ctx, &msg->cp)) { return false; }
-  if (!decode_float(ctx, &msg->cf)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_acq_result_dep_c_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_acq_result_dep_c_t *msg) {
+  if (!decode_float(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_acq_result_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_acq_result_dep_c_t *msg) {
+s8 sbp_decode_sbp_msg_acq_result_dep_c_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_acq_result_dep_c_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -145,33 +216,48 @@ s8 sbp_decode_sbp_msg_acq_result_dep_c_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_c_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_acq_result_dep_c_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_acq_result_dep_c_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_acq_result_dep_c_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT_DEP_C, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_acq_result_dep_c_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT_DEP_C, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_acq_result_dep_c_t(const sbp_msg_acq_result_dep_c_t *a, const sbp_msg_acq_result_dep_c_t *b) {
+int sbp_cmp_sbp_msg_acq_result_dep_c_t(const sbp_msg_acq_result_dep_c_t *a,
+                                       const sbp_msg_acq_result_dep_c_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_float(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cp, &b->cp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cf, &b->cf);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_acq_result_dep_b_t(const sbp_msg_acq_result_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_acq_result_dep_b_t(
+    const sbp_msg_acq_result_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_float(&msg->snr);
   packed_size += sbp_packed_size_float(&msg->cp);
@@ -180,16 +266,26 @@ size_t sbp_packed_size_sbp_msg_acq_result_dep_b_t(const sbp_msg_acq_result_dep_b
   return packed_size;
 }
 
-bool encode_sbp_msg_acq_result_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_dep_b_t *msg)
-{
-  if (!encode_float(ctx, &msg->snr)) { return false; }
-  if (!encode_float(ctx, &msg->cp)) { return false; }
-  if (!encode_float(ctx, &msg->cf)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_msg_acq_result_dep_b_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_acq_result_dep_b_t *msg) {
+  if (!encode_float(ctx, &msg->snr)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_acq_result_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_acq_result_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_acq_result_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_acq_result_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -203,16 +299,26 @@ s8 sbp_encode_sbp_msg_acq_result_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_acq_result_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_dep_b_t *msg)
-{
-  if (!decode_float(ctx, &msg->snr)) { return false; }
-  if (!decode_float(ctx, &msg->cp)) { return false; }
-  if (!decode_float(ctx, &msg->cf)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_acq_result_dep_b_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_acq_result_dep_b_t *msg) {
+  if (!decode_float(ctx, &msg->snr)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_acq_result_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_acq_result_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_acq_result_dep_b_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_acq_result_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -225,33 +331,48 @@ s8 sbp_decode_sbp_msg_acq_result_dep_b_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_acq_result_dep_b_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_acq_result_dep_b_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_acq_result_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_acq_result_dep_b_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT_DEP_B, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_acq_result_dep_b_t(const sbp_msg_acq_result_dep_b_t *a, const sbp_msg_acq_result_dep_b_t *b) {
+int sbp_cmp_sbp_msg_acq_result_dep_b_t(const sbp_msg_acq_result_dep_b_t *a,
+                                       const sbp_msg_acq_result_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_float(&a->snr, &b->snr);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cp, &b->cp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cf, &b->cf);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_acq_result_dep_a_t(const sbp_msg_acq_result_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_acq_result_dep_a_t(
+    const sbp_msg_acq_result_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_float(&msg->snr);
   packed_size += sbp_packed_size_float(&msg->cp);
@@ -260,16 +381,26 @@ size_t sbp_packed_size_sbp_msg_acq_result_dep_a_t(const sbp_msg_acq_result_dep_a
   return packed_size;
 }
 
-bool encode_sbp_msg_acq_result_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_result_dep_a_t *msg)
-{
-  if (!encode_float(ctx, &msg->snr)) { return false; }
-  if (!encode_float(ctx, &msg->cp)) { return false; }
-  if (!encode_float(ctx, &msg->cf)) { return false; }
-  if (!encode_u8(ctx, &msg->prn)) { return false; }
+bool encode_sbp_msg_acq_result_dep_a_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_acq_result_dep_a_t *msg) {
+  if (!encode_float(ctx, &msg->snr)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->prn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_acq_result_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_acq_result_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_acq_result_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_acq_result_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -283,16 +414,26 @@ s8 sbp_encode_sbp_msg_acq_result_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_acq_result_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_result_dep_a_t *msg)
-{
-  if (!decode_float(ctx, &msg->snr)) { return false; }
-  if (!decode_float(ctx, &msg->cp)) { return false; }
-  if (!decode_float(ctx, &msg->cf)) { return false; }
-  if (!decode_u8(ctx, &msg->prn)) { return false; }
+bool decode_sbp_msg_acq_result_dep_a_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_acq_result_dep_a_t *msg) {
+  if (!decode_float(ctx, &msg->snr)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cp)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->prn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_acq_result_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_acq_result_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_acq_result_dep_a_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_acq_result_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -305,29 +446,43 @@ s8 sbp_decode_sbp_msg_acq_result_dep_a_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_acq_result_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_acq_result_dep_a_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_acq_result_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_acq_result_dep_a_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ACQ_RESULT_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_acq_result_dep_a_t(const sbp_msg_acq_result_dep_a_t *a, const sbp_msg_acq_result_dep_a_t *b) {
+int sbp_cmp_sbp_msg_acq_result_dep_a_t(const sbp_msg_acq_result_dep_a_t *a,
+                                       const sbp_msg_acq_result_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_float(&a->snr, &b->snr);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cp, &b->cp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cf, &b->cf);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->prn, &b->prn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -348,24 +503,50 @@ size_t sbp_packed_size_sbp_acq_sv_profile_t(const sbp_acq_sv_profile_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_acq_sv_profile_t(sbp_encode_ctx_t *ctx, const sbp_acq_sv_profile_t *msg)
-{
-  if (!encode_u8(ctx, &msg->job_type)) { return false; }
-  if (!encode_u8(ctx, &msg->status)) { return false; }
-  if (!encode_u16(ctx, &msg->cn0)) { return false; }
-  if (!encode_u8(ctx, &msg->int_time)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u16(ctx, &msg->bin_width)) { return false; }
-  if (!encode_u32(ctx, &msg->timestamp)) { return false; }
-  if (!encode_u32(ctx, &msg->time_spent)) { return false; }
-  if (!encode_s32(ctx, &msg->cf_min)) { return false; }
-  if (!encode_s32(ctx, &msg->cf_max)) { return false; }
-  if (!encode_s32(ctx, &msg->cf)) { return false; }
-  if (!encode_u32(ctx, &msg->cp)) { return false; }
+bool encode_sbp_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_acq_sv_profile_t *msg) {
+  if (!encode_u8(ctx, &msg->job_type)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->int_time)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->bin_width)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->timestamp)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->time_spent)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cf_min)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cf_max)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->cp)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_acq_sv_profile_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_acq_sv_profile_t *msg) {
+s8 sbp_encode_sbp_acq_sv_profile_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_acq_sv_profile_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -379,24 +560,49 @@ s8 sbp_encode_sbp_acq_sv_profile_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_acq_sv_profile_t(sbp_decode_ctx_t *ctx, sbp_acq_sv_profile_t *msg)
-{
-  if (!decode_u8(ctx, &msg->job_type)) { return false; }
-  if (!decode_u8(ctx, &msg->status)) { return false; }
-  if (!decode_u16(ctx, &msg->cn0)) { return false; }
-  if (!decode_u8(ctx, &msg->int_time)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u16(ctx, &msg->bin_width)) { return false; }
-  if (!decode_u32(ctx, &msg->timestamp)) { return false; }
-  if (!decode_u32(ctx, &msg->time_spent)) { return false; }
-  if (!decode_s32(ctx, &msg->cf_min)) { return false; }
-  if (!decode_s32(ctx, &msg->cf_max)) { return false; }
-  if (!decode_s32(ctx, &msg->cf)) { return false; }
-  if (!decode_u32(ctx, &msg->cp)) { return false; }
+bool decode_sbp_acq_sv_profile_t(sbp_decode_ctx_t *ctx,
+                                 sbp_acq_sv_profile_t *msg) {
+  if (!decode_u8(ctx, &msg->job_type)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->int_time)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->bin_width)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->timestamp)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->time_spent)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cf_min)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cf_max)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->cp)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_acq_sv_profile_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_acq_sv_profile_t *msg) {
+s8 sbp_decode_sbp_acq_sv_profile_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_acq_sv_profile_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -410,48 +616,74 @@ s8 sbp_decode_sbp_acq_sv_profile_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_acq_sv_profile_t(const sbp_acq_sv_profile_t *a, const sbp_acq_sv_profile_t *b) {
+int sbp_cmp_sbp_acq_sv_profile_t(const sbp_acq_sv_profile_t *a,
+                                 const sbp_acq_sv_profile_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->job_type, &b->job_type);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->status, &b->status);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->int_time, &b->int_time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->bin_width, &b->bin_width);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->timestamp, &b->timestamp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->time_spent, &b->time_spent);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cf_min, &b->cf_min);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cf_max, &b->cf_max);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cf, &b->cf);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->cp, &b->cp);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_acq_sv_profile_dep_t(const sbp_acq_sv_profile_dep_t *msg) {
+size_t sbp_packed_size_sbp_acq_sv_profile_dep_t(
+    const sbp_acq_sv_profile_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->job_type);
   packed_size += sbp_packed_size_u8(&msg->status);
@@ -468,24 +700,50 @@ size_t sbp_packed_size_sbp_acq_sv_profile_dep_t(const sbp_acq_sv_profile_dep_t *
   return packed_size;
 }
 
-bool encode_sbp_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx, const sbp_acq_sv_profile_dep_t *msg)
-{
-  if (!encode_u8(ctx, &msg->job_type)) { return false; }
-  if (!encode_u8(ctx, &msg->status)) { return false; }
-  if (!encode_u16(ctx, &msg->cn0)) { return false; }
-  if (!encode_u8(ctx, &msg->int_time)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u16(ctx, &msg->bin_width)) { return false; }
-  if (!encode_u32(ctx, &msg->timestamp)) { return false; }
-  if (!encode_u32(ctx, &msg->time_spent)) { return false; }
-  if (!encode_s32(ctx, &msg->cf_min)) { return false; }
-  if (!encode_s32(ctx, &msg->cf_max)) { return false; }
-  if (!encode_s32(ctx, &msg->cf)) { return false; }
-  if (!encode_u32(ctx, &msg->cp)) { return false; }
+bool encode_sbp_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_acq_sv_profile_dep_t *msg) {
+  if (!encode_u8(ctx, &msg->job_type)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->int_time)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->bin_width)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->timestamp)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->time_spent)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cf_min)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cf_max)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->cp)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_acq_sv_profile_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_acq_sv_profile_dep_t *msg) {
+s8 sbp_encode_sbp_acq_sv_profile_dep_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_acq_sv_profile_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -499,24 +757,50 @@ s8 sbp_encode_sbp_acq_sv_profile_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx, sbp_acq_sv_profile_dep_t *msg)
-{
-  if (!decode_u8(ctx, &msg->job_type)) { return false; }
-  if (!decode_u8(ctx, &msg->status)) { return false; }
-  if (!decode_u16(ctx, &msg->cn0)) { return false; }
-  if (!decode_u8(ctx, &msg->int_time)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u16(ctx, &msg->bin_width)) { return false; }
-  if (!decode_u32(ctx, &msg->timestamp)) { return false; }
-  if (!decode_u32(ctx, &msg->time_spent)) { return false; }
-  if (!decode_s32(ctx, &msg->cf_min)) { return false; }
-  if (!decode_s32(ctx, &msg->cf_max)) { return false; }
-  if (!decode_s32(ctx, &msg->cf)) { return false; }
-  if (!decode_u32(ctx, &msg->cp)) { return false; }
+bool decode_sbp_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx,
+                                     sbp_acq_sv_profile_dep_t *msg) {
+  if (!decode_u8(ctx, &msg->job_type)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->int_time)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->bin_width)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->timestamp)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->time_spent)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cf_min)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cf_max)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cf)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->cp)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_acq_sv_profile_dep_t *msg) {
+s8 sbp_decode_sbp_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_acq_sv_profile_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -530,63 +814,93 @@ s8 sbp_decode_sbp_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_acq_sv_profile_dep_t(const sbp_acq_sv_profile_dep_t *a, const sbp_acq_sv_profile_dep_t *b) {
+int sbp_cmp_sbp_acq_sv_profile_dep_t(const sbp_acq_sv_profile_dep_t *a,
+                                     const sbp_acq_sv_profile_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->job_type, &b->job_type);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->status, &b->status);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->int_time, &b->int_time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->bin_width, &b->bin_width);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->timestamp, &b->timestamp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->time_spent, &b->time_spent);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cf_min, &b->cf_min);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cf_max, &b->cf_max);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cf, &b->cf);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->cp, &b->cp);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_acq_sv_profile_t(const sbp_msg_acq_sv_profile_t *msg) {
+size_t sbp_packed_size_sbp_msg_acq_sv_profile_t(
+    const sbp_msg_acq_sv_profile_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_acq_sv_profile * sbp_packed_size_sbp_acq_sv_profile_t(&msg->acq_sv_profile[0]));
+  packed_size += (msg->n_acq_sv_profile * sbp_packed_size_sbp_acq_sv_profile_t(
+                                              &msg->acq_sv_profile[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++)
-  {
-    if (!encode_sbp_acq_sv_profile_t(ctx, &msg->acq_sv_profile[i])) { return false; }
+bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_acq_sv_profile_t *msg) {
+  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
+    if (!encode_sbp_acq_sv_profile_t(ctx, &msg->acq_sv_profile[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_acq_sv_profile_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_acq_sv_profile_t *msg) {
+s8 sbp_encode_sbp_msg_acq_sv_profile_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_acq_sv_profile_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -600,16 +914,22 @@ s8 sbp_encode_sbp_msg_acq_sv_profile_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_acq_sv_profile_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_sv_profile_t *msg)
-{
-    msg->n_acq_sv_profile = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_acq_sv_profile_t(&msg->acq_sv_profile[0]));
+bool decode_sbp_msg_acq_sv_profile_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_acq_sv_profile_t *msg) {
+  msg->n_acq_sv_profile =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_acq_sv_profile_t(&msg->acq_sv_profile[0]));
   for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
-    if (!decode_sbp_acq_sv_profile_t(ctx, &msg->acq_sv_profile[i])) { return false; }
+    if (!decode_sbp_acq_sv_profile_t(ctx, &msg->acq_sv_profile[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_acq_sv_profile_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_acq_sv_profile_t *msg) {
+s8 sbp_decode_sbp_msg_acq_sv_profile_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_acq_sv_profile_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -622,43 +942,57 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_sv_profile_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_acq_sv_profile_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_acq_sv_profile_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_acq_sv_profile_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ACQ_SV_PROFILE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_acq_sv_profile_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ACQ_SV_PROFILE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_acq_sv_profile_t(const sbp_msg_acq_sv_profile_t *a, const sbp_msg_acq_sv_profile_t *b) {
+int sbp_cmp_sbp_msg_acq_sv_profile_t(const sbp_msg_acq_sv_profile_t *a,
+                                     const sbp_msg_acq_sv_profile_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_acq_sv_profile, &b->n_acq_sv_profile);
-  for (uint8_t i = 0; i < a->n_acq_sv_profile && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_acq_sv_profile_t(&a->acq_sv_profile[i], &b->acq_sv_profile[i]);
+  for (uint8_t i = 0; i < a->n_acq_sv_profile && ret == 0; i++) {
+    ret = sbp_cmp_sbp_acq_sv_profile_t(&a->acq_sv_profile[i],
+                                       &b->acq_sv_profile[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_acq_sv_profile_dep_t(const sbp_msg_acq_sv_profile_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_acq_sv_profile_dep_t(
+    const sbp_msg_acq_sv_profile_dep_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_acq_sv_profile * sbp_packed_size_sbp_acq_sv_profile_dep_t(&msg->acq_sv_profile[0]));
+  packed_size +=
+      (msg->n_acq_sv_profile *
+       sbp_packed_size_sbp_acq_sv_profile_dep_t(&msg->acq_sv_profile[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_acq_sv_profile_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++)
-  {
-    if (!encode_sbp_acq_sv_profile_dep_t(ctx, &msg->acq_sv_profile[i])) { return false; }
+bool encode_sbp_msg_acq_sv_profile_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg) {
+  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
+    if (!encode_sbp_acq_sv_profile_dep_t(ctx, &msg->acq_sv_profile[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_acq_sv_profile_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_acq_sv_profile_dep_t *msg) {
+s8 sbp_encode_sbp_msg_acq_sv_profile_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_acq_sv_profile_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -672,16 +1006,22 @@ s8 sbp_encode_sbp_msg_acq_sv_profile_dep_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_acq_sv_profile_dep_t *msg)
-{
-    msg->n_acq_sv_profile = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_acq_sv_profile_dep_t(&msg->acq_sv_profile[0]));
+bool decode_sbp_msg_acq_sv_profile_dep_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_acq_sv_profile_dep_t *msg) {
+  msg->n_acq_sv_profile = (uint8_t)(
+      (ctx->buf_len - ctx->offset) /
+      sbp_packed_size_sbp_acq_sv_profile_dep_t(&msg->acq_sv_profile[0]));
   for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
-    if (!decode_sbp_acq_sv_profile_dep_t(ctx, &msg->acq_sv_profile[i])) { return false; }
+    if (!decode_sbp_acq_sv_profile_dep_t(ctx, &msg->acq_sv_profile[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_acq_sv_profile_dep_t *msg) {
+s8 sbp_decode_sbp_msg_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_acq_sv_profile_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -694,23 +1034,32 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_sv_profile_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_acq_sv_profile_dep_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_dep_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_acq_sv_profile_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ACQ_SV_PROFILE_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_acq_sv_profile_dep_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ACQ_SV_PROFILE_DEP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_acq_sv_profile_dep_t(const sbp_msg_acq_sv_profile_dep_t *a, const sbp_msg_acq_sv_profile_dep_t *b) {
+int sbp_cmp_sbp_msg_acq_sv_profile_dep_t(
+    const sbp_msg_acq_sv_profile_dep_t *a,
+    const sbp_msg_acq_sv_profile_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_acq_sv_profile, &b->n_acq_sv_profile);
-  for (uint8_t i = 0; i < a->n_acq_sv_profile && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_acq_sv_profile_dep_t(&a->acq_sv_profile[i], &b->acq_sv_profile[i]);
+  for (uint8_t i = 0; i < a->n_acq_sv_profile && ret == 0; i++) {
+    ret = sbp_cmp_sbp_acq_sv_profile_dep_t(&a->acq_sv_profile[i],
+                                           &b->acq_sv_profile[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/acquisition.c
+++ b/c/src/new/acquisition.c
@@ -882,7 +882,7 @@ size_t sbp_packed_size_sbp_msg_acq_sv_profile_t(
 
 bool encode_sbp_msg_acq_sv_profile_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_acq_sv_profile_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_acq_sv_profile; i++) {
+  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
     if (!encode_sbp_acq_sv_profile_t(ctx, &msg->acq_sv_profile[i])) {
       return false;
     }
@@ -975,7 +975,7 @@ size_t sbp_packed_size_sbp_msg_acq_sv_profile_dep_t(
 
 bool encode_sbp_msg_acq_sv_profile_dep_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_acq_sv_profile_dep_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_acq_sv_profile; i++) {
+  for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
     if (!encode_sbp_acq_sv_profile_dep_t(ctx, &msg->acq_sv_profile[i])) {
       return false;
     }

--- a/c/src/new/bootload.c
+++ b/c/src/new/bootload.c
@@ -1,29 +1,49 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
-#include <libsbp/internal/new/common.h>
-#include <libsbp/new/bootload.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/bootload.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/bootload.h>
+#include <libsbp/internal/new/common.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/bootload.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_msg_bootloader_handshake_req_t(const sbp_msg_bootloader_handshake_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_bootloader_handshake_req_t(
+    const sbp_msg_bootloader_handshake_req_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_bootloader_handshake_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_req_t *msg)
-{
+bool encode_sbp_msg_bootloader_handshake_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_req_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_bootloader_handshake_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_bootloader_handshake_req_t *msg) {
+s8 sbp_encode_sbp_msg_bootloader_handshake_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_bootloader_handshake_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -37,14 +57,16 @@ s8 sbp_encode_sbp_msg_bootloader_handshake_req_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_msg_bootloader_handshake_req_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_req_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_bootloader_handshake_req_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_req_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_bootloader_handshake_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_bootloader_handshake_req_t *msg) {
+s8 sbp_decode_sbp_msg_bootloader_handshake_req_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_bootloader_handshake_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -57,103 +79,129 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_req_t(const uint8_t *buf, uint8_t len
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_handshake_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_bootloader_handshake_req_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_bootloader_handshake_req_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_bootloader_handshake_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_HANDSHAKE_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_bootloader_handshake_req_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_HANDSHAKE_REQ, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_bootloader_handshake_req_t(const sbp_msg_bootloader_handshake_req_t *a, const sbp_msg_bootloader_handshake_req_t *b) {
+int sbp_cmp_sbp_msg_bootloader_handshake_req_t(
+    const sbp_msg_bootloader_handshake_req_t *a,
+    const sbp_msg_bootloader_handshake_req_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_bootloader_handshake_resp_tversion_params = 
-{
-  .max_packed_len = 251
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_bootloader_handshake_resp_tversion_params = {.max_packed_len = 251};
 
-  void sbp_msg_bootloader_handshake_resp_t_version_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_bootloader_handshake_resp_tversion_params);
+void sbp_msg_bootloader_handshake_resp_t_version_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params);
 }
 
-  bool sbp_msg_bootloader_handshake_resp_t_version_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_bootloader_handshake_resp_tversion_params);
+bool sbp_msg_bootloader_handshake_resp_t_version_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params);
 }
 
-  int sbp_msg_bootloader_handshake_resp_t_version_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_bootloader_handshake_resp_tversion_params);
+int sbp_msg_bootloader_handshake_resp_t_version_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_bootloader_handshake_resp_tversion_params);
 }
 
-  uint8_t sbp_msg_bootloader_handshake_resp_t_version_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_bootloader_handshake_resp_tversion_params);
+uint8_t sbp_msg_bootloader_handshake_resp_t_version_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params);
 }
 
-  uint8_t sbp_msg_bootloader_handshake_resp_t_version_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_bootloader_handshake_resp_tversion_params);
-      }
-  bool sbp_msg_bootloader_handshake_resp_t_version_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_bootloader_handshake_resp_tversion_params, new_str);
-  }
+uint8_t sbp_msg_bootloader_handshake_resp_t_version_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params);
+}
+bool sbp_msg_bootloader_handshake_resp_t_version_set(
+    sbp_unterminated_string_t *s, const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params, new_str);
+}
 
-  bool sbp_msg_bootloader_handshake_resp_t_version_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_bootloader_handshake_resp_t_version_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_bootloader_handshake_resp_t_version_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
-  }
-
-  bool sbp_msg_bootloader_handshake_resp_t_version_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_bootloader_handshake_resp_t_version_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
+bool sbp_msg_bootloader_handshake_resp_t_version_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
 }
 
-  const char *sbp_msg_bootloader_handshake_resp_t_version_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_bootloader_handshake_resp_tversion_params);
+bool sbp_msg_bootloader_handshake_resp_t_version_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_bootloader_handshake_resp_t(const sbp_msg_bootloader_handshake_resp_t *msg) {
+bool sbp_msg_bootloader_handshake_resp_t_version_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params, fmt, ap);
+}
+
+const char *sbp_msg_bootloader_handshake_resp_t_version_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_bootloader_handshake_resp_tversion_params);
+}
+
+size_t sbp_packed_size_sbp_msg_bootloader_handshake_resp_t(
+    const sbp_msg_bootloader_handshake_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->flags);
-  packed_size += sbp_unterminated_string_packed_len(&msg->version, &sbp_msg_bootloader_handshake_resp_tversion_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->version, &sbp_msg_bootloader_handshake_resp_tversion_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_bootloader_handshake_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_resp_t *msg)
-{
-  if (!encode_u32(ctx, &msg->flags)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->version, &sbp_msg_bootloader_handshake_resp_tversion_params, ctx)) { return false; }
+bool encode_sbp_msg_bootloader_handshake_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_resp_t *msg) {
+  if (!encode_u32(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->version, &sbp_msg_bootloader_handshake_resp_tversion_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_bootloader_handshake_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_bootloader_handshake_resp_t *msg) {
+s8 sbp_encode_sbp_msg_bootloader_handshake_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_bootloader_handshake_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -167,14 +215,22 @@ s8 sbp_encode_sbp_msg_bootloader_handshake_resp_t(uint8_t *buf, uint8_t len, uin
   return SBP_OK;
 }
 
-bool decode_sbp_msg_bootloader_handshake_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_resp_t *msg)
-{
-  if (!decode_u32(ctx, &msg->flags)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->version, &sbp_msg_bootloader_handshake_resp_tversion_params, ctx)) { return false; }
+bool decode_sbp_msg_bootloader_handshake_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_resp_t *msg) {
+  if (!decode_u32(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->version, &sbp_msg_bootloader_handshake_resp_tversion_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_bootloader_handshake_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_bootloader_handshake_resp_t *msg) {
+s8 sbp_decode_sbp_msg_bootloader_handshake_resp_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_bootloader_handshake_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -187,39 +243,57 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_resp_t(const uint8_t *buf, uint8_t le
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_handshake_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_bootloader_handshake_resp_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_bootloader_handshake_resp_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_bootloader_handshake_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_bootloader_handshake_resp_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_bootloader_handshake_resp_t(const sbp_msg_bootloader_handshake_resp_t *a, const sbp_msg_bootloader_handshake_resp_t *b) {
+int sbp_cmp_sbp_msg_bootloader_handshake_resp_t(
+    const sbp_msg_bootloader_handshake_resp_t *a,
+    const sbp_msg_bootloader_handshake_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->version, &b->version, &sbp_msg_bootloader_handshake_resp_tversion_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->version, &b->version,
+      &sbp_msg_bootloader_handshake_resp_tversion_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_bootloader_jump_to_app_t(const sbp_msg_bootloader_jump_to_app_t *msg) {
+size_t sbp_packed_size_sbp_msg_bootloader_jump_to_app_t(
+    const sbp_msg_bootloader_jump_to_app_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->jump);
   return packed_size;
 }
 
-bool encode_sbp_msg_bootloader_jump_to_app_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_jump_to_app_t *msg)
-{
-  if (!encode_u8(ctx, &msg->jump)) { return false; }
+bool encode_sbp_msg_bootloader_jump_to_app_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_jump_to_app_t *msg) {
+  if (!encode_u8(ctx, &msg->jump)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_bootloader_jump_to_app_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_bootloader_jump_to_app_t *msg) {
+s8 sbp_encode_sbp_msg_bootloader_jump_to_app_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_bootloader_jump_to_app_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -233,13 +307,17 @@ s8 sbp_encode_sbp_msg_bootloader_jump_to_app_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_bootloader_jump_to_app_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_jump_to_app_t *msg)
-{
-  if (!decode_u8(ctx, &msg->jump)) { return false; }
+bool decode_sbp_msg_bootloader_jump_to_app_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_jump_to_app_t *msg) {
+  if (!decode_u8(ctx, &msg->jump)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_bootloader_jump_to_app_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_bootloader_jump_to_app_t *msg) {
+s8 sbp_decode_sbp_msg_bootloader_jump_to_app_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_bootloader_jump_to_app_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -252,36 +330,48 @@ s8 sbp_decode_sbp_msg_bootloader_jump_to_app_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_jump_to_app_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_jump_to_app_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_bootloader_jump_to_app_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_bootloader_jump_to_app_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_bootloader_jump_to_app_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_JUMP_TO_APP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_bootloader_jump_to_app_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_JUMP_TO_APP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_bootloader_jump_to_app_t(const sbp_msg_bootloader_jump_to_app_t *a, const sbp_msg_bootloader_jump_to_app_t *b) {
+int sbp_cmp_sbp_msg_bootloader_jump_to_app_t(
+    const sbp_msg_bootloader_jump_to_app_t *a,
+    const sbp_msg_bootloader_jump_to_app_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->jump, &b->jump);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_nap_device_dna_req_t(const sbp_msg_nap_device_dna_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_nap_device_dna_req_t(
+    const sbp_msg_nap_device_dna_req_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_nap_device_dna_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_req_t *msg)
-{
+bool encode_sbp_msg_nap_device_dna_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_req_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_nap_device_dna_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_nap_device_dna_req_t *msg) {
+s8 sbp_encode_sbp_msg_nap_device_dna_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_nap_device_dna_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -295,14 +385,16 @@ s8 sbp_encode_sbp_msg_nap_device_dna_req_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_nap_device_dna_req_t(sbp_decode_ctx_t *ctx, sbp_msg_nap_device_dna_req_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_nap_device_dna_req_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_nap_device_dna_req_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_nap_device_dna_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_nap_device_dna_req_t *msg) {
+s8 sbp_decode_sbp_msg_nap_device_dna_req_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_nap_device_dna_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -315,38 +407,49 @@ s8 sbp_decode_sbp_msg_nap_device_dna_req_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_nap_device_dna_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_nap_device_dna_req_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_req_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_nap_device_dna_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_NAP_DEVICE_DNA_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_nap_device_dna_req_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_NAP_DEVICE_DNA_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_nap_device_dna_req_t(const sbp_msg_nap_device_dna_req_t *a, const sbp_msg_nap_device_dna_req_t *b) {
+int sbp_cmp_sbp_msg_nap_device_dna_req_t(
+    const sbp_msg_nap_device_dna_req_t *a,
+    const sbp_msg_nap_device_dna_req_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_nap_device_dna_resp_t(const sbp_msg_nap_device_dna_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_nap_device_dna_resp_t(
+    const sbp_msg_nap_device_dna_resp_t *msg) {
   size_t packed_size = 0;
-  packed_size += ( 8 * sbp_packed_size_u8(&msg->dna[0]));
+  packed_size += (8 * sbp_packed_size_u8(&msg->dna[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_nap_device_dna_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg)
-{
-  for (uint8_t i = 0; i < 8; i++)
-  {
-    if (!encode_u8(ctx, &msg->dna[i])) { return false; }
+bool encode_sbp_msg_nap_device_dna_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg) {
+  for (uint8_t i = 0; i < 8; i++) {
+    if (!encode_u8(ctx, &msg->dna[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_nap_device_dna_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_nap_device_dna_resp_t *msg) {
+s8 sbp_encode_sbp_msg_nap_device_dna_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_nap_device_dna_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -360,15 +463,19 @@ s8 sbp_encode_sbp_msg_nap_device_dna_resp_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_nap_device_dna_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_nap_device_dna_resp_t *msg)
-{
+bool decode_sbp_msg_nap_device_dna_resp_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_nap_device_dna_resp_t *msg) {
   for (uint8_t i = 0; i < 8; i++) {
-    if (!decode_u8(ctx, &msg->dna[i])) { return false; }
+    if (!decode_u8(ctx, &msg->dna[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_nap_device_dna_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_nap_device_dna_resp_t *msg) {
+s8 sbp_decode_sbp_msg_nap_device_dna_resp_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_nap_device_dna_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -381,105 +488,131 @@ s8 sbp_decode_sbp_msg_nap_device_dna_resp_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_nap_device_dna_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_nap_device_dna_resp_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_nap_device_dna_resp_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_nap_device_dna_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_NAP_DEVICE_DNA_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_nap_device_dna_resp_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_NAP_DEVICE_DNA_RESP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_nap_device_dna_resp_t(const sbp_msg_nap_device_dna_resp_t *a, const sbp_msg_nap_device_dna_resp_t *b) {
+int sbp_cmp_sbp_msg_nap_device_dna_resp_t(
+    const sbp_msg_nap_device_dna_resp_t *a,
+    const sbp_msg_nap_device_dna_resp_t *b) {
   int ret = 0;
-  
-  for (uint8_t i = 0; i < 8 && ret == 0; i++)
-  {
+
+  for (uint8_t i = 0; i < 8 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->dna[i], &b->dna[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_bootloader_handshake_dep_a_thandshake_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_bootloader_handshake_dep_a_thandshake_params = {.max_packed_len =
+                                                                255};
 
-  void sbp_msg_bootloader_handshake_dep_a_t_handshake_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+void sbp_msg_bootloader_handshake_dep_a_t_handshake_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
 }
 
-  bool sbp_msg_bootloader_handshake_dep_a_t_handshake_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+bool sbp_msg_bootloader_handshake_dep_a_t_handshake_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
 }
 
-  int sbp_msg_bootloader_handshake_dep_a_t_handshake_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+int sbp_msg_bootloader_handshake_dep_a_t_handshake_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
 }
 
-  uint8_t sbp_msg_bootloader_handshake_dep_a_t_handshake_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+uint8_t sbp_msg_bootloader_handshake_dep_a_t_handshake_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
 }
 
-  uint8_t sbp_msg_bootloader_handshake_dep_a_t_handshake_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
-      }
-  bool sbp_msg_bootloader_handshake_dep_a_t_handshake_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, new_str);
-  }
+uint8_t sbp_msg_bootloader_handshake_dep_a_t_handshake_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+}
+bool sbp_msg_bootloader_handshake_dep_a_t_handshake_set(
+    sbp_unterminated_string_t *s, const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, new_str);
+}
 
-  bool sbp_msg_bootloader_handshake_dep_a_t_handshake_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_bootloader_handshake_dep_a_t_handshake_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_bootloader_handshake_dep_a_t_handshake_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
-  }
-
-  bool sbp_msg_bootloader_handshake_dep_a_t_handshake_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_bootloader_handshake_dep_a_t_handshake_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
+bool sbp_msg_bootloader_handshake_dep_a_t_handshake_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
 }
 
-  const char *sbp_msg_bootloader_handshake_dep_a_t_handshake_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+bool sbp_msg_bootloader_handshake_dep_a_t_handshake_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_bootloader_handshake_dep_a_t(const sbp_msg_bootloader_handshake_dep_a_t *msg) {
+bool sbp_msg_bootloader_handshake_dep_a_t_handshake_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, fmt, ap);
+}
+
+const char *sbp_msg_bootloader_handshake_dep_a_t_handshake_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+}
+
+size_t sbp_packed_size_sbp_msg_bootloader_handshake_dep_a_t(
+    const sbp_msg_bootloader_handshake_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_unterminated_string_packed_len(&msg->handshake, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->handshake, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_bootloader_handshake_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_dep_a_t *msg)
-{
-  if (!sbp_unterminated_string_pack(&msg->handshake, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, ctx)) { return false; }
+bool encode_sbp_msg_bootloader_handshake_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_dep_a_t *msg) {
+  if (!sbp_unterminated_string_pack(
+          &msg->handshake,
+          &sbp_msg_bootloader_handshake_dep_a_thandshake_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_bootloader_handshake_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_bootloader_handshake_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -493,13 +626,19 @@ s8 sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-bool decode_sbp_msg_bootloader_handshake_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_dep_a_t *msg)
-{
-  if (!sbp_unterminated_string_unpack(&msg->handshake, &sbp_msg_bootloader_handshake_dep_a_thandshake_params, ctx)) { return false; }
+bool decode_sbp_msg_bootloader_handshake_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_dep_a_t *msg) {
+  if (!sbp_unterminated_string_unpack(
+          &msg->handshake,
+          &sbp_msg_bootloader_handshake_dep_a_thandshake_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_bootloader_handshake_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_bootloader_handshake_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -512,19 +651,30 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(const uint8_t *buf, uint8_t l
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_handshake_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_bootloader_handshake_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_bootloader_handshake_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_bootloader_handshake_dep_a_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_bootloader_handshake_dep_a_t(const sbp_msg_bootloader_handshake_dep_a_t *a, const sbp_msg_bootloader_handshake_dep_a_t *b) {
+int sbp_cmp_sbp_msg_bootloader_handshake_dep_a_t(
+    const sbp_msg_bootloader_handshake_dep_a_t *a,
+    const sbp_msg_bootloader_handshake_dep_a_t *b) {
   int ret = 0;
-  
-  ret = sbp_unterminated_string_strcmp(&a->handshake, &b->handshake, &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->handshake, &b->handshake,
+      &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/bootload.c
+++ b/c/src/new/bootload.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/bootload.yaml
  * with generate.py. Please do not hand edit!
@@ -79,6 +67,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_req_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_bootloader_handshake_req_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_bootloader_handshake_req_t *msg, sbp_write_fn_t write) {
@@ -243,6 +232,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_resp_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_bootloader_handshake_resp_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_bootloader_handshake_resp_t *msg, sbp_write_fn_t write) {
@@ -267,9 +257,8 @@ int sbp_cmp_sbp_msg_bootloader_handshake_resp_t(
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->version, &b->version,
-      &sbp_msg_bootloader_handshake_resp_tversion_params);
+  ret = sbp_msg_bootloader_handshake_resp_t_version_strcmp(&a->version,
+                                                           &b->version);
   if (ret != 0) {
     return ret;
   }
@@ -330,6 +319,7 @@ s8 sbp_decode_sbp_msg_bootloader_jump_to_app_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_bootloader_jump_to_app_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_bootloader_jump_to_app_t *msg, sbp_write_fn_t write) {
@@ -407,6 +397,7 @@ s8 sbp_decode_sbp_msg_nap_device_dna_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_nap_device_dna_req_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_req_t *msg,
     sbp_write_fn_t write) {
@@ -439,7 +430,7 @@ size_t sbp_packed_size_sbp_msg_nap_device_dna_resp_t(
 
 bool encode_sbp_msg_nap_device_dna_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg) {
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
     if (!encode_u8(ctx, &msg->dna[i])) {
       return false;
     }
@@ -488,6 +479,7 @@ s8 sbp_decode_sbp_msg_nap_device_dna_resp_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_nap_device_dna_resp_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_nap_device_dna_resp_t *msg, sbp_write_fn_t write) {
@@ -507,7 +499,7 @@ int sbp_cmp_sbp_msg_nap_device_dna_resp_t(
     const sbp_msg_nap_device_dna_resp_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; i < 8 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
     ret = sbp_cmp_u8(&a->dna[i], &b->dna[i]);
   }
   if (ret != 0) {
@@ -651,6 +643,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_bootloader_handshake_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_bootloader_handshake_dep_a_t *msg, sbp_write_fn_t write) {
@@ -670,9 +663,8 @@ int sbp_cmp_sbp_msg_bootloader_handshake_dep_a_t(
     const sbp_msg_bootloader_handshake_dep_a_t *b) {
   int ret = 0;
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->handshake, &b->handshake,
-      &sbp_msg_bootloader_handshake_dep_a_thandshake_params);
+  ret = sbp_msg_bootloader_handshake_dep_a_t_handshake_strcmp(&a->handshake,
+                                                              &b->handshake);
   if (ret != 0) {
     return ret;
   }

--- a/c/src/new/bootload.c
+++ b/c/src/new/bootload.c
@@ -430,7 +430,7 @@ size_t sbp_packed_size_sbp_msg_nap_device_dna_resp_t(
 
 bool encode_sbp_msg_nap_device_dna_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
+  for (uint8_t i = 0; i < 8; i++) {
     if (!encode_u8(ctx, &msg->dna[i])) {
       return false;
     }

--- a/c/src/new/ext_events.c
+++ b/c/src/new/ext_events.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ext_events.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/ext_events.h>
 #include <libsbp/internal/new/ext_events.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/ext_events.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_ext_event_t(const sbp_msg_ext_event_t *msg) {
   size_t packed_size = 0;
@@ -21,17 +38,28 @@ size_t sbp_packed_size_sbp_msg_ext_event_t(const sbp_msg_ext_event_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_ext_event_t(sbp_encode_ctx_t *ctx, const sbp_msg_ext_event_t *msg)
-{
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_u8(ctx, &msg->pin)) { return false; }
+bool encode_sbp_msg_ext_event_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_ext_event_t *msg) {
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pin)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ext_event_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ext_event_t *msg) {
+s8 sbp_encode_sbp_msg_ext_event_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_ext_event_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -45,17 +73,28 @@ s8 sbp_encode_sbp_msg_ext_event_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ext_event_t(sbp_decode_ctx_t *ctx, sbp_msg_ext_event_t *msg)
-{
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_u8(ctx, &msg->pin)) { return false; }
+bool decode_sbp_msg_ext_event_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_ext_event_t *msg) {
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pin)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ext_event_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ext_event_t *msg) {
+s8 sbp_decode_sbp_msg_ext_event_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_ext_event_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -68,31 +107,47 @@ s8 sbp_decode_sbp_msg_ext_event_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ext_event_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ext_event_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ext_event_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_ext_event_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ext_event_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EXT_EVENT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ext_event_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EXT_EVENT, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_ext_event_t(const sbp_msg_ext_event_t *a, const sbp_msg_ext_event_t *b) {
+int sbp_cmp_sbp_msg_ext_event_t(const sbp_msg_ext_event_t *a,
+                                const sbp_msg_ext_event_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->ns_residual, &b->ns_residual);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pin, &b->pin);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/ext_events.c
+++ b/c/src/new/ext_events.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/ext_events.yaml
  * with generate.py. Please do not hand edit!
@@ -107,6 +95,7 @@ s8 sbp_decode_sbp_msg_ext_event_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ext_event_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_ext_event_t *msg,
                                 sbp_write_fn_t write) {

--- a/c/src/new/file_io.c
+++ b/c/src/new/file_io.c
@@ -222,7 +222,7 @@ bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->sequence)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_contents; i++) {
+  for (uint8_t i = 0; i < msg->n_contents; i++) {
     if (!encode_u8(ctx, &msg->contents[i])) {
       return false;
     }
@@ -939,7 +939,7 @@ bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx,
           &msg->filename, &sbp_msg_fileio_write_req_tfilename_params, ctx)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_data; i++) {
+  for (uint8_t i = 0; i < msg->n_data; i++) {
     if (!encode_u8(ctx, &msg->data[i])) {
       return false;
     }

--- a/c/src/new/file_io.c
+++ b/c/src/new/file_io.c
@@ -1,101 +1,139 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/file_io.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/file_io.h>
 #include <libsbp/internal/new/file_io.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
-static const sbp_null_terminated_string_params_t sbp_msg_fileio_read_req_tfilename_params = 
-{
-  .max_packed_len = 246
-};
+#include <libsbp/new/file_io.h>
+#include <libsbp/sbp.h>
+static const sbp_null_terminated_string_params_t
+    sbp_msg_fileio_read_req_tfilename_params = {.max_packed_len = 246};
 
-  void sbp_msg_fileio_read_req_t_filename_init(sbp_null_terminated_string_t *s)
-{
+void sbp_msg_fileio_read_req_t_filename_init(sbp_null_terminated_string_t *s) {
   sbp_null_terminated_string_init(s, &sbp_msg_fileio_read_req_tfilename_params);
 }
 
-  bool sbp_msg_fileio_read_req_t_filename_valid(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_valid(s, &sbp_msg_fileio_read_req_tfilename_params);
+bool sbp_msg_fileio_read_req_t_filename_valid(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_valid(
+      s, &sbp_msg_fileio_read_req_tfilename_params);
 }
 
-  int sbp_msg_fileio_read_req_t_filename_strcmp(const sbp_null_terminated_string_t *a, const sbp_null_terminated_string_t *b)
-{
-  return sbp_null_terminated_string_strcmp(a, b, &sbp_msg_fileio_read_req_tfilename_params);
+int sbp_msg_fileio_read_req_t_filename_strcmp(
+    const sbp_null_terminated_string_t *a,
+    const sbp_null_terminated_string_t *b) {
+  return sbp_null_terminated_string_strcmp(
+      a, b, &sbp_msg_fileio_read_req_tfilename_params);
 }
 
-  uint8_t sbp_msg_fileio_read_req_t_filename_packed_len(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_packed_len(s, &sbp_msg_fileio_read_req_tfilename_params);
+uint8_t sbp_msg_fileio_read_req_t_filename_packed_len(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_packed_len(
+      s, &sbp_msg_fileio_read_req_tfilename_params);
 }
 
-  uint8_t sbp_msg_fileio_read_req_t_filename_space_remaining(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_space_remaining(s, &sbp_msg_fileio_read_req_tfilename_params);
-      }
-  bool sbp_msg_fileio_read_req_t_filename_set(sbp_null_terminated_string_t *s, const char *new_str)
-  {
-  return sbp_null_terminated_string_set(s, &sbp_msg_fileio_read_req_tfilename_params, new_str);
-  }
+uint8_t sbp_msg_fileio_read_req_t_filename_space_remaining(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_space_remaining(
+      s, &sbp_msg_fileio_read_req_tfilename_params);
+}
+bool sbp_msg_fileio_read_req_t_filename_set(sbp_null_terminated_string_t *s,
+                                            const char *new_str) {
+  return sbp_null_terminated_string_set(
+      s, &sbp_msg_fileio_read_req_tfilename_params, new_str);
+}
 
-  bool sbp_msg_fileio_read_req_t_filename_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_fileio_read_req_t_filename_printf(sbp_null_terminated_string_t *s,
+                                               const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_fileio_read_req_t_filename_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
-  }
-
-  bool sbp_msg_fileio_read_req_t_filename_append_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_fileio_read_req_t_filename_append_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
+bool sbp_msg_fileio_read_req_t_filename_vprintf(sbp_null_terminated_string_t *s,
+                                                const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
 }
 
-  const char *sbp_msg_fileio_read_req_t_filename_get(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_get(s, &sbp_msg_fileio_read_req_tfilename_params);
+bool sbp_msg_fileio_read_req_t_filename_append_printf(
+    sbp_null_terminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_read_req_t(const sbp_msg_fileio_read_req_t *msg) {
+bool sbp_msg_fileio_read_req_t_filename_append_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_read_req_tfilename_params, fmt, ap);
+}
+
+const char *sbp_msg_fileio_read_req_t_filename_get(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_get(
+      s, &sbp_msg_fileio_read_req_tfilename_params);
+}
+
+size_t sbp_packed_size_sbp_msg_fileio_read_req_t(
+    const sbp_msg_fileio_read_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += sbp_packed_size_u32(&msg->offset);
   packed_size += sbp_packed_size_u8(&msg->chunk_size);
-  packed_size += sbp_null_terminated_string_packed_len(&msg->filename, &sbp_msg_fileio_read_req_tfilename_params);
+  packed_size += sbp_null_terminated_string_packed_len(
+      &msg->filename, &sbp_msg_fileio_read_req_tfilename_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_read_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_req_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!encode_u32(ctx, &msg->offset)) { return false; }
-  if (!encode_u8(ctx, &msg->chunk_size)) { return false; }
-  if (!sbp_null_terminated_string_pack(&msg->filename, &sbp_msg_fileio_read_req_tfilename_params, ctx)) { return false; }
+bool encode_sbp_msg_fileio_read_req_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_fileio_read_req_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->offset)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->chunk_size)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_pack(
+          &msg->filename, &sbp_msg_fileio_read_req_tfilename_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_read_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_read_req_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_read_req_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_fileio_read_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -109,16 +147,27 @@ s8 sbp_encode_sbp_msg_fileio_read_req_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_read_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_req_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!decode_u32(ctx, &msg->offset)) { return false; }
-  if (!decode_u8(ctx, &msg->chunk_size)) { return false; }
-  if (!sbp_null_terminated_string_unpack(&msg->filename, &sbp_msg_fileio_read_req_tfilename_params, ctx)) { return false; }
+bool decode_sbp_msg_fileio_read_req_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_fileio_read_req_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->offset)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->chunk_size)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_unpack(
+          &msg->filename, &sbp_msg_fileio_read_req_tfilename_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_read_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_read_req_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_read_req_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_fileio_read_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -131,50 +180,71 @@ s8 sbp_decode_sbp_msg_fileio_read_req_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_read_req_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_fileio_read_req_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_read_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_read_req_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_read_req_t(const sbp_msg_fileio_read_req_t *a, const sbp_msg_fileio_read_req_t *b) {
+int sbp_cmp_sbp_msg_fileio_read_req_t(const sbp_msg_fileio_read_req_t *a,
+                                      const sbp_msg_fileio_read_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->offset, &b->offset);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->chunk_size, &b->chunk_size);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_null_terminated_string_strcmp(&a->filename, &b->filename, &sbp_msg_fileio_read_req_tfilename_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_null_terminated_string_strcmp(
+      &a->filename, &b->filename, &sbp_msg_fileio_read_req_tfilename_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_read_resp_t(const sbp_msg_fileio_read_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_fileio_read_resp_t(
+    const sbp_msg_fileio_read_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += (msg->n_contents * sbp_packed_size_u8(&msg->contents[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_resp_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  for (uint8_t i = 0; i < msg->n_contents; i++)
-  {
-    if (!encode_u8(ctx, &msg->contents[i])) { return false; }
+bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_fileio_read_resp_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_contents; i++) {
+    if (!encode_u8(ctx, &msg->contents[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_read_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_read_resp_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_read_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_read_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -188,17 +258,24 @@ s8 sbp_encode_sbp_msg_fileio_read_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_read_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_resp_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-    msg->n_contents = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->contents[0]));
+bool decode_sbp_msg_fileio_read_resp_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_fileio_read_resp_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  msg->n_contents = (uint8_t)((ctx->buf_len - ctx->offset) /
+                              sbp_packed_size_u8(&msg->contents[0]));
   for (uint8_t i = 0; i < msg->n_contents; i++) {
-    if (!decode_u8(ctx, &msg->contents[i])) { return false; }
+    if (!decode_u8(ctx, &msg->contents[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_read_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_read_resp_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_read_resp_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_fileio_read_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -211,113 +288,143 @@ s8 sbp_decode_sbp_msg_fileio_read_resp_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_read_resp_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_fileio_read_resp_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_read_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_read_resp_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_read_resp_t(const sbp_msg_fileio_read_resp_t *a, const sbp_msg_fileio_read_resp_t *b) {
+int sbp_cmp_sbp_msg_fileio_read_resp_t(const sbp_msg_fileio_read_resp_t *a,
+                                       const sbp_msg_fileio_read_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_contents, &b->n_contents);
-  for (uint8_t i = 0; i < a->n_contents && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_contents && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->contents[i], &b->contents[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_null_terminated_string_params_t sbp_msg_fileio_read_dir_req_tdirname_params = 
-{
-  .max_packed_len = 247
-};
+static const sbp_null_terminated_string_params_t
+    sbp_msg_fileio_read_dir_req_tdirname_params = {.max_packed_len = 247};
 
-  void sbp_msg_fileio_read_dir_req_t_dirname_init(sbp_null_terminated_string_t *s)
-{
-  sbp_null_terminated_string_init(s, &sbp_msg_fileio_read_dir_req_tdirname_params);
+void sbp_msg_fileio_read_dir_req_t_dirname_init(
+    sbp_null_terminated_string_t *s) {
+  sbp_null_terminated_string_init(s,
+                                  &sbp_msg_fileio_read_dir_req_tdirname_params);
 }
 
-  bool sbp_msg_fileio_read_dir_req_t_dirname_valid(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_valid(s, &sbp_msg_fileio_read_dir_req_tdirname_params);
+bool sbp_msg_fileio_read_dir_req_t_dirname_valid(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_valid(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params);
 }
 
-  int sbp_msg_fileio_read_dir_req_t_dirname_strcmp(const sbp_null_terminated_string_t *a, const sbp_null_terminated_string_t *b)
-{
-  return sbp_null_terminated_string_strcmp(a, b, &sbp_msg_fileio_read_dir_req_tdirname_params);
+int sbp_msg_fileio_read_dir_req_t_dirname_strcmp(
+    const sbp_null_terminated_string_t *a,
+    const sbp_null_terminated_string_t *b) {
+  return sbp_null_terminated_string_strcmp(
+      a, b, &sbp_msg_fileio_read_dir_req_tdirname_params);
 }
 
-  uint8_t sbp_msg_fileio_read_dir_req_t_dirname_packed_len(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_packed_len(s, &sbp_msg_fileio_read_dir_req_tdirname_params);
+uint8_t sbp_msg_fileio_read_dir_req_t_dirname_packed_len(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_packed_len(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params);
 }
 
-  uint8_t sbp_msg_fileio_read_dir_req_t_dirname_space_remaining(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_space_remaining(s, &sbp_msg_fileio_read_dir_req_tdirname_params);
-      }
-  bool sbp_msg_fileio_read_dir_req_t_dirname_set(sbp_null_terminated_string_t *s, const char *new_str)
-  {
-  return sbp_null_terminated_string_set(s, &sbp_msg_fileio_read_dir_req_tdirname_params, new_str);
-  }
+uint8_t sbp_msg_fileio_read_dir_req_t_dirname_space_remaining(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_space_remaining(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params);
+}
+bool sbp_msg_fileio_read_dir_req_t_dirname_set(sbp_null_terminated_string_t *s,
+                                               const char *new_str) {
+  return sbp_null_terminated_string_set(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params, new_str);
+}
 
-  bool sbp_msg_fileio_read_dir_req_t_dirname_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_fileio_read_dir_req_t_dirname_printf(
+    sbp_null_terminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_fileio_read_dir_req_t_dirname_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
-  }
-
-  bool sbp_msg_fileio_read_dir_req_t_dirname_append_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_fileio_read_dir_req_t_dirname_append_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
+bool sbp_msg_fileio_read_dir_req_t_dirname_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
 }
 
-  const char *sbp_msg_fileio_read_dir_req_t_dirname_get(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_get(s, &sbp_msg_fileio_read_dir_req_tdirname_params);
+bool sbp_msg_fileio_read_dir_req_t_dirname_append_printf(
+    sbp_null_terminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_read_dir_req_t(const sbp_msg_fileio_read_dir_req_t *msg) {
+bool sbp_msg_fileio_read_dir_req_t_dirname_append_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params, fmt, ap);
+}
+
+const char *sbp_msg_fileio_read_dir_req_t_dirname_get(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_get(
+      s, &sbp_msg_fileio_read_dir_req_tdirname_params);
+}
+
+size_t sbp_packed_size_sbp_msg_fileio_read_dir_req_t(
+    const sbp_msg_fileio_read_dir_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += sbp_packed_size_u32(&msg->offset);
-  packed_size += sbp_null_terminated_string_packed_len(&msg->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params);
+  packed_size += sbp_null_terminated_string_packed_len(
+      &msg->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_read_dir_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_req_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!encode_u32(ctx, &msg->offset)) { return false; }
-  if (!sbp_null_terminated_string_pack(&msg->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params, ctx)) { return false; }
+bool encode_sbp_msg_fileio_read_dir_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_req_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->offset)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_pack(
+          &msg->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_read_dir_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_read_dir_req_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_read_dir_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_read_dir_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -331,15 +438,24 @@ s8 sbp_encode_sbp_msg_fileio_read_dir_req_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_read_dir_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_dir_req_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!decode_u32(ctx, &msg->offset)) { return false; }
-  if (!sbp_null_terminated_string_unpack(&msg->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params, ctx)) { return false; }
+bool decode_sbp_msg_fileio_read_dir_req_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_fileio_read_dir_req_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->offset)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_unpack(
+          &msg->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_read_dir_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_read_dir_req_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_read_dir_req_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_fileio_read_dir_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -352,125 +468,159 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_req_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_dir_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_dir_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_read_dir_req_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_fileio_read_dir_req_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_read_dir_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_DIR_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_read_dir_req_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_DIR_REQ, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_read_dir_req_t(const sbp_msg_fileio_read_dir_req_t *a, const sbp_msg_fileio_read_dir_req_t *b) {
+int sbp_cmp_sbp_msg_fileio_read_dir_req_t(
+    const sbp_msg_fileio_read_dir_req_t *a,
+    const sbp_msg_fileio_read_dir_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->offset, &b->offset);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_null_terminated_string_strcmp(&a->dirname, &b->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_null_terminated_string_strcmp(
+      &a->dirname, &b->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_fileio_read_dir_resp_tcontents_params = 
-{
-  .max_packed_len = 251
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_fileio_read_dir_resp_tcontents_params = {.max_packed_len = 251};
 
-  void sbp_msg_fileio_read_dir_resp_t_contents_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_fileio_read_dir_resp_t_contents_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
+bool sbp_msg_fileio_read_dir_resp_t_contents_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
 }
 
-  int sbp_msg_fileio_read_dir_resp_t_contents_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_fileio_read_dir_resp_tcontents_params);
+int sbp_msg_fileio_read_dir_resp_t_contents_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_fileio_read_dir_resp_tcontents_params);
 }
 
-  uint8_t sbp_msg_fileio_read_dir_resp_t_contents_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
+uint8_t sbp_msg_fileio_read_dir_resp_t_contents_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
 }
 
-  uint8_t sbp_msg_fileio_read_dir_resp_t_contents_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
-      }
-  uint8_t sbp_msg_fileio_read_dir_resp_t_contents_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
+uint8_t sbp_msg_fileio_read_dir_resp_t_contents_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
+}
+uint8_t sbp_msg_fileio_read_dir_resp_t_contents_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params);
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, new_str);
+bool sbp_msg_fileio_read_dir_resp_t_contents_add_section(
+    sbp_multipart_string_t *s, const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, new_str);
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_fileio_read_dir_resp_t_contents_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
+bool sbp_msg_fileio_read_dir_resp_t_contents_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, str);
+bool sbp_msg_fileio_read_dir_resp_t_contents_append(sbp_multipart_string_t *s,
+                                                    const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, str);
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_fileio_read_dir_resp_t_contents_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_fileio_read_dir_resp_t_contents_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
+bool sbp_msg_fileio_read_dir_resp_t_contents_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, fmt, ap);
 }
 
-  const char *sbp_msg_fileio_read_dir_resp_t_contents_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, section);
+const char *sbp_msg_fileio_read_dir_resp_t_contents_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, section);
 }
 
-  uint8_t sbp_msg_fileio_read_dir_resp_t_contents_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_fileio_read_dir_resp_tcontents_params, section);
+uint8_t sbp_msg_fileio_read_dir_resp_t_contents_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_fileio_read_dir_resp_tcontents_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_read_dir_resp_t(const sbp_msg_fileio_read_dir_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_fileio_read_dir_resp_t(
+    const sbp_msg_fileio_read_dir_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
-  packed_size += sbp_multipart_string_packed_len(&msg->contents, &sbp_msg_fileio_read_dir_resp_tcontents_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->contents, &sbp_msg_fileio_read_dir_resp_tcontents_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_read_dir_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_resp_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!sbp_multipart_string_pack(&msg->contents, &sbp_msg_fileio_read_dir_resp_tcontents_params, ctx)) { return false; }
+bool encode_sbp_msg_fileio_read_dir_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_read_dir_resp_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!sbp_multipart_string_pack(&msg->contents,
+                                 &sbp_msg_fileio_read_dir_resp_tcontents_params,
+                                 ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_read_dir_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_read_dir_resp_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_read_dir_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_read_dir_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -484,14 +634,22 @@ s8 sbp_encode_sbp_msg_fileio_read_dir_resp_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_read_dir_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_dir_resp_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!sbp_multipart_string_unpack(&msg->contents, &sbp_msg_fileio_read_dir_resp_tcontents_params, ctx)) { return false; }
+bool decode_sbp_msg_fileio_read_dir_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_fileio_read_dir_resp_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!sbp_multipart_string_unpack(
+          &msg->contents, &sbp_msg_fileio_read_dir_resp_tcontents_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_read_dir_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_read_dir_resp_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_read_dir_resp_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_fileio_read_dir_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -504,105 +662,133 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_resp_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_dir_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_dir_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_read_dir_resp_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_fileio_read_dir_resp_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_read_dir_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_DIR_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_read_dir_resp_t(payload, sizeof(payload),
+                                                     &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_READ_DIR_RESP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_read_dir_resp_t(const sbp_msg_fileio_read_dir_resp_t *a, const sbp_msg_fileio_read_dir_resp_t *b) {
+int sbp_cmp_sbp_msg_fileio_read_dir_resp_t(
+    const sbp_msg_fileio_read_dir_resp_t *a,
+    const sbp_msg_fileio_read_dir_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_multipart_string_strcmp(&a->contents, &b->contents, &sbp_msg_fileio_read_dir_resp_tcontents_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_multipart_string_strcmp(
+      &a->contents, &b->contents,
+      &sbp_msg_fileio_read_dir_resp_tcontents_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_null_terminated_string_params_t sbp_msg_fileio_remove_tfilename_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_null_terminated_string_params_t
+    sbp_msg_fileio_remove_tfilename_params = {.max_packed_len = 255};
 
-  void sbp_msg_fileio_remove_t_filename_init(sbp_null_terminated_string_t *s)
-{
+void sbp_msg_fileio_remove_t_filename_init(sbp_null_terminated_string_t *s) {
   sbp_null_terminated_string_init(s, &sbp_msg_fileio_remove_tfilename_params);
 }
 
-  bool sbp_msg_fileio_remove_t_filename_valid(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_valid(s, &sbp_msg_fileio_remove_tfilename_params);
+bool sbp_msg_fileio_remove_t_filename_valid(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_valid(
+      s, &sbp_msg_fileio_remove_tfilename_params);
 }
 
-  int sbp_msg_fileio_remove_t_filename_strcmp(const sbp_null_terminated_string_t *a, const sbp_null_terminated_string_t *b)
-{
-  return sbp_null_terminated_string_strcmp(a, b, &sbp_msg_fileio_remove_tfilename_params);
+int sbp_msg_fileio_remove_t_filename_strcmp(
+    const sbp_null_terminated_string_t *a,
+    const sbp_null_terminated_string_t *b) {
+  return sbp_null_terminated_string_strcmp(
+      a, b, &sbp_msg_fileio_remove_tfilename_params);
 }
 
-  uint8_t sbp_msg_fileio_remove_t_filename_packed_len(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_packed_len(s, &sbp_msg_fileio_remove_tfilename_params);
+uint8_t sbp_msg_fileio_remove_t_filename_packed_len(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_packed_len(
+      s, &sbp_msg_fileio_remove_tfilename_params);
 }
 
-  uint8_t sbp_msg_fileio_remove_t_filename_space_remaining(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_space_remaining(s, &sbp_msg_fileio_remove_tfilename_params);
-      }
-  bool sbp_msg_fileio_remove_t_filename_set(sbp_null_terminated_string_t *s, const char *new_str)
-  {
-  return sbp_null_terminated_string_set(s, &sbp_msg_fileio_remove_tfilename_params, new_str);
-  }
+uint8_t sbp_msg_fileio_remove_t_filename_space_remaining(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_space_remaining(
+      s, &sbp_msg_fileio_remove_tfilename_params);
+}
+bool sbp_msg_fileio_remove_t_filename_set(sbp_null_terminated_string_t *s,
+                                          const char *new_str) {
+  return sbp_null_terminated_string_set(
+      s, &sbp_msg_fileio_remove_tfilename_params, new_str);
+}
 
-  bool sbp_msg_fileio_remove_t_filename_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_fileio_remove_t_filename_printf(sbp_null_terminated_string_t *s,
+                                             const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_fileio_remove_t_filename_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
-  }
-
-  bool sbp_msg_fileio_remove_t_filename_append_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_fileio_remove_t_filename_append_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
+bool sbp_msg_fileio_remove_t_filename_vprintf(sbp_null_terminated_string_t *s,
+                                              const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
 }
 
-  const char *sbp_msg_fileio_remove_t_filename_get(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_get(s, &sbp_msg_fileio_remove_tfilename_params);
+bool sbp_msg_fileio_remove_t_filename_append_printf(
+    sbp_null_terminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_remove_t(const sbp_msg_fileio_remove_t *msg) {
+bool sbp_msg_fileio_remove_t_filename_append_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_remove_tfilename_params, fmt, ap);
+}
+
+const char *sbp_msg_fileio_remove_t_filename_get(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_get(
+      s, &sbp_msg_fileio_remove_tfilename_params);
+}
+
+size_t sbp_packed_size_sbp_msg_fileio_remove_t(
+    const sbp_msg_fileio_remove_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_null_terminated_string_packed_len(&msg->filename, &sbp_msg_fileio_remove_tfilename_params);
+  packed_size += sbp_null_terminated_string_packed_len(
+      &msg->filename, &sbp_msg_fileio_remove_tfilename_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_remove_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_remove_t *msg)
-{
-  if (!sbp_null_terminated_string_pack(&msg->filename, &sbp_msg_fileio_remove_tfilename_params, ctx)) { return false; }
+bool encode_sbp_msg_fileio_remove_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_fileio_remove_t *msg) {
+  if (!sbp_null_terminated_string_pack(
+          &msg->filename, &sbp_msg_fileio_remove_tfilename_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_remove_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_remove_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_remove_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_fileio_remove_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -616,13 +802,18 @@ s8 sbp_encode_sbp_msg_fileio_remove_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_remove_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_remove_t *msg)
-{
-  if (!sbp_null_terminated_string_unpack(&msg->filename, &sbp_msg_fileio_remove_tfilename_params, ctx)) { return false; }
+bool decode_sbp_msg_fileio_remove_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_fileio_remove_t *msg) {
+  if (!sbp_null_terminated_string_unpack(
+          &msg->filename, &sbp_msg_fileio_remove_tfilename_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_remove_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_remove_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_remove_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_fileio_remove_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -635,111 +826,141 @@ s8 sbp_decode_sbp_msg_fileio_remove_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_remove_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_remove_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_remove_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_fileio_remove_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_remove_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_REMOVE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_remove_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_REMOVE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_remove_t(const sbp_msg_fileio_remove_t *a, const sbp_msg_fileio_remove_t *b) {
+int sbp_cmp_sbp_msg_fileio_remove_t(const sbp_msg_fileio_remove_t *a,
+                                    const sbp_msg_fileio_remove_t *b) {
   int ret = 0;
-  
-  ret = sbp_null_terminated_string_strcmp(&a->filename, &b->filename, &sbp_msg_fileio_remove_tfilename_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_null_terminated_string_strcmp(
+      &a->filename, &b->filename, &sbp_msg_fileio_remove_tfilename_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_null_terminated_string_params_t sbp_msg_fileio_write_req_tfilename_params = 
-{
-  .max_packed_len = 247
-};
+static const sbp_null_terminated_string_params_t
+    sbp_msg_fileio_write_req_tfilename_params = {.max_packed_len = 247};
 
-  void sbp_msg_fileio_write_req_t_filename_init(sbp_null_terminated_string_t *s)
-{
-  sbp_null_terminated_string_init(s, &sbp_msg_fileio_write_req_tfilename_params);
+void sbp_msg_fileio_write_req_t_filename_init(sbp_null_terminated_string_t *s) {
+  sbp_null_terminated_string_init(s,
+                                  &sbp_msg_fileio_write_req_tfilename_params);
 }
 
-  bool sbp_msg_fileio_write_req_t_filename_valid(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_valid(s, &sbp_msg_fileio_write_req_tfilename_params);
+bool sbp_msg_fileio_write_req_t_filename_valid(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_valid(
+      s, &sbp_msg_fileio_write_req_tfilename_params);
 }
 
-  int sbp_msg_fileio_write_req_t_filename_strcmp(const sbp_null_terminated_string_t *a, const sbp_null_terminated_string_t *b)
-{
-  return sbp_null_terminated_string_strcmp(a, b, &sbp_msg_fileio_write_req_tfilename_params);
+int sbp_msg_fileio_write_req_t_filename_strcmp(
+    const sbp_null_terminated_string_t *a,
+    const sbp_null_terminated_string_t *b) {
+  return sbp_null_terminated_string_strcmp(
+      a, b, &sbp_msg_fileio_write_req_tfilename_params);
 }
 
-  uint8_t sbp_msg_fileio_write_req_t_filename_packed_len(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_packed_len(s, &sbp_msg_fileio_write_req_tfilename_params);
+uint8_t sbp_msg_fileio_write_req_t_filename_packed_len(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_packed_len(
+      s, &sbp_msg_fileio_write_req_tfilename_params);
 }
 
-  uint8_t sbp_msg_fileio_write_req_t_filename_space_remaining(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_space_remaining(s, &sbp_msg_fileio_write_req_tfilename_params);
-      }
-  bool sbp_msg_fileio_write_req_t_filename_set(sbp_null_terminated_string_t *s, const char *new_str)
-  {
-  return sbp_null_terminated_string_set(s, &sbp_msg_fileio_write_req_tfilename_params, new_str);
-  }
+uint8_t sbp_msg_fileio_write_req_t_filename_space_remaining(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_space_remaining(
+      s, &sbp_msg_fileio_write_req_tfilename_params);
+}
+bool sbp_msg_fileio_write_req_t_filename_set(sbp_null_terminated_string_t *s,
+                                             const char *new_str) {
+  return sbp_null_terminated_string_set(
+      s, &sbp_msg_fileio_write_req_tfilename_params, new_str);
+}
 
-  bool sbp_msg_fileio_write_req_t_filename_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_fileio_write_req_t_filename_printf(sbp_null_terminated_string_t *s,
+                                                const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_fileio_write_req_t_filename_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_null_terminated_string_vprintf(s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
-  }
-
-  bool sbp_msg_fileio_write_req_t_filename_append_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_fileio_write_req_t_filename_append_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_null_terminated_string_append_vprintf(s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
+bool sbp_msg_fileio_write_req_t_filename_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
 }
 
-  const char *sbp_msg_fileio_write_req_t_filename_get(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_get(s, &sbp_msg_fileio_write_req_tfilename_params);
+bool sbp_msg_fileio_write_req_t_filename_append_printf(
+    sbp_null_terminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_write_req_t(const sbp_msg_fileio_write_req_t *msg) {
+bool sbp_msg_fileio_write_req_t_filename_append_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_fileio_write_req_tfilename_params, fmt, ap);
+}
+
+const char *sbp_msg_fileio_write_req_t_filename_get(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_get(
+      s, &sbp_msg_fileio_write_req_tfilename_params);
+}
+
+size_t sbp_packed_size_sbp_msg_fileio_write_req_t(
+    const sbp_msg_fileio_write_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += sbp_packed_size_u32(&msg->offset);
-  packed_size += sbp_null_terminated_string_packed_len(&msg->filename, &sbp_msg_fileio_write_req_tfilename_params);
+  packed_size += sbp_null_terminated_string_packed_len(
+      &msg->filename, &sbp_msg_fileio_write_req_tfilename_params);
   packed_size += (msg->n_data * sbp_packed_size_u8(&msg->data[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_write_req_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!encode_u32(ctx, &msg->offset)) { return false; }
-  if (!sbp_null_terminated_string_pack(&msg->filename, &sbp_msg_fileio_write_req_tfilename_params, ctx)) { return false; }
-  for (uint8_t i = 0; i < msg->n_data; i++)
-  {
-    if (!encode_u8(ctx, &msg->data[i])) { return false; }
+bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_fileio_write_req_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->offset)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_pack(
+          &msg->filename, &sbp_msg_fileio_write_req_tfilename_params, ctx)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_data; i++) {
+    if (!encode_u8(ctx, &msg->data[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_write_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_write_req_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_write_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_write_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -753,19 +974,31 @@ s8 sbp_encode_sbp_msg_fileio_write_req_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_write_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_write_req_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!decode_u32(ctx, &msg->offset)) { return false; }
-  if (!sbp_null_terminated_string_unpack(&msg->filename, &sbp_msg_fileio_write_req_tfilename_params, ctx)) { return false; }
-    msg->n_data = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->data[0]));
+bool decode_sbp_msg_fileio_write_req_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_fileio_write_req_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->offset)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_unpack(
+          &msg->filename, &sbp_msg_fileio_write_req_tfilename_params, ctx)) {
+    return false;
+  }
+  msg->n_data = (uint8_t)((ctx->buf_len - ctx->offset) /
+                          sbp_packed_size_u8(&msg->data[0]));
   for (uint8_t i = 0; i < msg->n_data; i++) {
-    if (!decode_u8(ctx, &msg->data[i])) { return false; }
+    if (!decode_u8(ctx, &msg->data[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_write_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_write_req_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_write_req_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_fileio_write_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -778,49 +1011,68 @@ s8 sbp_decode_sbp_msg_fileio_write_req_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_write_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_write_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_write_req_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_fileio_write_req_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_write_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_WRITE_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_write_req_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_WRITE_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_write_req_t(const sbp_msg_fileio_write_req_t *a, const sbp_msg_fileio_write_req_t *b) {
+int sbp_cmp_sbp_msg_fileio_write_req_t(const sbp_msg_fileio_write_req_t *a,
+                                       const sbp_msg_fileio_write_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->offset, &b->offset);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_null_terminated_string_strcmp(&a->filename, &b->filename, &sbp_msg_fileio_write_req_tfilename_params);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_null_terminated_string_strcmp(
+      &a->filename, &b->filename, &sbp_msg_fileio_write_req_tfilename_params);
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_data, &b->n_data);
-  for (uint8_t i = 0; i < a->n_data && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_data && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->data[i], &b->data[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_write_resp_t(const sbp_msg_fileio_write_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_fileio_write_resp_t(
+    const sbp_msg_fileio_write_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_write_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_write_resp_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
+bool encode_sbp_msg_fileio_write_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_write_resp_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_write_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_write_resp_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_write_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_write_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -834,13 +1086,17 @@ s8 sbp_encode_sbp_msg_fileio_write_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_write_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_write_resp_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
+bool decode_sbp_msg_fileio_write_resp_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_fileio_write_resp_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_write_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_write_resp_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_write_resp_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_fileio_write_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -853,36 +1109,49 @@ s8 sbp_decode_sbp_msg_fileio_write_resp_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_write_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_write_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_write_resp_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_fileio_write_resp_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_write_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_WRITE_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_write_resp_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_WRITE_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_write_resp_t(const sbp_msg_fileio_write_resp_t *a, const sbp_msg_fileio_write_resp_t *b) {
+int sbp_cmp_sbp_msg_fileio_write_resp_t(const sbp_msg_fileio_write_resp_t *a,
+                                        const sbp_msg_fileio_write_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_config_req_t(const sbp_msg_fileio_config_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_fileio_config_req_t(
+    const sbp_msg_fileio_config_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_config_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_req_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
+bool encode_sbp_msg_fileio_config_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_req_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_config_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_config_req_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_config_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_config_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -896,13 +1165,17 @@ s8 sbp_encode_sbp_msg_fileio_config_req_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_config_req_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_config_req_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
+bool decode_sbp_msg_fileio_config_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_fileio_config_req_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_config_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_config_req_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_config_req_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_fileio_config_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -915,24 +1188,33 @@ s8 sbp_decode_sbp_msg_fileio_config_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_config_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_config_req_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_fileio_config_req_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_config_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_CONFIG_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_config_req_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_CONFIG_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_config_req_t(const sbp_msg_fileio_config_req_t *a, const sbp_msg_fileio_config_req_t *b) {
+int sbp_cmp_sbp_msg_fileio_config_req_t(const sbp_msg_fileio_config_req_t *a,
+                                        const sbp_msg_fileio_config_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_fileio_config_resp_t(const sbp_msg_fileio_config_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_fileio_config_resp_t(
+    const sbp_msg_fileio_config_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += sbp_packed_size_u32(&msg->window_size);
@@ -941,16 +1223,26 @@ size_t sbp_packed_size_sbp_msg_fileio_config_resp_t(const sbp_msg_fileio_config_
   return packed_size;
 }
 
-bool encode_sbp_msg_fileio_config_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_resp_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!encode_u32(ctx, &msg->window_size)) { return false; }
-  if (!encode_u32(ctx, &msg->batch_size)) { return false; }
-  if (!encode_u32(ctx, &msg->fileio_version)) { return false; }
+bool encode_sbp_msg_fileio_config_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_fileio_config_resp_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->window_size)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->batch_size)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->fileio_version)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fileio_config_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fileio_config_resp_t *msg) {
+s8 sbp_encode_sbp_msg_fileio_config_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_fileio_config_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -964,16 +1256,26 @@ s8 sbp_encode_sbp_msg_fileio_config_resp_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fileio_config_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_fileio_config_resp_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!decode_u32(ctx, &msg->window_size)) { return false; }
-  if (!decode_u32(ctx, &msg->batch_size)) { return false; }
-  if (!decode_u32(ctx, &msg->fileio_version)) { return false; }
+bool decode_sbp_msg_fileio_config_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_fileio_config_resp_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->window_size)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->batch_size)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->fileio_version)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fileio_config_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fileio_config_resp_t *msg) {
+s8 sbp_decode_sbp_msg_fileio_config_resp_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_fileio_config_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -986,28 +1288,43 @@ s8 sbp_decode_sbp_msg_fileio_config_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_config_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fileio_config_resp_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_resp_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fileio_config_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FILEIO_CONFIG_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_fileio_config_resp_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FILEIO_CONFIG_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_fileio_config_resp_t(const sbp_msg_fileio_config_resp_t *a, const sbp_msg_fileio_config_resp_t *b) {
+int sbp_cmp_sbp_msg_fileio_config_resp_t(
+    const sbp_msg_fileio_config_resp_t *a,
+    const sbp_msg_fileio_config_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->window_size, &b->window_size);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->batch_size, &b->batch_size);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->fileio_version, &b->fileio_version);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/file_io.c
+++ b/c/src/new/file_io.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/file_io.yaml
  * with generate.py. Please do not hand edit!
@@ -180,6 +168,7 @@ s8 sbp_decode_sbp_msg_fileio_read_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_read_req_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_fileio_read_req_t *msg,
                                       sbp_write_fn_t write) {
@@ -213,8 +202,7 @@ int sbp_cmp_sbp_msg_fileio_read_req_t(const sbp_msg_fileio_read_req_t *a,
     return ret;
   }
 
-  ret = sbp_null_terminated_string_strcmp(
-      &a->filename, &b->filename, &sbp_msg_fileio_read_req_tfilename_params);
+  ret = sbp_msg_fileio_read_req_t_filename_strcmp(&a->filename, &b->filename);
   if (ret != 0) {
     return ret;
   }
@@ -234,7 +222,7 @@ bool encode_sbp_msg_fileio_read_resp_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->sequence)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_contents; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_contents; i++) {
     if (!encode_u8(ctx, &msg->contents[i])) {
       return false;
     }
@@ -288,6 +276,7 @@ s8 sbp_decode_sbp_msg_fileio_read_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_read_resp_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_fileio_read_resp_t *msg,
                                        sbp_write_fn_t write) {
@@ -312,7 +301,7 @@ int sbp_cmp_sbp_msg_fileio_read_resp_t(const sbp_msg_fileio_read_resp_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_contents, &b->n_contents);
-  for (uint8_t i = 0; i < a->n_contents && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_contents; i++) {
     ret = sbp_cmp_u8(&a->contents[i], &b->contents[i]);
   }
   if (ret != 0) {
@@ -468,6 +457,7 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_req_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_read_dir_req_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_fileio_read_dir_req_t *msg, sbp_write_fn_t write) {
@@ -497,8 +487,7 @@ int sbp_cmp_sbp_msg_fileio_read_dir_req_t(
     return ret;
   }
 
-  ret = sbp_null_terminated_string_strcmp(
-      &a->dirname, &b->dirname, &sbp_msg_fileio_read_dir_req_tdirname_params);
+  ret = sbp_msg_fileio_read_dir_req_t_dirname_strcmp(&a->dirname, &b->dirname);
   if (ret != 0) {
     return ret;
   }
@@ -662,6 +651,7 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_resp_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_read_dir_resp_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_fileio_read_dir_resp_t *msg, sbp_write_fn_t write) {
@@ -686,9 +676,8 @@ int sbp_cmp_sbp_msg_fileio_read_dir_resp_t(
     return ret;
   }
 
-  ret = sbp_multipart_string_strcmp(
-      &a->contents, &b->contents,
-      &sbp_msg_fileio_read_dir_resp_tcontents_params);
+  ret = sbp_msg_fileio_read_dir_resp_t_contents_strcmp(&a->contents,
+                                                       &b->contents);
   if (ret != 0) {
     return ret;
   }
@@ -826,6 +815,7 @@ s8 sbp_decode_sbp_msg_fileio_remove_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_remove_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_fileio_remove_t *msg,
                                     sbp_write_fn_t write) {
@@ -844,8 +834,7 @@ int sbp_cmp_sbp_msg_fileio_remove_t(const sbp_msg_fileio_remove_t *a,
                                     const sbp_msg_fileio_remove_t *b) {
   int ret = 0;
 
-  ret = sbp_null_terminated_string_strcmp(
-      &a->filename, &b->filename, &sbp_msg_fileio_remove_tfilename_params);
+  ret = sbp_msg_fileio_remove_t_filename_strcmp(&a->filename, &b->filename);
   if (ret != 0) {
     return ret;
   }
@@ -950,7 +939,7 @@ bool encode_sbp_msg_fileio_write_req_t(sbp_encode_ctx_t *ctx,
           &msg->filename, &sbp_msg_fileio_write_req_tfilename_params, ctx)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_data; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_data; i++) {
     if (!encode_u8(ctx, &msg->data[i])) {
       return false;
     }
@@ -1011,6 +1000,7 @@ s8 sbp_decode_sbp_msg_fileio_write_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_write_req_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_fileio_write_req_t *msg,
                                        sbp_write_fn_t write) {
@@ -1039,14 +1029,13 @@ int sbp_cmp_sbp_msg_fileio_write_req_t(const sbp_msg_fileio_write_req_t *a,
     return ret;
   }
 
-  ret = sbp_null_terminated_string_strcmp(
-      &a->filename, &b->filename, &sbp_msg_fileio_write_req_tfilename_params);
+  ret = sbp_msg_fileio_write_req_t_filename_strcmp(&a->filename, &b->filename);
   if (ret != 0) {
     return ret;
   }
 
   ret = sbp_cmp_u8(&a->n_data, &b->n_data);
-  for (uint8_t i = 0; i < a->n_data && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_data; i++) {
     ret = sbp_cmp_u8(&a->data[i], &b->data[i]);
   }
   if (ret != 0) {
@@ -1109,6 +1098,7 @@ s8 sbp_decode_sbp_msg_fileio_write_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_write_resp_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_fileio_write_resp_t *msg,
                                         sbp_write_fn_t write) {
@@ -1188,6 +1178,7 @@ s8 sbp_decode_sbp_msg_fileio_config_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_config_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_fileio_config_req_t *msg,
                                         sbp_write_fn_t write) {
@@ -1288,6 +1279,7 @@ s8 sbp_decode_sbp_msg_fileio_config_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fileio_config_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_resp_t *msg,
     sbp_write_fn_t write) {

--- a/c/src/new/flash.c
+++ b/c/src/new/flash.c
@@ -1,41 +1,67 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/flash.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/flash.h>
 #include <libsbp/internal/new/flash.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/flash.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_msg_flash_program_t(const sbp_msg_flash_program_t *msg) {
+size_t sbp_packed_size_sbp_msg_flash_program_t(
+    const sbp_msg_flash_program_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->target);
-  packed_size += ( 3 * sbp_packed_size_u8(&msg->addr_start[0]));
+  packed_size += (3 * sbp_packed_size_u8(&msg->addr_start[0]));
   packed_size += sbp_packed_size_u8(&msg->addr_len);
   packed_size += (msg->addr_len * sbp_packed_size_u8(&msg->data[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_program_t *msg)
-{
-  if (!encode_u8(ctx, &msg->target)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_u8(ctx, &msg->addr_start[i])) { return false; }
+bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_flash_program_t *msg) {
+  if (!encode_u8(ctx, &msg->target)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->addr_len)) { return false; }
-  for (uint8_t i = 0; i < msg->addr_len; i++)
-  {
-    if (!encode_u8(ctx, &msg->data[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_u8(ctx, &msg->addr_start[i])) {
+      return false;
+    }
+  }
+  if (!encode_u8(ctx, &msg->addr_len)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->addr_len; i++) {
+    if (!encode_u8(ctx, &msg->data[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_flash_program_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_flash_program_t *msg) {
+s8 sbp_encode_sbp_msg_flash_program_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_flash_program_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -49,21 +75,32 @@ s8 sbp_encode_sbp_msg_flash_program_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_flash_program_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_program_t *msg)
-{
-  if (!decode_u8(ctx, &msg->target)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_u8(ctx, &msg->addr_start[i])) { return false; }
+bool decode_sbp_msg_flash_program_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_flash_program_t *msg) {
+  if (!decode_u8(ctx, &msg->target)) {
+    return false;
   }
-  if (!decode_u8(ctx, &msg->addr_len)) { return false; }
-    msg->addr_len = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->data[0]));
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_u8(ctx, &msg->addr_start[i])) {
+      return false;
+    }
+  }
+  if (!decode_u8(ctx, &msg->addr_len)) {
+    return false;
+  }
+  msg->addr_len = (uint8_t)((ctx->buf_len - ctx->offset) /
+                            sbp_packed_size_u8(&msg->data[0]));
   for (uint8_t i = 0; i < msg->addr_len; i++) {
-    if (!decode_u8(ctx, &msg->data[i])) { return false; }
+    if (!decode_u8(ctx, &msg->data[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_flash_program_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_flash_program_t *msg) {
+s8 sbp_decode_sbp_msg_flash_program_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_flash_program_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -76,36 +113,48 @@ s8 sbp_decode_sbp_msg_flash_program_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_program_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_program_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_flash_program_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_flash_program_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_flash_program_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FLASH_PROGRAM, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_flash_program_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FLASH_PROGRAM, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_flash_program_t(const sbp_msg_flash_program_t *a, const sbp_msg_flash_program_t *b) {
+int sbp_cmp_sbp_msg_flash_program_t(const sbp_msg_flash_program_t *a,
+                                    const sbp_msg_flash_program_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->target, &b->target);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->addr_start[i], &b->addr_start[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->addr_len, &b->addr_len);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->addr_len, &b->addr_len);
-  for (uint8_t i = 0; i < a->addr_len && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->addr_len && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->data[i], &b->data[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -115,13 +164,17 @@ size_t sbp_packed_size_sbp_msg_flash_done_t(const sbp_msg_flash_done_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_flash_done_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_done_t *msg)
-{
-  if (!encode_u8(ctx, &msg->response)) { return false; }
+bool encode_sbp_msg_flash_done_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_flash_done_t *msg) {
+  if (!encode_u8(ctx, &msg->response)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_flash_done_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_flash_done_t *msg) {
+s8 sbp_encode_sbp_msg_flash_done_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_flash_done_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -135,13 +188,16 @@ s8 sbp_encode_sbp_msg_flash_done_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_flash_done_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_done_t *msg)
-{
-  if (!decode_u8(ctx, &msg->response)) { return false; }
+bool decode_sbp_msg_flash_done_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_flash_done_t *msg) {
+  if (!decode_u8(ctx, &msg->response)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_flash_done_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_flash_done_t *msg) {
+s8 sbp_decode_sbp_msg_flash_done_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_flash_done_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -154,43 +210,59 @@ s8 sbp_decode_sbp_msg_flash_done_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_done_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_done_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_flash_done_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_flash_done_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_flash_done_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FLASH_DONE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_flash_done_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FLASH_DONE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_flash_done_t(const sbp_msg_flash_done_t *a, const sbp_msg_flash_done_t *b) {
+int sbp_cmp_sbp_msg_flash_done_t(const sbp_msg_flash_done_t *a,
+                                 const sbp_msg_flash_done_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->response, &b->response);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_flash_read_req_t(const sbp_msg_flash_read_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_flash_read_req_t(
+    const sbp_msg_flash_read_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->target);
-  packed_size += ( 3 * sbp_packed_size_u8(&msg->addr_start[0]));
+  packed_size += (3 * sbp_packed_size_u8(&msg->addr_start[0]));
   packed_size += sbp_packed_size_u8(&msg->addr_len);
   return packed_size;
 }
 
-bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_read_req_t *msg)
-{
-  if (!encode_u8(ctx, &msg->target)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_u8(ctx, &msg->addr_start[i])) { return false; }
+bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_flash_read_req_t *msg) {
+  if (!encode_u8(ctx, &msg->target)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->addr_len)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_u8(ctx, &msg->addr_start[i])) {
+      return false;
+    }
+  }
+  if (!encode_u8(ctx, &msg->addr_len)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_flash_read_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_flash_read_req_t *msg) {
+s8 sbp_encode_sbp_msg_flash_read_req_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_flash_read_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -204,17 +276,25 @@ s8 sbp_encode_sbp_msg_flash_read_req_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_flash_read_req_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_read_req_t *msg)
-{
-  if (!decode_u8(ctx, &msg->target)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_u8(ctx, &msg->addr_start[i])) { return false; }
+bool decode_sbp_msg_flash_read_req_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_flash_read_req_t *msg) {
+  if (!decode_u8(ctx, &msg->target)) {
+    return false;
   }
-  if (!decode_u8(ctx, &msg->addr_len)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_u8(ctx, &msg->addr_start[i])) {
+      return false;
+    }
+  }
+  if (!decode_u8(ctx, &msg->addr_len)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_flash_read_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_flash_read_req_t *msg) {
+s8 sbp_decode_sbp_msg_flash_read_req_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_flash_read_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -227,52 +307,71 @@ s8 sbp_decode_sbp_msg_flash_read_req_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_read_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_flash_read_req_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_flash_read_req_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_flash_read_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FLASH_READ_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_flash_read_req_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FLASH_READ_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_flash_read_req_t(const sbp_msg_flash_read_req_t *a, const sbp_msg_flash_read_req_t *b) {
+int sbp_cmp_sbp_msg_flash_read_req_t(const sbp_msg_flash_read_req_t *a,
+                                     const sbp_msg_flash_read_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->target, &b->target);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->addr_start[i], &b->addr_start[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->addr_len, &b->addr_len);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_flash_read_resp_t(const sbp_msg_flash_read_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_flash_read_resp_t(
+    const sbp_msg_flash_read_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->target);
-  packed_size += ( 3 * sbp_packed_size_u8(&msg->addr_start[0]));
+  packed_size += (3 * sbp_packed_size_u8(&msg->addr_start[0]));
   packed_size += sbp_packed_size_u8(&msg->addr_len);
   return packed_size;
 }
 
-bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_read_resp_t *msg)
-{
-  if (!encode_u8(ctx, &msg->target)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_u8(ctx, &msg->addr_start[i])) { return false; }
+bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_flash_read_resp_t *msg) {
+  if (!encode_u8(ctx, &msg->target)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->addr_len)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_u8(ctx, &msg->addr_start[i])) {
+      return false;
+    }
+  }
+  if (!encode_u8(ctx, &msg->addr_len)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_flash_read_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_flash_read_resp_t *msg) {
+s8 sbp_encode_sbp_msg_flash_read_resp_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_flash_read_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -286,17 +385,25 @@ s8 sbp_encode_sbp_msg_flash_read_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_flash_read_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_read_resp_t *msg)
-{
-  if (!decode_u8(ctx, &msg->target)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_u8(ctx, &msg->addr_start[i])) { return false; }
+bool decode_sbp_msg_flash_read_resp_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_flash_read_resp_t *msg) {
+  if (!decode_u8(ctx, &msg->target)) {
+    return false;
   }
-  if (!decode_u8(ctx, &msg->addr_len)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_u8(ctx, &msg->addr_start[i])) {
+      return false;
+    }
+  }
+  if (!decode_u8(ctx, &msg->addr_len)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_flash_read_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_flash_read_resp_t *msg) {
+s8 sbp_decode_sbp_msg_flash_read_resp_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_flash_read_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -309,29 +416,40 @@ s8 sbp_decode_sbp_msg_flash_read_resp_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_read_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_flash_read_resp_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_flash_read_resp_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_flash_read_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FLASH_READ_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_flash_read_resp_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FLASH_READ_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_flash_read_resp_t(const sbp_msg_flash_read_resp_t *a, const sbp_msg_flash_read_resp_t *b) {
+int sbp_cmp_sbp_msg_flash_read_resp_t(const sbp_msg_flash_read_resp_t *a,
+                                      const sbp_msg_flash_read_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->target, &b->target);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->addr_start[i], &b->addr_start[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->addr_len, &b->addr_len);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -342,14 +460,20 @@ size_t sbp_packed_size_sbp_msg_flash_erase_t(const sbp_msg_flash_erase_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_flash_erase_t(sbp_encode_ctx_t *ctx, const sbp_msg_flash_erase_t *msg)
-{
-  if (!encode_u8(ctx, &msg->target)) { return false; }
-  if (!encode_u32(ctx, &msg->sector_num)) { return false; }
+bool encode_sbp_msg_flash_erase_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_flash_erase_t *msg) {
+  if (!encode_u8(ctx, &msg->target)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->sector_num)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_flash_erase_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_flash_erase_t *msg) {
+s8 sbp_encode_sbp_msg_flash_erase_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_flash_erase_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -363,14 +487,20 @@ s8 sbp_encode_sbp_msg_flash_erase_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_flash_erase_t(sbp_decode_ctx_t *ctx, sbp_msg_flash_erase_t *msg)
-{
-  if (!decode_u8(ctx, &msg->target)) { return false; }
-  if (!decode_u32(ctx, &msg->sector_num)) { return false; }
+bool decode_sbp_msg_flash_erase_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_flash_erase_t *msg) {
+  if (!decode_u8(ctx, &msg->target)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->sector_num)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_flash_erase_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_flash_erase_t *msg) {
+s8 sbp_decode_sbp_msg_flash_erase_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_flash_erase_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -383,39 +513,54 @@ s8 sbp_decode_sbp_msg_flash_erase_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_erase_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_erase_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_flash_erase_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_flash_erase_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_flash_erase_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FLASH_ERASE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_flash_erase_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FLASH_ERASE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_flash_erase_t(const sbp_msg_flash_erase_t *a, const sbp_msg_flash_erase_t *b) {
+int sbp_cmp_sbp_msg_flash_erase_t(const sbp_msg_flash_erase_t *a,
+                                  const sbp_msg_flash_erase_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->target, &b->target);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->sector_num, &b->sector_num);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_stm_flash_lock_sector_t(const sbp_msg_stm_flash_lock_sector_t *msg) {
+size_t sbp_packed_size_sbp_msg_stm_flash_lock_sector_t(
+    const sbp_msg_stm_flash_lock_sector_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sector);
   return packed_size;
 }
 
-bool encode_sbp_msg_stm_flash_lock_sector_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_lock_sector_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sector)) { return false; }
+bool encode_sbp_msg_stm_flash_lock_sector_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_lock_sector_t *msg) {
+  if (!encode_u32(ctx, &msg->sector)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_stm_flash_lock_sector_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_stm_flash_lock_sector_t *msg) {
+s8 sbp_encode_sbp_msg_stm_flash_lock_sector_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_stm_flash_lock_sector_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -429,13 +574,17 @@ s8 sbp_encode_sbp_msg_stm_flash_lock_sector_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_msg_stm_flash_lock_sector_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_lock_sector_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sector)) { return false; }
+bool decode_sbp_msg_stm_flash_lock_sector_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_lock_sector_t *msg) {
+  if (!decode_u32(ctx, &msg->sector)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_stm_flash_lock_sector_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_stm_flash_lock_sector_t *msg) {
+s8 sbp_decode_sbp_msg_stm_flash_lock_sector_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_stm_flash_lock_sector_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -448,36 +597,50 @@ s8 sbp_decode_sbp_msg_stm_flash_lock_sector_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_flash_lock_sector_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_flash_lock_sector_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_stm_flash_lock_sector_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_stm_flash_lock_sector_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_stm_flash_lock_sector_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_STM_FLASH_LOCK_SECTOR, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_stm_flash_lock_sector_t(payload, sizeof(payload),
+                                                      &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_STM_FLASH_LOCK_SECTOR, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_stm_flash_lock_sector_t(const sbp_msg_stm_flash_lock_sector_t *a, const sbp_msg_stm_flash_lock_sector_t *b) {
+int sbp_cmp_sbp_msg_stm_flash_lock_sector_t(
+    const sbp_msg_stm_flash_lock_sector_t *a,
+    const sbp_msg_stm_flash_lock_sector_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sector, &b->sector);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_stm_flash_unlock_sector_t(const sbp_msg_stm_flash_unlock_sector_t *msg) {
+size_t sbp_packed_size_sbp_msg_stm_flash_unlock_sector_t(
+    const sbp_msg_stm_flash_unlock_sector_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sector);
   return packed_size;
 }
 
-bool encode_sbp_msg_stm_flash_unlock_sector_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_unlock_sector_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sector)) { return false; }
+bool encode_sbp_msg_stm_flash_unlock_sector_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_flash_unlock_sector_t *msg) {
+  if (!encode_u32(ctx, &msg->sector)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_stm_flash_unlock_sector_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_stm_flash_unlock_sector_t *msg) {
+s8 sbp_encode_sbp_msg_stm_flash_unlock_sector_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_stm_flash_unlock_sector_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -491,13 +654,17 @@ s8 sbp_encode_sbp_msg_stm_flash_unlock_sector_t(uint8_t *buf, uint8_t len, uint8
   return SBP_OK;
 }
 
-bool decode_sbp_msg_stm_flash_unlock_sector_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_unlock_sector_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sector)) { return false; }
+bool decode_sbp_msg_stm_flash_unlock_sector_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_stm_flash_unlock_sector_t *msg) {
+  if (!decode_u32(ctx, &msg->sector)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_stm_flash_unlock_sector_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_stm_flash_unlock_sector_t *msg) {
+s8 sbp_decode_sbp_msg_stm_flash_unlock_sector_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_stm_flash_unlock_sector_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -510,36 +677,48 @@ s8 sbp_decode_sbp_msg_stm_flash_unlock_sector_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_flash_unlock_sector_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_flash_unlock_sector_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_stm_flash_unlock_sector_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_stm_flash_unlock_sector_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_stm_flash_unlock_sector_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_STM_FLASH_UNLOCK_SECTOR, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_stm_flash_unlock_sector_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_STM_FLASH_UNLOCK_SECTOR, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_stm_flash_unlock_sector_t(const sbp_msg_stm_flash_unlock_sector_t *a, const sbp_msg_stm_flash_unlock_sector_t *b) {
+int sbp_cmp_sbp_msg_stm_flash_unlock_sector_t(
+    const sbp_msg_stm_flash_unlock_sector_t *a,
+    const sbp_msg_stm_flash_unlock_sector_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sector, &b->sector);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_stm_unique_id_req_t(const sbp_msg_stm_unique_id_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_stm_unique_id_req_t(
+    const sbp_msg_stm_unique_id_req_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_stm_unique_id_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_req_t *msg)
-{
+bool encode_sbp_msg_stm_unique_id_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_req_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_stm_unique_id_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_stm_unique_id_req_t *msg) {
+s8 sbp_encode_sbp_msg_stm_unique_id_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_stm_unique_id_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -553,14 +732,16 @@ s8 sbp_encode_sbp_msg_stm_unique_id_req_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_stm_unique_id_req_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_unique_id_req_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_stm_unique_id_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_stm_unique_id_req_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_stm_unique_id_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_stm_unique_id_req_t *msg) {
+s8 sbp_decode_sbp_msg_stm_unique_id_req_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_stm_unique_id_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -573,38 +754,48 @@ s8 sbp_decode_sbp_msg_stm_unique_id_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_unique_id_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_stm_unique_id_req_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_stm_unique_id_req_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_stm_unique_id_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_STM_UNIQUE_ID_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_stm_unique_id_req_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_STM_UNIQUE_ID_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_stm_unique_id_req_t(const sbp_msg_stm_unique_id_req_t *a, const sbp_msg_stm_unique_id_req_t *b) {
+int sbp_cmp_sbp_msg_stm_unique_id_req_t(const sbp_msg_stm_unique_id_req_t *a,
+                                        const sbp_msg_stm_unique_id_req_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_stm_unique_id_resp_t(const sbp_msg_stm_unique_id_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_stm_unique_id_resp_t(
+    const sbp_msg_stm_unique_id_resp_t *msg) {
   size_t packed_size = 0;
-  packed_size += ( 12 * sbp_packed_size_u8(&msg->stm_id[0]));
+  packed_size += (12 * sbp_packed_size_u8(&msg->stm_id[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_stm_unique_id_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg)
-{
-  for (uint8_t i = 0; i < 12; i++)
-  {
-    if (!encode_u8(ctx, &msg->stm_id[i])) { return false; }
+bool encode_sbp_msg_stm_unique_id_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg) {
+  for (uint8_t i = 0; i < 12; i++) {
+    if (!encode_u8(ctx, &msg->stm_id[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_stm_unique_id_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_stm_unique_id_resp_t *msg) {
+s8 sbp_encode_sbp_msg_stm_unique_id_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_stm_unique_id_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -618,15 +809,19 @@ s8 sbp_encode_sbp_msg_stm_unique_id_resp_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_stm_unique_id_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_stm_unique_id_resp_t *msg)
-{
+bool decode_sbp_msg_stm_unique_id_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_stm_unique_id_resp_t *msg) {
   for (uint8_t i = 0; i < 12; i++) {
-    if (!decode_u8(ctx, &msg->stm_id[i])) { return false; }
+    if (!decode_u8(ctx, &msg->stm_id[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_stm_unique_id_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_stm_unique_id_resp_t *msg) {
+s8 sbp_decode_sbp_msg_stm_unique_id_resp_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_stm_unique_id_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -639,42 +834,54 @@ s8 sbp_decode_sbp_msg_stm_unique_id_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_unique_id_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_stm_unique_id_resp_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_resp_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_stm_unique_id_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_STM_UNIQUE_ID_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_stm_unique_id_resp_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_STM_UNIQUE_ID_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_stm_unique_id_resp_t(const sbp_msg_stm_unique_id_resp_t *a, const sbp_msg_stm_unique_id_resp_t *b) {
+int sbp_cmp_sbp_msg_stm_unique_id_resp_t(
+    const sbp_msg_stm_unique_id_resp_t *a,
+    const sbp_msg_stm_unique_id_resp_t *b) {
   int ret = 0;
-  
-  for (uint8_t i = 0; i < 12 && ret == 0; i++)
-  {
+
+  for (uint8_t i = 0; i < 12 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->stm_id[i], &b->stm_id[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_m25_flash_write_status_t(const sbp_msg_m25_flash_write_status_t *msg) {
+size_t sbp_packed_size_sbp_msg_m25_flash_write_status_t(
+    const sbp_msg_m25_flash_write_status_t *msg) {
   size_t packed_size = 0;
-  packed_size += ( 1 * sbp_packed_size_u8(&msg->status[0]));
+  packed_size += (1 * sbp_packed_size_u8(&msg->status[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_m25_flash_write_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg)
-{
-  for (uint8_t i = 0; i < 1; i++)
-  {
-    if (!encode_u8(ctx, &msg->status[i])) { return false; }
+bool encode_sbp_msg_m25_flash_write_status_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg) {
+  for (uint8_t i = 0; i < 1; i++) {
+    if (!encode_u8(ctx, &msg->status[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_m25_flash_write_status_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_m25_flash_write_status_t *msg) {
+s8 sbp_encode_sbp_msg_m25_flash_write_status_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_m25_flash_write_status_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -688,15 +895,19 @@ s8 sbp_encode_sbp_msg_m25_flash_write_status_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_m25_flash_write_status_t(sbp_decode_ctx_t *ctx, sbp_msg_m25_flash_write_status_t *msg)
-{
+bool decode_sbp_msg_m25_flash_write_status_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_m25_flash_write_status_t *msg) {
   for (uint8_t i = 0; i < 1; i++) {
-    if (!decode_u8(ctx, &msg->status[i])) { return false; }
+    if (!decode_u8(ctx, &msg->status[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_m25_flash_write_status_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_m25_flash_write_status_t *msg) {
+s8 sbp_decode_sbp_msg_m25_flash_write_status_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_m25_flash_write_status_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -709,22 +920,30 @@ s8 sbp_decode_sbp_msg_m25_flash_write_status_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_m25_flash_write_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_m25_flash_write_status_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_m25_flash_write_status_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_m25_flash_write_status_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_m25_flash_write_status_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_M25_FLASH_WRITE_STATUS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_m25_flash_write_status_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_M25_FLASH_WRITE_STATUS, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_m25_flash_write_status_t(const sbp_msg_m25_flash_write_status_t *a, const sbp_msg_m25_flash_write_status_t *b) {
+int sbp_cmp_sbp_msg_m25_flash_write_status_t(
+    const sbp_msg_m25_flash_write_status_t *a,
+    const sbp_msg_m25_flash_write_status_t *b) {
   int ret = 0;
-  
-  for (uint8_t i = 0; i < 1 && ret == 0; i++)
-  {
+
+  for (uint8_t i = 0; i < 1 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->status[i], &b->status[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/flash.c
+++ b/c/src/new/flash.c
@@ -31,7 +31,7 @@ bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_u8(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -39,7 +39,7 @@ bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->addr_len)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->addr_len; i++) {
+  for (uint8_t i = 0; i < msg->addr_len; i++) {
     if (!encode_u8(ctx, &msg->data[i])) {
       return false;
     }
@@ -239,7 +239,7 @@ bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_u8(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -349,7 +349,7 @@ bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_u8(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -781,7 +781,7 @@ size_t sbp_packed_size_sbp_msg_stm_unique_id_resp_t(
 
 bool encode_sbp_msg_stm_unique_id_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < 12; i++) {
+  for (uint8_t i = 0; i < 12; i++) {
     if (!encode_u8(ctx, &msg->stm_id[i])) {
       return false;
     }
@@ -868,7 +868,7 @@ size_t sbp_packed_size_sbp_msg_m25_flash_write_status_t(
 
 bool encode_sbp_msg_m25_flash_write_status_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < 1; i++) {
+  for (uint8_t i = 0; i < 1; i++) {
     if (!encode_u8(ctx, &msg->status[i])) {
       return false;
     }

--- a/c/src/new/flash.c
+++ b/c/src/new/flash.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/flash.yaml
  * with generate.py. Please do not hand edit!
@@ -43,7 +31,7 @@ bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_u8(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -51,7 +39,7 @@ bool encode_sbp_msg_flash_program_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->addr_len)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->addr_len; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->addr_len; i++) {
     if (!encode_u8(ctx, &msg->data[i])) {
       return false;
     }
@@ -113,6 +101,7 @@ s8 sbp_decode_sbp_msg_flash_program_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_flash_program_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_flash_program_t *msg,
                                     sbp_write_fn_t write) {
@@ -136,7 +125,7 @@ int sbp_cmp_sbp_msg_flash_program_t(const sbp_msg_flash_program_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_u8(&a->addr_start[i], &b->addr_start[i]);
   }
   if (ret != 0) {
@@ -149,7 +138,7 @@ int sbp_cmp_sbp_msg_flash_program_t(const sbp_msg_flash_program_t *a,
   }
 
   ret = sbp_cmp_u8(&a->addr_len, &b->addr_len);
-  for (uint8_t i = 0; i < a->addr_len && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->addr_len; i++) {
     ret = sbp_cmp_u8(&a->data[i], &b->data[i]);
   }
   if (ret != 0) {
@@ -210,6 +199,7 @@ s8 sbp_decode_sbp_msg_flash_done_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_flash_done_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_flash_done_t *msg,
                                  sbp_write_fn_t write) {
@@ -249,7 +239,7 @@ bool encode_sbp_msg_flash_read_req_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_u8(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -307,6 +297,7 @@ s8 sbp_decode_sbp_msg_flash_read_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_flash_read_req_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_flash_read_req_t *msg,
                                      sbp_write_fn_t write) {
@@ -330,7 +321,7 @@ int sbp_cmp_sbp_msg_flash_read_req_t(const sbp_msg_flash_read_req_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_u8(&a->addr_start[i], &b->addr_start[i]);
   }
   if (ret != 0) {
@@ -358,7 +349,7 @@ bool encode_sbp_msg_flash_read_resp_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_u8(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -416,6 +407,7 @@ s8 sbp_decode_sbp_msg_flash_read_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_flash_read_resp_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_flash_read_resp_t *msg,
                                       sbp_write_fn_t write) {
@@ -439,7 +431,7 @@ int sbp_cmp_sbp_msg_flash_read_resp_t(const sbp_msg_flash_read_resp_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_u8(&a->addr_start[i], &b->addr_start[i]);
   }
   if (ret != 0) {
@@ -513,6 +505,7 @@ s8 sbp_decode_sbp_msg_flash_erase_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_flash_erase_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_flash_erase_t *msg,
                                   sbp_write_fn_t write) {
@@ -597,6 +590,7 @@ s8 sbp_decode_sbp_msg_stm_flash_lock_sector_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_stm_flash_lock_sector_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_stm_flash_lock_sector_t *msg, sbp_write_fn_t write) {
@@ -677,6 +671,7 @@ s8 sbp_decode_sbp_msg_stm_flash_unlock_sector_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_stm_flash_unlock_sector_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_stm_flash_unlock_sector_t *msg, sbp_write_fn_t write) {
@@ -754,6 +749,7 @@ s8 sbp_decode_sbp_msg_stm_unique_id_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_stm_unique_id_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_stm_unique_id_req_t *msg,
                                         sbp_write_fn_t write) {
@@ -785,7 +781,7 @@ size_t sbp_packed_size_sbp_msg_stm_unique_id_resp_t(
 
 bool encode_sbp_msg_stm_unique_id_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg) {
-  for (uint8_t i = 0; i < 12; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 12; i++) {
     if (!encode_u8(ctx, &msg->stm_id[i])) {
       return false;
     }
@@ -834,6 +830,7 @@ s8 sbp_decode_sbp_msg_stm_unique_id_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_stm_unique_id_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_resp_t *msg,
     sbp_write_fn_t write) {
@@ -853,7 +850,7 @@ int sbp_cmp_sbp_msg_stm_unique_id_resp_t(
     const sbp_msg_stm_unique_id_resp_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; i < 12 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 12; i++) {
     ret = sbp_cmp_u8(&a->stm_id[i], &b->stm_id[i]);
   }
   if (ret != 0) {
@@ -871,7 +868,7 @@ size_t sbp_packed_size_sbp_msg_m25_flash_write_status_t(
 
 bool encode_sbp_msg_m25_flash_write_status_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg) {
-  for (uint8_t i = 0; i < 1; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 1; i++) {
     if (!encode_u8(ctx, &msg->status[i])) {
       return false;
     }
@@ -920,6 +917,7 @@ s8 sbp_decode_sbp_msg_m25_flash_write_status_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_m25_flash_write_status_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_m25_flash_write_status_t *msg, sbp_write_fn_t write) {
@@ -939,7 +937,7 @@ int sbp_cmp_sbp_msg_m25_flash_write_status_t(
     const sbp_msg_m25_flash_write_status_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; i < 1 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 1; i++) {
     ret = sbp_cmp_u8(&a->status[i], &b->status[i]);
   }
   if (ret != 0) {

--- a/c/src/new/gnss.c
+++ b/c/src/new/gnss.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/gnss.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/gnss.h>
 #include <libsbp/internal/new/gnss.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/gnss.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_sbp_gnss_signal_t(const sbp_sbp_gnss_signal_t *msg) {
   size_t packed_size = 0;
@@ -18,14 +35,20 @@ size_t sbp_packed_size_sbp_sbp_gnss_signal_t(const sbp_sbp_gnss_signal_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_sbp_gnss_signal_t(sbp_encode_ctx_t *ctx, const sbp_sbp_gnss_signal_t *msg)
-{
-  if (!encode_u8(ctx, &msg->sat)) { return false; }
-  if (!encode_u8(ctx, &msg->code)) { return false; }
+bool encode_sbp_sbp_gnss_signal_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_sbp_gnss_signal_t *msg) {
+  if (!encode_u8(ctx, &msg->sat)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->code)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_sbp_gnss_signal_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_sbp_gnss_signal_t *msg) {
+s8 sbp_encode_sbp_sbp_gnss_signal_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_sbp_gnss_signal_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -39,14 +62,20 @@ s8 sbp_encode_sbp_sbp_gnss_signal_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_sbp_gnss_signal_t(sbp_decode_ctx_t *ctx, sbp_sbp_gnss_signal_t *msg)
-{
-  if (!decode_u8(ctx, &msg->sat)) { return false; }
-  if (!decode_u8(ctx, &msg->code)) { return false; }
+bool decode_sbp_sbp_gnss_signal_t(sbp_decode_ctx_t *ctx,
+                                  sbp_sbp_gnss_signal_t *msg) {
+  if (!decode_u8(ctx, &msg->sat)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->code)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_sbp_gnss_signal_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_sbp_gnss_signal_t *msg) {
+s8 sbp_decode_sbp_sbp_gnss_signal_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_sbp_gnss_signal_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -60,14 +89,19 @@ s8 sbp_decode_sbp_sbp_gnss_signal_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_sbp_gnss_signal_t(const sbp_sbp_gnss_signal_t *a, const sbp_sbp_gnss_signal_t *b) {
+int sbp_cmp_sbp_sbp_gnss_signal_t(const sbp_sbp_gnss_signal_t *a,
+                                  const sbp_sbp_gnss_signal_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->sat, &b->sat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->code, &b->code);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -78,14 +112,18 @@ size_t sbp_packed_size_sbp_sv_id_t(const sbp_sv_id_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_sv_id_t(sbp_encode_ctx_t *ctx, const sbp_sv_id_t *msg)
-{
-  if (!encode_u8(ctx, &msg->satId)) { return false; }
-  if (!encode_u8(ctx, &msg->constellation)) { return false; }
+bool encode_sbp_sv_id_t(sbp_encode_ctx_t *ctx, const sbp_sv_id_t *msg) {
+  if (!encode_u8(ctx, &msg->satId)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->constellation)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_sv_id_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_sv_id_t *msg) {
+s8 sbp_encode_sbp_sv_id_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                          const sbp_sv_id_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -99,14 +137,18 @@ s8 sbp_encode_sbp_sv_id_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const s
   return SBP_OK;
 }
 
-bool decode_sbp_sv_id_t(sbp_decode_ctx_t *ctx, sbp_sv_id_t *msg)
-{
-  if (!decode_u8(ctx, &msg->satId)) { return false; }
-  if (!decode_u8(ctx, &msg->constellation)) { return false; }
+bool decode_sbp_sv_id_t(sbp_decode_ctx_t *ctx, sbp_sv_id_t *msg) {
+  if (!decode_u8(ctx, &msg->satId)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->constellation)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_sv_id_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_sv_id_t *msg) {
+s8 sbp_decode_sbp_sv_id_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                          sbp_sv_id_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -122,12 +164,16 @@ s8 sbp_decode_sbp_sv_id_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_
 
 int sbp_cmp_sbp_sv_id_t(const sbp_sv_id_t *a, const sbp_sv_id_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->satId, &b->satId);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->constellation, &b->constellation);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -139,15 +185,23 @@ size_t sbp_packed_size_sbp_gnss_signal_dep_t(const sbp_gnss_signal_dep_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_gnss_signal_dep_t(sbp_encode_ctx_t *ctx, const sbp_gnss_signal_dep_t *msg)
-{
-  if (!encode_u16(ctx, &msg->sat)) { return false; }
-  if (!encode_u8(ctx, &msg->code)) { return false; }
-  if (!encode_u8(ctx, &msg->reserved)) { return false; }
+bool encode_sbp_gnss_signal_dep_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_gnss_signal_dep_t *msg) {
+  if (!encode_u16(ctx, &msg->sat)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->code)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gnss_signal_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gnss_signal_dep_t *msg) {
+s8 sbp_encode_sbp_gnss_signal_dep_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_gnss_signal_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -161,15 +215,23 @@ s8 sbp_encode_sbp_gnss_signal_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_gnss_signal_dep_t(sbp_decode_ctx_t *ctx, sbp_gnss_signal_dep_t *msg)
-{
-  if (!decode_u16(ctx, &msg->sat)) { return false; }
-  if (!decode_u8(ctx, &msg->code)) { return false; }
-  if (!decode_u8(ctx, &msg->reserved)) { return false; }
+bool decode_sbp_gnss_signal_dep_t(sbp_decode_ctx_t *ctx,
+                                  sbp_gnss_signal_dep_t *msg) {
+  if (!decode_u16(ctx, &msg->sat)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->code)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gnss_signal_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gnss_signal_dep_t *msg) {
+s8 sbp_decode_sbp_gnss_signal_dep_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_gnss_signal_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -183,17 +245,24 @@ s8 sbp_decode_sbp_gnss_signal_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gnss_signal_dep_t(const sbp_gnss_signal_dep_t *a, const sbp_gnss_signal_dep_t *b) {
+int sbp_cmp_sbp_gnss_signal_dep_t(const sbp_gnss_signal_dep_t *a,
+                                  const sbp_gnss_signal_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->sat, &b->sat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->code, &b->code);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->reserved, &b->reserved);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -204,14 +273,19 @@ size_t sbp_packed_size_sbp_gps_time_dep_t(const sbp_gps_time_dep_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_gps_time_dep_t(sbp_encode_ctx_t *ctx, const sbp_gps_time_dep_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
+bool encode_sbp_gps_time_dep_t(sbp_encode_ctx_t *ctx,
+                               const sbp_gps_time_dep_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gps_time_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gps_time_dep_t *msg) {
+s8 sbp_encode_sbp_gps_time_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_gps_time_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -225,14 +299,18 @@ s8 sbp_encode_sbp_gps_time_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_gps_time_dep_t(sbp_decode_ctx_t *ctx, sbp_gps_time_dep_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
+bool decode_sbp_gps_time_dep_t(sbp_decode_ctx_t *ctx, sbp_gps_time_dep_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gps_time_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gps_time_dep_t *msg) {
+s8 sbp_decode_sbp_gps_time_dep_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_gps_time_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -246,14 +324,19 @@ s8 sbp_decode_sbp_gps_time_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gps_time_dep_t(const sbp_gps_time_dep_t *a, const sbp_gps_time_dep_t *b) {
+int sbp_cmp_sbp_gps_time_dep_t(const sbp_gps_time_dep_t *a,
+                               const sbp_gps_time_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -264,14 +347,19 @@ size_t sbp_packed_size_sbp_gps_time_sec_t(const sbp_gps_time_sec_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_gps_time_sec_t(sbp_encode_ctx_t *ctx, const sbp_gps_time_sec_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
+bool encode_sbp_gps_time_sec_t(sbp_encode_ctx_t *ctx,
+                               const sbp_gps_time_sec_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gps_time_sec_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gps_time_sec_t *msg) {
+s8 sbp_encode_sbp_gps_time_sec_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_gps_time_sec_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -285,14 +373,18 @@ s8 sbp_encode_sbp_gps_time_sec_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_gps_time_sec_t(sbp_decode_ctx_t *ctx, sbp_gps_time_sec_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
+bool decode_sbp_gps_time_sec_t(sbp_decode_ctx_t *ctx, sbp_gps_time_sec_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gps_time_sec_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gps_time_sec_t *msg) {
+s8 sbp_decode_sbp_gps_time_sec_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_gps_time_sec_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -306,14 +398,19 @@ s8 sbp_decode_sbp_gps_time_sec_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gps_time_sec_t(const sbp_gps_time_sec_t *a, const sbp_gps_time_sec_t *b) {
+int sbp_cmp_sbp_gps_time_sec_t(const sbp_gps_time_sec_t *a,
+                               const sbp_gps_time_sec_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -325,15 +422,22 @@ size_t sbp_packed_size_sbp_sbp_gps_time_t(const sbp_sbp_gps_time_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_sbp_gps_time_t(sbp_encode_ctx_t *ctx, const sbp_sbp_gps_time_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
+bool encode_sbp_sbp_gps_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_sbp_gps_time_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_sbp_gps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_sbp_gps_time_t *msg) {
+s8 sbp_encode_sbp_sbp_gps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_sbp_gps_time_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -347,15 +451,21 @@ s8 sbp_encode_sbp_sbp_gps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_sbp_gps_time_t(sbp_decode_ctx_t *ctx, sbp_sbp_gps_time_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
+bool decode_sbp_sbp_gps_time_t(sbp_decode_ctx_t *ctx, sbp_sbp_gps_time_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_sbp_gps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_sbp_gps_time_t *msg) {
+s8 sbp_decode_sbp_sbp_gps_time_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_sbp_gps_time_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -369,17 +479,24 @@ s8 sbp_decode_sbp_sbp_gps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_sbp_gps_time_t(const sbp_sbp_gps_time_t *a, const sbp_sbp_gps_time_t *b) {
+int sbp_cmp_sbp_sbp_gps_time_t(const sbp_sbp_gps_time_t *a,
+                               const sbp_sbp_gps_time_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->ns_residual, &b->ns_residual);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -390,14 +507,19 @@ size_t sbp_packed_size_sbp_carrier_phase_t(const sbp_carrier_phase_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_carrier_phase_t(sbp_encode_ctx_t *ctx, const sbp_carrier_phase_t *msg)
-{
-  if (!encode_s32(ctx, &msg->i)) { return false; }
-  if (!encode_u8(ctx, &msg->f)) { return false; }
+bool encode_sbp_carrier_phase_t(sbp_encode_ctx_t *ctx,
+                                const sbp_carrier_phase_t *msg) {
+  if (!encode_s32(ctx, &msg->i)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->f)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_carrier_phase_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_carrier_phase_t *msg) {
+s8 sbp_encode_sbp_carrier_phase_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_carrier_phase_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -411,14 +533,19 @@ s8 sbp_encode_sbp_carrier_phase_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_carrier_phase_t(sbp_decode_ctx_t *ctx, sbp_carrier_phase_t *msg)
-{
-  if (!decode_s32(ctx, &msg->i)) { return false; }
-  if (!decode_u8(ctx, &msg->f)) { return false; }
+bool decode_sbp_carrier_phase_t(sbp_decode_ctx_t *ctx,
+                                sbp_carrier_phase_t *msg) {
+  if (!decode_s32(ctx, &msg->i)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->f)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_carrier_phase_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_carrier_phase_t *msg) {
+s8 sbp_decode_sbp_carrier_phase_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_carrier_phase_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -432,13 +559,18 @@ s8 sbp_decode_sbp_carrier_phase_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_carrier_phase_t(const sbp_carrier_phase_t *a, const sbp_carrier_phase_t *b) {
+int sbp_cmp_sbp_carrier_phase_t(const sbp_carrier_phase_t *a,
+                                const sbp_carrier_phase_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s32(&a->i, &b->i);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->f, &b->f);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/gnss.c
+++ b/c/src/new/gnss.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/gnss.yaml
  * with generate.py. Please do not hand edit!

--- a/c/src/new/imu.c
+++ b/c/src/new/imu.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/imu.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/imu.h>
 #include <libsbp/internal/new/imu.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/imu.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_imu_raw_t(const sbp_msg_imu_raw_t *msg) {
   size_t packed_size = 0;
@@ -24,20 +41,37 @@ size_t sbp_packed_size_sbp_msg_imu_raw_t(const sbp_msg_imu_raw_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_imu_raw_t(sbp_encode_ctx_t *ctx, const sbp_msg_imu_raw_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u8(ctx, &msg->tow_f)) { return false; }
-  if (!encode_s16(ctx, &msg->acc_x)) { return false; }
-  if (!encode_s16(ctx, &msg->acc_y)) { return false; }
-  if (!encode_s16(ctx, &msg->acc_z)) { return false; }
-  if (!encode_s16(ctx, &msg->gyr_x)) { return false; }
-  if (!encode_s16(ctx, &msg->gyr_y)) { return false; }
-  if (!encode_s16(ctx, &msg->gyr_z)) { return false; }
+bool encode_sbp_msg_imu_raw_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_imu_raw_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tow_f)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->acc_x)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->acc_y)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->acc_z)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->gyr_x)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->gyr_y)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->gyr_z)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_imu_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_imu_raw_t *msg) {
+s8 sbp_encode_sbp_msg_imu_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_imu_raw_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -51,20 +85,36 @@ s8 sbp_encode_sbp_msg_imu_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_imu_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_raw_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u8(ctx, &msg->tow_f)) { return false; }
-  if (!decode_s16(ctx, &msg->acc_x)) { return false; }
-  if (!decode_s16(ctx, &msg->acc_y)) { return false; }
-  if (!decode_s16(ctx, &msg->acc_z)) { return false; }
-  if (!decode_s16(ctx, &msg->gyr_x)) { return false; }
-  if (!decode_s16(ctx, &msg->gyr_y)) { return false; }
-  if (!decode_s16(ctx, &msg->gyr_z)) { return false; }
+bool decode_sbp_msg_imu_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_raw_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tow_f)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->acc_x)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->acc_y)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->acc_z)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->gyr_x)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->gyr_y)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->gyr_z)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_imu_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_imu_raw_t *msg) {
+s8 sbp_decode_sbp_msg_imu_raw_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_imu_raw_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -77,41 +127,63 @@ s8 sbp_decode_sbp_msg_imu_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_imu_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_imu_raw_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_imu_raw_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_imu_raw_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_imu_raw_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_IMU_RAW, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_imu_raw_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_IMU_RAW, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_imu_raw_t(const sbp_msg_imu_raw_t *a, const sbp_msg_imu_raw_t *b) {
+int sbp_cmp_sbp_msg_imu_raw_t(const sbp_msg_imu_raw_t *a,
+                              const sbp_msg_imu_raw_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tow_f, &b->tow_f);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->acc_x, &b->acc_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->acc_y, &b->acc_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->acc_z, &b->acc_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->gyr_x, &b->gyr_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->gyr_y, &b->gyr_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->gyr_z, &b->gyr_z);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -123,15 +195,22 @@ size_t sbp_packed_size_sbp_msg_imu_aux_t(const sbp_msg_imu_aux_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_imu_aux_t(sbp_encode_ctx_t *ctx, const sbp_msg_imu_aux_t *msg)
-{
-  if (!encode_u8(ctx, &msg->imu_type)) { return false; }
-  if (!encode_s16(ctx, &msg->temp)) { return false; }
-  if (!encode_u8(ctx, &msg->imu_conf)) { return false; }
+bool encode_sbp_msg_imu_aux_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_imu_aux_t *msg) {
+  if (!encode_u8(ctx, &msg->imu_type)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->temp)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->imu_conf)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_imu_aux_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_imu_aux_t *msg) {
+s8 sbp_encode_sbp_msg_imu_aux_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_imu_aux_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -145,15 +224,21 @@ s8 sbp_encode_sbp_msg_imu_aux_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_imu_aux_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_aux_t *msg)
-{
-  if (!decode_u8(ctx, &msg->imu_type)) { return false; }
-  if (!decode_s16(ctx, &msg->temp)) { return false; }
-  if (!decode_u8(ctx, &msg->imu_conf)) { return false; }
+bool decode_sbp_msg_imu_aux_t(sbp_decode_ctx_t *ctx, sbp_msg_imu_aux_t *msg) {
+  if (!decode_u8(ctx, &msg->imu_type)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->temp)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->imu_conf)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_imu_aux_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_imu_aux_t *msg) {
+s8 sbp_decode_sbp_msg_imu_aux_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_imu_aux_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -166,25 +251,37 @@ s8 sbp_decode_sbp_msg_imu_aux_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_imu_aux_t(struct sbp_state *s, u16 sender_id, const sbp_msg_imu_aux_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_imu_aux_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_imu_aux_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_imu_aux_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_IMU_AUX, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_imu_aux_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_IMU_AUX, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_imu_aux_t(const sbp_msg_imu_aux_t *a, const sbp_msg_imu_aux_t *b) {
+int sbp_cmp_sbp_msg_imu_aux_t(const sbp_msg_imu_aux_t *a,
+                              const sbp_msg_imu_aux_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->imu_type, &b->imu_type);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->temp, &b->temp);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->imu_conf, &b->imu_conf);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/imu.c
+++ b/c/src/new/imu.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/imu.yaml
  * with generate.py. Please do not hand edit!
@@ -127,6 +115,7 @@ s8 sbp_decode_sbp_msg_imu_raw_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_imu_raw_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_imu_raw_t *msg,
                               sbp_write_fn_t write) {
@@ -251,6 +240,7 @@ s8 sbp_decode_sbp_msg_imu_aux_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_imu_aux_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_imu_aux_t *msg,
                               sbp_write_fn_t write) {

--- a/c/src/new/linux.c
+++ b/c/src/new/linux.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/linux.yaml
  * with generate.py. Please do not hand edit!
@@ -126,7 +114,7 @@ bool encode_sbp_msg_linux_cpu_state_dep_a_t(
   if (!encode_u8(ctx, &msg->pcpu)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -192,6 +180,7 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_cpu_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_cpu_state_dep_a_t *msg, sbp_write_fn_t write) {
@@ -226,15 +215,15 @@ int sbp_cmp_sbp_msg_linux_cpu_state_dep_a_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+  ret =
+      sbp_msg_linux_cpu_state_dep_a_t_cmdline_strcmp(&a->cmdline, &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -339,7 +328,7 @@ bool encode_sbp_msg_linux_mem_state_dep_a_t(
   if (!encode_u8(ctx, &msg->pmem)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -405,6 +394,7 @@ s8 sbp_decode_sbp_msg_linux_mem_state_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_mem_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_mem_state_dep_a_t *msg, sbp_write_fn_t write) {
@@ -439,15 +429,15 @@ int sbp_cmp_sbp_msg_linux_mem_state_dep_a_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+  ret =
+      sbp_msg_linux_mem_state_dep_a_t_cmdline_strcmp(&a->cmdline, &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -543,6 +533,7 @@ s8 sbp_decode_sbp_msg_linux_sys_state_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_sys_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_sys_state_dep_a_t *msg, sbp_write_fn_t write) {
@@ -764,6 +755,7 @@ s8 sbp_decode_sbp_msg_linux_process_socket_counts_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_process_socket_counts_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_process_socket_counts_t *msg, sbp_write_fn_t write) {
@@ -808,9 +800,8 @@ int sbp_cmp_sbp_msg_linux_process_socket_counts_t(
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline,
-      &sbp_msg_linux_process_socket_counts_tcmdline_params);
+  ret = sbp_msg_linux_process_socket_counts_t_cmdline_strcmp(&a->cmdline,
+                                                             &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -928,7 +919,7 @@ bool encode_sbp_msg_linux_process_socket_queues_t(
   if (!encode_u16(ctx, &msg->socket_states)) {
     return false;
   }
-  for (uint8_t i = 0; i < 64; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 64; i++) {
     if (!encode_char(ctx, &msg->address_of_largest[i])) {
       return false;
     }
@@ -1005,6 +996,7 @@ s8 sbp_decode_sbp_msg_linux_process_socket_queues_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_process_socket_queues_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_process_socket_queues_t *msg, sbp_write_fn_t write) {
@@ -1054,16 +1046,15 @@ int sbp_cmp_sbp_msg_linux_process_socket_queues_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 64 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 64; i++) {
     ret = sbp_cmp_char(&a->address_of_largest[i], &b->address_of_largest[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline,
-      &sbp_msg_linux_process_socket_queues_tcmdline_params);
+  ret = sbp_msg_linux_process_socket_queues_t_cmdline_strcmp(&a->cmdline,
+                                                             &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -1088,12 +1079,12 @@ bool encode_sbp_msg_linux_socket_usage_t(
   if (!encode_u32(ctx, &msg->max_queue_depth)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     if (!encode_u16(ctx, &msg->socket_state_counts[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     if (!encode_u16(ctx, &msg->socket_type_counts[i])) {
       return false;
     }
@@ -1153,6 +1144,7 @@ s8 sbp_decode_sbp_msg_linux_socket_usage_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_socket_usage_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_linux_socket_usage_t *msg,
     sbp_write_fn_t write) {
@@ -1182,14 +1174,14 @@ int sbp_cmp_sbp_msg_linux_socket_usage_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     ret = sbp_cmp_u16(&a->socket_state_counts[i], &b->socket_state_counts[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     ret = sbp_cmp_u16(&a->socket_type_counts[i], &b->socket_type_counts[i]);
   }
   if (ret != 0) {
@@ -1353,6 +1345,7 @@ s8 sbp_decode_sbp_msg_linux_process_fd_count_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_process_fd_count_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_process_fd_count_t *msg, sbp_write_fn_t write) {
@@ -1387,9 +1380,8 @@ int sbp_cmp_sbp_msg_linux_process_fd_count_t(
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline,
-      &sbp_msg_linux_process_fd_count_tcmdline_params);
+  ret =
+      sbp_msg_linux_process_fd_count_t_cmdline_strcmp(&a->cmdline, &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -1557,6 +1549,7 @@ s8 sbp_decode_sbp_msg_linux_process_fd_summary_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_process_fd_summary_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_linux_process_fd_summary_t *msg, sbp_write_fn_t write) {
@@ -1581,9 +1574,8 @@ int sbp_cmp_sbp_msg_linux_process_fd_summary_t(
     return ret;
   }
 
-  ret = sbp_double_null_terminated_string_strcmp(
-      &a->most_opened, &b->most_opened,
-      &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+  ret = sbp_msg_linux_process_fd_summary_t_most_opened_strcmp(&a->most_opened,
+                                                              &b->most_opened);
   if (ret != 0) {
     return ret;
   }
@@ -1694,7 +1686,7 @@ bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->flags)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -1766,6 +1758,7 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_cpu_state_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_linux_cpu_state_t *msg,
                                       sbp_write_fn_t write) {
@@ -1809,15 +1802,14 @@ int sbp_cmp_sbp_msg_linux_cpu_state_t(const sbp_msg_linux_cpu_state_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params);
+  ret = sbp_msg_linux_cpu_state_t_cmdline_strcmp(&a->cmdline, &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -1928,7 +1920,7 @@ bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->flags)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -2000,6 +1992,7 @@ s8 sbp_decode_sbp_msg_linux_mem_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_mem_state_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_linux_mem_state_t *msg,
                                       sbp_write_fn_t write) {
@@ -2043,15 +2036,14 @@ int sbp_cmp_sbp_msg_linux_mem_state_t(const sbp_msg_linux_mem_state_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->cmdline, &b->cmdline, &sbp_msg_linux_mem_state_tcmdline_params);
+  ret = sbp_msg_linux_mem_state_t_cmdline_strcmp(&a->cmdline, &b->cmdline);
   if (ret != 0) {
     return ret;
   }
@@ -2161,6 +2153,7 @@ s8 sbp_decode_sbp_msg_linux_sys_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_linux_sys_state_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_linux_sys_state_t *msg,
                                       sbp_write_fn_t write) {

--- a/c/src/new/linux.c
+++ b/c/src/new/linux.c
@@ -1,106 +1,146 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/linux.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/linux.h>
 #include <libsbp/internal/new/linux.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
-static const sbp_unterminated_string_params_t sbp_msg_linux_cpu_state_dep_a_tcmdline_params = 
-{
-  .max_packed_len = 236
-};
+#include <libsbp/new/linux.h>
+#include <libsbp/sbp.h>
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_cpu_state_dep_a_tcmdline_params = {.max_packed_len = 236};
 
-  void sbp_msg_linux_cpu_state_dep_a_t_cmdline_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+void sbp_msg_linux_cpu_state_dep_a_t_cmdline_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(s,
+                               &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
 }
 
-  bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
 }
 
-  int sbp_msg_linux_cpu_state_dep_a_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+int sbp_msg_linux_cpu_state_dep_a_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_cpu_state_dep_a_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+uint8_t sbp_msg_linux_cpu_state_dep_a_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_cpu_state_dep_a_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
-      }
-  bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, new_str);
-  }
+uint8_t sbp_msg_linux_cpu_state_dep_a_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+}
+bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_set(sbp_unterminated_string_t *s,
+                                                 const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, new_str);
+}
 
-  bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
-  }
-
-  bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_cpu_state_dep_a_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_cpu_state_dep_a_t(const sbp_msg_linux_cpu_state_dep_a_t *msg) {
+bool sbp_msg_linux_cpu_state_dep_a_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, fmt, ap);
+}
+
+const char *sbp_msg_linux_cpu_state_dep_a_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+}
+
+size_t sbp_packed_size_sbp_msg_linux_cpu_state_dep_a_t(
+    const sbp_msg_linux_cpu_state_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
   packed_size += sbp_packed_size_u8(&msg->pcpu);
-  packed_size += ( 15 * sbp_packed_size_char(&msg->tname[0]));
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+  packed_size += (15 * sbp_packed_size_char(&msg->tname[0]));
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_cpu_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_dep_a_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u8(ctx, &msg->pcpu)) { return false; }
-  for (uint8_t i = 0; i < 15; i++)
-  {
-    if (!encode_char(ctx, &msg->tname[i])) { return false; }
+bool encode_sbp_msg_linux_cpu_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_dep_a_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, ctx)) { return false; }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!encode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_cpu_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_cpu_state_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_linux_cpu_state_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_cpu_state_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -114,19 +154,32 @@ s8 sbp_encode_sbp_msg_linux_cpu_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_cpu_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_dep_a_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u8(ctx, &msg->pcpu)) { return false; }
-  for (uint8_t i = 0; i < 15; i++) {
-    if (!decode_char(ctx, &msg->tname[i])) { return false; }
+bool decode_sbp_msg_linux_cpu_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_dep_a_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, ctx)) { return false; }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!decode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_cpu_state_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_cpu_state_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -139,128 +192,168 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_cpu_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_cpu_state_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_cpu_state_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_cpu_state_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_cpu_state_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_CPU_STATE_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_cpu_state_dep_a_t(payload, sizeof(payload),
+                                                      &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_CPU_STATE_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_cpu_state_dep_a_t(const sbp_msg_linux_cpu_state_dep_a_t *a, const sbp_msg_linux_cpu_state_dep_a_t *b) {
+int sbp_cmp_sbp_msg_linux_cpu_state_dep_a_t(
+    const sbp_msg_linux_cpu_state_dep_a_t *a,
+    const sbp_msg_linux_cpu_state_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pcpu, &b->pcpu);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 15 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, &sbp_msg_linux_cpu_state_dep_a_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_linux_mem_state_dep_a_tcmdline_params = 
-{
-  .max_packed_len = 236
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_mem_state_dep_a_tcmdline_params = {.max_packed_len = 236};
 
-  void sbp_msg_linux_mem_state_dep_a_t_cmdline_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+void sbp_msg_linux_mem_state_dep_a_t_cmdline_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(s,
+                               &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
 }
 
-  bool sbp_msg_linux_mem_state_dep_a_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+bool sbp_msg_linux_mem_state_dep_a_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
 }
 
-  int sbp_msg_linux_mem_state_dep_a_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+int sbp_msg_linux_mem_state_dep_a_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_mem_state_dep_a_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+uint8_t sbp_msg_linux_mem_state_dep_a_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_mem_state_dep_a_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
-      }
-  bool sbp_msg_linux_mem_state_dep_a_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, new_str);
-  }
+uint8_t sbp_msg_linux_mem_state_dep_a_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+}
+bool sbp_msg_linux_mem_state_dep_a_t_cmdline_set(sbp_unterminated_string_t *s,
+                                                 const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, new_str);
+}
 
-  bool sbp_msg_linux_mem_state_dep_a_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_linux_mem_state_dep_a_t_cmdline_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_linux_mem_state_dep_a_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
-  }
-
-  bool sbp_msg_linux_mem_state_dep_a_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_mem_state_dep_a_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_mem_state_dep_a_t_cmdline_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_mem_state_dep_a_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+bool sbp_msg_linux_mem_state_dep_a_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_mem_state_dep_a_t(const sbp_msg_linux_mem_state_dep_a_t *msg) {
+bool sbp_msg_linux_mem_state_dep_a_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, fmt, ap);
+}
+
+const char *sbp_msg_linux_mem_state_dep_a_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+}
+
+size_t sbp_packed_size_sbp_msg_linux_mem_state_dep_a_t(
+    const sbp_msg_linux_mem_state_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
   packed_size += sbp_packed_size_u8(&msg->pmem);
-  packed_size += ( 15 * sbp_packed_size_char(&msg->tname[0]));
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+  packed_size += (15 * sbp_packed_size_char(&msg->tname[0]));
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_mem_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_dep_a_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u8(ctx, &msg->pmem)) { return false; }
-  for (uint8_t i = 0; i < 15; i++)
-  {
-    if (!encode_char(ctx, &msg->tname[i])) { return false; }
+bool encode_sbp_msg_linux_mem_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_dep_a_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, ctx)) { return false; }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!encode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_mem_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_mem_state_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_linux_mem_state_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_mem_state_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -274,19 +367,32 @@ s8 sbp_encode_sbp_msg_linux_mem_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_mem_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_dep_a_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u8(ctx, &msg->pmem)) { return false; }
-  for (uint8_t i = 0; i < 15; i++) {
-    if (!decode_char(ctx, &msg->tname[i])) { return false; }
+bool decode_sbp_msg_linux_mem_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_dep_a_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, ctx)) { return false; }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!decode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_mem_state_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_mem_state_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_linux_mem_state_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_mem_state_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -299,39 +405,57 @@ s8 sbp_decode_sbp_msg_linux_mem_state_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_mem_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_mem_state_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_mem_state_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_mem_state_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_mem_state_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_MEM_STATE_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_mem_state_dep_a_t(payload, sizeof(payload),
+                                                      &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_MEM_STATE_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_mem_state_dep_a_t(const sbp_msg_linux_mem_state_dep_a_t *a, const sbp_msg_linux_mem_state_dep_a_t *b) {
+int sbp_cmp_sbp_msg_linux_mem_state_dep_a_t(
+    const sbp_msg_linux_mem_state_dep_a_t *a,
+    const sbp_msg_linux_mem_state_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pmem, &b->pmem);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 15 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, &sbp_msg_linux_mem_state_dep_a_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_sys_state_dep_a_t(const sbp_msg_linux_sys_state_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_linux_sys_state_dep_a_t(
+    const sbp_msg_linux_sys_state_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->mem_total);
   packed_size += sbp_packed_size_u8(&msg->pcpu);
@@ -342,18 +466,32 @@ size_t sbp_packed_size_sbp_msg_linux_sys_state_dep_a_t(const sbp_msg_linux_sys_s
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_sys_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_dep_a_t *msg)
-{
-  if (!encode_u16(ctx, &msg->mem_total)) { return false; }
-  if (!encode_u8(ctx, &msg->pcpu)) { return false; }
-  if (!encode_u8(ctx, &msg->pmem)) { return false; }
-  if (!encode_u16(ctx, &msg->procs_starting)) { return false; }
-  if (!encode_u16(ctx, &msg->procs_stopping)) { return false; }
-  if (!encode_u16(ctx, &msg->pid_count)) { return false; }
+bool encode_sbp_msg_linux_sys_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_dep_a_t *msg) {
+  if (!encode_u16(ctx, &msg->mem_total)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->procs_starting)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->procs_stopping)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pid_count)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_sys_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_sys_state_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_linux_sys_state_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_sys_state_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -367,18 +505,32 @@ s8 sbp_encode_sbp_msg_linux_sys_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_sys_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_dep_a_t *msg)
-{
-  if (!decode_u16(ctx, &msg->mem_total)) { return false; }
-  if (!decode_u8(ctx, &msg->pcpu)) { return false; }
-  if (!decode_u8(ctx, &msg->pmem)) { return false; }
-  if (!decode_u16(ctx, &msg->procs_starting)) { return false; }
-  if (!decode_u16(ctx, &msg->procs_stopping)) { return false; }
-  if (!decode_u16(ctx, &msg->pid_count)) { return false; }
+bool decode_sbp_msg_linux_sys_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_dep_a_t *msg) {
+  if (!decode_u16(ctx, &msg->mem_total)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->procs_starting)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->procs_stopping)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pid_count)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_sys_state_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_sys_state_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_linux_sys_state_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_sys_state_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -391,127 +543,174 @@ s8 sbp_decode_sbp_msg_linux_sys_state_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_sys_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_sys_state_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_sys_state_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_sys_state_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_sys_state_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_SYS_STATE_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_sys_state_dep_a_t(payload, sizeof(payload),
+                                                      &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_SYS_STATE_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_sys_state_dep_a_t(const sbp_msg_linux_sys_state_dep_a_t *a, const sbp_msg_linux_sys_state_dep_a_t *b) {
+int sbp_cmp_sbp_msg_linux_sys_state_dep_a_t(
+    const sbp_msg_linux_sys_state_dep_a_t *a,
+    const sbp_msg_linux_sys_state_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->mem_total, &b->mem_total);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pcpu, &b->pcpu);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pmem, &b->pmem);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->procs_starting, &b->procs_starting);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->procs_stopping, &b->procs_stopping);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid_count, &b->pid_count);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_linux_process_socket_counts_tcmdline_params = 
-{
-  .max_packed_len = 246
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_process_socket_counts_tcmdline_params = {.max_packed_len =
+                                                               246};
 
-  void sbp_msg_linux_process_socket_counts_t_cmdline_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+void sbp_msg_linux_process_socket_counts_t_cmdline_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
 }
 
-  bool sbp_msg_linux_process_socket_counts_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+bool sbp_msg_linux_process_socket_counts_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
 }
 
-  int sbp_msg_linux_process_socket_counts_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+int sbp_msg_linux_process_socket_counts_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_process_socket_counts_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_process_socket_counts_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+uint8_t sbp_msg_linux_process_socket_counts_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_process_socket_counts_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
-      }
-  bool sbp_msg_linux_process_socket_counts_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_process_socket_counts_tcmdline_params, new_str);
-  }
+uint8_t sbp_msg_linux_process_socket_counts_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+}
+bool sbp_msg_linux_process_socket_counts_t_cmdline_set(
+    sbp_unterminated_string_t *s, const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params, new_str);
+}
 
-  bool sbp_msg_linux_process_socket_counts_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_linux_process_socket_counts_t_cmdline_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_linux_process_socket_counts_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
-  }
-
-  bool sbp_msg_linux_process_socket_counts_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_process_socket_counts_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_process_socket_counts_t_cmdline_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_process_socket_counts_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+bool sbp_msg_linux_process_socket_counts_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_process_socket_counts_t(const sbp_msg_linux_process_socket_counts_t *msg) {
+bool sbp_msg_linux_process_socket_counts_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params, fmt, ap);
+}
+
+const char *sbp_msg_linux_process_socket_counts_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+}
+
+size_t sbp_packed_size_sbp_msg_linux_process_socket_counts_t(
+    const sbp_msg_linux_process_socket_counts_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
   packed_size += sbp_packed_size_u16(&msg->socket_count);
   packed_size += sbp_packed_size_u16(&msg->socket_types);
   packed_size += sbp_packed_size_u16(&msg->socket_states);
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_process_socket_counts_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_counts_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u16(ctx, &msg->socket_count)) { return false; }
-  if (!encode_u16(ctx, &msg->socket_types)) { return false; }
-  if (!encode_u16(ctx, &msg->socket_states)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params, ctx)) { return false; }
+bool encode_sbp_msg_linux_process_socket_counts_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_counts_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->socket_count)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->socket_types)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->socket_states)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_process_socket_counts_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_process_socket_counts_t *msg) {
+s8 sbp_encode_sbp_msg_linux_process_socket_counts_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_process_socket_counts_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -525,18 +724,34 @@ s8 sbp_encode_sbp_msg_linux_process_socket_counts_t(uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_process_socket_counts_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_counts_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u16(ctx, &msg->socket_count)) { return false; }
-  if (!decode_u16(ctx, &msg->socket_types)) { return false; }
-  if (!decode_u16(ctx, &msg->socket_states)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params, ctx)) { return false; }
+bool decode_sbp_msg_linux_process_socket_counts_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_counts_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->socket_count)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->socket_types)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->socket_states)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_process_socket_counts_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_process_socket_counts_t *msg) {
+s8 sbp_decode_sbp_msg_linux_process_socket_counts_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_process_socket_counts_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -549,105 +764,137 @@ s8 sbp_decode_sbp_msg_linux_process_socket_counts_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_socket_counts_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_socket_counts_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_process_socket_counts_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_process_socket_counts_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_process_socket_counts_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_process_socket_counts_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_process_socket_counts_t(const sbp_msg_linux_process_socket_counts_t *a, const sbp_msg_linux_process_socket_counts_t *b) {
+int sbp_cmp_sbp_msg_linux_process_socket_counts_t(
+    const sbp_msg_linux_process_socket_counts_t *a,
+    const sbp_msg_linux_process_socket_counts_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->socket_count, &b->socket_count);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->socket_types, &b->socket_types);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->socket_states, &b->socket_states);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_process_socket_counts_tcmdline_params);
-  if (ret != 0) { return ret; }
-  return ret;
-}
-static const sbp_unterminated_string_params_t sbp_msg_linux_process_socket_queues_tcmdline_params = 
-{
-  .max_packed_len = 180
-};
-
-  void sbp_msg_linux_process_socket_queues_t_cmdline_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
-}
-
-  bool sbp_msg_linux_process_socket_queues_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
-}
-
-  int sbp_msg_linux_process_socket_queues_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_process_socket_queues_tcmdline_params);
-}
-
-  uint8_t sbp_msg_linux_process_socket_queues_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
-}
-
-  uint8_t sbp_msg_linux_process_socket_queues_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
-      }
-  bool sbp_msg_linux_process_socket_queues_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_process_socket_queues_tcmdline_params, new_str);
+  if (ret != 0) {
+    return ret;
   }
 
-  bool sbp_msg_linux_process_socket_queues_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline,
+      &sbp_msg_linux_process_socket_counts_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
+  return ret;
+}
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_process_socket_queues_tcmdline_params = {.max_packed_len =
+                                                               180};
+
+void sbp_msg_linux_process_socket_queues_t_cmdline_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+}
+
+bool sbp_msg_linux_process_socket_queues_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+}
+
+int sbp_msg_linux_process_socket_queues_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+}
+
+uint8_t sbp_msg_linux_process_socket_queues_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+}
+
+uint8_t sbp_msg_linux_process_socket_queues_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+}
+bool sbp_msg_linux_process_socket_queues_t_cmdline_set(
+    sbp_unterminated_string_t *s, const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params, new_str);
+}
+
+bool sbp_msg_linux_process_socket_queues_t_cmdline_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
-  }
+}
 
-  bool sbp_msg_linux_process_socket_queues_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
-  }
+bool sbp_msg_linux_process_socket_queues_t_cmdline_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
+}
 
-  bool sbp_msg_linux_process_socket_queues_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_linux_process_socket_queues_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_process_socket_queues_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_process_socket_queues_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_process_socket_queues_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+const char *sbp_msg_linux_process_socket_queues_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_linux_process_socket_queues_tcmdline_params);
 }
 
-size_t sbp_packed_size_sbp_msg_linux_process_socket_queues_t(const sbp_msg_linux_process_socket_queues_t *msg) {
+size_t sbp_packed_size_sbp_msg_linux_process_socket_queues_t(
+    const sbp_msg_linux_process_socket_queues_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
@@ -655,28 +902,48 @@ size_t sbp_packed_size_sbp_msg_linux_process_socket_queues_t(const sbp_msg_linux
   packed_size += sbp_packed_size_u16(&msg->send_queued);
   packed_size += sbp_packed_size_u16(&msg->socket_types);
   packed_size += sbp_packed_size_u16(&msg->socket_states);
-  packed_size += ( 64 * sbp_packed_size_char(&msg->address_of_largest[0]));
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params);
+  packed_size += (64 * sbp_packed_size_char(&msg->address_of_largest[0]));
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_process_socket_queues_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_queues_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u16(ctx, &msg->recv_queued)) { return false; }
-  if (!encode_u16(ctx, &msg->send_queued)) { return false; }
-  if (!encode_u16(ctx, &msg->socket_types)) { return false; }
-  if (!encode_u16(ctx, &msg->socket_states)) { return false; }
-  for (uint8_t i = 0; i < 64; i++)
-  {
-    if (!encode_char(ctx, &msg->address_of_largest[i])) { return false; }
+bool encode_sbp_msg_linux_process_socket_queues_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_socket_queues_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params, ctx)) { return false; }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->recv_queued)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->send_queued)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->socket_types)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->socket_states)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 64; i++) {
+    if (!encode_char(ctx, &msg->address_of_largest[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_process_socket_queues_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_process_socket_queues_t *msg) {
+s8 sbp_encode_sbp_msg_linux_process_socket_queues_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_process_socket_queues_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -690,22 +957,42 @@ s8 sbp_encode_sbp_msg_linux_process_socket_queues_t(uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_process_socket_queues_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_queues_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u16(ctx, &msg->recv_queued)) { return false; }
-  if (!decode_u16(ctx, &msg->send_queued)) { return false; }
-  if (!decode_u16(ctx, &msg->socket_types)) { return false; }
-  if (!decode_u16(ctx, &msg->socket_states)) { return false; }
-  for (uint8_t i = 0; i < 64; i++) {
-    if (!decode_char(ctx, &msg->address_of_largest[i])) { return false; }
+bool decode_sbp_msg_linux_process_socket_queues_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_socket_queues_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params, ctx)) { return false; }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->recv_queued)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->send_queued)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->socket_types)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->socket_states)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 64; i++) {
+    if (!decode_char(ctx, &msg->address_of_largest[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_process_socket_queues_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_process_socket_queues_t *msg) {
+s8 sbp_decode_sbp_msg_linux_process_socket_queues_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_process_socket_queues_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -718,72 +1005,105 @@ s8 sbp_decode_sbp_msg_linux_process_socket_queues_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_socket_queues_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_socket_queues_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_process_socket_queues_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_process_socket_queues_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_process_socket_queues_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_process_socket_queues_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_process_socket_queues_t(const sbp_msg_linux_process_socket_queues_t *a, const sbp_msg_linux_process_socket_queues_t *b) {
+int sbp_cmp_sbp_msg_linux_process_socket_queues_t(
+    const sbp_msg_linux_process_socket_queues_t *a,
+    const sbp_msg_linux_process_socket_queues_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->recv_queued, &b->recv_queued);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->send_queued, &b->send_queued);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->socket_types, &b->socket_types);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->socket_states, &b->socket_states);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 64 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 64 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->address_of_largest[i], &b->address_of_largest[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_process_socket_queues_tcmdline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline,
+      &sbp_msg_linux_process_socket_queues_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_socket_usage_t(const sbp_msg_linux_socket_usage_t *msg) {
+size_t sbp_packed_size_sbp_msg_linux_socket_usage_t(
+    const sbp_msg_linux_socket_usage_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->avg_queue_depth);
   packed_size += sbp_packed_size_u32(&msg->max_queue_depth);
-  packed_size += ( 16 * sbp_packed_size_u16(&msg->socket_state_counts[0]));
-  packed_size += ( 16 * sbp_packed_size_u16(&msg->socket_type_counts[0]));
+  packed_size += (16 * sbp_packed_size_u16(&msg->socket_state_counts[0]));
+  packed_size += (16 * sbp_packed_size_u16(&msg->socket_type_counts[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_socket_usage_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_socket_usage_t *msg)
-{
-  if (!encode_u32(ctx, &msg->avg_queue_depth)) { return false; }
-  if (!encode_u32(ctx, &msg->max_queue_depth)) { return false; }
-  for (uint8_t i = 0; i < 16; i++)
-  {
-    if (!encode_u16(ctx, &msg->socket_state_counts[i])) { return false; }
+bool encode_sbp_msg_linux_socket_usage_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_socket_usage_t *msg) {
+  if (!encode_u32(ctx, &msg->avg_queue_depth)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 16; i++)
-  {
-    if (!encode_u16(ctx, &msg->socket_type_counts[i])) { return false; }
+  if (!encode_u32(ctx, &msg->max_queue_depth)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 16; i++) {
+    if (!encode_u16(ctx, &msg->socket_state_counts[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 16; i++) {
+    if (!encode_u16(ctx, &msg->socket_type_counts[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_socket_usage_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_socket_usage_t *msg) {
+s8 sbp_encode_sbp_msg_linux_socket_usage_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_socket_usage_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -797,20 +1117,30 @@ s8 sbp_encode_sbp_msg_linux_socket_usage_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_socket_usage_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_socket_usage_t *msg)
-{
-  if (!decode_u32(ctx, &msg->avg_queue_depth)) { return false; }
-  if (!decode_u32(ctx, &msg->max_queue_depth)) { return false; }
-  for (uint8_t i = 0; i < 16; i++) {
-    if (!decode_u16(ctx, &msg->socket_state_counts[i])) { return false; }
+bool decode_sbp_msg_linux_socket_usage_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_linux_socket_usage_t *msg) {
+  if (!decode_u32(ctx, &msg->avg_queue_depth)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->max_queue_depth)) {
+    return false;
   }
   for (uint8_t i = 0; i < 16; i++) {
-    if (!decode_u16(ctx, &msg->socket_type_counts[i])) { return false; }
+    if (!decode_u16(ctx, &msg->socket_state_counts[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 16; i++) {
+    if (!decode_u16(ctx, &msg->socket_type_counts[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_socket_usage_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_socket_usage_t *msg) {
+s8 sbp_decode_sbp_msg_linux_socket_usage_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_linux_socket_usage_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -823,123 +1153,159 @@ s8 sbp_decode_sbp_msg_linux_socket_usage_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_socket_usage_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_socket_usage_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_socket_usage_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_linux_socket_usage_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_socket_usage_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_SOCKET_USAGE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_socket_usage_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_SOCKET_USAGE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_socket_usage_t(const sbp_msg_linux_socket_usage_t *a, const sbp_msg_linux_socket_usage_t *b) {
+int sbp_cmp_sbp_msg_linux_socket_usage_t(
+    const sbp_msg_linux_socket_usage_t *a,
+    const sbp_msg_linux_socket_usage_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->avg_queue_depth, &b->avg_queue_depth);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->max_queue_depth, &b->max_queue_depth);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 16 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
     ret = sbp_cmp_u16(&a->socket_state_counts[i], &b->socket_state_counts[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 16 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
     ret = sbp_cmp_u16(&a->socket_type_counts[i], &b->socket_type_counts[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_linux_process_fd_count_tcmdline_params = 
-{
-  .max_packed_len = 250
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_process_fd_count_tcmdline_params = {.max_packed_len = 250};
 
-  void sbp_msg_linux_process_fd_count_t_cmdline_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_linux_process_fd_count_tcmdline_params);
+void sbp_msg_linux_process_fd_count_t_cmdline_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(s,
+                               &sbp_msg_linux_process_fd_count_tcmdline_params);
 }
 
-  bool sbp_msg_linux_process_fd_count_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_process_fd_count_tcmdline_params);
+bool sbp_msg_linux_process_fd_count_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params);
 }
 
-  int sbp_msg_linux_process_fd_count_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_process_fd_count_tcmdline_params);
+int sbp_msg_linux_process_fd_count_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_process_fd_count_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_process_fd_count_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_process_fd_count_tcmdline_params);
+uint8_t sbp_msg_linux_process_fd_count_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_process_fd_count_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_process_fd_count_tcmdline_params);
-      }
-  bool sbp_msg_linux_process_fd_count_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_process_fd_count_tcmdline_params, new_str);
-  }
+uint8_t sbp_msg_linux_process_fd_count_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params);
+}
+bool sbp_msg_linux_process_fd_count_t_cmdline_set(sbp_unterminated_string_t *s,
+                                                  const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params, new_str);
+}
 
-  bool sbp_msg_linux_process_fd_count_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_linux_process_fd_count_t_cmdline_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_linux_process_fd_count_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
-  }
-
-  bool sbp_msg_linux_process_fd_count_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_process_fd_count_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_process_fd_count_t_cmdline_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_process_fd_count_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_process_fd_count_tcmdline_params);
+bool sbp_msg_linux_process_fd_count_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_process_fd_count_t(const sbp_msg_linux_process_fd_count_t *msg) {
+bool sbp_msg_linux_process_fd_count_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params, fmt, ap);
+}
+
+const char *sbp_msg_linux_process_fd_count_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_linux_process_fd_count_tcmdline_params);
+}
+
+size_t sbp_packed_size_sbp_msg_linux_process_fd_count_t(
+    const sbp_msg_linux_process_fd_count_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
   packed_size += sbp_packed_size_u16(&msg->fd_count);
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_process_fd_count_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_count_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u16(ctx, &msg->fd_count)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params, ctx)) { return false; }
+bool encode_sbp_msg_linux_process_fd_count_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_count_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->fd_count)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_process_fd_count_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_process_fd_count_t *msg) {
+s8 sbp_encode_sbp_msg_linux_process_fd_count_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_process_fd_count_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -953,16 +1319,28 @@ s8 sbp_encode_sbp_msg_linux_process_fd_count_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_process_fd_count_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_count_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u16(ctx, &msg->fd_count)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params, ctx)) { return false; }
+bool decode_sbp_msg_linux_process_fd_count_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_count_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->fd_count)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_process_fd_count_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_process_fd_count_t *msg) {
+s8 sbp_decode_sbp_msg_linux_process_fd_count_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_process_fd_count_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -975,128 +1353,169 @@ s8 sbp_decode_sbp_msg_linux_process_fd_count_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_fd_count_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_fd_count_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_process_fd_count_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_process_fd_count_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_process_fd_count_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_FD_COUNT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_process_fd_count_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_FD_COUNT, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_process_fd_count_t(const sbp_msg_linux_process_fd_count_t *a, const sbp_msg_linux_process_fd_count_t *b) {
+int sbp_cmp_sbp_msg_linux_process_fd_count_t(
+    const sbp_msg_linux_process_fd_count_t *a,
+    const sbp_msg_linux_process_fd_count_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->fd_count, &b->fd_count);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_process_fd_count_tcmdline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline,
+      &sbp_msg_linux_process_fd_count_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_double_null_terminated_string_params_t sbp_msg_linux_process_fd_summary_tmost_opened_params = 
-{
-  .max_packed_len = 251
-};
+static const sbp_double_null_terminated_string_params_t
+    sbp_msg_linux_process_fd_summary_tmost_opened_params = {.max_packed_len =
+                                                                251};
 
-  void sbp_msg_linux_process_fd_summary_t_most_opened_init(sbp_double_null_terminated_string_t *s)
-{
-  sbp_double_null_terminated_string_init(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+void sbp_msg_linux_process_fd_summary_t_most_opened_init(
+    sbp_double_null_terminated_string_t *s) {
+  sbp_double_null_terminated_string_init(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_valid(const sbp_double_null_terminated_string_t *s)
-{
-  return sbp_double_null_terminated_string_valid(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+bool sbp_msg_linux_process_fd_summary_t_most_opened_valid(
+    const sbp_double_null_terminated_string_t *s) {
+  return sbp_double_null_terminated_string_valid(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
 }
 
-  int sbp_msg_linux_process_fd_summary_t_most_opened_strcmp(const sbp_double_null_terminated_string_t *a, const sbp_double_null_terminated_string_t *b)
-{
-  return sbp_double_null_terminated_string_strcmp(a, b, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+int sbp_msg_linux_process_fd_summary_t_most_opened_strcmp(
+    const sbp_double_null_terminated_string_t *a,
+    const sbp_double_null_terminated_string_t *b) {
+  return sbp_double_null_terminated_string_strcmp(
+      a, b, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
 }
 
-  uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_packed_len(const sbp_double_null_terminated_string_t *s)
-{
-  return sbp_double_null_terminated_string_packed_len(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_packed_len(
+    const sbp_double_null_terminated_string_t *s) {
+  return sbp_double_null_terminated_string_packed_len(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
 }
 
-  uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_space_remaining(const sbp_double_null_terminated_string_t *s)
-{
-  return sbp_double_null_terminated_string_space_remaining(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
-      }
-  uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_count_sections(const sbp_double_null_terminated_string_t *s)
-{
-  return sbp_double_null_terminated_string_count_sections(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_space_remaining(
+    const sbp_double_null_terminated_string_t *s) {
+  return sbp_double_null_terminated_string_space_remaining(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+}
+uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_count_sections(
+    const sbp_double_null_terminated_string_t *s) {
+  return sbp_double_null_terminated_string_count_sections(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_add_section(sbp_double_null_terminated_string_t *s, const char *new_str)
-{
-  return sbp_double_null_terminated_string_add_section(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, new_str);
+bool sbp_msg_linux_process_fd_summary_t_most_opened_add_section(
+    sbp_double_null_terminated_string_t *s, const char *new_str) {
+  return sbp_double_null_terminated_string_add_section(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, new_str);
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_add_section_printf(sbp_double_null_terminated_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_linux_process_fd_summary_t_most_opened_add_section_printf(
+    sbp_double_null_terminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_double_null_terminated_string_add_section_vprintf(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
+  bool ret = sbp_double_null_terminated_string_add_section_vprintf(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_add_section_vprintf(sbp_double_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_double_null_terminated_string_add_section_vprintf(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
+bool sbp_msg_linux_process_fd_summary_t_most_opened_add_section_vprintf(
+    sbp_double_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_double_null_terminated_string_add_section_vprintf(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_append(sbp_double_null_terminated_string_t *s, const char *str)
-{
-  return sbp_double_null_terminated_string_append(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, str);
+bool sbp_msg_linux_process_fd_summary_t_most_opened_append(
+    sbp_double_null_terminated_string_t *s, const char *str) {
+  return sbp_double_null_terminated_string_append(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, str);
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_append_printf(sbp_double_null_terminated_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_linux_process_fd_summary_t_most_opened_append_printf(
+    sbp_double_null_terminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_double_null_terminated_string_append_vprintf(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
+  bool ret = sbp_double_null_terminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_process_fd_summary_t_most_opened_append_vprintf(sbp_double_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_double_null_terminated_string_append_vprintf(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
+bool sbp_msg_linux_process_fd_summary_t_most_opened_append_vprintf(
+    sbp_double_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_double_null_terminated_string_append_vprintf(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_process_fd_summary_t_most_opened_get_section(const sbp_double_null_terminated_string_t *s, uint8_t section)
-{
-  return sbp_double_null_terminated_string_get_section(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, section);
+const char *sbp_msg_linux_process_fd_summary_t_most_opened_get_section(
+    const sbp_double_null_terminated_string_t *s, uint8_t section) {
+  return sbp_double_null_terminated_string_get_section(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, section);
 }
 
-  uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_section_strlen(const sbp_double_null_terminated_string_t *s, uint8_t section)
-{
-  return sbp_double_null_terminated_string_section_strlen(s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, section);
+uint8_t sbp_msg_linux_process_fd_summary_t_most_opened_section_strlen(
+    const sbp_double_null_terminated_string_t *s, uint8_t section) {
+  return sbp_double_null_terminated_string_section_strlen(
+      s, &sbp_msg_linux_process_fd_summary_tmost_opened_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_linux_process_fd_summary_t(const sbp_msg_linux_process_fd_summary_t *msg) {
+size_t sbp_packed_size_sbp_msg_linux_process_fd_summary_t(
+    const sbp_msg_linux_process_fd_summary_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sys_fd_count);
-  packed_size += sbp_double_null_terminated_string_packed_len(&msg->most_opened, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+  packed_size += sbp_double_null_terminated_string_packed_len(
+      &msg->most_opened, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_process_fd_summary_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_summary_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sys_fd_count)) { return false; }
-  if (!sbp_double_null_terminated_string_pack(&msg->most_opened, &sbp_msg_linux_process_fd_summary_tmost_opened_params, ctx)) { return false; }
+bool encode_sbp_msg_linux_process_fd_summary_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_linux_process_fd_summary_t *msg) {
+  if (!encode_u32(ctx, &msg->sys_fd_count)) {
+    return false;
+  }
+  if (!sbp_double_null_terminated_string_pack(
+          &msg->most_opened,
+          &sbp_msg_linux_process_fd_summary_tmost_opened_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_process_fd_summary_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_process_fd_summary_t *msg) {
+s8 sbp_encode_sbp_msg_linux_process_fd_summary_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_linux_process_fd_summary_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1110,14 +1529,22 @@ s8 sbp_encode_sbp_msg_linux_process_fd_summary_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_process_fd_summary_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_summary_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sys_fd_count)) { return false; }
-  if (!sbp_double_null_terminated_string_unpack(&msg->most_opened, &sbp_msg_linux_process_fd_summary_tmost_opened_params, ctx)) { return false; }
+bool decode_sbp_msg_linux_process_fd_summary_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_linux_process_fd_summary_t *msg) {
+  if (!decode_u32(ctx, &msg->sys_fd_count)) {
+    return false;
+  }
+  if (!sbp_double_null_terminated_string_unpack(
+          &msg->most_opened,
+          &sbp_msg_linux_process_fd_summary_tmost_opened_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_process_fd_summary_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_process_fd_summary_t *msg) {
+s8 sbp_decode_sbp_msg_linux_process_fd_summary_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_linux_process_fd_summary_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1130,120 +1557,158 @@ s8 sbp_decode_sbp_msg_linux_process_fd_summary_t(const uint8_t *buf, uint8_t len
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_fd_summary_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_fd_summary_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_process_fd_summary_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_linux_process_fd_summary_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_process_fd_summary_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_FD_SUMMARY, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_process_fd_summary_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_PROCESS_FD_SUMMARY, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_process_fd_summary_t(const sbp_msg_linux_process_fd_summary_t *a, const sbp_msg_linux_process_fd_summary_t *b) {
+int sbp_cmp_sbp_msg_linux_process_fd_summary_t(
+    const sbp_msg_linux_process_fd_summary_t *a,
+    const sbp_msg_linux_process_fd_summary_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sys_fd_count, &b->sys_fd_count);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_double_null_terminated_string_strcmp(&a->most_opened, &b->most_opened, &sbp_msg_linux_process_fd_summary_tmost_opened_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_double_null_terminated_string_strcmp(
+      &a->most_opened, &b->most_opened,
+      &sbp_msg_linux_process_fd_summary_tmost_opened_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_linux_cpu_state_tcmdline_params = 
-{
-  .max_packed_len = 231
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_cpu_state_tcmdline_params = {.max_packed_len = 231};
 
-  void sbp_msg_linux_cpu_state_t_cmdline_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_linux_cpu_state_t_cmdline_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_linux_cpu_state_tcmdline_params);
 }
 
-  bool sbp_msg_linux_cpu_state_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_cpu_state_tcmdline_params);
+bool sbp_msg_linux_cpu_state_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params);
 }
 
-  int sbp_msg_linux_cpu_state_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_cpu_state_tcmdline_params);
+int sbp_msg_linux_cpu_state_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_cpu_state_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_cpu_state_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_cpu_state_tcmdline_params);
+uint8_t sbp_msg_linux_cpu_state_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_cpu_state_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_cpu_state_tcmdline_params);
-      }
-  bool sbp_msg_linux_cpu_state_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_cpu_state_tcmdline_params, new_str);
-  }
+uint8_t sbp_msg_linux_cpu_state_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params);
+}
+bool sbp_msg_linux_cpu_state_t_cmdline_set(sbp_unterminated_string_t *s,
+                                           const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params, new_str);
+}
 
-  bool sbp_msg_linux_cpu_state_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_linux_cpu_state_t_cmdline_printf(sbp_unterminated_string_t *s,
+                                              const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_linux_cpu_state_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
-  }
-
-  bool sbp_msg_linux_cpu_state_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_cpu_state_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_cpu_state_t_cmdline_vprintf(sbp_unterminated_string_t *s,
+                                               const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_cpu_state_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_cpu_state_tcmdline_params);
+bool sbp_msg_linux_cpu_state_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_cpu_state_t(const sbp_msg_linux_cpu_state_t *msg) {
+bool sbp_msg_linux_cpu_state_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_cpu_state_tcmdline_params, fmt, ap);
+}
+
+const char *sbp_msg_linux_cpu_state_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(s,
+                                     &sbp_msg_linux_cpu_state_tcmdline_params);
+}
+
+size_t sbp_packed_size_sbp_msg_linux_cpu_state_t(
+    const sbp_msg_linux_cpu_state_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
   packed_size += sbp_packed_size_u8(&msg->pcpu);
   packed_size += sbp_packed_size_u32(&msg->time);
   packed_size += sbp_packed_size_u8(&msg->flags);
-  packed_size += ( 15 * sbp_packed_size_char(&msg->tname[0]));
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params);
+  packed_size += (15 * sbp_packed_size_char(&msg->tname[0]));
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_cpu_state_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u8(ctx, &msg->pcpu)) { return false; }
-  if (!encode_u32(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  for (uint8_t i = 0; i < 15; i++)
-  {
-    if (!encode_char(ctx, &msg->tname[i])) { return false; }
+bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_linux_cpu_state_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params, ctx)) { return false; }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!encode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_cpu_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_cpu_state_t *msg) {
+s8 sbp_encode_sbp_msg_linux_cpu_state_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_linux_cpu_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1257,21 +1722,38 @@ s8 sbp_encode_sbp_msg_linux_cpu_state_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_cpu_state_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_cpu_state_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u8(ctx, &msg->pcpu)) { return false; }
-  if (!decode_u32(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  for (uint8_t i = 0; i < 15; i++) {
-    if (!decode_char(ctx, &msg->tname[i])) { return false; }
+bool decode_sbp_msg_linux_cpu_state_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_linux_cpu_state_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params, ctx)) { return false; }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!decode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_cpu_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_cpu_state_t *msg) {
+s8 sbp_decode_sbp_msg_linux_cpu_state_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_linux_cpu_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1284,138 +1766,183 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_cpu_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_cpu_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_cpu_state_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_linux_cpu_state_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_cpu_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_CPU_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_cpu_state_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_CPU_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_cpu_state_t(const sbp_msg_linux_cpu_state_t *a, const sbp_msg_linux_cpu_state_t *b) {
+int sbp_cmp_sbp_msg_linux_cpu_state_t(const sbp_msg_linux_cpu_state_t *a,
+                                      const sbp_msg_linux_cpu_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pcpu, &b->pcpu);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 15 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, &sbp_msg_linux_cpu_state_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_linux_mem_state_tcmdline_params = 
-{
-  .max_packed_len = 231
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_linux_mem_state_tcmdline_params = {.max_packed_len = 231};
 
-  void sbp_msg_linux_mem_state_t_cmdline_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_linux_mem_state_t_cmdline_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_linux_mem_state_tcmdline_params);
 }
 
-  bool sbp_msg_linux_mem_state_t_cmdline_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_linux_mem_state_tcmdline_params);
+bool sbp_msg_linux_mem_state_t_cmdline_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_linux_mem_state_tcmdline_params);
 }
 
-  int sbp_msg_linux_mem_state_t_cmdline_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_linux_mem_state_tcmdline_params);
+int sbp_msg_linux_mem_state_t_cmdline_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_linux_mem_state_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_mem_state_t_cmdline_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_linux_mem_state_tcmdline_params);
+uint8_t sbp_msg_linux_mem_state_t_cmdline_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_linux_mem_state_tcmdline_params);
 }
 
-  uint8_t sbp_msg_linux_mem_state_t_cmdline_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_linux_mem_state_tcmdline_params);
-      }
-  bool sbp_msg_linux_mem_state_t_cmdline_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_linux_mem_state_tcmdline_params, new_str);
-  }
+uint8_t sbp_msg_linux_mem_state_t_cmdline_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_linux_mem_state_tcmdline_params);
+}
+bool sbp_msg_linux_mem_state_t_cmdline_set(sbp_unterminated_string_t *s,
+                                           const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_linux_mem_state_tcmdline_params, new_str);
+}
 
-  bool sbp_msg_linux_mem_state_t_cmdline_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_linux_mem_state_t_cmdline_printf(sbp_unterminated_string_t *s,
+                                              const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_linux_mem_state_t_cmdline_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
-  }
-
-  bool sbp_msg_linux_mem_state_t_cmdline_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_linux_mem_state_t_cmdline_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
+bool sbp_msg_linux_mem_state_t_cmdline_vprintf(sbp_unterminated_string_t *s,
+                                               const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
 }
 
-  const char *sbp_msg_linux_mem_state_t_cmdline_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_linux_mem_state_tcmdline_params);
+bool sbp_msg_linux_mem_state_t_cmdline_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_mem_state_t(const sbp_msg_linux_mem_state_t *msg) {
+bool sbp_msg_linux_mem_state_t_cmdline_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_linux_mem_state_tcmdline_params, fmt, ap);
+}
+
+const char *sbp_msg_linux_mem_state_t_cmdline_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(s,
+                                     &sbp_msg_linux_mem_state_tcmdline_params);
+}
+
+size_t sbp_packed_size_sbp_msg_linux_mem_state_t(
+    const sbp_msg_linux_mem_state_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->index);
   packed_size += sbp_packed_size_u16(&msg->pid);
   packed_size += sbp_packed_size_u8(&msg->pmem);
   packed_size += sbp_packed_size_u32(&msg->time);
   packed_size += sbp_packed_size_u8(&msg->flags);
-  packed_size += ( 15 * sbp_packed_size_char(&msg->tname[0]));
-  packed_size += sbp_unterminated_string_packed_len(&msg->cmdline, &sbp_msg_linux_mem_state_tcmdline_params);
+  packed_size += (15 * sbp_packed_size_char(&msg->tname[0]));
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->cmdline, &sbp_msg_linux_mem_state_tcmdline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_mem_state_t *msg)
-{
-  if (!encode_u8(ctx, &msg->index)) { return false; }
-  if (!encode_u16(ctx, &msg->pid)) { return false; }
-  if (!encode_u8(ctx, &msg->pmem)) { return false; }
-  if (!encode_u32(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  for (uint8_t i = 0; i < 15; i++)
-  {
-    if (!encode_char(ctx, &msg->tname[i])) { return false; }
+bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_linux_mem_state_t *msg) {
+  if (!encode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_pack(&msg->cmdline, &sbp_msg_linux_mem_state_tcmdline_params, ctx)) { return false; }
+  if (!encode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!encode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->cmdline, &sbp_msg_linux_mem_state_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_mem_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_mem_state_t *msg) {
+s8 sbp_encode_sbp_msg_linux_mem_state_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_linux_mem_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1429,21 +1956,38 @@ s8 sbp_encode_sbp_msg_linux_mem_state_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_mem_state_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_mem_state_t *msg)
-{
-  if (!decode_u8(ctx, &msg->index)) { return false; }
-  if (!decode_u16(ctx, &msg->pid)) { return false; }
-  if (!decode_u8(ctx, &msg->pmem)) { return false; }
-  if (!decode_u32(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  for (uint8_t i = 0; i < 15; i++) {
-    if (!decode_char(ctx, &msg->tname[i])) { return false; }
+bool decode_sbp_msg_linux_mem_state_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_linux_mem_state_t *msg) {
+  if (!decode_u8(ctx, &msg->index)) {
+    return false;
   }
-  if (!sbp_unterminated_string_unpack(&msg->cmdline, &sbp_msg_linux_mem_state_tcmdline_params, ctx)) { return false; }
+  if (!decode_u16(ctx, &msg->pid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 15; i++) {
+    if (!decode_char(ctx, &msg->tname[i])) {
+      return false;
+    }
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->cmdline, &sbp_msg_linux_mem_state_tcmdline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_mem_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_mem_state_t *msg) {
+s8 sbp_decode_sbp_msg_linux_mem_state_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_linux_mem_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1456,45 +2000,66 @@ s8 sbp_decode_sbp_msg_linux_mem_state_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_mem_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_mem_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_mem_state_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_linux_mem_state_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_mem_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_MEM_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_mem_state_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_MEM_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_mem_state_t(const sbp_msg_linux_mem_state_t *a, const sbp_msg_linux_mem_state_t *b) {
+int sbp_cmp_sbp_msg_linux_mem_state_t(const sbp_msg_linux_mem_state_t *a,
+                                      const sbp_msg_linux_mem_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid, &b->pid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pmem, &b->pmem);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 15 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 15 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->tname[i], &b->tname[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, &sbp_msg_linux_mem_state_tcmdline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, &sbp_msg_linux_mem_state_tcmdline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_linux_sys_state_t(const sbp_msg_linux_sys_state_t *msg) {
+size_t sbp_packed_size_sbp_msg_linux_sys_state_t(
+    const sbp_msg_linux_sys_state_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->mem_total);
   packed_size += sbp_packed_size_u8(&msg->pcpu);
@@ -1507,20 +2072,38 @@ size_t sbp_packed_size_sbp_msg_linux_sys_state_t(const sbp_msg_linux_sys_state_t
   return packed_size;
 }
 
-bool encode_sbp_msg_linux_sys_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_linux_sys_state_t *msg)
-{
-  if (!encode_u16(ctx, &msg->mem_total)) { return false; }
-  if (!encode_u8(ctx, &msg->pcpu)) { return false; }
-  if (!encode_u8(ctx, &msg->pmem)) { return false; }
-  if (!encode_u16(ctx, &msg->procs_starting)) { return false; }
-  if (!encode_u16(ctx, &msg->procs_stopping)) { return false; }
-  if (!encode_u16(ctx, &msg->pid_count)) { return false; }
-  if (!encode_u32(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_linux_sys_state_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_linux_sys_state_t *msg) {
+  if (!encode_u16(ctx, &msg->mem_total)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->procs_starting)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->procs_stopping)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pid_count)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_linux_sys_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_linux_sys_state_t *msg) {
+s8 sbp_encode_sbp_msg_linux_sys_state_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_linux_sys_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1534,20 +2117,38 @@ s8 sbp_encode_sbp_msg_linux_sys_state_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_linux_sys_state_t(sbp_decode_ctx_t *ctx, sbp_msg_linux_sys_state_t *msg)
-{
-  if (!decode_u16(ctx, &msg->mem_total)) { return false; }
-  if (!decode_u8(ctx, &msg->pcpu)) { return false; }
-  if (!decode_u8(ctx, &msg->pmem)) { return false; }
-  if (!decode_u16(ctx, &msg->procs_starting)) { return false; }
-  if (!decode_u16(ctx, &msg->procs_stopping)) { return false; }
-  if (!decode_u16(ctx, &msg->pid_count)) { return false; }
-  if (!decode_u32(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_linux_sys_state_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_linux_sys_state_t *msg) {
+  if (!decode_u16(ctx, &msg->mem_total)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pcpu)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pmem)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->procs_starting)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->procs_stopping)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pid_count)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_linux_sys_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_linux_sys_state_t *msg) {
+s8 sbp_decode_sbp_msg_linux_sys_state_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_linux_sys_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1560,40 +2161,62 @@ s8 sbp_decode_sbp_msg_linux_sys_state_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_sys_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_sys_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_linux_sys_state_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_linux_sys_state_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_linux_sys_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LINUX_SYS_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_linux_sys_state_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LINUX_SYS_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_linux_sys_state_t(const sbp_msg_linux_sys_state_t *a, const sbp_msg_linux_sys_state_t *b) {
+int sbp_cmp_sbp_msg_linux_sys_state_t(const sbp_msg_linux_sys_state_t *a,
+                                      const sbp_msg_linux_sys_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->mem_total, &b->mem_total);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pcpu, &b->pcpu);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pmem, &b->pmem);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->procs_starting, &b->procs_starting);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->procs_stopping, &b->procs_stopping);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pid_count, &b->pid_count);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/linux.c
+++ b/c/src/new/linux.c
@@ -114,7 +114,7 @@ bool encode_sbp_msg_linux_cpu_state_dep_a_t(
   if (!encode_u8(ctx, &msg->pcpu)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -328,7 +328,7 @@ bool encode_sbp_msg_linux_mem_state_dep_a_t(
   if (!encode_u8(ctx, &msg->pmem)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -919,7 +919,7 @@ bool encode_sbp_msg_linux_process_socket_queues_t(
   if (!encode_u16(ctx, &msg->socket_states)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 64; i++) {
+  for (uint8_t i = 0; i < 64; i++) {
     if (!encode_char(ctx, &msg->address_of_largest[i])) {
       return false;
     }
@@ -1079,12 +1079,12 @@ bool encode_sbp_msg_linux_socket_usage_t(
   if (!encode_u32(ctx, &msg->max_queue_depth)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0; i < 16; i++) {
     if (!encode_u16(ctx, &msg->socket_state_counts[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0; i < 16; i++) {
     if (!encode_u16(ctx, &msg->socket_type_counts[i])) {
       return false;
     }
@@ -1686,7 +1686,7 @@ bool encode_sbp_msg_linux_cpu_state_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->flags)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }
@@ -1920,7 +1920,7 @@ bool encode_sbp_msg_linux_mem_state_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->flags)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; i < 15; i++) {
     if (!encode_char(ctx, &msg->tname[i])) {
       return false;
     }

--- a/c/src/new/logging.c
+++ b/c/src/new/logging.c
@@ -1,97 +1,115 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/logging.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/logging.h>
 #include <libsbp/internal/new/logging.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
-static const sbp_unterminated_string_params_t sbp_msg_log_ttext_params = 
-{
-  .max_packed_len = 254
-};
+#include <libsbp/new/logging.h>
+#include <libsbp/sbp.h>
+static const sbp_unterminated_string_params_t sbp_msg_log_ttext_params = {
+    .max_packed_len = 254};
 
-  void sbp_msg_log_t_text_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_log_t_text_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_log_ttext_params);
 }
 
-  bool sbp_msg_log_t_text_valid(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_log_t_text_valid(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_valid(s, &sbp_msg_log_ttext_params);
 }
 
-  int sbp_msg_log_t_text_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
+int sbp_msg_log_t_text_strcmp(const sbp_unterminated_string_t *a,
+                              const sbp_unterminated_string_t *b) {
   return sbp_unterminated_string_strcmp(a, b, &sbp_msg_log_ttext_params);
 }
 
-  uint8_t sbp_msg_log_t_text_packed_len(const sbp_unterminated_string_t *s)
-{
+uint8_t sbp_msg_log_t_text_packed_len(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_packed_len(s, &sbp_msg_log_ttext_params);
 }
 
-  uint8_t sbp_msg_log_t_text_space_remaining(const sbp_unterminated_string_t *s)
-{
+uint8_t sbp_msg_log_t_text_space_remaining(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_space_remaining(s, &sbp_msg_log_ttext_params);
-      }
-  bool sbp_msg_log_t_text_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
+}
+bool sbp_msg_log_t_text_set(sbp_unterminated_string_t *s, const char *new_str) {
   return sbp_unterminated_string_set(s, &sbp_msg_log_ttext_params, new_str);
-  }
+}
 
-  bool sbp_msg_log_t_text_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_log_t_text_printf(sbp_unterminated_string_t *s, const char *fmt,
+                               ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_log_ttext_params, fmt, ap);
+  bool ret =
+      sbp_unterminated_string_vprintf(s, &sbp_msg_log_ttext_params, fmt, ap);
   va_end(ap);
   return ret;
-  }
+}
 
-  bool sbp_msg_log_t_text_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
+bool sbp_msg_log_t_text_vprintf(sbp_unterminated_string_t *s, const char *fmt,
+                                va_list ap) {
   return sbp_unterminated_string_vprintf(s, &sbp_msg_log_ttext_params, fmt, ap);
-  }
+}
 
-  bool sbp_msg_log_t_text_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_log_t_text_append_printf(sbp_unterminated_string_t *s,
+                                      const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_log_ttext_params, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_log_ttext_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_log_t_text_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_log_ttext_params, fmt, ap);
+bool sbp_msg_log_t_text_append_vprintf(sbp_unterminated_string_t *s,
+                                       const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_log_ttext_params,
+                                                fmt, ap);
 }
 
-  const char *sbp_msg_log_t_text_get(const sbp_unterminated_string_t *s)
-{
+const char *sbp_msg_log_t_text_get(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_get(s, &sbp_msg_log_ttext_params);
 }
 
 size_t sbp_packed_size_sbp_msg_log_t(const sbp_msg_log_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->level);
-  packed_size += sbp_unterminated_string_packed_len(&msg->text, &sbp_msg_log_ttext_params);
+  packed_size +=
+      sbp_unterminated_string_packed_len(&msg->text, &sbp_msg_log_ttext_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_log_t(sbp_encode_ctx_t *ctx, const sbp_msg_log_t *msg)
-{
-  if (!encode_u8(ctx, &msg->level)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->text, &sbp_msg_log_ttext_params, ctx)) { return false; }
+bool encode_sbp_msg_log_t(sbp_encode_ctx_t *ctx, const sbp_msg_log_t *msg) {
+  if (!encode_u8(ctx, &msg->level)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(&msg->text, &sbp_msg_log_ttext_params,
+                                    ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_log_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_log_t *msg) {
+s8 sbp_encode_sbp_msg_log_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                            const sbp_msg_log_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -105,14 +123,19 @@ s8 sbp_encode_sbp_msg_log_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const
   return SBP_OK;
 }
 
-bool decode_sbp_msg_log_t(sbp_decode_ctx_t *ctx, sbp_msg_log_t *msg)
-{
-  if (!decode_u8(ctx, &msg->level)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->text, &sbp_msg_log_ttext_params, ctx)) { return false; }
+bool decode_sbp_msg_log_t(sbp_decode_ctx_t *ctx, sbp_msg_log_t *msg) {
+  if (!decode_u8(ctx, &msg->level)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(&msg->text, &sbp_msg_log_ttext_params,
+                                      ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_log_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_log_t *msg) {
+s8 sbp_decode_sbp_msg_log_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                            sbp_msg_log_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -125,23 +148,32 @@ s8 sbp_decode_sbp_msg_log_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_log_t(struct sbp_state *s, u16 sender_id, const sbp_msg_log_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_log_t(struct sbp_state *s, u16 sender_id,
+                          const sbp_msg_log_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_log_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_LOG, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_log_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_LOG, sender_id, payload_len, payload,
+                          write);
 }
 
 int sbp_cmp_sbp_msg_log_t(const sbp_msg_log_t *a, const sbp_msg_log_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->level, &b->level);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->text, &b->text, &sbp_msg_log_ttext_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(&a->text, &b->text,
+                                       &sbp_msg_log_ttext_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -149,22 +181,28 @@ size_t sbp_packed_size_sbp_msg_fwd_t(const sbp_msg_fwd_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->source);
   packed_size += sbp_packed_size_u8(&msg->protocol);
-  packed_size += (msg->n_fwd_payload * sbp_packed_size_u8(&msg->fwd_payload[0]));
+  packed_size +=
+      (msg->n_fwd_payload * sbp_packed_size_u8(&msg->fwd_payload[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_fwd_t(sbp_encode_ctx_t *ctx, const sbp_msg_fwd_t *msg)
-{
-  if (!encode_u8(ctx, &msg->source)) { return false; }
-  if (!encode_u8(ctx, &msg->protocol)) { return false; }
-  for (uint8_t i = 0; i < msg->n_fwd_payload; i++)
-  {
-    if (!encode_u8(ctx, &msg->fwd_payload[i])) { return false; }
+bool encode_sbp_msg_fwd_t(sbp_encode_ctx_t *ctx, const sbp_msg_fwd_t *msg) {
+  if (!encode_u8(ctx, &msg->source)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->protocol)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_fwd_payload; i++) {
+    if (!encode_u8(ctx, &msg->fwd_payload[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_fwd_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_fwd_t *msg) {
+s8 sbp_encode_sbp_msg_fwd_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                            const sbp_msg_fwd_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -178,18 +216,25 @@ s8 sbp_encode_sbp_msg_fwd_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const
   return SBP_OK;
 }
 
-bool decode_sbp_msg_fwd_t(sbp_decode_ctx_t *ctx, sbp_msg_fwd_t *msg)
-{
-  if (!decode_u8(ctx, &msg->source)) { return false; }
-  if (!decode_u8(ctx, &msg->protocol)) { return false; }
-    msg->n_fwd_payload = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->fwd_payload[0]));
+bool decode_sbp_msg_fwd_t(sbp_decode_ctx_t *ctx, sbp_msg_fwd_t *msg) {
+  if (!decode_u8(ctx, &msg->source)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->protocol)) {
+    return false;
+  }
+  msg->n_fwd_payload = (uint8_t)((ctx->buf_len - ctx->offset) /
+                                 sbp_packed_size_u8(&msg->fwd_payload[0]));
   for (uint8_t i = 0; i < msg->n_fwd_payload; i++) {
-    if (!decode_u8(ctx, &msg->fwd_payload[i])) { return false; }
+    if (!decode_u8(ctx, &msg->fwd_payload[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_fwd_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_fwd_t *msg) {
+s8 sbp_decode_sbp_msg_fwd_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                            sbp_msg_fwd_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -202,112 +247,127 @@ s8 sbp_decode_sbp_msg_fwd_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fwd_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fwd_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_fwd_t(struct sbp_state *s, u16 sender_id,
+                          const sbp_msg_fwd_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_fwd_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FWD, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_fwd_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FWD, sender_id, payload_len, payload,
+                          write);
 }
 
 int sbp_cmp_sbp_msg_fwd_t(const sbp_msg_fwd_t *a, const sbp_msg_fwd_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->source, &b->source);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->protocol, &b->protocol);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_fwd_payload, &b->n_fwd_payload);
-  for (uint8_t i = 0; i < a->n_fwd_payload && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_fwd_payload && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->fwd_payload[i], &b->fwd_payload[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_print_dep_ttext_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_unterminated_string_params_t sbp_msg_print_dep_ttext_params = {
+    .max_packed_len = 255};
 
-  void sbp_msg_print_dep_t_text_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_print_dep_t_text_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_print_dep_ttext_params);
 }
 
-  bool sbp_msg_print_dep_t_text_valid(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_print_dep_t_text_valid(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_valid(s, &sbp_msg_print_dep_ttext_params);
 }
 
-  int sbp_msg_print_dep_t_text_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
+int sbp_msg_print_dep_t_text_strcmp(const sbp_unterminated_string_t *a,
+                                    const sbp_unterminated_string_t *b) {
   return sbp_unterminated_string_strcmp(a, b, &sbp_msg_print_dep_ttext_params);
 }
 
-  uint8_t sbp_msg_print_dep_t_text_packed_len(const sbp_unterminated_string_t *s)
-{
+uint8_t sbp_msg_print_dep_t_text_packed_len(
+    const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_packed_len(s, &sbp_msg_print_dep_ttext_params);
 }
 
-  uint8_t sbp_msg_print_dep_t_text_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_print_dep_ttext_params);
-      }
-  bool sbp_msg_print_dep_t_text_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_print_dep_ttext_params, new_str);
-  }
+uint8_t sbp_msg_print_dep_t_text_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_print_dep_ttext_params);
+}
+bool sbp_msg_print_dep_t_text_set(sbp_unterminated_string_t *s,
+                                  const char *new_str) {
+  return sbp_unterminated_string_set(s, &sbp_msg_print_dep_ttext_params,
+                                     new_str);
+}
 
-  bool sbp_msg_print_dep_t_text_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_print_dep_t_text_printf(sbp_unterminated_string_t *s,
+                                     const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_print_dep_ttext_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_print_dep_t_text_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_print_dep_ttext_params, fmt, ap);
-  }
-
-  bool sbp_msg_print_dep_t_text_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_print_dep_ttext_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_print_dep_ttext_params,
+                                             fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_print_dep_t_text_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_print_dep_ttext_params, fmt, ap);
+bool sbp_msg_print_dep_t_text_vprintf(sbp_unterminated_string_t *s,
+                                      const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(s, &sbp_msg_print_dep_ttext_params,
+                                         fmt, ap);
 }
 
-  const char *sbp_msg_print_dep_t_text_get(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_print_dep_t_text_append_printf(sbp_unterminated_string_t *s,
+                                            const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_print_dep_ttext_params, fmt, ap);
+  va_end(ap);
+  return ret;
+}
+
+bool sbp_msg_print_dep_t_text_append_vprintf(sbp_unterminated_string_t *s,
+                                             const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_print_dep_ttext_params, fmt, ap);
+}
+
+const char *sbp_msg_print_dep_t_text_get(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_get(s, &sbp_msg_print_dep_ttext_params);
 }
 
 size_t sbp_packed_size_sbp_msg_print_dep_t(const sbp_msg_print_dep_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_unterminated_string_packed_len(&msg->text, &sbp_msg_print_dep_ttext_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->text, &sbp_msg_print_dep_ttext_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_print_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_print_dep_t *msg)
-{
-  if (!sbp_unterminated_string_pack(&msg->text, &sbp_msg_print_dep_ttext_params, ctx)) { return false; }
+bool encode_sbp_msg_print_dep_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_print_dep_t *msg) {
+  if (!sbp_unterminated_string_pack(&msg->text, &sbp_msg_print_dep_ttext_params,
+                                    ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_print_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_print_dep_t *msg) {
+s8 sbp_encode_sbp_msg_print_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_print_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -321,13 +381,17 @@ s8 sbp_encode_sbp_msg_print_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_print_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_print_dep_t *msg)
-{
-  if (!sbp_unterminated_string_unpack(&msg->text, &sbp_msg_print_dep_ttext_params, ctx)) { return false; }
+bool decode_sbp_msg_print_dep_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_print_dep_t *msg) {
+  if (!sbp_unterminated_string_unpack(&msg->text,
+                                      &sbp_msg_print_dep_ttext_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_print_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_print_dep_t *msg) {
+s8 sbp_decode_sbp_msg_print_dep_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_print_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -340,19 +404,28 @@ s8 sbp_decode_sbp_msg_print_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_print_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_print_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_print_dep_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_print_dep_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_print_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_PRINT_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_print_dep_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_PRINT_DEP, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_print_dep_t(const sbp_msg_print_dep_t *a, const sbp_msg_print_dep_t *b) {
+int sbp_cmp_sbp_msg_print_dep_t(const sbp_msg_print_dep_t *a,
+                                const sbp_msg_print_dep_t *b) {
   int ret = 0;
-  
-  ret = sbp_unterminated_string_strcmp(&a->text, &b->text, &sbp_msg_print_dep_ttext_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_unterminated_string_strcmp(&a->text, &b->text,
+                                       &sbp_msg_print_dep_ttext_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/logging.c
+++ b/c/src/new/logging.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/logging.yaml
  * with generate.py. Please do not hand edit!
@@ -148,6 +136,7 @@ s8 sbp_decode_sbp_msg_log_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_log_t(struct sbp_state *s, u16 sender_id,
                           const sbp_msg_log_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -169,8 +158,7 @@ int sbp_cmp_sbp_msg_log_t(const sbp_msg_log_t *a, const sbp_msg_log_t *b) {
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(&a->text, &b->text,
-                                       &sbp_msg_log_ttext_params);
+  ret = sbp_msg_log_t_text_strcmp(&a->text, &b->text);
   if (ret != 0) {
     return ret;
   }
@@ -193,7 +181,7 @@ bool encode_sbp_msg_fwd_t(sbp_encode_ctx_t *ctx, const sbp_msg_fwd_t *msg) {
   if (!encode_u8(ctx, &msg->protocol)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_fwd_payload; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_fwd_payload; i++) {
     if (!encode_u8(ctx, &msg->fwd_payload[i])) {
       return false;
     }
@@ -247,6 +235,7 @@ s8 sbp_decode_sbp_msg_fwd_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_fwd_t(struct sbp_state *s, u16 sender_id,
                           const sbp_msg_fwd_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -274,7 +263,7 @@ int sbp_cmp_sbp_msg_fwd_t(const sbp_msg_fwd_t *a, const sbp_msg_fwd_t *b) {
   }
 
   ret = sbp_cmp_u8(&a->n_fwd_payload, &b->n_fwd_payload);
-  for (uint8_t i = 0; i < a->n_fwd_payload && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_fwd_payload; i++) {
     ret = sbp_cmp_u8(&a->fwd_payload[i], &b->fwd_payload[i]);
   }
   if (ret != 0) {
@@ -404,6 +393,7 @@ s8 sbp_decode_sbp_msg_print_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_print_dep_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_print_dep_t *msg,
                                 sbp_write_fn_t write) {
@@ -422,8 +412,7 @@ int sbp_cmp_sbp_msg_print_dep_t(const sbp_msg_print_dep_t *a,
                                 const sbp_msg_print_dep_t *b) {
   int ret = 0;
 
-  ret = sbp_unterminated_string_strcmp(&a->text, &b->text,
-                                       &sbp_msg_print_dep_ttext_params);
+  ret = sbp_msg_print_dep_t_text_strcmp(&a->text, &b->text);
   if (ret != 0) {
     return ret;
   }

--- a/c/src/new/logging.c
+++ b/c/src/new/logging.c
@@ -181,7 +181,7 @@ bool encode_sbp_msg_fwd_t(sbp_encode_ctx_t *ctx, const sbp_msg_fwd_t *msg) {
   if (!encode_u8(ctx, &msg->protocol)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_fwd_payload; i++) {
+  for (uint8_t i = 0; i < msg->n_fwd_payload; i++) {
     if (!encode_u8(ctx, &msg->fwd_payload[i])) {
       return false;
     }

--- a/c/src/new/mag.c
+++ b/c/src/new/mag.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/mag.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/mag.h>
 #include <libsbp/internal/new/mag.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/mag.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_mag_raw_t(const sbp_msg_mag_raw_t *msg) {
   size_t packed_size = 0;
@@ -21,17 +38,28 @@ size_t sbp_packed_size_sbp_msg_mag_raw_t(const sbp_msg_mag_raw_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_mag_raw_t(sbp_encode_ctx_t *ctx, const sbp_msg_mag_raw_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u8(ctx, &msg->tow_f)) { return false; }
-  if (!encode_s16(ctx, &msg->mag_x)) { return false; }
-  if (!encode_s16(ctx, &msg->mag_y)) { return false; }
-  if (!encode_s16(ctx, &msg->mag_z)) { return false; }
+bool encode_sbp_msg_mag_raw_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_mag_raw_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tow_f)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->mag_x)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->mag_y)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->mag_z)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_mag_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_mag_raw_t *msg) {
+s8 sbp_encode_sbp_msg_mag_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_mag_raw_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -45,17 +73,27 @@ s8 sbp_encode_sbp_msg_mag_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_mag_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_mag_raw_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u8(ctx, &msg->tow_f)) { return false; }
-  if (!decode_s16(ctx, &msg->mag_x)) { return false; }
-  if (!decode_s16(ctx, &msg->mag_y)) { return false; }
-  if (!decode_s16(ctx, &msg->mag_z)) { return false; }
+bool decode_sbp_msg_mag_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_mag_raw_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tow_f)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->mag_x)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->mag_y)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->mag_z)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_mag_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_mag_raw_t *msg) {
+s8 sbp_decode_sbp_msg_mag_raw_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_mag_raw_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -68,31 +106,47 @@ s8 sbp_decode_sbp_msg_mag_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_mag_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mag_raw_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_mag_raw_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_mag_raw_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_mag_raw_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_MAG_RAW, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_mag_raw_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_MAG_RAW, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_mag_raw_t(const sbp_msg_mag_raw_t *a, const sbp_msg_mag_raw_t *b) {
+int sbp_cmp_sbp_msg_mag_raw_t(const sbp_msg_mag_raw_t *a,
+                              const sbp_msg_mag_raw_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tow_f, &b->tow_f);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->mag_x, &b->mag_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->mag_y, &b->mag_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->mag_z, &b->mag_z);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/mag.c
+++ b/c/src/new/mag.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/mag.yaml
  * with generate.py. Please do not hand edit!
@@ -106,6 +94,7 @@ s8 sbp_decode_sbp_msg_mag_raw_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_mag_raw_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_mag_raw_t *msg,
                               sbp_write_fn_t write) {

--- a/c/src/new/navigation.c
+++ b/c/src/new/navigation.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/navigation.yaml
  * with generate.py. Please do not hand edit!
@@ -99,6 +87,7 @@ s8 sbp_decode_sbp_msg_gps_time_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_gps_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_gps_time_t *msg,
                                sbp_write_fn_t write) {
@@ -214,6 +203,7 @@ s8 sbp_decode_sbp_msg_gps_time_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_gps_time_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_gps_time_gnss_t *msg,
                                     sbp_write_fn_t write) {
@@ -360,6 +350,7 @@ s8 sbp_decode_sbp_msg_utc_time_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_utc_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_utc_time_t *msg,
                                sbp_write_fn_t write) {
@@ -535,6 +526,7 @@ s8 sbp_decode_sbp_msg_utc_time_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_utc_time_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_utc_time_gnss_t *msg,
                                     sbp_write_fn_t write) {
@@ -691,6 +683,7 @@ s8 sbp_decode_sbp_msg_dops_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_dops_t(struct sbp_state *s, u16 sender_id,
                            const sbp_msg_dops_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -836,6 +829,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_ecef_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_pos_ecef_t *msg,
                                sbp_write_fn_t write) {
@@ -1022,6 +1016,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_ecef_cov_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_pos_ecef_cov_t *msg,
                                    sbp_write_fn_t write) {
@@ -1201,6 +1196,7 @@ s8 sbp_decode_sbp_msg_pos_llh_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_llh_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_pos_llh_t *msg,
                               sbp_write_fn_t write) {
@@ -1391,6 +1387,7 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_llh_cov_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_pos_llh_cov_t *msg,
                                   sbp_write_fn_t write) {
@@ -1567,6 +1564,7 @@ s8 sbp_decode_sbp_msg_baseline_ecef_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_baseline_ecef_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_baseline_ecef_t *msg,
                                     sbp_write_fn_t write) {
@@ -1725,6 +1723,7 @@ s8 sbp_decode_sbp_msg_baseline_ned_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_baseline_ned_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_baseline_ned_t *msg,
                                    sbp_write_fn_t write) {
@@ -1877,6 +1876,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ecef_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_vel_ecef_t *msg,
                                sbp_write_fn_t write) {
@@ -2063,6 +2063,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ecef_cov_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_vel_ecef_cov_t *msg,
                                    sbp_write_fn_t write) {
@@ -2242,6 +2243,7 @@ s8 sbp_decode_sbp_msg_vel_ned_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ned_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_vel_ned_t *msg,
                               sbp_write_fn_t write) {
@@ -2432,6 +2434,7 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ned_cov_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_vel_ned_cov_t *msg,
                                   sbp_write_fn_t write) {
@@ -2608,6 +2611,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_ecef_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_pos_ecef_gnss_t *msg,
                                     sbp_write_fn_t write) {
@@ -2794,6 +2798,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_pos_ecef_cov_gnss_t *msg,
                                         sbp_write_fn_t write) {
@@ -2977,6 +2982,7 @@ s8 sbp_decode_sbp_msg_pos_llh_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_llh_gnss_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_pos_llh_gnss_t *msg,
                                    sbp_write_fn_t write) {
@@ -3168,6 +3174,7 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_llh_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_pos_llh_cov_gnss_t *msg,
                                        sbp_write_fn_t write) {
@@ -3344,6 +3351,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ecef_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_vel_ecef_gnss_t *msg,
                                     sbp_write_fn_t write) {
@@ -3530,6 +3538,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_vel_ecef_cov_gnss_t *msg,
                                         sbp_write_fn_t write) {
@@ -3713,6 +3722,7 @@ s8 sbp_decode_sbp_msg_vel_ned_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ned_gnss_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_vel_ned_gnss_t *msg,
                                    sbp_write_fn_t write) {
@@ -3904,6 +3914,7 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_gnss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ned_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_vel_ned_cov_gnss_t *msg,
                                        sbp_write_fn_t write) {
@@ -4111,6 +4122,7 @@ s8 sbp_decode_sbp_msg_vel_body_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_body_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_vel_body_t *msg,
                                sbp_write_fn_t write) {
@@ -4252,6 +4264,7 @@ s8 sbp_decode_sbp_msg_age_corrections_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_age_corrections_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_age_corrections_t *msg,
                                       sbp_write_fn_t write) {
@@ -4357,6 +4370,7 @@ s8 sbp_decode_sbp_msg_gps_time_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_gps_time_dep_a_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_gps_time_dep_a_t *msg,
                                      sbp_write_fn_t write) {
@@ -4484,6 +4498,7 @@ s8 sbp_decode_sbp_msg_dops_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_dops_dep_a_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_dops_dep_a_t *msg,
                                  sbp_write_fn_t write) {
@@ -4630,6 +4645,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_ecef_dep_a_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_pos_ecef_dep_a_t *msg,
                                      sbp_write_fn_t write) {
@@ -4788,6 +4804,7 @@ s8 sbp_decode_sbp_msg_pos_llh_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pos_llh_dep_a_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_pos_llh_dep_a_t *msg,
                                     sbp_write_fn_t write) {
@@ -4944,6 +4961,7 @@ s8 sbp_decode_sbp_msg_baseline_ecef_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_baseline_ecef_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_baseline_ecef_dep_a_t *msg, sbp_write_fn_t write) {
@@ -5103,6 +5121,7 @@ s8 sbp_decode_sbp_msg_baseline_ned_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_baseline_ned_dep_a_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_dep_a_t *msg,
     sbp_write_fn_t write) {
@@ -5260,6 +5279,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ecef_dep_a_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_vel_ecef_dep_a_t *msg,
                                      sbp_write_fn_t write) {
@@ -5418,6 +5438,7 @@ s8 sbp_decode_sbp_msg_vel_ned_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_vel_ned_dep_a_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_vel_ned_dep_a_t *msg,
                                     sbp_write_fn_t write) {
@@ -5553,6 +5574,7 @@ s8 sbp_decode_sbp_msg_baseline_heading_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_baseline_heading_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_baseline_heading_dep_a_t *msg, sbp_write_fn_t write) {
@@ -5690,6 +5712,7 @@ s8 sbp_decode_sbp_msg_protection_level_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_protection_level_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_protection_level_dep_a_t *msg, sbp_write_fn_t write) {
@@ -5940,6 +5963,7 @@ s8 sbp_decode_sbp_msg_protection_level_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_protection_level_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_protection_level_t *msg,
                                        sbp_write_fn_t write) {

--- a/c/src/new/navigation.c
+++ b/c/src/new/navigation.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/navigation.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/navigation.h>
 #include <libsbp/internal/new/navigation.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/navigation.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_gps_time_t(const sbp_msg_gps_time_t *msg) {
   size_t packed_size = 0;
@@ -20,16 +37,25 @@ size_t sbp_packed_size_sbp_msg_gps_time_t(const sbp_msg_gps_time_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_gps_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_gps_time_t *msg)
-{
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_gps_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_gps_time_t *msg) {
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_gps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_gps_time_t *msg) {
+s8 sbp_encode_sbp_msg_gps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_gps_time_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -43,16 +69,24 @@ s8 sbp_encode_sbp_msg_gps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_gps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_t *msg)
-{
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_gps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_t *msg) {
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_gps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_gps_time_t *msg) {
+s8 sbp_decode_sbp_msg_gps_time_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_gps_time_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -65,33 +99,48 @@ s8 sbp_decode_sbp_msg_gps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gps_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_gps_time_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_gps_time_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_gps_time_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GPS_TIME, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_gps_time_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GPS_TIME, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_gps_time_t(const sbp_msg_gps_time_t *a, const sbp_msg_gps_time_t *b) {
+int sbp_cmp_sbp_msg_gps_time_t(const sbp_msg_gps_time_t *a,
+                               const sbp_msg_gps_time_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->ns_residual, &b->ns_residual);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_gps_time_gnss_t(const sbp_msg_gps_time_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_gps_time_gnss_t(
+    const sbp_msg_gps_time_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->wn);
   packed_size += sbp_packed_size_u32(&msg->tow);
@@ -100,16 +149,26 @@ size_t sbp_packed_size_sbp_msg_gps_time_gnss_t(const sbp_msg_gps_time_gnss_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_gps_time_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_gps_time_gnss_t *msg)
-{
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_gps_time_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_gps_time_gnss_t *msg) {
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_gps_time_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_gps_time_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_gps_time_gnss_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_gps_time_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -123,16 +182,26 @@ s8 sbp_encode_sbp_msg_gps_time_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_gps_time_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_gnss_t *msg)
-{
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_gps_time_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_gps_time_gnss_t *msg) {
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_gps_time_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_gps_time_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_gps_time_gnss_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_gps_time_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -145,29 +214,43 @@ s8 sbp_decode_sbp_msg_gps_time_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gps_time_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_gps_time_gnss_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_gps_time_gnss_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_gps_time_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GPS_TIME_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_gps_time_gnss_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GPS_TIME_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_gps_time_gnss_t(const sbp_msg_gps_time_gnss_t *a, const sbp_msg_gps_time_gnss_t *b) {
+int sbp_cmp_sbp_msg_gps_time_gnss_t(const sbp_msg_gps_time_gnss_t *a,
+                                    const sbp_msg_gps_time_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->ns_residual, &b->ns_residual);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -185,21 +268,40 @@ size_t sbp_packed_size_sbp_msg_utc_time_t(const sbp_msg_utc_time_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_utc_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_utc_time_t *msg)
-{
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->year)) { return false; }
-  if (!encode_u8(ctx, &msg->month)) { return false; }
-  if (!encode_u8(ctx, &msg->day)) { return false; }
-  if (!encode_u8(ctx, &msg->hours)) { return false; }
-  if (!encode_u8(ctx, &msg->minutes)) { return false; }
-  if (!encode_u8(ctx, &msg->seconds)) { return false; }
-  if (!encode_u32(ctx, &msg->ns)) { return false; }
+bool encode_sbp_msg_utc_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_utc_time_t *msg) {
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->year)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->month)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->day)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->hours)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->minutes)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->seconds)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->ns)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_utc_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_utc_time_t *msg) {
+s8 sbp_encode_sbp_msg_utc_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_utc_time_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -213,21 +315,39 @@ s8 sbp_encode_sbp_msg_utc_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_utc_time_t(sbp_decode_ctx_t *ctx, sbp_msg_utc_time_t *msg)
-{
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->year)) { return false; }
-  if (!decode_u8(ctx, &msg->month)) { return false; }
-  if (!decode_u8(ctx, &msg->day)) { return false; }
-  if (!decode_u8(ctx, &msg->hours)) { return false; }
-  if (!decode_u8(ctx, &msg->minutes)) { return false; }
-  if (!decode_u8(ctx, &msg->seconds)) { return false; }
-  if (!decode_u32(ctx, &msg->ns)) { return false; }
+bool decode_sbp_msg_utc_time_t(sbp_decode_ctx_t *ctx, sbp_msg_utc_time_t *msg) {
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->year)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->month)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->day)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->hours)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->minutes)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->seconds)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->ns)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_utc_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_utc_time_t *msg) {
+s8 sbp_decode_sbp_msg_utc_time_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_utc_time_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -240,48 +360,73 @@ s8 sbp_decode_sbp_msg_utc_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_utc_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_utc_time_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_utc_time_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_utc_time_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_utc_time_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_UTC_TIME, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_utc_time_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_UTC_TIME, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_utc_time_t(const sbp_msg_utc_time_t *a, const sbp_msg_utc_time_t *b) {
+int sbp_cmp_sbp_msg_utc_time_t(const sbp_msg_utc_time_t *a,
+                               const sbp_msg_utc_time_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->year, &b->year);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->month, &b->month);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->day, &b->day);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->hours, &b->hours);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->minutes, &b->minutes);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->seconds, &b->seconds);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->ns, &b->ns);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_utc_time_gnss_t(const sbp_msg_utc_time_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_utc_time_gnss_t(
+    const sbp_msg_utc_time_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->flags);
   packed_size += sbp_packed_size_u32(&msg->tow);
@@ -295,21 +440,41 @@ size_t sbp_packed_size_sbp_msg_utc_time_gnss_t(const sbp_msg_utc_time_gnss_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_utc_time_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_utc_time_gnss_t *msg)
-{
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->year)) { return false; }
-  if (!encode_u8(ctx, &msg->month)) { return false; }
-  if (!encode_u8(ctx, &msg->day)) { return false; }
-  if (!encode_u8(ctx, &msg->hours)) { return false; }
-  if (!encode_u8(ctx, &msg->minutes)) { return false; }
-  if (!encode_u8(ctx, &msg->seconds)) { return false; }
-  if (!encode_u32(ctx, &msg->ns)) { return false; }
+bool encode_sbp_msg_utc_time_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_utc_time_gnss_t *msg) {
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->year)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->month)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->day)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->hours)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->minutes)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->seconds)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->ns)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_utc_time_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_utc_time_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_utc_time_gnss_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_utc_time_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -323,21 +488,41 @@ s8 sbp_encode_sbp_msg_utc_time_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_utc_time_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_utc_time_gnss_t *msg)
-{
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->year)) { return false; }
-  if (!decode_u8(ctx, &msg->month)) { return false; }
-  if (!decode_u8(ctx, &msg->day)) { return false; }
-  if (!decode_u8(ctx, &msg->hours)) { return false; }
-  if (!decode_u8(ctx, &msg->minutes)) { return false; }
-  if (!decode_u8(ctx, &msg->seconds)) { return false; }
-  if (!decode_u32(ctx, &msg->ns)) { return false; }
+bool decode_sbp_msg_utc_time_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_utc_time_gnss_t *msg) {
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->year)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->month)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->day)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->hours)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->minutes)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->seconds)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->ns)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_utc_time_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_utc_time_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_utc_time_gnss_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_utc_time_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -350,44 +535,68 @@ s8 sbp_decode_sbp_msg_utc_time_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_utc_time_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_utc_time_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_utc_time_gnss_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_utc_time_gnss_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_utc_time_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_UTC_TIME_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_utc_time_gnss_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_UTC_TIME_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_utc_time_gnss_t(const sbp_msg_utc_time_gnss_t *a, const sbp_msg_utc_time_gnss_t *b) {
+int sbp_cmp_sbp_msg_utc_time_gnss_t(const sbp_msg_utc_time_gnss_t *a,
+                                    const sbp_msg_utc_time_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->year, &b->year);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->month, &b->month);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->day, &b->day);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->hours, &b->hours);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->minutes, &b->minutes);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->seconds, &b->seconds);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->ns, &b->ns);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -403,19 +612,33 @@ size_t sbp_packed_size_sbp_msg_dops_t(const sbp_msg_dops_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_dops_t(sbp_encode_ctx_t *ctx, const sbp_msg_dops_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->gdop)) { return false; }
-  if (!encode_u16(ctx, &msg->pdop)) { return false; }
-  if (!encode_u16(ctx, &msg->tdop)) { return false; }
-  if (!encode_u16(ctx, &msg->hdop)) { return false; }
-  if (!encode_u16(ctx, &msg->vdop)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_dops_t(sbp_encode_ctx_t *ctx, const sbp_msg_dops_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->gdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->tdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_dops_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_dops_t *msg) {
+s8 sbp_encode_sbp_msg_dops_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                             const sbp_msg_dops_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -429,19 +652,33 @@ s8 sbp_encode_sbp_msg_dops_t(uint8_t *buf, uint8_t len, uint8_t *n_written, cons
   return SBP_OK;
 }
 
-bool decode_sbp_msg_dops_t(sbp_decode_ctx_t *ctx, sbp_msg_dops_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->gdop)) { return false; }
-  if (!decode_u16(ctx, &msg->pdop)) { return false; }
-  if (!decode_u16(ctx, &msg->tdop)) { return false; }
-  if (!decode_u16(ctx, &msg->hdop)) { return false; }
-  if (!decode_u16(ctx, &msg->vdop)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_dops_t(sbp_decode_ctx_t *ctx, sbp_msg_dops_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->gdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->tdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_dops_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_dops_t *msg) {
+s8 sbp_decode_sbp_msg_dops_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                             sbp_msg_dops_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -454,38 +691,56 @@ s8 sbp_decode_sbp_msg_dops_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, s
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_dops_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dops_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_dops_t(struct sbp_state *s, u16 sender_id,
+                           const sbp_msg_dops_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_dops_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_DOPS, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_dops_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_DOPS, sender_id, payload_len, payload,
+                          write);
 }
 
 int sbp_cmp_sbp_msg_dops_t(const sbp_msg_dops_t *a, const sbp_msg_dops_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->gdop, &b->gdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pdop, &b->pdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->tdop, &b->tdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hdop, &b->hdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vdop, &b->vdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -501,19 +756,34 @@ size_t sbp_packed_size_sbp_msg_pos_ecef_t(const sbp_msg_pos_ecef_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->x)) { return false; }
-  if (!encode_double(ctx, &msg->y)) { return false; }
-  if (!encode_double(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_ecef_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_pos_ecef_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_ecef_t *msg) {
+s8 sbp_encode_sbp_msg_pos_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_pos_ecef_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -527,19 +797,33 @@ s8 sbp_encode_sbp_msg_pos_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->x)) { return false; }
-  if (!decode_double(ctx, &msg->y)) { return false; }
-  if (!decode_double(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_ecef_t *msg) {
+s8 sbp_decode_sbp_msg_pos_ecef_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_pos_ecef_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -552,42 +836,63 @@ s8 sbp_decode_sbp_msg_pos_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_ecef_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_pos_ecef_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_ecef_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_ECEF, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_ecef_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_ECEF, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_pos_ecef_t(const sbp_msg_pos_ecef_t *a, const sbp_msg_pos_ecef_t *b) {
+int sbp_cmp_sbp_msg_pos_ecef_t(const sbp_msg_pos_ecef_t *a,
+                               const sbp_msg_pos_ecef_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_ecef_cov_t(const sbp_msg_pos_ecef_cov_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_ecef_cov_t(
+    const sbp_msg_pos_ecef_cov_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->x);
@@ -604,24 +909,50 @@ size_t sbp_packed_size_sbp_msg_pos_ecef_cov_t(const sbp_msg_pos_ecef_cov_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_ecef_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_cov_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->x)) { return false; }
-  if (!encode_double(ctx, &msg->y)) { return false; }
-  if (!encode_double(ctx, &msg->z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_ecef_cov_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_pos_ecef_cov_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_ecef_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_ecef_cov_t *msg) {
+s8 sbp_encode_sbp_msg_pos_ecef_cov_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_pos_ecef_cov_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -635,24 +966,50 @@ s8 sbp_encode_sbp_msg_pos_ecef_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_ecef_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_cov_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->x)) { return false; }
-  if (!decode_double(ctx, &msg->y)) { return false; }
-  if (!decode_double(ctx, &msg->z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_ecef_cov_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_pos_ecef_cov_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_ecef_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_ecef_cov_t *msg) {
+s8 sbp_decode_sbp_msg_pos_ecef_cov_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_pos_ecef_cov_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -665,53 +1022,83 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_cov_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_ecef_cov_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_pos_ecef_cov_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_ecef_cov_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_ECEF_COV, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_ecef_cov_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_ECEF_COV, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_ecef_cov_t(const sbp_msg_pos_ecef_cov_t *a, const sbp_msg_pos_ecef_cov_t *b) {
+int sbp_cmp_sbp_msg_pos_ecef_cov_t(const sbp_msg_pos_ecef_cov_t *a,
+                                   const sbp_msg_pos_ecef_cov_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_x, &b->cov_x_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_y, &b->cov_x_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_z, &b->cov_x_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_y, &b->cov_y_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_z, &b->cov_y_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_z_z, &b->cov_z_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -728,20 +1115,37 @@ size_t sbp_packed_size_sbp_msg_pos_llh_t(const sbp_msg_pos_llh_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_llh_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_llh_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_pos_llh_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_llh_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_llh_t *msg) {
+s8 sbp_encode_sbp_msg_pos_llh_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_pos_llh_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -755,20 +1159,36 @@ s8 sbp_encode_sbp_msg_pos_llh_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_llh_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_llh_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_llh_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_llh_t *msg) {
+s8 sbp_decode_sbp_msg_pos_llh_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_pos_llh_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -781,41 +1201,63 @@ s8 sbp_decode_sbp_msg_pos_llh_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_llh_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_pos_llh_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_llh_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_LLH, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_pos_llh_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_LLH, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_pos_llh_t(const sbp_msg_pos_llh_t *a, const sbp_msg_pos_llh_t *b) {
+int sbp_cmp_sbp_msg_pos_llh_t(const sbp_msg_pos_llh_t *a,
+                              const sbp_msg_pos_llh_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -836,24 +1278,50 @@ size_t sbp_packed_size_sbp_msg_pos_llh_cov_t(const sbp_msg_pos_llh_cov_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_llh_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_cov_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_llh_cov_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_pos_llh_cov_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_llh_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_llh_cov_t *msg) {
+s8 sbp_encode_sbp_msg_pos_llh_cov_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_pos_llh_cov_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -867,24 +1335,50 @@ s8 sbp_encode_sbp_msg_pos_llh_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_llh_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_cov_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_llh_cov_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_pos_llh_cov_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_llh_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_llh_cov_t *msg) {
+s8 sbp_decode_sbp_msg_pos_llh_cov_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_pos_llh_cov_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -897,57 +1391,88 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_cov_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_llh_cov_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_pos_llh_cov_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_llh_cov_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_LLH_COV, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_llh_cov_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_LLH_COV, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_llh_cov_t(const sbp_msg_pos_llh_cov_t *a, const sbp_msg_pos_llh_cov_t *b) {
+int sbp_cmp_sbp_msg_pos_llh_cov_t(const sbp_msg_pos_llh_cov_t *a,
+                                  const sbp_msg_pos_llh_cov_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_n, &b->cov_n_n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_e, &b->cov_n_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_d, &b->cov_n_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_e, &b->cov_e_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_d, &b->cov_e_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_d_d, &b->cov_d_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_baseline_ecef_t(const sbp_msg_baseline_ecef_t *msg) {
+size_t sbp_packed_size_sbp_msg_baseline_ecef_t(
+    const sbp_msg_baseline_ecef_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -959,19 +1484,35 @@ size_t sbp_packed_size_sbp_msg_baseline_ecef_t(const sbp_msg_baseline_ecef_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_baseline_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_baseline_ecef_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_baseline_ecef_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_baseline_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_baseline_ecef_t *msg) {
+s8 sbp_encode_sbp_msg_baseline_ecef_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_baseline_ecef_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -985,19 +1526,35 @@ s8 sbp_encode_sbp_msg_baseline_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_baseline_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ecef_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_baseline_ecef_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_baseline_ecef_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_baseline_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_baseline_ecef_t *msg) {
+s8 sbp_decode_sbp_msg_baseline_ecef_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_baseline_ecef_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1010,42 +1567,63 @@ s8 sbp_decode_sbp_msg_baseline_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ecef_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_baseline_ecef_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_baseline_ecef_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_baseline_ecef_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASELINE_ECEF, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_baseline_ecef_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASELINE_ECEF, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_baseline_ecef_t(const sbp_msg_baseline_ecef_t *a, const sbp_msg_baseline_ecef_t *b) {
+int sbp_cmp_sbp_msg_baseline_ecef_t(const sbp_msg_baseline_ecef_t *a,
+                                    const sbp_msg_baseline_ecef_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_baseline_ned_t(const sbp_msg_baseline_ned_t *msg) {
+size_t sbp_packed_size_sbp_msg_baseline_ned_t(
+    const sbp_msg_baseline_ned_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->n);
@@ -1058,20 +1636,38 @@ size_t sbp_packed_size_sbp_msg_baseline_ned_t(const sbp_msg_baseline_ned_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_baseline_ned_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_baseline_ned_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_baseline_ned_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_baseline_ned_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_baseline_ned_t *msg) {
+s8 sbp_encode_sbp_msg_baseline_ned_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_baseline_ned_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1085,20 +1681,38 @@ s8 sbp_encode_sbp_msg_baseline_ned_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_baseline_ned_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ned_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_baseline_ned_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_baseline_ned_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_baseline_ned_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_baseline_ned_t *msg) {
+s8 sbp_decode_sbp_msg_baseline_ned_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_baseline_ned_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1111,41 +1725,63 @@ s8 sbp_decode_sbp_msg_baseline_ned_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ned_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_baseline_ned_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_baseline_ned_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_baseline_ned_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASELINE_NED, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_baseline_ned_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASELINE_NED, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_baseline_ned_t(const sbp_msg_baseline_ned_t *a, const sbp_msg_baseline_ned_t *b) {
+int sbp_cmp_sbp_msg_baseline_ned_t(const sbp_msg_baseline_ned_t *a,
+                                   const sbp_msg_baseline_ned_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -1161,19 +1797,34 @@ size_t sbp_packed_size_sbp_msg_vel_ecef_t(const sbp_msg_vel_ecef_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ecef_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_vel_ecef_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ecef_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_vel_ecef_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1187,19 +1838,33 @@ s8 sbp_encode_sbp_msg_vel_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ecef_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ecef_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_vel_ecef_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1212,42 +1877,63 @@ s8 sbp_decode_sbp_msg_vel_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ecef_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_vel_ecef_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ecef_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_ECEF, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ecef_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_ECEF, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_vel_ecef_t(const sbp_msg_vel_ecef_t *a, const sbp_msg_vel_ecef_t *b) {
+int sbp_cmp_sbp_msg_vel_ecef_t(const sbp_msg_vel_ecef_t *a,
+                               const sbp_msg_vel_ecef_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ecef_cov_t(const sbp_msg_vel_ecef_cov_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ecef_cov_t(
+    const sbp_msg_vel_ecef_cov_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -1264,24 +1950,50 @@ size_t sbp_packed_size_sbp_msg_vel_ecef_cov_t(const sbp_msg_vel_ecef_cov_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ecef_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_cov_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ecef_cov_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_vel_ecef_cov_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ecef_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ecef_cov_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ecef_cov_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_vel_ecef_cov_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1295,24 +2007,50 @@ s8 sbp_encode_sbp_msg_vel_ecef_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ecef_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_cov_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ecef_cov_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_vel_ecef_cov_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ecef_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ecef_cov_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ecef_cov_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_vel_ecef_cov_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1325,53 +2063,83 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_cov_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ecef_cov_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_vel_ecef_cov_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ecef_cov_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_COV, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ecef_cov_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_COV, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ecef_cov_t(const sbp_msg_vel_ecef_cov_t *a, const sbp_msg_vel_ecef_cov_t *b) {
+int sbp_cmp_sbp_msg_vel_ecef_cov_t(const sbp_msg_vel_ecef_cov_t *a,
+                                   const sbp_msg_vel_ecef_cov_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_x, &b->cov_x_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_y, &b->cov_x_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_z, &b->cov_x_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_y, &b->cov_y_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_z, &b->cov_y_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_z_z, &b->cov_z_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -1388,20 +2156,37 @@ size_t sbp_packed_size_sbp_msg_vel_ned_t(const sbp_msg_vel_ned_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ned_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ned_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_vel_ned_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ned_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ned_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ned_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_vel_ned_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1415,20 +2200,36 @@ s8 sbp_encode_sbp_msg_vel_ned_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ned_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ned_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ned_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ned_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ned_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_vel_ned_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1441,41 +2242,63 @@ s8 sbp_decode_sbp_msg_vel_ned_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ned_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_vel_ned_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ned_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_NED, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_vel_ned_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_NED, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_vel_ned_t(const sbp_msg_vel_ned_t *a, const sbp_msg_vel_ned_t *b) {
+int sbp_cmp_sbp_msg_vel_ned_t(const sbp_msg_vel_ned_t *a,
+                              const sbp_msg_vel_ned_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -1496,24 +2319,50 @@ size_t sbp_packed_size_sbp_msg_vel_ned_cov_t(const sbp_msg_vel_ned_cov_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ned_cov_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_cov_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ned_cov_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_vel_ned_cov_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ned_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ned_cov_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ned_cov_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_vel_ned_cov_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1527,24 +2376,50 @@ s8 sbp_encode_sbp_msg_vel_ned_cov_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ned_cov_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_cov_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ned_cov_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_vel_ned_cov_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ned_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ned_cov_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ned_cov_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_vel_ned_cov_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1557,57 +2432,88 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_cov_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ned_cov_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_vel_ned_cov_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ned_cov_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_NED_COV, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ned_cov_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_NED_COV, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ned_cov_t(const sbp_msg_vel_ned_cov_t *a, const sbp_msg_vel_ned_cov_t *b) {
+int sbp_cmp_sbp_msg_vel_ned_cov_t(const sbp_msg_vel_ned_cov_t *a,
+                                  const sbp_msg_vel_ned_cov_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_n, &b->cov_n_n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_e, &b->cov_n_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_d, &b->cov_n_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_e, &b->cov_e_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_d, &b->cov_e_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_d_d, &b->cov_d_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_ecef_gnss_t(const sbp_msg_pos_ecef_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_ecef_gnss_t(
+    const sbp_msg_pos_ecef_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->x);
@@ -1619,19 +2525,35 @@ size_t sbp_packed_size_sbp_msg_pos_ecef_gnss_t(const sbp_msg_pos_ecef_gnss_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_ecef_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->x)) { return false; }
-  if (!encode_double(ctx, &msg->y)) { return false; }
-  if (!encode_double(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_ecef_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_pos_ecef_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_ecef_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_ecef_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_pos_ecef_gnss_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_pos_ecef_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1645,19 +2567,35 @@ s8 sbp_encode_sbp_msg_pos_ecef_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_ecef_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->x)) { return false; }
-  if (!decode_double(ctx, &msg->y)) { return false; }
-  if (!decode_double(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_ecef_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_pos_ecef_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_ecef_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_ecef_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_pos_ecef_gnss_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_pos_ecef_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1670,42 +2608,63 @@ s8 sbp_decode_sbp_msg_pos_ecef_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_ecef_gnss_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_pos_ecef_gnss_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_ecef_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_ECEF_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_ecef_gnss_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_ECEF_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_ecef_gnss_t(const sbp_msg_pos_ecef_gnss_t *a, const sbp_msg_pos_ecef_gnss_t *b) {
+int sbp_cmp_sbp_msg_pos_ecef_gnss_t(const sbp_msg_pos_ecef_gnss_t *a,
+                                    const sbp_msg_pos_ecef_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_ecef_cov_gnss_t(const sbp_msg_pos_ecef_cov_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_ecef_cov_gnss_t(
+    const sbp_msg_pos_ecef_cov_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->x);
@@ -1722,24 +2681,50 @@ size_t sbp_packed_size_sbp_msg_pos_ecef_cov_gnss_t(const sbp_msg_pos_ecef_cov_gn
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_cov_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->x)) { return false; }
-  if (!encode_double(ctx, &msg->y)) { return false; }
-  if (!encode_double(ctx, &msg->z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_ecef_cov_gnss_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_cov_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_ecef_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_ecef_cov_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_pos_ecef_cov_gnss_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_pos_ecef_cov_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1753,24 +2738,50 @@ s8 sbp_encode_sbp_msg_pos_ecef_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_cov_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->x)) { return false; }
-  if (!decode_double(ctx, &msg->y)) { return false; }
-  if (!decode_double(ctx, &msg->z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_pos_ecef_cov_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_ecef_cov_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_pos_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_pos_ecef_cov_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1783,57 +2794,88 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_cov_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_pos_ecef_cov_gnss_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_ecef_cov_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_ECEF_COV_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_ecef_cov_gnss_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_ECEF_COV_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_ecef_cov_gnss_t(const sbp_msg_pos_ecef_cov_gnss_t *a, const sbp_msg_pos_ecef_cov_gnss_t *b) {
+int sbp_cmp_sbp_msg_pos_ecef_cov_gnss_t(const sbp_msg_pos_ecef_cov_gnss_t *a,
+                                        const sbp_msg_pos_ecef_cov_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_x, &b->cov_x_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_y, &b->cov_x_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_z, &b->cov_x_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_y, &b->cov_y_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_z, &b->cov_y_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_z_z, &b->cov_z_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_llh_gnss_t(const sbp_msg_pos_llh_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_llh_gnss_t(
+    const sbp_msg_pos_llh_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->lat);
@@ -1846,20 +2888,38 @@ size_t sbp_packed_size_sbp_msg_pos_llh_gnss_t(const sbp_msg_pos_llh_gnss_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_llh_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_llh_gnss_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_pos_llh_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_llh_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_llh_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_pos_llh_gnss_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_pos_llh_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1873,20 +2933,38 @@ s8 sbp_encode_sbp_msg_pos_llh_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_llh_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_llh_gnss_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_pos_llh_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_llh_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_llh_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_pos_llh_gnss_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_pos_llh_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1899,45 +2977,68 @@ s8 sbp_decode_sbp_msg_pos_llh_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_llh_gnss_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_pos_llh_gnss_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_llh_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_LLH_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_llh_gnss_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_LLH_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_llh_gnss_t(const sbp_msg_pos_llh_gnss_t *a, const sbp_msg_pos_llh_gnss_t *b) {
+int sbp_cmp_sbp_msg_pos_llh_gnss_t(const sbp_msg_pos_llh_gnss_t *a,
+                                   const sbp_msg_pos_llh_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_llh_cov_gnss_t(const sbp_msg_pos_llh_cov_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_llh_cov_gnss_t(
+    const sbp_msg_pos_llh_cov_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->lat);
@@ -1954,24 +3055,50 @@ size_t sbp_packed_size_sbp_msg_pos_llh_cov_gnss_t(const sbp_msg_pos_llh_cov_gnss
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_llh_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_cov_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_llh_cov_gnss_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_pos_llh_cov_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_llh_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_llh_cov_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_pos_llh_cov_gnss_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_pos_llh_cov_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1985,24 +3112,50 @@ s8 sbp_encode_sbp_msg_pos_llh_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_llh_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_cov_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_llh_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_pos_llh_cov_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_llh_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_llh_cov_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_pos_llh_cov_gnss_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_pos_llh_cov_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2015,57 +3168,88 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_cov_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_llh_cov_gnss_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_pos_llh_cov_gnss_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_llh_cov_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_LLH_COV_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_llh_cov_gnss_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_LLH_COV_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_llh_cov_gnss_t(const sbp_msg_pos_llh_cov_gnss_t *a, const sbp_msg_pos_llh_cov_gnss_t *b) {
+int sbp_cmp_sbp_msg_pos_llh_cov_gnss_t(const sbp_msg_pos_llh_cov_gnss_t *a,
+                                       const sbp_msg_pos_llh_cov_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_n, &b->cov_n_n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_e, &b->cov_n_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_d, &b->cov_n_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_e, &b->cov_e_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_d, &b->cov_e_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_d_d, &b->cov_d_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ecef_gnss_t(const sbp_msg_vel_ecef_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ecef_gnss_t(
+    const sbp_msg_vel_ecef_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -2077,19 +3261,35 @@ size_t sbp_packed_size_sbp_msg_vel_ecef_gnss_t(const sbp_msg_vel_ecef_gnss_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ecef_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ecef_gnss_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_vel_ecef_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ecef_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ecef_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ecef_gnss_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_vel_ecef_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2103,19 +3303,35 @@ s8 sbp_encode_sbp_msg_vel_ecef_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ecef_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ecef_gnss_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_vel_ecef_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ecef_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ecef_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ecef_gnss_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_vel_ecef_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2128,42 +3344,63 @@ s8 sbp_decode_sbp_msg_vel_ecef_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ecef_gnss_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_vel_ecef_gnss_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ecef_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ecef_gnss_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ecef_gnss_t(const sbp_msg_vel_ecef_gnss_t *a, const sbp_msg_vel_ecef_gnss_t *b) {
+int sbp_cmp_sbp_msg_vel_ecef_gnss_t(const sbp_msg_vel_ecef_gnss_t *a,
+                                    const sbp_msg_vel_ecef_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ecef_cov_gnss_t(const sbp_msg_vel_ecef_cov_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ecef_cov_gnss_t(
+    const sbp_msg_vel_ecef_cov_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -2180,24 +3417,50 @@ size_t sbp_packed_size_sbp_msg_vel_ecef_cov_gnss_t(const sbp_msg_vel_ecef_cov_gn
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ecef_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_cov_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ecef_cov_gnss_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_cov_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ecef_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ecef_cov_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ecef_cov_gnss_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_vel_ecef_cov_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2211,24 +3474,50 @@ s8 sbp_encode_sbp_msg_vel_ecef_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_cov_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ecef_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_vel_ecef_cov_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ecef_cov_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_vel_ecef_cov_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2241,57 +3530,88 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_cov_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_vel_ecef_cov_gnss_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ecef_cov_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_COV_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ecef_cov_gnss_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_COV_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ecef_cov_gnss_t(const sbp_msg_vel_ecef_cov_gnss_t *a, const sbp_msg_vel_ecef_cov_gnss_t *b) {
+int sbp_cmp_sbp_msg_vel_ecef_cov_gnss_t(const sbp_msg_vel_ecef_cov_gnss_t *a,
+                                        const sbp_msg_vel_ecef_cov_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_x, &b->cov_x_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_y, &b->cov_x_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_z, &b->cov_x_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_y, &b->cov_y_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_z, &b->cov_y_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_z_z, &b->cov_z_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ned_gnss_t(const sbp_msg_vel_ned_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ned_gnss_t(
+    const sbp_msg_vel_ned_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->n);
@@ -2304,20 +3624,38 @@ size_t sbp_packed_size_sbp_msg_vel_ned_gnss_t(const sbp_msg_vel_ned_gnss_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ned_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ned_gnss_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_vel_ned_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ned_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ned_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ned_gnss_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_vel_ned_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2331,20 +3669,38 @@ s8 sbp_encode_sbp_msg_vel_ned_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ned_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ned_gnss_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_vel_ned_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ned_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ned_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ned_gnss_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_vel_ned_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2357,45 +3713,68 @@ s8 sbp_decode_sbp_msg_vel_ned_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ned_gnss_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_vel_ned_gnss_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ned_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_NED_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ned_gnss_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_NED_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ned_gnss_t(const sbp_msg_vel_ned_gnss_t *a, const sbp_msg_vel_ned_gnss_t *b) {
+int sbp_cmp_sbp_msg_vel_ned_gnss_t(const sbp_msg_vel_ned_gnss_t *a,
+                                   const sbp_msg_vel_ned_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ned_cov_gnss_t(const sbp_msg_vel_ned_cov_gnss_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ned_cov_gnss_t(
+    const sbp_msg_vel_ned_cov_gnss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->n);
@@ -2412,24 +3791,50 @@ size_t sbp_packed_size_sbp_msg_vel_ned_cov_gnss_t(const sbp_msg_vel_ned_cov_gnss
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ned_cov_gnss_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_cov_gnss_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!encode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!encode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ned_cov_gnss_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_vel_ned_cov_gnss_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ned_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ned_cov_gnss_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ned_cov_gnss_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_vel_ned_cov_gnss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2443,24 +3848,50 @@ s8 sbp_encode_sbp_msg_vel_ned_cov_gnss_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ned_cov_gnss_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_cov_gnss_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_n)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_n_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_e)) { return false; }
-  if (!decode_float(ctx, &msg->cov_e_d)) { return false; }
-  if (!decode_float(ctx, &msg->cov_d_d)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ned_cov_gnss_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_vel_ned_cov_gnss_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_n)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_n_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_e)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_e_d)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_d_d)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ned_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ned_cov_gnss_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ned_cov_gnss_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_vel_ned_cov_gnss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2473,53 +3904,83 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_cov_gnss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ned_cov_gnss_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_vel_ned_cov_gnss_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ned_cov_gnss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_NED_COV_GNSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ned_cov_gnss_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_NED_COV_GNSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ned_cov_gnss_t(const sbp_msg_vel_ned_cov_gnss_t *a, const sbp_msg_vel_ned_cov_gnss_t *b) {
+int sbp_cmp_sbp_msg_vel_ned_cov_gnss_t(const sbp_msg_vel_ned_cov_gnss_t *a,
+                                       const sbp_msg_vel_ned_cov_gnss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_n, &b->cov_n_n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_e, &b->cov_n_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_n_d, &b->cov_n_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_e, &b->cov_e_e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_e_d, &b->cov_e_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_d_d, &b->cov_d_d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -2540,24 +4001,49 @@ size_t sbp_packed_size_sbp_msg_vel_body_t(const sbp_msg_vel_body_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_body_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_body_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!encode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!encode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_body_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_vel_body_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_body_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_body_t *msg) {
+s8 sbp_encode_sbp_msg_vel_body_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_vel_body_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2571,24 +4057,48 @@ s8 sbp_encode_sbp_msg_vel_body_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_body_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_body_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_x)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_x_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_y)) { return false; }
-  if (!decode_float(ctx, &msg->cov_y_z)) { return false; }
-  if (!decode_float(ctx, &msg->cov_z_z)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_body_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_body_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_x)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_x_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_y)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_y_z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cov_z_z)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_body_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_body_t *msg) {
+s8 sbp_decode_sbp_msg_vel_body_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_vel_body_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2601,71 +4111,108 @@ s8 sbp_decode_sbp_msg_vel_body_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_body_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_body_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_body_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_vel_body_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_body_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_BODY, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_body_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_BODY, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_vel_body_t(const sbp_msg_vel_body_t *a, const sbp_msg_vel_body_t *b) {
+int sbp_cmp_sbp_msg_vel_body_t(const sbp_msg_vel_body_t *a,
+                               const sbp_msg_vel_body_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_x, &b->cov_x_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_y, &b->cov_x_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_x_z, &b->cov_x_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_y, &b->cov_y_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_y_z, &b->cov_y_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cov_z_z, &b->cov_z_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_age_corrections_t(const sbp_msg_age_corrections_t *msg) {
+size_t sbp_packed_size_sbp_msg_age_corrections_t(
+    const sbp_msg_age_corrections_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_u16(&msg->age);
   return packed_size;
 }
 
-bool encode_sbp_msg_age_corrections_t(sbp_encode_ctx_t *ctx, const sbp_msg_age_corrections_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->age)) { return false; }
+bool encode_sbp_msg_age_corrections_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_age_corrections_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->age)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_age_corrections_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_age_corrections_t *msg) {
+s8 sbp_encode_sbp_msg_age_corrections_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_age_corrections_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2679,14 +4226,20 @@ s8 sbp_encode_sbp_msg_age_corrections_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_age_corrections_t(sbp_decode_ctx_t *ctx, sbp_msg_age_corrections_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->age)) { return false; }
+bool decode_sbp_msg_age_corrections_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_age_corrections_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->age)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_age_corrections_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_age_corrections_t *msg) {
+s8 sbp_decode_sbp_msg_age_corrections_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_age_corrections_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2699,27 +4252,38 @@ s8 sbp_decode_sbp_msg_age_corrections_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_age_corrections_t(struct sbp_state *s, u16 sender_id, const sbp_msg_age_corrections_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_age_corrections_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_age_corrections_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_age_corrections_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_AGE_CORRECTIONS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_age_corrections_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_AGE_CORRECTIONS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_age_corrections_t(const sbp_msg_age_corrections_t *a, const sbp_msg_age_corrections_t *b) {
+int sbp_cmp_sbp_msg_age_corrections_t(const sbp_msg_age_corrections_t *a,
+                                      const sbp_msg_age_corrections_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->age, &b->age);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_gps_time_dep_a_t(const sbp_msg_gps_time_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_gps_time_dep_a_t(
+    const sbp_msg_gps_time_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->wn);
   packed_size += sbp_packed_size_u32(&msg->tow);
@@ -2728,16 +4292,26 @@ size_t sbp_packed_size_sbp_msg_gps_time_dep_a_t(const sbp_msg_gps_time_dep_a_t *
   return packed_size;
 }
 
-bool encode_sbp_msg_gps_time_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_gps_time_dep_a_t *msg)
-{
-  if (!encode_u16(ctx, &msg->wn)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_gps_time_dep_a_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_gps_time_dep_a_t *msg) {
+  if (!encode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_gps_time_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_gps_time_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_gps_time_dep_a_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_gps_time_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2751,16 +4325,26 @@ s8 sbp_encode_sbp_msg_gps_time_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_gps_time_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_gps_time_dep_a_t *msg)
-{
-  if (!decode_u16(ctx, &msg->wn)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->ns_residual)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_gps_time_dep_a_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_gps_time_dep_a_t *msg) {
+  if (!decode_u16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->ns_residual)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_gps_time_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_gps_time_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_gps_time_dep_a_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_gps_time_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2773,29 +4357,43 @@ s8 sbp_decode_sbp_msg_gps_time_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gps_time_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_gps_time_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_gps_time_dep_a_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_gps_time_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GPS_TIME_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_gps_time_dep_a_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GPS_TIME_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_gps_time_dep_a_t(const sbp_msg_gps_time_dep_a_t *a, const sbp_msg_gps_time_dep_a_t *b) {
+int sbp_cmp_sbp_msg_gps_time_dep_a_t(const sbp_msg_gps_time_dep_a_t *a,
+                                     const sbp_msg_gps_time_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->ns_residual, &b->ns_residual);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -2810,18 +4408,32 @@ size_t sbp_packed_size_sbp_msg_dops_dep_a_t(const sbp_msg_dops_dep_a_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_dops_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_dops_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->gdop)) { return false; }
-  if (!encode_u16(ctx, &msg->pdop)) { return false; }
-  if (!encode_u16(ctx, &msg->tdop)) { return false; }
-  if (!encode_u16(ctx, &msg->hdop)) { return false; }
-  if (!encode_u16(ctx, &msg->vdop)) { return false; }
+bool encode_sbp_msg_dops_dep_a_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_dops_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->gdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->tdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_dops_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_dops_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_dops_dep_a_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_dops_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2835,18 +4447,31 @@ s8 sbp_encode_sbp_msg_dops_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_dops_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_dops_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->gdop)) { return false; }
-  if (!decode_u16(ctx, &msg->pdop)) { return false; }
-  if (!decode_u16(ctx, &msg->tdop)) { return false; }
-  if (!decode_u16(ctx, &msg->hdop)) { return false; }
-  if (!decode_u16(ctx, &msg->vdop)) { return false; }
+bool decode_sbp_msg_dops_dep_a_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_dops_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->gdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->tdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_dops_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_dops_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_dops_dep_a_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_dops_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2859,39 +4484,58 @@ s8 sbp_decode_sbp_msg_dops_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_dops_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dops_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_dops_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_dops_dep_a_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_dops_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_DOPS_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_dops_dep_a_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_DOPS_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_dops_dep_a_t(const sbp_msg_dops_dep_a_t *a, const sbp_msg_dops_dep_a_t *b) {
+int sbp_cmp_sbp_msg_dops_dep_a_t(const sbp_msg_dops_dep_a_t *a,
+                                 const sbp_msg_dops_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->gdop, &b->gdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pdop, &b->pdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->tdop, &b->tdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hdop, &b->hdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vdop, &b->vdop);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_ecef_dep_a_t(const sbp_msg_pos_ecef_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_ecef_dep_a_t(
+    const sbp_msg_pos_ecef_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->x);
@@ -2903,19 +4547,35 @@ size_t sbp_packed_size_sbp_msg_pos_ecef_dep_a_t(const sbp_msg_pos_ecef_dep_a_t *
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_ecef_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_ecef_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->x)) { return false; }
-  if (!encode_double(ctx, &msg->y)) { return false; }
-  if (!encode_double(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_ecef_dep_a_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_pos_ecef_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_ecef_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_ecef_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_pos_ecef_dep_a_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_pos_ecef_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2929,19 +4589,35 @@ s8 sbp_encode_sbp_msg_pos_ecef_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_ecef_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_ecef_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->x)) { return false; }
-  if (!decode_double(ctx, &msg->y)) { return false; }
-  if (!decode_double(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_pos_ecef_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_ecef_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_pos_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_pos_ecef_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2954,42 +4630,63 @@ s8 sbp_decode_sbp_msg_pos_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_ecef_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_pos_ecef_dep_a_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_ecef_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_ECEF_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_ecef_dep_a_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_ECEF_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_ecef_dep_a_t(const sbp_msg_pos_ecef_dep_a_t *a, const sbp_msg_pos_ecef_dep_a_t *b) {
+int sbp_cmp_sbp_msg_pos_ecef_dep_a_t(const sbp_msg_pos_ecef_dep_a_t *a,
+                                     const sbp_msg_pos_ecef_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_pos_llh_dep_a_t(const sbp_msg_pos_llh_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_pos_llh_dep_a_t(
+    const sbp_msg_pos_llh_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_double(&msg->lat);
@@ -3002,20 +4699,38 @@ size_t sbp_packed_size_sbp_msg_pos_llh_dep_a_t(const sbp_msg_pos_llh_dep_a_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_pos_llh_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_pos_llh_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pos_llh_dep_a_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_pos_llh_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pos_llh_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pos_llh_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_pos_llh_dep_a_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_pos_llh_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3029,20 +4744,38 @@ s8 sbp_encode_sbp_msg_pos_llh_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pos_llh_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_pos_llh_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pos_llh_dep_a_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_pos_llh_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pos_llh_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pos_llh_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_pos_llh_dep_a_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_pos_llh_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3055,45 +4788,68 @@ s8 sbp_decode_sbp_msg_pos_llh_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pos_llh_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_pos_llh_dep_a_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pos_llh_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_POS_LLH_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pos_llh_dep_a_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_POS_LLH_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_pos_llh_dep_a_t(const sbp_msg_pos_llh_dep_a_t *a, const sbp_msg_pos_llh_dep_a_t *b) {
+int sbp_cmp_sbp_msg_pos_llh_dep_a_t(const sbp_msg_pos_llh_dep_a_t *a,
+                                    const sbp_msg_pos_llh_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_baseline_ecef_dep_a_t(const sbp_msg_baseline_ecef_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_baseline_ecef_dep_a_t(
+    const sbp_msg_baseline_ecef_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -3105,19 +4861,35 @@ size_t sbp_packed_size_sbp_msg_baseline_ecef_dep_a_t(const sbp_msg_baseline_ecef
   return packed_size;
 }
 
-bool encode_sbp_msg_baseline_ecef_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_baseline_ecef_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ecef_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_baseline_ecef_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_baseline_ecef_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_baseline_ecef_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_baseline_ecef_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3131,19 +4903,35 @@ s8 sbp_encode_sbp_msg_baseline_ecef_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_baseline_ecef_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ecef_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_baseline_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_baseline_ecef_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_baseline_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_baseline_ecef_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_baseline_ecef_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_baseline_ecef_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3156,42 +4944,64 @@ s8 sbp_decode_sbp_msg_baseline_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ecef_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_baseline_ecef_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_baseline_ecef_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_baseline_ecef_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASELINE_ECEF_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_baseline_ecef_dep_a_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASELINE_ECEF_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_baseline_ecef_dep_a_t(const sbp_msg_baseline_ecef_dep_a_t *a, const sbp_msg_baseline_ecef_dep_a_t *b) {
+int sbp_cmp_sbp_msg_baseline_ecef_dep_a_t(
+    const sbp_msg_baseline_ecef_dep_a_t *a,
+    const sbp_msg_baseline_ecef_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_baseline_ned_dep_a_t(const sbp_msg_baseline_ned_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_baseline_ned_dep_a_t(
+    const sbp_msg_baseline_ned_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->n);
@@ -3204,20 +5014,38 @@ size_t sbp_packed_size_sbp_msg_baseline_ned_dep_a_t(const sbp_msg_baseline_ned_d
   return packed_size;
 }
 
-bool encode_sbp_msg_baseline_ned_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_baseline_ned_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_baseline_ned_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_baseline_ned_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_baseline_ned_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_baseline_ned_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_baseline_ned_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3231,20 +5059,38 @@ s8 sbp_encode_sbp_msg_baseline_ned_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_baseline_ned_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_ned_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_baseline_ned_dep_a_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_baseline_ned_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_baseline_ned_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_baseline_ned_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_baseline_ned_dep_a_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_baseline_ned_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3257,45 +5103,69 @@ s8 sbp_decode_sbp_msg_baseline_ned_dep_a_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ned_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_baseline_ned_dep_a_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_dep_a_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_baseline_ned_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASELINE_NED_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_baseline_ned_dep_a_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASELINE_NED_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_baseline_ned_dep_a_t(const sbp_msg_baseline_ned_dep_a_t *a, const sbp_msg_baseline_ned_dep_a_t *b) {
+int sbp_cmp_sbp_msg_baseline_ned_dep_a_t(
+    const sbp_msg_baseline_ned_dep_a_t *a,
+    const sbp_msg_baseline_ned_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ecef_dep_a_t(const sbp_msg_vel_ecef_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ecef_dep_a_t(
+    const sbp_msg_vel_ecef_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -3307,19 +5177,35 @@ size_t sbp_packed_size_sbp_msg_vel_ecef_dep_a_t(const sbp_msg_vel_ecef_dep_a_t *
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ecef_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ecef_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ecef_dep_a_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_vel_ecef_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ecef_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ecef_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ecef_dep_a_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_vel_ecef_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3333,19 +5219,35 @@ s8 sbp_encode_sbp_msg_vel_ecef_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ecef_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ecef_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_u16(ctx, &msg->accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ecef_dep_a_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_vel_ecef_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ecef_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_vel_ecef_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3358,42 +5260,63 @@ s8 sbp_decode_sbp_msg_vel_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ecef_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_vel_ecef_dep_a_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ecef_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ecef_dep_a_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_ECEF_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ecef_dep_a_t(const sbp_msg_vel_ecef_dep_a_t *a, const sbp_msg_vel_ecef_dep_a_t *b) {
+int sbp_cmp_sbp_msg_vel_ecef_dep_a_t(const sbp_msg_vel_ecef_dep_a_t *a,
+                                     const sbp_msg_vel_ecef_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->accuracy, &b->accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_vel_ned_dep_a_t(const sbp_msg_vel_ned_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_vel_ned_dep_a_t(
+    const sbp_msg_vel_ned_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->n);
@@ -3406,20 +5329,38 @@ size_t sbp_packed_size_sbp_msg_vel_ned_dep_a_t(const sbp_msg_vel_ned_dep_a_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_vel_ned_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_vel_ned_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->n)) { return false; }
-  if (!encode_s32(ctx, &msg->e)) { return false; }
-  if (!encode_s32(ctx, &msg->d)) { return false; }
-  if (!encode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!encode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_vel_ned_dep_a_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_vel_ned_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_vel_ned_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_vel_ned_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_vel_ned_dep_a_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_vel_ned_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3433,20 +5374,38 @@ s8 sbp_encode_sbp_msg_vel_ned_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_vel_ned_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_vel_ned_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->n)) { return false; }
-  if (!decode_s32(ctx, &msg->e)) { return false; }
-  if (!decode_s32(ctx, &msg->d)) { return false; }
-  if (!decode_u16(ctx, &msg->h_accuracy)) { return false; }
-  if (!decode_u16(ctx, &msg->v_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_vel_ned_dep_a_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_vel_ned_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->n)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->e)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->d)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->h_accuracy)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->v_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_vel_ned_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_vel_ned_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_vel_ned_dep_a_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_vel_ned_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3459,45 +5418,68 @@ s8 sbp_decode_sbp_msg_vel_ned_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_vel_ned_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_vel_ned_dep_a_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_vel_ned_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_VEL_NED_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_vel_ned_dep_a_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_VEL_NED_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_vel_ned_dep_a_t(const sbp_msg_vel_ned_dep_a_t *a, const sbp_msg_vel_ned_dep_a_t *b) {
+int sbp_cmp_sbp_msg_vel_ned_dep_a_t(const sbp_msg_vel_ned_dep_a_t *a,
+                                    const sbp_msg_vel_ned_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->n, &b->n);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->e, &b->e);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->d, &b->d);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->h_accuracy, &b->h_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->v_accuracy, &b->v_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_baseline_heading_dep_a_t(const sbp_msg_baseline_heading_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_baseline_heading_dep_a_t(
+    const sbp_msg_baseline_heading_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_u32(&msg->heading);
@@ -3506,16 +5488,26 @@ size_t sbp_packed_size_sbp_msg_baseline_heading_dep_a_t(const sbp_msg_baseline_h
   return packed_size;
 }
 
-bool encode_sbp_msg_baseline_heading_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u32(ctx, &msg->heading)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_baseline_heading_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->heading)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_baseline_heading_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_baseline_heading_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_baseline_heading_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_baseline_heading_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3529,16 +5521,26 @@ s8 sbp_encode_sbp_msg_baseline_heading_dep_a_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_baseline_heading_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u32(ctx, &msg->heading)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_baseline_heading_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->heading)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_baseline_heading_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_baseline_heading_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_baseline_heading_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_baseline_heading_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3551,33 +5553,49 @@ s8 sbp_decode_sbp_msg_baseline_heading_dep_a_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_heading_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_heading_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_baseline_heading_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_baseline_heading_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_baseline_heading_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASELINE_HEADING_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_baseline_heading_dep_a_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASELINE_HEADING_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_baseline_heading_dep_a_t(const sbp_msg_baseline_heading_dep_a_t *a, const sbp_msg_baseline_heading_dep_a_t *b) {
+int sbp_cmp_sbp_msg_baseline_heading_dep_a_t(
+    const sbp_msg_baseline_heading_dep_a_t *a,
+    const sbp_msg_baseline_heading_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->heading, &b->heading);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_protection_level_dep_a_t(const sbp_msg_protection_level_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_protection_level_dep_a_t(
+    const sbp_msg_protection_level_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_u16(&msg->vpl);
@@ -3589,19 +5607,35 @@ size_t sbp_packed_size_sbp_msg_protection_level_dep_a_t(const sbp_msg_protection
   return packed_size;
 }
 
-bool encode_sbp_msg_protection_level_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->vpl)) { return false; }
-  if (!encode_u16(ctx, &msg->hpl)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_protection_level_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hpl)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_protection_level_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_protection_level_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_protection_level_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_protection_level_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3615,19 +5649,35 @@ s8 sbp_encode_sbp_msg_protection_level_dep_a_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_protection_level_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_protection_level_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->vpl)) { return false; }
-  if (!decode_u16(ctx, &msg->hpl)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_protection_level_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_protection_level_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hpl)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_protection_level_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_protection_level_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_protection_level_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_protection_level_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3640,42 +5690,64 @@ s8 sbp_decode_sbp_msg_protection_level_dep_a_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_protection_level_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_protection_level_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_protection_level_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_protection_level_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_protection_level_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_PROTECTION_LEVEL_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_protection_level_dep_a_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_PROTECTION_LEVEL_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_protection_level_dep_a_t(const sbp_msg_protection_level_dep_a_t *a, const sbp_msg_protection_level_dep_a_t *b) {
+int sbp_cmp_sbp_msg_protection_level_dep_a_t(
+    const sbp_msg_protection_level_dep_a_t *a,
+    const sbp_msg_protection_level_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vpl, &b->vpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hpl, &b->hpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_protection_level_t(const sbp_msg_protection_level_t *msg) {
+size_t sbp_packed_size_sbp_msg_protection_level_t(
+    const sbp_msg_protection_level_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s16(&msg->wn);
@@ -3701,33 +5773,77 @@ size_t sbp_packed_size_sbp_msg_protection_level_t(const sbp_msg_protection_level
   return packed_size;
 }
 
-bool encode_sbp_msg_protection_level_t(sbp_encode_ctx_t *ctx, const sbp_msg_protection_level_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s16(ctx, &msg->wn)) { return false; }
-  if (!encode_u16(ctx, &msg->hpl)) { return false; }
-  if (!encode_u16(ctx, &msg->vpl)) { return false; }
-  if (!encode_u16(ctx, &msg->atpl)) { return false; }
-  if (!encode_u16(ctx, &msg->ctpl)) { return false; }
-  if (!encode_u16(ctx, &msg->hvpl)) { return false; }
-  if (!encode_u16(ctx, &msg->vvpl)) { return false; }
-  if (!encode_u16(ctx, &msg->hopl)) { return false; }
-  if (!encode_u16(ctx, &msg->popl)) { return false; }
-  if (!encode_u16(ctx, &msg->ropl)) { return false; }
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
-  if (!encode_s32(ctx, &msg->v_x)) { return false; }
-  if (!encode_s32(ctx, &msg->v_y)) { return false; }
-  if (!encode_s32(ctx, &msg->v_z)) { return false; }
-  if (!encode_s32(ctx, &msg->roll)) { return false; }
-  if (!encode_s32(ctx, &msg->pitch)) { return false; }
-  if (!encode_s32(ctx, &msg->heading)) { return false; }
-  if (!encode_u32(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_protection_level_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_protection_level_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->atpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->ctpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hvpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vvpl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hopl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->popl)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->ropl)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->v_x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->v_y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->v_z)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->roll)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->pitch)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->heading)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_protection_level_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_protection_level_t *msg) {
+s8 sbp_encode_sbp_msg_protection_level_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_protection_level_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3741,33 +5857,77 @@ s8 sbp_encode_sbp_msg_protection_level_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_protection_level_t(sbp_decode_ctx_t *ctx, sbp_msg_protection_level_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s16(ctx, &msg->wn)) { return false; }
-  if (!decode_u16(ctx, &msg->hpl)) { return false; }
-  if (!decode_u16(ctx, &msg->vpl)) { return false; }
-  if (!decode_u16(ctx, &msg->atpl)) { return false; }
-  if (!decode_u16(ctx, &msg->ctpl)) { return false; }
-  if (!decode_u16(ctx, &msg->hvpl)) { return false; }
-  if (!decode_u16(ctx, &msg->vvpl)) { return false; }
-  if (!decode_u16(ctx, &msg->hopl)) { return false; }
-  if (!decode_u16(ctx, &msg->popl)) { return false; }
-  if (!decode_u16(ctx, &msg->ropl)) { return false; }
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
-  if (!decode_s32(ctx, &msg->v_x)) { return false; }
-  if (!decode_s32(ctx, &msg->v_y)) { return false; }
-  if (!decode_s32(ctx, &msg->v_z)) { return false; }
-  if (!decode_s32(ctx, &msg->roll)) { return false; }
-  if (!decode_s32(ctx, &msg->pitch)) { return false; }
-  if (!decode_s32(ctx, &msg->heading)) { return false; }
-  if (!decode_u32(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_protection_level_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_protection_level_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->wn)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->atpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->ctpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hvpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vvpl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hopl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->popl)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->ropl)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->v_x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->v_y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->v_z)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->roll)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->pitch)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->heading)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_protection_level_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_protection_level_t *msg) {
+s8 sbp_decode_sbp_msg_protection_level_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_protection_level_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3780,79 +5940,127 @@ s8 sbp_decode_sbp_msg_protection_level_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_protection_level_t(struct sbp_state *s, u16 sender_id, const sbp_msg_protection_level_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_protection_level_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_protection_level_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_protection_level_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_PROTECTION_LEVEL, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_protection_level_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_PROTECTION_LEVEL, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_protection_level_t(const sbp_msg_protection_level_t *a, const sbp_msg_protection_level_t *b) {
+int sbp_cmp_sbp_msg_protection_level_t(const sbp_msg_protection_level_t *a,
+                                       const sbp_msg_protection_level_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->wn, &b->wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hpl, &b->hpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vpl, &b->vpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->atpl, &b->atpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->ctpl, &b->ctpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hvpl, &b->hvpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vvpl, &b->vvpl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hopl, &b->hopl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->popl, &b->popl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->ropl, &b->ropl);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->v_x, &b->v_x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->v_y, &b->v_y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->v_z, &b->v_z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->roll, &b->roll);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->pitch, &b->pitch);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->heading, &b->heading);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/ndb.c
+++ b/c/src/new/ndb.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ndb.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/ndb.h>
 #include <libsbp/internal/new/ndb.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/ndb.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_ndb_event_t(const sbp_msg_ndb_event_t *msg) {
   size_t packed_size = 0;
@@ -24,20 +41,37 @@ size_t sbp_packed_size_sbp_msg_ndb_event_t(const sbp_msg_ndb_event_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_ndb_event_t(sbp_encode_ctx_t *ctx, const sbp_msg_ndb_event_t *msg)
-{
-  if (!encode_u64(ctx, &msg->recv_time)) { return false; }
-  if (!encode_u8(ctx, &msg->event)) { return false; }
-  if (!encode_u8(ctx, &msg->object_type)) { return false; }
-  if (!encode_u8(ctx, &msg->result)) { return false; }
-  if (!encode_u8(ctx, &msg->data_source)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->object_sid)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->src_sid)) { return false; }
-  if (!encode_u16(ctx, &msg->original_sender)) { return false; }
+bool encode_sbp_msg_ndb_event_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_ndb_event_t *msg) {
+  if (!encode_u64(ctx, &msg->recv_time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->event)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->object_type)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->result)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->data_source)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->object_sid)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->src_sid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->original_sender)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ndb_event_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ndb_event_t *msg) {
+s8 sbp_encode_sbp_msg_ndb_event_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_ndb_event_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -51,20 +85,37 @@ s8 sbp_encode_sbp_msg_ndb_event_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ndb_event_t(sbp_decode_ctx_t *ctx, sbp_msg_ndb_event_t *msg)
-{
-  if (!decode_u64(ctx, &msg->recv_time)) { return false; }
-  if (!decode_u8(ctx, &msg->event)) { return false; }
-  if (!decode_u8(ctx, &msg->object_type)) { return false; }
-  if (!decode_u8(ctx, &msg->result)) { return false; }
-  if (!decode_u8(ctx, &msg->data_source)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->object_sid)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->src_sid)) { return false; }
-  if (!decode_u16(ctx, &msg->original_sender)) { return false; }
+bool decode_sbp_msg_ndb_event_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_ndb_event_t *msg) {
+  if (!decode_u64(ctx, &msg->recv_time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->event)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->object_type)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->result)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->data_source)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->object_sid)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->src_sid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->original_sender)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ndb_event_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ndb_event_t *msg) {
+s8 sbp_decode_sbp_msg_ndb_event_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_ndb_event_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -77,40 +128,62 @@ s8 sbp_decode_sbp_msg_ndb_event_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ndb_event_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ndb_event_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ndb_event_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_ndb_event_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ndb_event_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_NDB_EVENT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ndb_event_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_NDB_EVENT, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_ndb_event_t(const sbp_msg_ndb_event_t *a, const sbp_msg_ndb_event_t *b) {
+int sbp_cmp_sbp_msg_ndb_event_t(const sbp_msg_ndb_event_t *a,
+                                const sbp_msg_ndb_event_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->recv_time, &b->recv_time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->event, &b->event);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->object_type, &b->object_type);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->result, &b->result);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->data_source, &b->data_source);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->object_sid, &b->object_sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->src_sid, &b->src_sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->original_sender, &b->original_sender);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/ndb.c
+++ b/c/src/new/ndb.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/ndb.yaml
  * with generate.py. Please do not hand edit!
@@ -128,6 +116,7 @@ s8 sbp_decode_sbp_msg_ndb_event_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ndb_event_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_ndb_event_t *msg,
                                 sbp_write_fn_t write) {

--- a/c/src/new/observation.c
+++ b/c/src/new/observation.c
@@ -466,7 +466,7 @@ bool encode_sbp_msg_obs_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_t *msg) {
   if (!encode_sbp_observation_header_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -3618,17 +3618,17 @@ bool encode_sbp_msg_ephemeris_sbas_dep_a_t(
   if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3784,17 +3784,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_a_t(
   if (!encode_double(ctx, &msg->tau)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3938,17 +3938,17 @@ bool encode_sbp_msg_ephemeris_sbas_dep_b_t(
   if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4097,17 +4097,17 @@ bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_float(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_float(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4262,17 +4262,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_b_t(
   if (!encode_double(ctx, &msg->tau)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4427,17 +4427,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_c_t(
   if (!encode_double(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4612,17 +4612,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_d_t(
   if (!encode_double(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4807,17 +4807,17 @@ bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx,
   if (!encode_float(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_float(ctx, &msg->acc[i])) {
       return false;
     }
@@ -7091,7 +7091,7 @@ bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_dep_a_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -7191,7 +7191,7 @@ bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_dep_b_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -7291,7 +7291,7 @@ bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_dep_c_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -9551,7 +9551,7 @@ size_t sbp_packed_size_sbp_msg_sv_az_el_t(const sbp_msg_sv_az_el_t *msg) {
 
 bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_sv_az_el_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_azel; i++) {
+  for (uint8_t i = 0; i < msg->n_azel; i++) {
     if (!encode_sbp_sv_az_el_t(ctx, &msg->azel[i])) {
       return false;
     }
@@ -9640,7 +9640,7 @@ bool encode_sbp_msg_osr_t(sbp_encode_ctx_t *ctx, const sbp_msg_osr_t *msg) {
   if (!encode_sbp_observation_header_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
     if (!encode_sbp_packed_osr_content_t(ctx, &msg->obs[i])) {
       return false;
     }

--- a/c/src/new/observation.c
+++ b/c/src/new/observation.c
@@ -1,31 +1,55 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/observation.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/observation.h>
 #include <libsbp/internal/new/observation.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/observation.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_observation_header_t(const sbp_observation_header_t *msg) {
+size_t sbp_packed_size_sbp_observation_header_t(
+    const sbp_observation_header_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gps_time_t(&msg->t);
   packed_size += sbp_packed_size_u8(&msg->n_obs);
   return packed_size;
 }
 
-bool encode_sbp_observation_header_t(sbp_encode_ctx_t *ctx, const sbp_observation_header_t *msg)
-{
-  if (!encode_sbp_sbp_gps_time_t(ctx, &msg->t)) { return false; }
-  if (!encode_u8(ctx, &msg->n_obs)) { return false; }
+bool encode_sbp_observation_header_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_observation_header_t *msg) {
+  if (!encode_sbp_sbp_gps_time_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_obs)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_observation_header_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_observation_header_t *msg) {
+s8 sbp_encode_sbp_observation_header_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_observation_header_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -39,14 +63,20 @@ s8 sbp_encode_sbp_observation_header_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_observation_header_t(sbp_decode_ctx_t *ctx, sbp_observation_header_t *msg)
-{
-  if (!decode_sbp_sbp_gps_time_t(ctx, &msg->t)) { return false; }
-  if (!decode_u8(ctx, &msg->n_obs)) { return false; }
+bool decode_sbp_observation_header_t(sbp_decode_ctx_t *ctx,
+                                     sbp_observation_header_t *msg) {
+  if (!decode_sbp_sbp_gps_time_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_obs)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_observation_header_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_observation_header_t *msg) {
+s8 sbp_decode_sbp_observation_header_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_observation_header_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -60,14 +90,19 @@ s8 sbp_decode_sbp_observation_header_t(const uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_observation_header_t(const sbp_observation_header_t *a, const sbp_observation_header_t *b) {
+int sbp_cmp_sbp_observation_header_t(const sbp_observation_header_t *a,
+                                     const sbp_observation_header_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gps_time_t(&a->t, &b->t);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -78,14 +113,18 @@ size_t sbp_packed_size_sbp_doppler_t(const sbp_doppler_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_doppler_t(sbp_encode_ctx_t *ctx, const sbp_doppler_t *msg)
-{
-  if (!encode_s16(ctx, &msg->i)) { return false; }
-  if (!encode_u8(ctx, &msg->f)) { return false; }
+bool encode_sbp_doppler_t(sbp_encode_ctx_t *ctx, const sbp_doppler_t *msg) {
+  if (!encode_s16(ctx, &msg->i)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->f)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_doppler_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_doppler_t *msg) {
+s8 sbp_encode_sbp_doppler_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                            const sbp_doppler_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -99,14 +138,18 @@ s8 sbp_encode_sbp_doppler_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const
   return SBP_OK;
 }
 
-bool decode_sbp_doppler_t(sbp_decode_ctx_t *ctx, sbp_doppler_t *msg)
-{
-  if (!decode_s16(ctx, &msg->i)) { return false; }
-  if (!decode_u8(ctx, &msg->f)) { return false; }
+bool decode_sbp_doppler_t(sbp_decode_ctx_t *ctx, sbp_doppler_t *msg) {
+  if (!decode_s16(ctx, &msg->i)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->f)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_doppler_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_doppler_t *msg) {
+s8 sbp_decode_sbp_doppler_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                            sbp_doppler_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -122,16 +165,21 @@ s8 sbp_decode_sbp_doppler_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
 
 int sbp_cmp_sbp_doppler_t(const sbp_doppler_t *a, const sbp_doppler_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s16(&a->i, &b->i);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->f, &b->f);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_packed_obs_content_t(const sbp_packed_obs_content_t *msg) {
+size_t sbp_packed_size_sbp_packed_obs_content_t(
+    const sbp_packed_obs_content_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->P);
   packed_size += sbp_packed_size_sbp_carrier_phase_t(&msg->L);
@@ -143,19 +191,35 @@ size_t sbp_packed_size_sbp_packed_obs_content_t(const sbp_packed_obs_content_t *
   return packed_size;
 }
 
-bool encode_sbp_packed_obs_content_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_t *msg)
-{
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!encode_sbp_doppler_t(ctx, &msg->D)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
-  if (!encode_u8(ctx, &msg->lock)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_packed_obs_content_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_packed_obs_content_t *msg) {
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_sbp_doppler_t(ctx, &msg->D)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_packed_obs_content_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_packed_obs_content_t *msg) {
+s8 sbp_encode_sbp_packed_obs_content_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_packed_obs_content_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -169,19 +233,35 @@ s8 sbp_encode_sbp_packed_obs_content_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_packed_obs_content_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_t *msg)
-{
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!decode_sbp_doppler_t(ctx, &msg->D)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
-  if (!decode_u8(ctx, &msg->lock)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_packed_obs_content_t(sbp_decode_ctx_t *ctx,
+                                     sbp_packed_obs_content_t *msg) {
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_sbp_doppler_t(ctx, &msg->D)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_packed_obs_content_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_packed_obs_content_t *msg) {
+s8 sbp_decode_sbp_packed_obs_content_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_packed_obs_content_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -195,33 +275,49 @@ s8 sbp_decode_sbp_packed_obs_content_t(const uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_packed_obs_content_t(const sbp_packed_obs_content_t *a, const sbp_packed_obs_content_t *b) {
+int sbp_cmp_sbp_packed_obs_content_t(const sbp_packed_obs_content_t *a,
+                                     const sbp_packed_obs_content_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_doppler_t(&a->D, &b->D);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_packed_osr_content_t(const sbp_packed_osr_content_t *msg) {
+size_t sbp_packed_size_sbp_packed_osr_content_t(
+    const sbp_packed_osr_content_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->P);
   packed_size += sbp_packed_size_sbp_carrier_phase_t(&msg->L);
@@ -234,20 +330,38 @@ size_t sbp_packed_size_sbp_packed_osr_content_t(const sbp_packed_osr_content_t *
   return packed_size;
 }
 
-bool encode_sbp_packed_osr_content_t(sbp_encode_ctx_t *ctx, const sbp_packed_osr_content_t *msg)
-{
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!encode_u8(ctx, &msg->lock)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u16(ctx, &msg->iono_std)) { return false; }
-  if (!encode_u16(ctx, &msg->tropo_std)) { return false; }
-  if (!encode_u16(ctx, &msg->range_std)) { return false; }
+bool encode_sbp_packed_osr_content_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_packed_osr_content_t *msg) {
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iono_std)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->tropo_std)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->range_std)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_packed_osr_content_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_packed_osr_content_t *msg) {
+s8 sbp_encode_sbp_packed_osr_content_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_packed_osr_content_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -261,20 +375,38 @@ s8 sbp_encode_sbp_packed_osr_content_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_packed_osr_content_t(sbp_decode_ctx_t *ctx, sbp_packed_osr_content_t *msg)
-{
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!decode_u8(ctx, &msg->lock)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u16(ctx, &msg->iono_std)) { return false; }
-  if (!decode_u16(ctx, &msg->tropo_std)) { return false; }
-  if (!decode_u16(ctx, &msg->range_std)) { return false; }
+bool decode_sbp_packed_osr_content_t(sbp_decode_ctx_t *ctx,
+                                     sbp_packed_osr_content_t *msg) {
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iono_std)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->tropo_std)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->range_std)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_packed_osr_content_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_packed_osr_content_t *msg) {
+s8 sbp_decode_sbp_packed_osr_content_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_packed_osr_content_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -288,53 +420,74 @@ s8 sbp_decode_sbp_packed_osr_content_t(const uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_packed_osr_content_t(const sbp_packed_osr_content_t *a, const sbp_packed_osr_content_t *b) {
+int sbp_cmp_sbp_packed_osr_content_t(const sbp_packed_osr_content_t *a,
+                                     const sbp_packed_osr_content_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iono_std, &b->iono_std);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->tropo_std, &b->tropo_std);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->range_std, &b->range_std);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
 size_t sbp_packed_size_sbp_msg_obs_t(const sbp_msg_obs_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_observation_header_t(&msg->header);
-  packed_size += (msg->n_obs * sbp_packed_size_sbp_packed_obs_content_t(&msg->obs[0]));
+  packed_size +=
+      (msg->n_obs * sbp_packed_size_sbp_packed_obs_content_t(&msg->obs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_obs_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_t *msg)
-{
-  if (!encode_sbp_observation_header_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_obs; i++)
-  {
-    if (!encode_sbp_packed_obs_content_t(ctx, &msg->obs[i])) { return false; }
+bool encode_sbp_msg_obs_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_t *msg) {
+  if (!encode_sbp_observation_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
+    if (!encode_sbp_packed_obs_content_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_obs_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_obs_t *msg) {
+s8 sbp_encode_sbp_msg_obs_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                            const sbp_msg_obs_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -348,17 +501,23 @@ s8 sbp_encode_sbp_msg_obs_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const
   return SBP_OK;
 }
 
-bool decode_sbp_msg_obs_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_t *msg)
-{
-  if (!decode_sbp_observation_header_t(ctx, &msg->header)) { return false; }
-    msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_packed_obs_content_t(&msg->obs[0]));
+bool decode_sbp_msg_obs_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_t *msg) {
+  if (!decode_sbp_observation_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_obs =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_packed_obs_content_t(&msg->obs[0]));
   for (uint8_t i = 0; i < msg->n_obs; i++) {
-    if (!decode_sbp_packed_obs_content_t(ctx, &msg->obs[i])) { return false; }
+    if (!decode_sbp_packed_obs_content_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_obs_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_obs_t *msg) {
+s8 sbp_decode_sbp_msg_obs_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                            sbp_msg_obs_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -371,31 +530,39 @@ s8 sbp_decode_sbp_msg_obs_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_obs_t(struct sbp_state *s, u16 sender_id,
+                          const sbp_msg_obs_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_obs_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_OBS, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_obs_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_OBS, sender_id, payload_len, payload,
+                          write);
 }
 
 int sbp_cmp_sbp_msg_obs_t(const sbp_msg_obs_t *a, const sbp_msg_obs_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_observation_header_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_t(&a->obs[i], &b->obs[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_base_pos_llh_t(const sbp_msg_base_pos_llh_t *msg) {
+size_t sbp_packed_size_sbp_msg_base_pos_llh_t(
+    const sbp_msg_base_pos_llh_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_double(&msg->lat);
   packed_size += sbp_packed_size_double(&msg->lon);
@@ -403,15 +570,23 @@ size_t sbp_packed_size_sbp_msg_base_pos_llh_t(const sbp_msg_base_pos_llh_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_base_pos_llh_t(sbp_encode_ctx_t *ctx, const sbp_msg_base_pos_llh_t *msg)
-{
-  if (!encode_double(ctx, &msg->lat)) { return false; }
-  if (!encode_double(ctx, &msg->lon)) { return false; }
-  if (!encode_double(ctx, &msg->height)) { return false; }
+bool encode_sbp_msg_base_pos_llh_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_base_pos_llh_t *msg) {
+  if (!encode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->height)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_base_pos_llh_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_base_pos_llh_t *msg) {
+s8 sbp_encode_sbp_msg_base_pos_llh_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_base_pos_llh_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -425,15 +600,23 @@ s8 sbp_encode_sbp_msg_base_pos_llh_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_base_pos_llh_t(sbp_decode_ctx_t *ctx, sbp_msg_base_pos_llh_t *msg)
-{
-  if (!decode_double(ctx, &msg->lat)) { return false; }
-  if (!decode_double(ctx, &msg->lon)) { return false; }
-  if (!decode_double(ctx, &msg->height)) { return false; }
+bool decode_sbp_msg_base_pos_llh_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_base_pos_llh_t *msg) {
+  if (!decode_double(ctx, &msg->lat)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->height)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_base_pos_llh_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_base_pos_llh_t *msg) {
+s8 sbp_decode_sbp_msg_base_pos_llh_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_base_pos_llh_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -446,30 +629,43 @@ s8 sbp_decode_sbp_msg_base_pos_llh_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_base_pos_llh_t(struct sbp_state *s, u16 sender_id, const sbp_msg_base_pos_llh_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_base_pos_llh_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_base_pos_llh_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_base_pos_llh_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASE_POS_LLH, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_base_pos_llh_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASE_POS_LLH, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_base_pos_llh_t(const sbp_msg_base_pos_llh_t *a, const sbp_msg_base_pos_llh_t *b) {
+int sbp_cmp_sbp_msg_base_pos_llh_t(const sbp_msg_base_pos_llh_t *a,
+                                   const sbp_msg_base_pos_llh_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_double(&a->lat, &b->lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lon, &b->lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->height, &b->height);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_base_pos_ecef_t(const sbp_msg_base_pos_ecef_t *msg) {
+size_t sbp_packed_size_sbp_msg_base_pos_ecef_t(
+    const sbp_msg_base_pos_ecef_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_double(&msg->x);
   packed_size += sbp_packed_size_double(&msg->y);
@@ -477,15 +673,23 @@ size_t sbp_packed_size_sbp_msg_base_pos_ecef_t(const sbp_msg_base_pos_ecef_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_base_pos_ecef_t(sbp_encode_ctx_t *ctx, const sbp_msg_base_pos_ecef_t *msg)
-{
-  if (!encode_double(ctx, &msg->x)) { return false; }
-  if (!encode_double(ctx, &msg->y)) { return false; }
-  if (!encode_double(ctx, &msg->z)) { return false; }
+bool encode_sbp_msg_base_pos_ecef_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_base_pos_ecef_t *msg) {
+  if (!encode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->z)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_base_pos_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_base_pos_ecef_t *msg) {
+s8 sbp_encode_sbp_msg_base_pos_ecef_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_base_pos_ecef_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -499,15 +703,23 @@ s8 sbp_encode_sbp_msg_base_pos_ecef_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_base_pos_ecef_t(sbp_decode_ctx_t *ctx, sbp_msg_base_pos_ecef_t *msg)
-{
-  if (!decode_double(ctx, &msg->x)) { return false; }
-  if (!decode_double(ctx, &msg->y)) { return false; }
-  if (!decode_double(ctx, &msg->z)) { return false; }
+bool decode_sbp_msg_base_pos_ecef_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_base_pos_ecef_t *msg) {
+  if (!decode_double(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->z)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_base_pos_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_base_pos_ecef_t *msg) {
+s8 sbp_decode_sbp_msg_base_pos_ecef_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_base_pos_ecef_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -520,30 +732,43 @@ s8 sbp_decode_sbp_msg_base_pos_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_base_pos_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_base_pos_ecef_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_base_pos_ecef_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_base_pos_ecef_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_base_pos_ecef_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASE_POS_ECEF, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_base_pos_ecef_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASE_POS_ECEF, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_base_pos_ecef_t(const sbp_msg_base_pos_ecef_t *a, const sbp_msg_base_pos_ecef_t *b) {
+int sbp_cmp_sbp_msg_base_pos_ecef_t(const sbp_msg_base_pos_ecef_t *a,
+                                    const sbp_msg_base_pos_ecef_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_double(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->z, &b->z);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_ephemeris_common_content_t(const sbp_ephemeris_common_content_t *msg) {
+size_t sbp_packed_size_sbp_ephemeris_common_content_t(
+    const sbp_ephemeris_common_content_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->toe);
@@ -554,18 +779,32 @@ size_t sbp_packed_size_sbp_ephemeris_common_content_t(const sbp_ephemeris_common
   return packed_size;
 }
 
-bool encode_sbp_ephemeris_common_content_t(sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toe)) { return false; }
-  if (!encode_float(ctx, &msg->ura)) { return false; }
-  if (!encode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->health_bits)) { return false; }
+bool encode_sbp_ephemeris_common_content_t(
+    sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toe)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_ephemeris_common_content_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_ephemeris_common_content_t *msg) {
+s8 sbp_encode_sbp_ephemeris_common_content_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_ephemeris_common_content_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -579,18 +818,32 @@ s8 sbp_encode_sbp_ephemeris_common_content_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_ephemeris_common_content_t(sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toe)) { return false; }
-  if (!decode_float(ctx, &msg->ura)) { return false; }
-  if (!decode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->health_bits)) { return false; }
+bool decode_sbp_ephemeris_common_content_t(
+    sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toe)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_ephemeris_common_content_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_ephemeris_common_content_t *msg) {
+s8 sbp_decode_sbp_ephemeris_common_content_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_ephemeris_common_content_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -604,30 +857,45 @@ s8 sbp_decode_sbp_ephemeris_common_content_t(const uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_ephemeris_common_content_t(const sbp_ephemeris_common_content_t *a, const sbp_ephemeris_common_content_t *b) {
+int sbp_cmp_sbp_ephemeris_common_content_t(
+    const sbp_ephemeris_common_content_t *a,
+    const sbp_ephemeris_common_content_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toe, &b->toe);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->ura, &b->ura);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->fit_interval, &b->fit_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->health_bits, &b->health_bits);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(const sbp_ephemeris_common_content_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(
+    const sbp_ephemeris_common_content_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->toe);
@@ -638,18 +906,32 @@ size_t sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(const sbp_ephemeris_
   return packed_size;
 }
 
-bool encode_sbp_ephemeris_common_content_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_b_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toe)) { return false; }
-  if (!encode_double(ctx, &msg->ura)) { return false; }
-  if (!encode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->health_bits)) { return false; }
+bool encode_sbp_ephemeris_common_content_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_b_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toe)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_ephemeris_common_content_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_ephemeris_common_content_dep_b_t *msg) {
+s8 sbp_encode_sbp_ephemeris_common_content_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_ephemeris_common_content_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -663,18 +945,32 @@ s8 sbp_encode_sbp_ephemeris_common_content_dep_b_t(uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-bool decode_sbp_ephemeris_common_content_dep_b_t(sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_b_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toe)) { return false; }
-  if (!decode_double(ctx, &msg->ura)) { return false; }
-  if (!decode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->health_bits)) { return false; }
+bool decode_sbp_ephemeris_common_content_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_b_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toe)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_ephemeris_common_content_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_ephemeris_common_content_dep_b_t *msg) {
+s8 sbp_decode_sbp_ephemeris_common_content_dep_b_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_ephemeris_common_content_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -688,30 +984,45 @@ s8 sbp_decode_sbp_ephemeris_common_content_dep_b_t(const uint8_t *buf, uint8_t l
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_ephemeris_common_content_dep_b_t(const sbp_ephemeris_common_content_dep_b_t *a, const sbp_ephemeris_common_content_dep_b_t *b) {
+int sbp_cmp_sbp_ephemeris_common_content_dep_b_t(
+    const sbp_ephemeris_common_content_dep_b_t *a,
+    const sbp_ephemeris_common_content_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toe, &b->toe);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ura, &b->ura);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->fit_interval, &b->fit_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->health_bits, &b->health_bits);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(const sbp_ephemeris_common_content_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(
+    const sbp_ephemeris_common_content_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gnss_signal_dep_t(&msg->sid);
   packed_size += sbp_packed_size_sbp_gps_time_dep_t(&msg->toe);
@@ -722,18 +1033,32 @@ size_t sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(const sbp_ephemeris_
   return packed_size;
 }
 
-bool encode_sbp_ephemeris_common_content_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_a_t *msg)
-{
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_sbp_gps_time_dep_t(ctx, &msg->toe)) { return false; }
-  if (!encode_double(ctx, &msg->ura)) { return false; }
-  if (!encode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->health_bits)) { return false; }
+bool encode_sbp_ephemeris_common_content_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_ephemeris_common_content_dep_a_t *msg) {
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_dep_t(ctx, &msg->toe)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_ephemeris_common_content_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_ephemeris_common_content_dep_a_t *msg) {
+s8 sbp_encode_sbp_ephemeris_common_content_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_ephemeris_common_content_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -747,18 +1072,32 @@ s8 sbp_encode_sbp_ephemeris_common_content_dep_a_t(uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-bool decode_sbp_ephemeris_common_content_dep_a_t(sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_a_t *msg)
-{
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_sbp_gps_time_dep_t(ctx, &msg->toe)) { return false; }
-  if (!decode_double(ctx, &msg->ura)) { return false; }
-  if (!decode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->health_bits)) { return false; }
+bool decode_sbp_ephemeris_common_content_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_ephemeris_common_content_dep_a_t *msg) {
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_dep_t(ctx, &msg->toe)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_ephemeris_common_content_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_ephemeris_common_content_dep_a_t *msg) {
+s8 sbp_decode_sbp_ephemeris_common_content_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_ephemeris_common_content_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -772,32 +1111,48 @@ s8 sbp_decode_sbp_ephemeris_common_content_dep_a_t(const uint8_t *buf, uint8_t l
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_ephemeris_common_content_dep_a_t(const sbp_ephemeris_common_content_dep_a_t *a, const sbp_ephemeris_common_content_dep_a_t *b) {
+int sbp_cmp_sbp_ephemeris_common_content_dep_a_t(
+    const sbp_ephemeris_common_content_dep_a_t *a,
+    const sbp_ephemeris_common_content_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_dep_t(&a->toe, &b->toe);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ura, &b->ura);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->fit_interval, &b->fit_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->health_bits, &b->health_bits);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_gps_dep_e_t(const sbp_msg_ephemeris_gps_dep_e_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_gps_dep_e_t(
+    const sbp_msg_ephemeris_gps_dep_e_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(&msg->common);
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->tgd);
   packed_size += sbp_packed_size_double(&msg->c_rs);
   packed_size += sbp_packed_size_double(&msg->c_rc);
@@ -823,35 +1178,83 @@ size_t sbp_packed_size_sbp_msg_ephemeris_gps_dep_e_t(const sbp_msg_ephemeris_gps
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_gps_dep_e_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_e_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->tgd)) { return false; }
-  if (!encode_double(ctx, &msg->c_rs)) { return false; }
-  if (!encode_double(ctx, &msg->c_rc)) { return false; }
-  if (!encode_double(ctx, &msg->c_uc)) { return false; }
-  if (!encode_double(ctx, &msg->c_us)) { return false; }
-  if (!encode_double(ctx, &msg->c_ic)) { return false; }
-  if (!encode_double(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_double(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_dep_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
+bool encode_sbp_msg_ephemeris_gps_dep_e_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_e_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_dep_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_gps_dep_e_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_gps_dep_e_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_gps_dep_e_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_gps_dep_e_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -865,35 +1268,83 @@ s8 sbp_encode_sbp_msg_ephemeris_gps_dep_e_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_gps_dep_e_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gps_dep_e_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->tgd)) { return false; }
-  if (!decode_double(ctx, &msg->c_rs)) { return false; }
-  if (!decode_double(ctx, &msg->c_rc)) { return false; }
-  if (!decode_double(ctx, &msg->c_uc)) { return false; }
-  if (!decode_double(ctx, &msg->c_us)) { return false; }
-  if (!decode_double(ctx, &msg->c_ic)) { return false; }
-  if (!decode_double(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_double(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_dep_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
+bool decode_sbp_msg_ephemeris_gps_dep_e_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_gps_dep_e_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_dep_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_gps_dep_e_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_gps_dep_e_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_gps_dep_e_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_gps_dep_e_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -906,92 +1357,147 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_e_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gps_dep_e_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_dep_e_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_gps_dep_e_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_gps_dep_e_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_gps_dep_e_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GPS_DEP_E, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_gps_dep_e_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GPS_DEP_E, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_gps_dep_e_t(const sbp_msg_ephemeris_gps_dep_e_t *a, const sbp_msg_ephemeris_gps_dep_e_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_gps_dep_e_t(
+    const sbp_msg_ephemeris_gps_dep_e_t *a,
+    const sbp_msg_ephemeris_gps_dep_e_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_a_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_dep_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_gps_dep_f_t(const sbp_msg_ephemeris_gps_dep_f_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_gps_dep_f_t(
+    const sbp_msg_ephemeris_gps_dep_f_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->tgd);
   packed_size += sbp_packed_size_double(&msg->c_rs);
   packed_size += sbp_packed_size_double(&msg->c_rc);
@@ -1017,35 +1523,83 @@ size_t sbp_packed_size_sbp_msg_ephemeris_gps_dep_f_t(const sbp_msg_ephemeris_gps
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_gps_dep_f_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_f_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->tgd)) { return false; }
-  if (!encode_double(ctx, &msg->c_rs)) { return false; }
-  if (!encode_double(ctx, &msg->c_rc)) { return false; }
-  if (!encode_double(ctx, &msg->c_uc)) { return false; }
-  if (!encode_double(ctx, &msg->c_us)) { return false; }
-  if (!encode_double(ctx, &msg->c_ic)) { return false; }
-  if (!encode_double(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_double(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
+bool encode_sbp_msg_ephemeris_gps_dep_f_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_dep_f_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_gps_dep_f_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_gps_dep_f_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_gps_dep_f_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_gps_dep_f_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1059,35 +1613,83 @@ s8 sbp_encode_sbp_msg_ephemeris_gps_dep_f_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_gps_dep_f_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gps_dep_f_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->tgd)) { return false; }
-  if (!decode_double(ctx, &msg->c_rs)) { return false; }
-  if (!decode_double(ctx, &msg->c_rc)) { return false; }
-  if (!decode_double(ctx, &msg->c_uc)) { return false; }
-  if (!decode_double(ctx, &msg->c_us)) { return false; }
-  if (!decode_double(ctx, &msg->c_ic)) { return false; }
-  if (!decode_double(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_double(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
+bool decode_sbp_msg_ephemeris_gps_dep_f_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_gps_dep_f_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_gps_dep_f_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_gps_dep_f_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_gps_dep_f_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_gps_dep_f_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1100,90 +1702,144 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_f_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gps_dep_f_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_dep_f_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_gps_dep_f_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_gps_dep_f_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_gps_dep_f_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GPS_DEP_F, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_gps_dep_f_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GPS_DEP_F, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_gps_dep_f_t(const sbp_msg_ephemeris_gps_dep_f_t *a, const sbp_msg_ephemeris_gps_dep_f_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_gps_dep_f_t(
+    const sbp_msg_ephemeris_gps_dep_f_t *a,
+    const sbp_msg_ephemeris_gps_dep_f_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_b_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_gps_t(const sbp_msg_ephemeris_gps_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_gps_t(
+    const sbp_msg_ephemeris_gps_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
   packed_size += sbp_packed_size_float(&msg->tgd);
@@ -1211,35 +1867,83 @@ size_t sbp_packed_size_sbp_msg_ephemeris_gps_t(const sbp_msg_ephemeris_gps_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_gps_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gps_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_float(ctx, &msg->tgd)) { return false; }
-  if (!encode_float(ctx, &msg->c_rs)) { return false; }
-  if (!encode_float(ctx, &msg->c_rc)) { return false; }
-  if (!encode_float(ctx, &msg->c_uc)) { return false; }
-  if (!encode_float(ctx, &msg->c_us)) { return false; }
-  if (!encode_float(ctx, &msg->c_ic)) { return false; }
-  if (!encode_float(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_float(ctx, &msg->af0)) { return false; }
-  if (!encode_float(ctx, &msg->af1)) { return false; }
-  if (!encode_float(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
+bool encode_sbp_msg_ephemeris_gps_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_gps_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_gps_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_gps_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_gps_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_ephemeris_gps_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1253,35 +1957,83 @@ s8 sbp_encode_sbp_msg_ephemeris_gps_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_gps_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gps_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_float(ctx, &msg->tgd)) { return false; }
-  if (!decode_float(ctx, &msg->c_rs)) { return false; }
-  if (!decode_float(ctx, &msg->c_rc)) { return false; }
-  if (!decode_float(ctx, &msg->c_uc)) { return false; }
-  if (!decode_float(ctx, &msg->c_us)) { return false; }
-  if (!decode_float(ctx, &msg->c_ic)) { return false; }
-  if (!decode_float(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_float(ctx, &msg->af0)) { return false; }
-  if (!decode_float(ctx, &msg->af1)) { return false; }
-  if (!decode_float(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
+bool decode_sbp_msg_ephemeris_gps_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_gps_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_gps_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_gps_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_gps_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_ephemeris_gps_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1294,90 +2046,143 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gps_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_gps_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_ephemeris_gps_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_gps_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GPS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_gps_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GPS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_gps_t(const sbp_msg_ephemeris_gps_t *a, const sbp_msg_ephemeris_gps_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_gps_t(const sbp_msg_ephemeris_gps_t *a,
+                                    const sbp_msg_ephemeris_gps_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_qzss_t(const sbp_msg_ephemeris_qzss_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_qzss_t(
+    const sbp_msg_ephemeris_qzss_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
   packed_size += sbp_packed_size_float(&msg->tgd);
@@ -1405,35 +2210,83 @@ size_t sbp_packed_size_sbp_msg_ephemeris_qzss_t(const sbp_msg_ephemeris_qzss_t *
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_qzss_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_qzss_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_float(ctx, &msg->tgd)) { return false; }
-  if (!encode_float(ctx, &msg->c_rs)) { return false; }
-  if (!encode_float(ctx, &msg->c_rc)) { return false; }
-  if (!encode_float(ctx, &msg->c_uc)) { return false; }
-  if (!encode_float(ctx, &msg->c_us)) { return false; }
-  if (!encode_float(ctx, &msg->c_ic)) { return false; }
-  if (!encode_float(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_float(ctx, &msg->af0)) { return false; }
-  if (!encode_float(ctx, &msg->af1)) { return false; }
-  if (!encode_float(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
+bool encode_sbp_msg_ephemeris_qzss_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_ephemeris_qzss_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_qzss_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_qzss_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_qzss_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_ephemeris_qzss_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1447,35 +2300,83 @@ s8 sbp_encode_sbp_msg_ephemeris_qzss_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_qzss_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_qzss_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_float(ctx, &msg->tgd)) { return false; }
-  if (!decode_float(ctx, &msg->c_rs)) { return false; }
-  if (!decode_float(ctx, &msg->c_rc)) { return false; }
-  if (!decode_float(ctx, &msg->c_uc)) { return false; }
-  if (!decode_float(ctx, &msg->c_us)) { return false; }
-  if (!decode_float(ctx, &msg->c_ic)) { return false; }
-  if (!decode_float(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_float(ctx, &msg->af0)) { return false; }
-  if (!decode_float(ctx, &msg->af1)) { return false; }
-  if (!decode_float(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
+bool decode_sbp_msg_ephemeris_qzss_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_ephemeris_qzss_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_qzss_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_qzss_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_qzss_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_ephemeris_qzss_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1488,90 +2389,143 @@ s8 sbp_decode_sbp_msg_ephemeris_qzss_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_qzss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_qzss_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_qzss_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_ephemeris_qzss_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_qzss_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_QZSS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_qzss_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_QZSS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_qzss_t(const sbp_msg_ephemeris_qzss_t *a, const sbp_msg_ephemeris_qzss_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_qzss_t(const sbp_msg_ephemeris_qzss_t *a,
+                                     const sbp_msg_ephemeris_qzss_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_bds_t(const sbp_msg_ephemeris_bds_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_bds_t(
+    const sbp_msg_ephemeris_bds_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
   packed_size += sbp_packed_size_float(&msg->tgd1);
@@ -1600,36 +2554,86 @@ size_t sbp_packed_size_sbp_msg_ephemeris_bds_t(const sbp_msg_ephemeris_bds_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_bds_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_bds_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_float(ctx, &msg->tgd1)) { return false; }
-  if (!encode_float(ctx, &msg->tgd2)) { return false; }
-  if (!encode_float(ctx, &msg->c_rs)) { return false; }
-  if (!encode_float(ctx, &msg->c_rc)) { return false; }
-  if (!encode_float(ctx, &msg->c_uc)) { return false; }
-  if (!encode_float(ctx, &msg->c_us)) { return false; }
-  if (!encode_float(ctx, &msg->c_ic)) { return false; }
-  if (!encode_float(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_float(ctx, &msg->af1)) { return false; }
-  if (!encode_float(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
+bool encode_sbp_msg_ephemeris_bds_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_bds_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->tgd1)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->tgd2)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_bds_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_bds_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_bds_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_ephemeris_bds_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1643,36 +2647,86 @@ s8 sbp_encode_sbp_msg_ephemeris_bds_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_bds_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_bds_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_float(ctx, &msg->tgd1)) { return false; }
-  if (!decode_float(ctx, &msg->tgd2)) { return false; }
-  if (!decode_float(ctx, &msg->c_rs)) { return false; }
-  if (!decode_float(ctx, &msg->c_rc)) { return false; }
-  if (!decode_float(ctx, &msg->c_uc)) { return false; }
-  if (!decode_float(ctx, &msg->c_us)) { return false; }
-  if (!decode_float(ctx, &msg->c_ic)) { return false; }
-  if (!decode_float(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_float(ctx, &msg->af1)) { return false; }
-  if (!decode_float(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
+bool decode_sbp_msg_ephemeris_bds_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_bds_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->tgd1)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->tgd2)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_bds_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_bds_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_bds_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_ephemeris_bds_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1685,93 +2739,148 @@ s8 sbp_decode_sbp_msg_ephemeris_bds_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_bds_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_bds_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_bds_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_ephemeris_bds_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_bds_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_BDS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_bds_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_BDS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_bds_t(const sbp_msg_ephemeris_bds_t *a, const sbp_msg_ephemeris_bds_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_bds_t(const sbp_msg_ephemeris_bds_t *a,
+                                    const sbp_msg_ephemeris_bds_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->tgd1, &b->tgd1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->tgd2, &b->tgd2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_gal_dep_a_t(const sbp_msg_ephemeris_gal_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_gal_dep_a_t(
+    const sbp_msg_ephemeris_gal_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
   packed_size += sbp_packed_size_float(&msg->bgd_e1e5a);
@@ -1800,36 +2909,86 @@ size_t sbp_packed_size_sbp_msg_ephemeris_gal_dep_a_t(const sbp_msg_ephemeris_gal
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_gal_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_dep_a_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_float(ctx, &msg->bgd_e1e5a)) { return false; }
-  if (!encode_float(ctx, &msg->bgd_e1e5b)) { return false; }
-  if (!encode_float(ctx, &msg->c_rs)) { return false; }
-  if (!encode_float(ctx, &msg->c_rc)) { return false; }
-  if (!encode_float(ctx, &msg->c_uc)) { return false; }
-  if (!encode_float(ctx, &msg->c_us)) { return false; }
-  if (!encode_float(ctx, &msg->c_ic)) { return false; }
-  if (!encode_float(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_float(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u16(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
+bool encode_sbp_msg_ephemeris_gal_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_dep_a_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->bgd_e1e5a)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->bgd_e1e5b)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_gal_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_gal_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_gal_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_gal_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1843,36 +3002,86 @@ s8 sbp_encode_sbp_msg_ephemeris_gal_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_gal_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gal_dep_a_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_float(ctx, &msg->bgd_e1e5a)) { return false; }
-  if (!decode_float(ctx, &msg->bgd_e1e5b)) { return false; }
-  if (!decode_float(ctx, &msg->c_rs)) { return false; }
-  if (!decode_float(ctx, &msg->c_rc)) { return false; }
-  if (!decode_float(ctx, &msg->c_uc)) { return false; }
-  if (!decode_float(ctx, &msg->c_us)) { return false; }
-  if (!decode_float(ctx, &msg->c_ic)) { return false; }
-  if (!decode_float(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_float(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u16(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
+bool decode_sbp_msg_ephemeris_gal_dep_a_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_gal_dep_a_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->bgd_e1e5a)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->bgd_e1e5b)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_gal_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_gal_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_gal_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_gal_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1885,93 +3094,149 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_dep_a_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gal_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gal_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_gal_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_gal_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_gal_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GAL_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_gal_dep_a_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GAL_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_gal_dep_a_t(const sbp_msg_ephemeris_gal_dep_a_t *a, const sbp_msg_ephemeris_gal_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_gal_dep_a_t(
+    const sbp_msg_ephemeris_gal_dep_a_t *a,
+    const sbp_msg_ephemeris_gal_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->bgd_e1e5a, &b->bgd_e1e5a);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->bgd_e1e5b, &b->bgd_e1e5b);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_gal_t(const sbp_msg_ephemeris_gal_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_gal_t(
+    const sbp_msg_ephemeris_gal_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
   packed_size += sbp_packed_size_float(&msg->bgd_e1e5a);
@@ -2001,37 +3266,89 @@ size_t sbp_packed_size_sbp_msg_ephemeris_gal_t(const sbp_msg_ephemeris_gal_t *ms
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_gal_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_gal_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_float(ctx, &msg->bgd_e1e5a)) { return false; }
-  if (!encode_float(ctx, &msg->bgd_e1e5b)) { return false; }
-  if (!encode_float(ctx, &msg->c_rs)) { return false; }
-  if (!encode_float(ctx, &msg->c_rc)) { return false; }
-  if (!encode_float(ctx, &msg->c_uc)) { return false; }
-  if (!encode_float(ctx, &msg->c_us)) { return false; }
-  if (!encode_float(ctx, &msg->c_ic)) { return false; }
-  if (!encode_float(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_float(ctx, &msg->af2)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!encode_u16(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
-  if (!encode_u8(ctx, &msg->source)) { return false; }
+bool encode_sbp_msg_ephemeris_gal_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_gal_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->bgd_e1e5a)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->bgd_e1e5b)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->source)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_gal_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_gal_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_gal_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_ephemeris_gal_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2045,37 +3362,89 @@ s8 sbp_encode_sbp_msg_ephemeris_gal_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_gal_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_gal_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_float(ctx, &msg->bgd_e1e5a)) { return false; }
-  if (!decode_float(ctx, &msg->bgd_e1e5b)) { return false; }
-  if (!decode_float(ctx, &msg->c_rs)) { return false; }
-  if (!decode_float(ctx, &msg->c_rc)) { return false; }
-  if (!decode_float(ctx, &msg->c_uc)) { return false; }
-  if (!decode_float(ctx, &msg->c_us)) { return false; }
-  if (!decode_float(ctx, &msg->c_ic)) { return false; }
-  if (!decode_float(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_float(ctx, &msg->af2)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) { return false; }
-  if (!decode_u16(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
-  if (!decode_u8(ctx, &msg->source)) { return false; }
+bool decode_sbp_msg_ephemeris_gal_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_gal_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->bgd_e1e5a)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->bgd_e1e5b)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toc)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->source)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_gal_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_gal_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_gal_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_ephemeris_gal_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2088,127 +3457,196 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gal_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gal_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_gal_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_ephemeris_gal_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_gal_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GAL, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_gal_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GAL, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_gal_t(const sbp_msg_ephemeris_gal_t *a, const sbp_msg_ephemeris_gal_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_gal_t(const sbp_msg_ephemeris_gal_t *a,
+                                    const sbp_msg_ephemeris_gal_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->bgd_e1e5a, &b->bgd_e1e5a);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->bgd_e1e5b, &b->bgd_e1e5b);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toc, &b->toc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->source, &b->source);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_sbas_dep_a_t(const sbp_msg_ephemeris_sbas_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_sbas_dep_a_t(
+    const sbp_msg_ephemeris_sbas_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(&msg->common);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->acc[0]));
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(&msg->common);
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->acc[0]));
   packed_size += sbp_packed_size_double(&msg->a_gf0);
   packed_size += sbp_packed_size_double(&msg->a_gf1);
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_sbas_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_a_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_sbas_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_a_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->acc[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!encode_double(ctx, &msg->a_gf0)) { return false; }
-  if (!encode_double(ctx, &msg->a_gf1)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!encode_double(ctx, &msg->a_gf0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->a_gf1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_sbas_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_sbas_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_sbas_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_sbas_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2222,24 +3660,38 @@ s8 sbp_encode_sbp_msg_ephemeris_sbas_dep_a_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_sbas_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_dep_a_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_sbas_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_dep_a_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!decode_double(ctx, &msg->a_gf0)) { return false; }
-  if (!decode_double(ctx, &msg->a_gf1)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!decode_double(ctx, &msg->a_gf0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->a_gf1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_sbas_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_sbas_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2252,79 +3704,108 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_a_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_sbas_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_sbas_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_SBAS_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_sbas_dep_a_t(payload, sizeof(payload),
+                                                     &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_SBAS_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_sbas_dep_a_t(const sbp_msg_ephemeris_sbas_dep_a_t *a, const sbp_msg_ephemeris_sbas_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_sbas_dep_a_t(
+    const sbp_msg_ephemeris_sbas_dep_a_t *a,
+    const sbp_msg_ephemeris_sbas_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_a_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a_gf0, &b->a_gf0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a_gf1, &b->a_gf1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_a_t(const sbp_msg_ephemeris_glo_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_a_t(
+    const sbp_msg_ephemeris_glo_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(&msg->common);
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_a_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->gamma);
   packed_size += sbp_packed_size_double(&msg->tau);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->acc[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->acc[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_glo_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_a_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->gamma)) { return false; }
-  if (!encode_double(ctx, &msg->tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_glo_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_a_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  if (!encode_double(ctx, &msg->gamma)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->acc[i])) { return false; }
+  if (!encode_double(ctx, &msg->tau)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_glo_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_glo_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_glo_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_glo_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2338,24 +3819,38 @@ s8 sbp_encode_sbp_msg_ephemeris_glo_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_glo_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_a_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->gamma)) { return false; }
-  if (!decode_double(ctx, &msg->tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_glo_dep_a_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_a_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->gamma)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->tau)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_glo_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_glo_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_glo_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_glo_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2368,79 +3863,108 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_a_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_glo_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_a_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_glo_dep_a_t(const sbp_msg_ephemeris_glo_dep_a_t *a, const sbp_msg_ephemeris_glo_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_glo_dep_a_t(
+    const sbp_msg_ephemeris_glo_dep_a_t *a,
+    const sbp_msg_ephemeris_glo_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_a_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->gamma, &b->gamma);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->tau, &b->tau);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_sbas_dep_b_t(const sbp_msg_ephemeris_sbas_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_sbas_dep_b_t(
+    const sbp_msg_ephemeris_sbas_dep_b_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->acc[0]));
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->acc[0]));
   packed_size += sbp_packed_size_double(&msg->a_gf0);
   packed_size += sbp_packed_size_double(&msg->a_gf1);
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_sbas_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_b_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_sbas_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_dep_b_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->acc[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!encode_double(ctx, &msg->a_gf0)) { return false; }
-  if (!encode_double(ctx, &msg->a_gf1)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!encode_double(ctx, &msg->a_gf0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->a_gf1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_sbas_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_sbas_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_sbas_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_sbas_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2454,24 +3978,38 @@ s8 sbp_encode_sbp_msg_ephemeris_sbas_dep_b_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_sbas_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_dep_b_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_sbas_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_dep_b_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!decode_double(ctx, &msg->a_gf0)) { return false; }
-  if (!decode_double(ctx, &msg->a_gf1)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!decode_double(ctx, &msg->a_gf0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->a_gf1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_sbas_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_b_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_sbas_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2484,79 +4022,107 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_b_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_sbas_dep_b_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_sbas_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_SBAS_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_sbas_dep_b_t(payload, sizeof(payload),
+                                                     &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_SBAS_DEP_B, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_sbas_dep_b_t(const sbp_msg_ephemeris_sbas_dep_b_t *a, const sbp_msg_ephemeris_sbas_dep_b_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_sbas_dep_b_t(
+    const sbp_msg_ephemeris_sbas_dep_b_t *a,
+    const sbp_msg_ephemeris_sbas_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_b_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a_gf0, &b->a_gf0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a_gf1, &b->a_gf1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_sbas_t(const sbp_msg_ephemeris_sbas_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_sbas_t(
+    const sbp_msg_ephemeris_sbas_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_float(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_float(&msg->acc[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_float(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_float(&msg->acc[0]));
   packed_size += sbp_packed_size_float(&msg->a_gf0);
   packed_size += sbp_packed_size_float(&msg->a_gf1);
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_sbas_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_ephemeris_sbas_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_float(ctx, &msg->vel[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_float(ctx, &msg->acc[i])) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_float(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!encode_float(ctx, &msg->a_gf0)) { return false; }
-  if (!encode_float(ctx, &msg->a_gf1)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_float(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!encode_float(ctx, &msg->a_gf0)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->a_gf1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_sbas_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_sbas_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_sbas_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_ephemeris_sbas_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2570,24 +4136,38 @@ s8 sbp_encode_sbp_msg_ephemeris_sbas_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_sbas_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_sbas_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_sbas_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_ephemeris_sbas_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_float(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_float(ctx, &msg->acc[i])) { return false; }
+    if (!decode_float(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!decode_float(ctx, &msg->a_gf0)) { return false; }
-  if (!decode_float(ctx, &msg->a_gf1)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_float(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!decode_float(ctx, &msg->a_gf0)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->a_gf1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_sbas_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_sbas_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_sbas_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_ephemeris_sbas_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2600,79 +4180,107 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_sbas_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_sbas_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_ephemeris_sbas_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_sbas_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_SBAS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_sbas_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_SBAS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_sbas_t(const sbp_msg_ephemeris_sbas_t *a, const sbp_msg_ephemeris_sbas_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_sbas_t(const sbp_msg_ephemeris_sbas_t *a,
+                                     const sbp_msg_ephemeris_sbas_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_float(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_float(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->a_gf0, &b->a_gf0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->a_gf1, &b->a_gf1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_b_t(const sbp_msg_ephemeris_glo_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_b_t(
+    const sbp_msg_ephemeris_glo_dep_b_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->gamma);
   packed_size += sbp_packed_size_double(&msg->tau);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->acc[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->acc[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_glo_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_b_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->gamma)) { return false; }
-  if (!encode_double(ctx, &msg->tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_glo_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_b_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  if (!encode_double(ctx, &msg->gamma)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->acc[i])) { return false; }
+  if (!encode_double(ctx, &msg->tau)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_glo_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_glo_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_glo_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_glo_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2686,24 +4294,38 @@ s8 sbp_encode_sbp_msg_ephemeris_glo_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_glo_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_b_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->gamma)) { return false; }
-  if (!decode_double(ctx, &msg->tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_glo_dep_b_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_b_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->gamma)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->tau)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_glo_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_glo_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_glo_dep_b_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_glo_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2716,83 +4338,116 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_b_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_b_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_glo_dep_b_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_b_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_B, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_glo_dep_b_t(const sbp_msg_ephemeris_glo_dep_b_t *a, const sbp_msg_ephemeris_glo_dep_b_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_glo_dep_b_t(
+    const sbp_msg_ephemeris_glo_dep_b_t *a,
+    const sbp_msg_ephemeris_glo_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_b_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->gamma, &b->gamma);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->tau, &b->tau);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_c_t(const sbp_msg_ephemeris_glo_dep_c_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_c_t(
+    const sbp_msg_ephemeris_glo_dep_c_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->gamma);
   packed_size += sbp_packed_size_double(&msg->tau);
   packed_size += sbp_packed_size_double(&msg->d_tau);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->acc[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->acc[0]));
   packed_size += sbp_packed_size_u8(&msg->fcn);
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_glo_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_c_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->gamma)) { return false; }
-  if (!encode_double(ctx, &msg->tau)) { return false; }
-  if (!encode_double(ctx, &msg->d_tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_glo_dep_c_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_c_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  if (!encode_double(ctx, &msg->gamma)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->acc[i])) { return false; }
+  if (!encode_double(ctx, &msg->tau)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->fcn)) { return false; }
+  if (!encode_double(ctx, &msg->d_tau)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!encode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_glo_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_glo_dep_c_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_glo_dep_c_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_glo_dep_c_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2806,26 +4461,44 @@ s8 sbp_encode_sbp_msg_ephemeris_glo_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_glo_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_c_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->gamma)) { return false; }
-  if (!decode_double(ctx, &msg->tau)) { return false; }
-  if (!decode_double(ctx, &msg->d_tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_glo_dep_c_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_c_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->gamma)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->tau)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->d_tau)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!decode_u8(ctx, &msg->fcn)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!decode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_glo_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_glo_dep_c_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_glo_dep_c_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_glo_dep_c_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2838,91 +4511,130 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_c_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_c_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_c_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_glo_dep_c_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_c_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_C, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_c_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_C, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_glo_dep_c_t(const sbp_msg_ephemeris_glo_dep_c_t *a, const sbp_msg_ephemeris_glo_dep_c_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_glo_dep_c_t(
+    const sbp_msg_ephemeris_glo_dep_c_t *a,
+    const sbp_msg_ephemeris_glo_dep_c_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_b_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->gamma, &b->gamma);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->tau, &b->tau);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->d_tau, &b->d_tau);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->fcn, &b->fcn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_d_t(const sbp_msg_ephemeris_glo_dep_d_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_glo_dep_d_t(
+    const sbp_msg_ephemeris_glo_dep_d_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
+  packed_size +=
+      sbp_packed_size_sbp_ephemeris_common_content_dep_b_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->gamma);
   packed_size += sbp_packed_size_double(&msg->tau);
   packed_size += sbp_packed_size_double(&msg->d_tau);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->acc[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->acc[0]));
   packed_size += sbp_packed_size_u8(&msg->fcn);
   packed_size += sbp_packed_size_u8(&msg->iod);
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_glo_dep_d_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_d_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->gamma)) { return false; }
-  if (!encode_double(ctx, &msg->tau)) { return false; }
-  if (!encode_double(ctx, &msg->d_tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_glo_dep_d_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_dep_d_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  if (!encode_double(ctx, &msg->gamma)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->acc[i])) { return false; }
+  if (!encode_double(ctx, &msg->tau)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->fcn)) { return false; }
-  if (!encode_u8(ctx, &msg->iod)) { return false; }
+  if (!encode_double(ctx, &msg->d_tau)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!encode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_glo_dep_d_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_glo_dep_d_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_glo_dep_d_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ephemeris_glo_dep_d_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2936,27 +4648,47 @@ s8 sbp_encode_sbp_msg_ephemeris_glo_dep_d_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_glo_dep_d_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_dep_d_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->gamma)) { return false; }
-  if (!decode_double(ctx, &msg->tau)) { return false; }
-  if (!decode_double(ctx, &msg->d_tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_glo_dep_d_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ephemeris_glo_dep_d_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->gamma)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->tau)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->d_tau)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!decode_u8(ctx, &msg->fcn)) { return false; }
-  if (!decode_u8(ctx, &msg->iod)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_double(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!decode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_glo_dep_d_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_glo_dep_d_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_glo_dep_d_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ephemeris_glo_dep_d_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2969,94 +4701,134 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_d_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_d_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_d_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_d_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ephemeris_glo_dep_d_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_d_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_D, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_dep_d_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO_DEP_D, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_glo_dep_d_t(const sbp_msg_ephemeris_glo_dep_d_t *a, const sbp_msg_ephemeris_glo_dep_d_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_glo_dep_d_t(
+    const sbp_msg_ephemeris_glo_dep_d_t *a,
+    const sbp_msg_ephemeris_glo_dep_d_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_dep_b_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->gamma, &b->gamma);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->tau, &b->tau);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->d_tau, &b->d_tau);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->fcn, &b->fcn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod, &b->iod);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_glo_t(const sbp_msg_ephemeris_glo_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_glo_t(
+    const sbp_msg_ephemeris_glo_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_ephemeris_common_content_t(&msg->common);
   packed_size += sbp_packed_size_float(&msg->gamma);
   packed_size += sbp_packed_size_float(&msg->tau);
   packed_size += sbp_packed_size_float(&msg->d_tau);
-  packed_size += ( 3 * sbp_packed_size_double(&msg->pos[0]));
-  packed_size += ( 3 * sbp_packed_size_double(&msg->vel[0]));
-  packed_size += ( 3 * sbp_packed_size_float(&msg->acc[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->pos[0]));
+  packed_size += (3 * sbp_packed_size_double(&msg->vel[0]));
+  packed_size += (3 * sbp_packed_size_float(&msg->acc[0]));
   packed_size += sbp_packed_size_u8(&msg->fcn);
   packed_size += sbp_packed_size_u8(&msg->iod);
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_glo_t *msg)
-{
-  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_float(ctx, &msg->gamma)) { return false; }
-  if (!encode_float(ctx, &msg->tau)) { return false; }
-  if (!encode_float(ctx, &msg->d_tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->pos[i])) { return false; }
+bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_ephemeris_glo_t *msg) {
+  if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_double(ctx, &msg->vel[i])) { return false; }
+  if (!encode_float(ctx, &msg->gamma)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_float(ctx, &msg->acc[i])) { return false; }
+  if (!encode_float(ctx, &msg->tau)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->fcn)) { return false; }
-  if (!encode_u8(ctx, &msg->iod)) { return false; }
+  if (!encode_float(ctx, &msg->d_tau)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_float(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!encode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_glo_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_glo_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_glo_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_ephemeris_glo_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3070,27 +4842,47 @@ s8 sbp_encode_sbp_msg_ephemeris_glo_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_glo_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_glo_t *msg)
-{
-  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_float(ctx, &msg->gamma)) { return false; }
-  if (!decode_float(ctx, &msg->tau)) { return false; }
-  if (!decode_float(ctx, &msg->d_tau)) { return false; }
-  for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->pos[i])) { return false; }
+bool decode_sbp_msg_ephemeris_glo_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_ephemeris_glo_t *msg) {
+  if (!decode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->gamma)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->tau)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->d_tau)) {
+    return false;
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_double(ctx, &msg->vel[i])) { return false; }
+    if (!decode_double(ctx, &msg->pos[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_float(ctx, &msg->acc[i])) { return false; }
+    if (!decode_double(ctx, &msg->vel[i])) {
+      return false;
+    }
   }
-  if (!decode_u8(ctx, &msg->fcn)) { return false; }
-  if (!decode_u8(ctx, &msg->iod)) { return false; }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!decode_float(ctx, &msg->acc[i])) {
+      return false;
+    }
+  }
+  if (!decode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_glo_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_glo_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_glo_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_ephemeris_glo_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3103,57 +4895,79 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_glo_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_ephemeris_glo_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_glo_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_GLO, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_glo_t(const sbp_msg_ephemeris_glo_t *a, const sbp_msg_ephemeris_glo_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_glo_t(const sbp_msg_ephemeris_glo_t *a,
+                                    const sbp_msg_ephemeris_glo_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_ephemeris_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->gamma, &b->gamma);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->tau, &b->tau);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->d_tau, &b->d_tau);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_float(&a->acc[i], &b->acc[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->fcn, &b->fcn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod, &b->iod);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_dep_d_t(const sbp_msg_ephemeris_dep_d_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_dep_d_t(
+    const sbp_msg_ephemeris_dep_d_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_double(&msg->tgd);
   packed_size += sbp_packed_size_double(&msg->c_rs);
@@ -3187,41 +5001,101 @@ size_t sbp_packed_size_sbp_msg_ephemeris_dep_d_t(const sbp_msg_ephemeris_dep_d_t
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_dep_d_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_d_t *msg)
-{
-  if (!encode_double(ctx, &msg->tgd)) { return false; }
-  if (!encode_double(ctx, &msg->c_rs)) { return false; }
-  if (!encode_double(ctx, &msg->c_rc)) { return false; }
-  if (!encode_double(ctx, &msg->c_uc)) { return false; }
-  if (!encode_double(ctx, &msg->c_us)) { return false; }
-  if (!encode_double(ctx, &msg->c_ic)) { return false; }
-  if (!encode_double(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_double(ctx, &msg->af2)) { return false; }
-  if (!encode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!encode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->healthy)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
-  if (!encode_u32(ctx, &msg->reserved)) { return false; }
+bool encode_sbp_msg_ephemeris_dep_d_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_d_t *msg) {
+  if (!encode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_dep_d_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_dep_d_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_dep_d_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_ephemeris_dep_d_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3235,41 +5109,101 @@ s8 sbp_encode_sbp_msg_ephemeris_dep_d_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_dep_d_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_d_t *msg)
-{
-  if (!decode_double(ctx, &msg->tgd)) { return false; }
-  if (!decode_double(ctx, &msg->c_rs)) { return false; }
-  if (!decode_double(ctx, &msg->c_rc)) { return false; }
-  if (!decode_double(ctx, &msg->c_uc)) { return false; }
-  if (!decode_double(ctx, &msg->c_us)) { return false; }
-  if (!decode_double(ctx, &msg->c_ic)) { return false; }
-  if (!decode_double(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_double(ctx, &msg->af2)) { return false; }
-  if (!decode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!decode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->healthy)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
-  if (!decode_u32(ctx, &msg->reserved)) { return false; }
+bool decode_sbp_msg_ephemeris_dep_d_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_d_t *msg) {
+  if (!decode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_dep_d_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_dep_d_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_dep_d_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_ephemeris_dep_d_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3282,108 +5216,173 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_d_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_d_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_d_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_dep_d_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_ephemeris_dep_d_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_d_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_D, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_d_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_D, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_dep_d_t(const sbp_msg_ephemeris_dep_d_t *a, const sbp_msg_ephemeris_dep_d_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_dep_d_t(const sbp_msg_ephemeris_dep_d_t *a,
+                                      const sbp_msg_ephemeris_dep_d_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_double(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toe_tow, &b->toe_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toe_wn, &b->toe_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toc_tow, &b->toc_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toc_wn, &b->toc_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->healthy, &b->healthy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->reserved, &b->reserved);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_dep_a_t(const sbp_msg_ephemeris_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_dep_a_t(
+    const sbp_msg_ephemeris_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_double(&msg->tgd);
   packed_size += sbp_packed_size_double(&msg->c_rs);
@@ -3414,38 +5413,92 @@ size_t sbp_packed_size_sbp_msg_ephemeris_dep_a_t(const sbp_msg_ephemeris_dep_a_t
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_a_t *msg)
-{
-  if (!encode_double(ctx, &msg->tgd)) { return false; }
-  if (!encode_double(ctx, &msg->c_rs)) { return false; }
-  if (!encode_double(ctx, &msg->c_rc)) { return false; }
-  if (!encode_double(ctx, &msg->c_uc)) { return false; }
-  if (!encode_double(ctx, &msg->c_us)) { return false; }
-  if (!encode_double(ctx, &msg->c_ic)) { return false; }
-  if (!encode_double(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_double(ctx, &msg->af2)) { return false; }
-  if (!encode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!encode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->healthy)) { return false; }
-  if (!encode_u8(ctx, &msg->prn)) { return false; }
+bool encode_sbp_msg_ephemeris_dep_a_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_a_t *msg) {
+  if (!encode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->prn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_dep_a_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_ephemeris_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3459,38 +5512,92 @@ s8 sbp_encode_sbp_msg_ephemeris_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_a_t *msg)
-{
-  if (!decode_double(ctx, &msg->tgd)) { return false; }
-  if (!decode_double(ctx, &msg->c_rs)) { return false; }
-  if (!decode_double(ctx, &msg->c_rc)) { return false; }
-  if (!decode_double(ctx, &msg->c_uc)) { return false; }
-  if (!decode_double(ctx, &msg->c_us)) { return false; }
-  if (!decode_double(ctx, &msg->c_ic)) { return false; }
-  if (!decode_double(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_double(ctx, &msg->af2)) { return false; }
-  if (!decode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!decode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->healthy)) { return false; }
-  if (!decode_u8(ctx, &msg->prn)) { return false; }
+bool decode_sbp_msg_ephemeris_dep_a_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_a_t *msg) {
+  if (!decode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->prn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_dep_a_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_ephemeris_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3503,99 +5610,158 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_ephemeris_dep_a_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_a_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_dep_a_t(const sbp_msg_ephemeris_dep_a_t *a, const sbp_msg_ephemeris_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_dep_a_t(const sbp_msg_ephemeris_dep_a_t *a,
+                                      const sbp_msg_ephemeris_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_double(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toe_tow, &b->toe_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toe_wn, &b->toe_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toc_tow, &b->toc_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toc_wn, &b->toc_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->healthy, &b->healthy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->prn, &b->prn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_dep_b_t(const sbp_msg_ephemeris_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_dep_b_t(
+    const sbp_msg_ephemeris_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_double(&msg->tgd);
   packed_size += sbp_packed_size_double(&msg->c_rs);
@@ -3627,39 +5793,95 @@ size_t sbp_packed_size_sbp_msg_ephemeris_dep_b_t(const sbp_msg_ephemeris_dep_b_t
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_b_t *msg)
-{
-  if (!encode_double(ctx, &msg->tgd)) { return false; }
-  if (!encode_double(ctx, &msg->c_rs)) { return false; }
-  if (!encode_double(ctx, &msg->c_rc)) { return false; }
-  if (!encode_double(ctx, &msg->c_uc)) { return false; }
-  if (!encode_double(ctx, &msg->c_us)) { return false; }
-  if (!encode_double(ctx, &msg->c_ic)) { return false; }
-  if (!encode_double(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_double(ctx, &msg->af2)) { return false; }
-  if (!encode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!encode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->healthy)) { return false; }
-  if (!encode_u8(ctx, &msg->prn)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
+bool encode_sbp_msg_ephemeris_dep_b_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_b_t *msg) {
+  if (!encode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->prn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_dep_b_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_ephemeris_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3673,39 +5895,95 @@ s8 sbp_encode_sbp_msg_ephemeris_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_b_t *msg)
-{
-  if (!decode_double(ctx, &msg->tgd)) { return false; }
-  if (!decode_double(ctx, &msg->c_rs)) { return false; }
-  if (!decode_double(ctx, &msg->c_rc)) { return false; }
-  if (!decode_double(ctx, &msg->c_uc)) { return false; }
-  if (!decode_double(ctx, &msg->c_us)) { return false; }
-  if (!decode_double(ctx, &msg->c_ic)) { return false; }
-  if (!decode_double(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_double(ctx, &msg->af2)) { return false; }
-  if (!decode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!decode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->healthy)) { return false; }
-  if (!decode_u8(ctx, &msg->prn)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
+bool decode_sbp_msg_ephemeris_dep_b_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_b_t *msg) {
+  if (!decode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->prn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_dep_b_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_ephemeris_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3718,102 +5996,163 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_dep_b_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_ephemeris_dep_b_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_b_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_B, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_dep_b_t(const sbp_msg_ephemeris_dep_b_t *a, const sbp_msg_ephemeris_dep_b_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_dep_b_t(const sbp_msg_ephemeris_dep_b_t *a,
+                                      const sbp_msg_ephemeris_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_double(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toe_tow, &b->toe_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toe_wn, &b->toe_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toc_tow, &b->toc_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toc_wn, &b->toc_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->healthy, &b->healthy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->prn, &b->prn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ephemeris_dep_c_t(const sbp_msg_ephemeris_dep_c_t *msg) {
+size_t sbp_packed_size_sbp_msg_ephemeris_dep_c_t(
+    const sbp_msg_ephemeris_dep_c_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_double(&msg->tgd);
   packed_size += sbp_packed_size_double(&msg->c_rs);
@@ -3847,41 +6186,101 @@ size_t sbp_packed_size_sbp_msg_ephemeris_dep_c_t(const sbp_msg_ephemeris_dep_c_t
   return packed_size;
 }
 
-bool encode_sbp_msg_ephemeris_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_ephemeris_dep_c_t *msg)
-{
-  if (!encode_double(ctx, &msg->tgd)) { return false; }
-  if (!encode_double(ctx, &msg->c_rs)) { return false; }
-  if (!encode_double(ctx, &msg->c_rc)) { return false; }
-  if (!encode_double(ctx, &msg->c_uc)) { return false; }
-  if (!encode_double(ctx, &msg->c_us)) { return false; }
-  if (!encode_double(ctx, &msg->c_ic)) { return false; }
-  if (!encode_double(ctx, &msg->c_is)) { return false; }
-  if (!encode_double(ctx, &msg->dn)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
-  if (!encode_double(ctx, &msg->af2)) { return false; }
-  if (!encode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!encode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!encode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->healthy)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->iode)) { return false; }
-  if (!encode_u16(ctx, &msg->iodc)) { return false; }
-  if (!encode_u32(ctx, &msg->reserved)) { return false; }
+bool encode_sbp_msg_ephemeris_dep_c_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ephemeris_dep_c_t *msg) {
+  if (!encode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ephemeris_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ephemeris_dep_c_t *msg) {
+s8 sbp_encode_sbp_msg_ephemeris_dep_c_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_ephemeris_dep_c_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3895,41 +6294,101 @@ s8 sbp_encode_sbp_msg_ephemeris_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ephemeris_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_ephemeris_dep_c_t *msg)
-{
-  if (!decode_double(ctx, &msg->tgd)) { return false; }
-  if (!decode_double(ctx, &msg->c_rs)) { return false; }
-  if (!decode_double(ctx, &msg->c_rc)) { return false; }
-  if (!decode_double(ctx, &msg->c_uc)) { return false; }
-  if (!decode_double(ctx, &msg->c_us)) { return false; }
-  if (!decode_double(ctx, &msg->c_ic)) { return false; }
-  if (!decode_double(ctx, &msg->c_is)) { return false; }
-  if (!decode_double(ctx, &msg->dn)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->inc_dot)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
-  if (!decode_double(ctx, &msg->af2)) { return false; }
-  if (!decode_double(ctx, &msg->toe_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toe_wn)) { return false; }
-  if (!decode_double(ctx, &msg->toc_tow)) { return false; }
-  if (!decode_u16(ctx, &msg->toc_wn)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->healthy)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->iode)) { return false; }
-  if (!decode_u16(ctx, &msg->iodc)) { return false; }
-  if (!decode_u32(ctx, &msg->reserved)) { return false; }
+bool decode_sbp_msg_ephemeris_dep_c_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ephemeris_dep_c_t *msg) {
+  if (!decode_double(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rs)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_rc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_uc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_us)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_ic)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->c_is)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->dn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af2)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toe_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toe_wn)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->toc_tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->toc_wn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->healthy)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iode)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->iodc)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ephemeris_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ephemeris_dep_c_t *msg) {
+s8 sbp_decode_sbp_msg_ephemeris_dep_c_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_ephemeris_dep_c_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -3942,122 +6401,193 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_c_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ephemeris_dep_c_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_ephemeris_dep_c_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_c_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_C, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ephemeris_dep_c_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_EPHEMERIS_DEP_C, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ephemeris_dep_c_t(const sbp_msg_ephemeris_dep_c_t *a, const sbp_msg_ephemeris_dep_c_t *b) {
+int sbp_cmp_sbp_msg_ephemeris_dep_c_t(const sbp_msg_ephemeris_dep_c_t *a,
+                                      const sbp_msg_ephemeris_dep_c_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_double(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rs, &b->c_rs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_rc, &b->c_rc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_uc, &b->c_uc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_us, &b->c_us);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_ic, &b->c_ic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->c_is, &b->c_is);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->dn, &b->dn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc_dot, &b->inc_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af2, &b->af2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toe_tow, &b->toe_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toe_wn, &b->toe_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->toc_tow, &b->toc_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->toc_wn, &b->toc_wn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->healthy, &b->healthy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iode, &b->iode);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->iodc, &b->iodc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->reserved, &b->reserved);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_observation_header_dep_t(const sbp_observation_header_dep_t *msg) {
+size_t sbp_packed_size_sbp_observation_header_dep_t(
+    const sbp_observation_header_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_dep_t(&msg->t);
   packed_size += sbp_packed_size_u8(&msg->n_obs);
   return packed_size;
 }
 
-bool encode_sbp_observation_header_dep_t(sbp_encode_ctx_t *ctx, const sbp_observation_header_dep_t *msg)
-{
-  if (!encode_sbp_gps_time_dep_t(ctx, &msg->t)) { return false; }
-  if (!encode_u8(ctx, &msg->n_obs)) { return false; }
+bool encode_sbp_observation_header_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_observation_header_dep_t *msg) {
+  if (!encode_sbp_gps_time_dep_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_obs)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_observation_header_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_observation_header_dep_t *msg) {
+s8 sbp_encode_sbp_observation_header_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_observation_header_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4071,14 +6601,20 @@ s8 sbp_encode_sbp_observation_header_dep_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_observation_header_dep_t(sbp_decode_ctx_t *ctx, sbp_observation_header_dep_t *msg)
-{
-  if (!decode_sbp_gps_time_dep_t(ctx, &msg->t)) { return false; }
-  if (!decode_u8(ctx, &msg->n_obs)) { return false; }
+bool decode_sbp_observation_header_dep_t(sbp_decode_ctx_t *ctx,
+                                         sbp_observation_header_dep_t *msg) {
+  if (!decode_sbp_gps_time_dep_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_obs)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_observation_header_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_observation_header_dep_t *msg) {
+s8 sbp_decode_sbp_observation_header_dep_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_observation_header_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4092,32 +6628,45 @@ s8 sbp_decode_sbp_observation_header_dep_t(const uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_observation_header_dep_t(const sbp_observation_header_dep_t *a, const sbp_observation_header_dep_t *b) {
+int sbp_cmp_sbp_observation_header_dep_t(
+    const sbp_observation_header_dep_t *a,
+    const sbp_observation_header_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_dep_t(&a->t, &b->t);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_carrier_phase_dep_a_t(const sbp_carrier_phase_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_carrier_phase_dep_a_t(
+    const sbp_carrier_phase_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s32(&msg->i);
   packed_size += sbp_packed_size_u8(&msg->f);
   return packed_size;
 }
 
-bool encode_sbp_carrier_phase_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_carrier_phase_dep_a_t *msg)
-{
-  if (!encode_s32(ctx, &msg->i)) { return false; }
-  if (!encode_u8(ctx, &msg->f)) { return false; }
+bool encode_sbp_carrier_phase_dep_a_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_carrier_phase_dep_a_t *msg) {
+  if (!encode_s32(ctx, &msg->i)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->f)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_carrier_phase_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_carrier_phase_dep_a_t *msg) {
+s8 sbp_encode_sbp_carrier_phase_dep_a_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_carrier_phase_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4131,14 +6680,20 @@ s8 sbp_encode_sbp_carrier_phase_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_carrier_phase_dep_a_t(sbp_decode_ctx_t *ctx, sbp_carrier_phase_dep_a_t *msg)
-{
-  if (!decode_s32(ctx, &msg->i)) { return false; }
-  if (!decode_u8(ctx, &msg->f)) { return false; }
+bool decode_sbp_carrier_phase_dep_a_t(sbp_decode_ctx_t *ctx,
+                                      sbp_carrier_phase_dep_a_t *msg) {
+  if (!decode_s32(ctx, &msg->i)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->f)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_carrier_phase_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_carrier_phase_dep_a_t *msg) {
+s8 sbp_decode_sbp_carrier_phase_dep_a_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_carrier_phase_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4152,18 +6707,24 @@ s8 sbp_decode_sbp_carrier_phase_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_carrier_phase_dep_a_t(const sbp_carrier_phase_dep_a_t *a, const sbp_carrier_phase_dep_a_t *b) {
+int sbp_cmp_sbp_carrier_phase_dep_a_t(const sbp_carrier_phase_dep_a_t *a,
+                                      const sbp_carrier_phase_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s32(&a->i, &b->i);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->f, &b->f);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_packed_obs_content_dep_a_t(const sbp_packed_obs_content_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_packed_obs_content_dep_a_t(
+    const sbp_packed_obs_content_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->P);
   packed_size += sbp_packed_size_sbp_carrier_phase_dep_a_t(&msg->L);
@@ -4173,17 +6734,29 @@ size_t sbp_packed_size_sbp_packed_obs_content_dep_a_t(const sbp_packed_obs_conte
   return packed_size;
 }
 
-bool encode_sbp_packed_obs_content_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_a_t *msg)
-{
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
-  if (!encode_u16(ctx, &msg->lock)) { return false; }
-  if (!encode_u8(ctx, &msg->prn)) { return false; }
+bool encode_sbp_packed_obs_content_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_a_t *msg) {
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->prn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_packed_obs_content_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_packed_obs_content_dep_a_t *msg) {
+s8 sbp_encode_sbp_packed_obs_content_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_packed_obs_content_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4197,17 +6770,29 @@ s8 sbp_encode_sbp_packed_obs_content_dep_a_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_packed_obs_content_dep_a_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_a_t *msg)
-{
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
-  if (!decode_u16(ctx, &msg->lock)) { return false; }
-  if (!decode_u8(ctx, &msg->prn)) { return false; }
+bool decode_sbp_packed_obs_content_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_a_t *msg) {
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->prn)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_packed_obs_content_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_packed_obs_content_dep_a_t *msg) {
+s8 sbp_decode_sbp_packed_obs_content_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_packed_obs_content_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4221,27 +6806,40 @@ s8 sbp_decode_sbp_packed_obs_content_dep_a_t(const uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_packed_obs_content_dep_a_t(const sbp_packed_obs_content_dep_a_t *a, const sbp_packed_obs_content_dep_a_t *b) {
+int sbp_cmp_sbp_packed_obs_content_dep_a_t(
+    const sbp_packed_obs_content_dep_a_t *a,
+    const sbp_packed_obs_content_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_dep_a_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->prn, &b->prn);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_packed_obs_content_dep_b_t(const sbp_packed_obs_content_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_packed_obs_content_dep_b_t(
+    const sbp_packed_obs_content_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->P);
   packed_size += sbp_packed_size_sbp_carrier_phase_dep_a_t(&msg->L);
@@ -4251,17 +6849,29 @@ size_t sbp_packed_size_sbp_packed_obs_content_dep_b_t(const sbp_packed_obs_conte
   return packed_size;
 }
 
-bool encode_sbp_packed_obs_content_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_b_t *msg)
-{
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
-  if (!encode_u16(ctx, &msg->lock)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_packed_obs_content_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_b_t *msg) {
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_packed_obs_content_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_packed_obs_content_dep_b_t *msg) {
+s8 sbp_encode_sbp_packed_obs_content_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_packed_obs_content_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4275,17 +6885,29 @@ s8 sbp_encode_sbp_packed_obs_content_dep_b_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_packed_obs_content_dep_b_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_b_t *msg)
-{
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
-  if (!decode_u16(ctx, &msg->lock)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_packed_obs_content_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_b_t *msg) {
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_dep_a_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_packed_obs_content_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_packed_obs_content_dep_b_t *msg) {
+s8 sbp_decode_sbp_packed_obs_content_dep_b_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_packed_obs_content_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4299,27 +6921,40 @@ s8 sbp_decode_sbp_packed_obs_content_dep_b_t(const uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_packed_obs_content_dep_b_t(const sbp_packed_obs_content_dep_b_t *a, const sbp_packed_obs_content_dep_b_t *b) {
+int sbp_cmp_sbp_packed_obs_content_dep_b_t(
+    const sbp_packed_obs_content_dep_b_t *a,
+    const sbp_packed_obs_content_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_dep_a_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_packed_obs_content_dep_c_t(const sbp_packed_obs_content_dep_c_t *msg) {
+size_t sbp_packed_size_sbp_packed_obs_content_dep_c_t(
+    const sbp_packed_obs_content_dep_c_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->P);
   packed_size += sbp_packed_size_sbp_carrier_phase_t(&msg->L);
@@ -4329,17 +6964,29 @@ size_t sbp_packed_size_sbp_packed_obs_content_dep_c_t(const sbp_packed_obs_conte
   return packed_size;
 }
 
-bool encode_sbp_packed_obs_content_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_c_t *msg)
-{
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
-  if (!encode_u16(ctx, &msg->lock)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_packed_obs_content_dep_c_t(
+    sbp_encode_ctx_t *ctx, const sbp_packed_obs_content_dep_c_t *msg) {
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_packed_obs_content_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_packed_obs_content_dep_c_t *msg) {
+s8 sbp_encode_sbp_packed_obs_content_dep_c_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_packed_obs_content_dep_c_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4353,17 +7000,29 @@ s8 sbp_encode_sbp_packed_obs_content_dep_c_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_packed_obs_content_dep_c_t(sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_c_t *msg)
-{
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
-  if (!decode_u16(ctx, &msg->lock)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_packed_obs_content_dep_c_t(
+    sbp_decode_ctx_t *ctx, sbp_packed_obs_content_dep_c_t *msg) {
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_packed_obs_content_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_packed_obs_content_dep_c_t *msg) {
+s8 sbp_decode_sbp_packed_obs_content_dep_c_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_packed_obs_content_dep_c_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4377,44 +7036,61 @@ s8 sbp_decode_sbp_packed_obs_content_dep_c_t(const uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_packed_obs_content_dep_c_t(const sbp_packed_obs_content_dep_c_t *a, const sbp_packed_obs_content_dep_c_t *b) {
+int sbp_cmp_sbp_packed_obs_content_dep_c_t(
+    const sbp_packed_obs_content_dep_c_t *a,
+    const sbp_packed_obs_content_dep_c_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
 size_t sbp_packed_size_sbp_msg_obs_dep_a_t(const sbp_msg_obs_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_observation_header_dep_t(&msg->header);
-  packed_size += (msg->n_obs * sbp_packed_size_sbp_packed_obs_content_dep_a_t(&msg->obs[0]));
+  packed_size += (msg->n_obs *
+                  sbp_packed_size_sbp_packed_obs_content_dep_a_t(&msg->obs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_dep_a_t *msg)
-{
-  if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_obs; i++)
-  {
-    if (!encode_sbp_packed_obs_content_dep_a_t(ctx, &msg->obs[i])) { return false; }
+bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_obs_dep_a_t *msg) {
+  if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
+    if (!encode_sbp_packed_obs_content_dep_a_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_obs_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_obs_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_obs_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_obs_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4428,17 +7104,24 @@ s8 sbp_encode_sbp_msg_obs_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_obs_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_dep_a_t *msg)
-{
-  if (!decode_sbp_observation_header_dep_t(ctx, &msg->header)) { return false; }
-    msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_packed_obs_content_dep_a_t(&msg->obs[0]));
+bool decode_sbp_msg_obs_dep_a_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_obs_dep_a_t *msg) {
+  if (!decode_sbp_observation_header_dep_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_obs =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_packed_obs_content_dep_a_t(&msg->obs[0]));
   for (uint8_t i = 0; i < msg->n_obs; i++) {
-    if (!decode_sbp_packed_obs_content_dep_a_t(ctx, &msg->obs[i])) { return false; }
+    if (!decode_sbp_packed_obs_content_dep_a_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_obs_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_obs_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_obs_dep_a_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_obs_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4451,48 +7134,62 @@ s8 sbp_decode_sbp_msg_obs_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_obs_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_obs_dep_a_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_obs_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_OBS_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_obs_dep_a_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_OBS_DEP_A, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_obs_dep_a_t(const sbp_msg_obs_dep_a_t *a, const sbp_msg_obs_dep_a_t *b) {
+int sbp_cmp_sbp_msg_obs_dep_a_t(const sbp_msg_obs_dep_a_t *a,
+                                const sbp_msg_obs_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_observation_header_dep_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_dep_a_t(&a->obs[i], &b->obs[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
 size_t sbp_packed_size_sbp_msg_obs_dep_b_t(const sbp_msg_obs_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_observation_header_dep_t(&msg->header);
-  packed_size += (msg->n_obs * sbp_packed_size_sbp_packed_obs_content_dep_b_t(&msg->obs[0]));
+  packed_size += (msg->n_obs *
+                  sbp_packed_size_sbp_packed_obs_content_dep_b_t(&msg->obs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_dep_b_t *msg)
-{
-  if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_obs; i++)
-  {
-    if (!encode_sbp_packed_obs_content_dep_b_t(ctx, &msg->obs[i])) { return false; }
+bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_obs_dep_b_t *msg) {
+  if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
+    if (!encode_sbp_packed_obs_content_dep_b_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_obs_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_obs_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_obs_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_obs_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4506,17 +7203,24 @@ s8 sbp_encode_sbp_msg_obs_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_obs_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_dep_b_t *msg)
-{
-  if (!decode_sbp_observation_header_dep_t(ctx, &msg->header)) { return false; }
-    msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_packed_obs_content_dep_b_t(&msg->obs[0]));
+bool decode_sbp_msg_obs_dep_b_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_obs_dep_b_t *msg) {
+  if (!decode_sbp_observation_header_dep_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_obs =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_packed_obs_content_dep_b_t(&msg->obs[0]));
   for (uint8_t i = 0; i < msg->n_obs; i++) {
-    if (!decode_sbp_packed_obs_content_dep_b_t(ctx, &msg->obs[i])) { return false; }
+    if (!decode_sbp_packed_obs_content_dep_b_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_obs_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_obs_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_obs_dep_b_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_obs_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4529,48 +7233,62 @@ s8 sbp_decode_sbp_msg_obs_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_obs_dep_b_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_obs_dep_b_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_obs_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_OBS_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_obs_dep_b_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_OBS_DEP_B, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_obs_dep_b_t(const sbp_msg_obs_dep_b_t *a, const sbp_msg_obs_dep_b_t *b) {
+int sbp_cmp_sbp_msg_obs_dep_b_t(const sbp_msg_obs_dep_b_t *a,
+                                const sbp_msg_obs_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_observation_header_dep_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_dep_b_t(&a->obs[i], &b->obs[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
 size_t sbp_packed_size_sbp_msg_obs_dep_c_t(const sbp_msg_obs_dep_c_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_observation_header_dep_t(&msg->header);
-  packed_size += (msg->n_obs * sbp_packed_size_sbp_packed_obs_content_dep_c_t(&msg->obs[0]));
+  packed_size += (msg->n_obs *
+                  sbp_packed_size_sbp_packed_obs_content_dep_c_t(&msg->obs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_dep_c_t *msg)
-{
-  if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_obs; i++)
-  {
-    if (!encode_sbp_packed_obs_content_dep_c_t(ctx, &msg->obs[i])) { return false; }
+bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_obs_dep_c_t *msg) {
+  if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
+    if (!encode_sbp_packed_obs_content_dep_c_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_obs_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_obs_dep_c_t *msg) {
+s8 sbp_encode_sbp_msg_obs_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_obs_dep_c_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4584,17 +7302,24 @@ s8 sbp_encode_sbp_msg_obs_dep_c_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_obs_dep_c_t(sbp_decode_ctx_t *ctx, sbp_msg_obs_dep_c_t *msg)
-{
-  if (!decode_sbp_observation_header_dep_t(ctx, &msg->header)) { return false; }
-    msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_packed_obs_content_dep_c_t(&msg->obs[0]));
+bool decode_sbp_msg_obs_dep_c_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_obs_dep_c_t *msg) {
+  if (!decode_sbp_observation_header_dep_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_obs =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_packed_obs_content_dep_c_t(&msg->obs[0]));
   for (uint8_t i = 0; i < msg->n_obs; i++) {
-    if (!decode_sbp_packed_obs_content_dep_c_t(ctx, &msg->obs[i])) { return false; }
+    if (!decode_sbp_packed_obs_content_dep_c_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_obs_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_obs_dep_c_t *msg) {
+s8 sbp_decode_sbp_msg_obs_dep_c_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_obs_dep_c_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4607,27 +7332,36 @@ s8 sbp_decode_sbp_msg_obs_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_c_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_obs_dep_c_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_obs_dep_c_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_obs_dep_c_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_OBS_DEP_C, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_obs_dep_c_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_OBS_DEP_C, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_obs_dep_c_t(const sbp_msg_obs_dep_c_t *a, const sbp_msg_obs_dep_c_t *b) {
+int sbp_cmp_sbp_msg_obs_dep_c_t(const sbp_msg_obs_dep_c_t *a,
+                                const sbp_msg_obs_dep_c_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_observation_header_dep_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_dep_c_t(&a->obs[i], &b->obs[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -4645,21 +7379,39 @@ size_t sbp_packed_size_sbp_msg_iono_t(const sbp_msg_iono_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_iono_t(sbp_encode_ctx_t *ctx, const sbp_msg_iono_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) { return false; }
-  if (!encode_double(ctx, &msg->a0)) { return false; }
-  if (!encode_double(ctx, &msg->a1)) { return false; }
-  if (!encode_double(ctx, &msg->a2)) { return false; }
-  if (!encode_double(ctx, &msg->a3)) { return false; }
-  if (!encode_double(ctx, &msg->b0)) { return false; }
-  if (!encode_double(ctx, &msg->b1)) { return false; }
-  if (!encode_double(ctx, &msg->b2)) { return false; }
-  if (!encode_double(ctx, &msg->b3)) { return false; }
+bool encode_sbp_msg_iono_t(sbp_encode_ctx_t *ctx, const sbp_msg_iono_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->a0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->a1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->a2)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->a3)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->b0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->b1)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->b2)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->b3)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_iono_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_iono_t *msg) {
+s8 sbp_encode_sbp_msg_iono_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                             const sbp_msg_iono_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4673,21 +7425,39 @@ s8 sbp_encode_sbp_msg_iono_t(uint8_t *buf, uint8_t len, uint8_t *n_written, cons
   return SBP_OK;
 }
 
-bool decode_sbp_msg_iono_t(sbp_decode_ctx_t *ctx, sbp_msg_iono_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) { return false; }
-  if (!decode_double(ctx, &msg->a0)) { return false; }
-  if (!decode_double(ctx, &msg->a1)) { return false; }
-  if (!decode_double(ctx, &msg->a2)) { return false; }
-  if (!decode_double(ctx, &msg->a3)) { return false; }
-  if (!decode_double(ctx, &msg->b0)) { return false; }
-  if (!decode_double(ctx, &msg->b1)) { return false; }
-  if (!decode_double(ctx, &msg->b2)) { return false; }
-  if (!decode_double(ctx, &msg->b3)) { return false; }
+bool decode_sbp_msg_iono_t(sbp_decode_ctx_t *ctx, sbp_msg_iono_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->a0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->a1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->a2)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->a3)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->b0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->b1)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->b2)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->b3)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_iono_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_iono_t *msg) {
+s8 sbp_decode_sbp_msg_iono_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                             sbp_msg_iono_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4700,62 +7470,91 @@ s8 sbp_decode_sbp_msg_iono_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, s
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_iono_t(struct sbp_state *s, u16 sender_id, const sbp_msg_iono_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_iono_t(struct sbp_state *s, u16 sender_id,
+                           const sbp_msg_iono_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_iono_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_IONO, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_iono_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_IONO, sender_id, payload_len, payload,
+                          write);
 }
 
 int sbp_cmp_sbp_msg_iono_t(const sbp_msg_iono_t *a, const sbp_msg_iono_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->t_nmct, &b->t_nmct);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a0, &b->a0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a1, &b->a1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a2, &b->a2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->a3, &b->a3);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->b0, &b->b0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->b1, &b->b1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->b2, &b->b2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->b3, &b->b3);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_sv_configuration_gps_dep_t(const sbp_msg_sv_configuration_gps_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_sv_configuration_gps_dep_t(
+    const sbp_msg_sv_configuration_gps_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->t_nmct);
   packed_size += sbp_packed_size_u32(&msg->l2c_mask);
   return packed_size;
 }
 
-bool encode_sbp_msg_sv_configuration_gps_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_sv_configuration_gps_dep_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) { return false; }
-  if (!encode_u32(ctx, &msg->l2c_mask)) { return false; }
+bool encode_sbp_msg_sv_configuration_gps_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_sv_configuration_gps_dep_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->l2c_mask)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_sv_configuration_gps_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_sv_configuration_gps_dep_t *msg) {
+s8 sbp_encode_sbp_msg_sv_configuration_gps_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_sv_configuration_gps_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4769,14 +7568,20 @@ s8 sbp_encode_sbp_msg_sv_configuration_gps_dep_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_msg_sv_configuration_gps_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_sv_configuration_gps_dep_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) { return false; }
-  if (!decode_u32(ctx, &msg->l2c_mask)) { return false; }
+bool decode_sbp_msg_sv_configuration_gps_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_sv_configuration_gps_dep_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->l2c_mask)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_sv_configuration_gps_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_sv_configuration_gps_dep_t *msg) {
+s8 sbp_decode_sbp_msg_sv_configuration_gps_dep_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_sv_configuration_gps_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4789,23 +7594,34 @@ s8 sbp_decode_sbp_msg_sv_configuration_gps_dep_t(const uint8_t *buf, uint8_t len
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_sv_configuration_gps_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sv_configuration_gps_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_sv_configuration_gps_dep_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_sv_configuration_gps_dep_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_sv_configuration_gps_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SV_CONFIGURATION_GPS_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_sv_configuration_gps_dep_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SV_CONFIGURATION_GPS_DEP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_sv_configuration_gps_dep_t(const sbp_msg_sv_configuration_gps_dep_t *a, const sbp_msg_sv_configuration_gps_dep_t *b) {
+int sbp_cmp_sbp_msg_sv_configuration_gps_dep_t(
+    const sbp_msg_sv_configuration_gps_dep_t *a,
+    const sbp_msg_sv_configuration_gps_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->t_nmct, &b->t_nmct);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->l2c_mask, &b->l2c_mask);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -4829,27 +7645,57 @@ size_t sbp_packed_size_sbp_gnss_capb_t(const sbp_gnss_capb_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_gnss_capb_t(sbp_encode_ctx_t *ctx, const sbp_gnss_capb_t *msg)
-{
-  if (!encode_u64(ctx, &msg->gps_active)) { return false; }
-  if (!encode_u64(ctx, &msg->gps_l2c)) { return false; }
-  if (!encode_u64(ctx, &msg->gps_l5)) { return false; }
-  if (!encode_u32(ctx, &msg->glo_active)) { return false; }
-  if (!encode_u32(ctx, &msg->glo_l2of)) { return false; }
-  if (!encode_u32(ctx, &msg->glo_l3)) { return false; }
-  if (!encode_u64(ctx, &msg->sbas_active)) { return false; }
-  if (!encode_u64(ctx, &msg->sbas_l5)) { return false; }
-  if (!encode_u64(ctx, &msg->bds_active)) { return false; }
-  if (!encode_u64(ctx, &msg->bds_d2nav)) { return false; }
-  if (!encode_u64(ctx, &msg->bds_b2)) { return false; }
-  if (!encode_u64(ctx, &msg->bds_b2a)) { return false; }
-  if (!encode_u32(ctx, &msg->qzss_active)) { return false; }
-  if (!encode_u64(ctx, &msg->gal_active)) { return false; }
-  if (!encode_u64(ctx, &msg->gal_e5)) { return false; }
+bool encode_sbp_gnss_capb_t(sbp_encode_ctx_t *ctx, const sbp_gnss_capb_t *msg) {
+  if (!encode_u64(ctx, &msg->gps_active)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->gps_l2c)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->gps_l5)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->glo_active)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->glo_l2of)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->glo_l3)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->sbas_active)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->sbas_l5)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->bds_active)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->bds_d2nav)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->bds_b2)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->bds_b2a)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->qzss_active)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->gal_active)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->gal_e5)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gnss_capb_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gnss_capb_t *msg) {
+s8 sbp_encode_sbp_gnss_capb_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                              const sbp_gnss_capb_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4863,27 +7709,57 @@ s8 sbp_encode_sbp_gnss_capb_t(uint8_t *buf, uint8_t len, uint8_t *n_written, con
   return SBP_OK;
 }
 
-bool decode_sbp_gnss_capb_t(sbp_decode_ctx_t *ctx, sbp_gnss_capb_t *msg)
-{
-  if (!decode_u64(ctx, &msg->gps_active)) { return false; }
-  if (!decode_u64(ctx, &msg->gps_l2c)) { return false; }
-  if (!decode_u64(ctx, &msg->gps_l5)) { return false; }
-  if (!decode_u32(ctx, &msg->glo_active)) { return false; }
-  if (!decode_u32(ctx, &msg->glo_l2of)) { return false; }
-  if (!decode_u32(ctx, &msg->glo_l3)) { return false; }
-  if (!decode_u64(ctx, &msg->sbas_active)) { return false; }
-  if (!decode_u64(ctx, &msg->sbas_l5)) { return false; }
-  if (!decode_u64(ctx, &msg->bds_active)) { return false; }
-  if (!decode_u64(ctx, &msg->bds_d2nav)) { return false; }
-  if (!decode_u64(ctx, &msg->bds_b2)) { return false; }
-  if (!decode_u64(ctx, &msg->bds_b2a)) { return false; }
-  if (!decode_u32(ctx, &msg->qzss_active)) { return false; }
-  if (!decode_u64(ctx, &msg->gal_active)) { return false; }
-  if (!decode_u64(ctx, &msg->gal_e5)) { return false; }
+bool decode_sbp_gnss_capb_t(sbp_decode_ctx_t *ctx, sbp_gnss_capb_t *msg) {
+  if (!decode_u64(ctx, &msg->gps_active)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->gps_l2c)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->gps_l5)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->glo_active)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->glo_l2of)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->glo_l3)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->sbas_active)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->sbas_l5)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->bds_active)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->bds_d2nav)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->bds_b2)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->bds_b2a)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->qzss_active)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->gal_active)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->gal_e5)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gnss_capb_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gnss_capb_t *msg) {
+s8 sbp_decode_sbp_gnss_capb_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                              sbp_gnss_capb_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4897,53 +7773,84 @@ s8 sbp_decode_sbp_gnss_capb_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gnss_capb_t(const sbp_gnss_capb_t *a, const sbp_gnss_capb_t *b) {
+int sbp_cmp_sbp_gnss_capb_t(const sbp_gnss_capb_t *a,
+                            const sbp_gnss_capb_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->gps_active, &b->gps_active);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->gps_l2c, &b->gps_l2c);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->gps_l5, &b->gps_l5);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->glo_active, &b->glo_active);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->glo_l2of, &b->glo_l2of);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->glo_l3, &b->glo_l3);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->sbas_active, &b->sbas_active);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->sbas_l5, &b->sbas_l5);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->bds_active, &b->bds_active);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->bds_d2nav, &b->bds_d2nav);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->bds_b2, &b->bds_b2);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->bds_b2a, &b->bds_b2a);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->qzss_active, &b->qzss_active);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->gal_active, &b->gal_active);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->gal_e5, &b->gal_e5);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -4954,14 +7861,19 @@ size_t sbp_packed_size_sbp_msg_gnss_capb_t(const sbp_msg_gnss_capb_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_gnss_capb_t(sbp_encode_ctx_t *ctx, const sbp_msg_gnss_capb_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) { return false; }
-  if (!encode_sbp_gnss_capb_t(ctx, &msg->gc)) { return false; }
+bool encode_sbp_msg_gnss_capb_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_gnss_capb_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_capb_t(ctx, &msg->gc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_gnss_capb_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_gnss_capb_t *msg) {
+s8 sbp_encode_sbp_msg_gnss_capb_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_gnss_capb_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4975,14 +7887,19 @@ s8 sbp_encode_sbp_msg_gnss_capb_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_gnss_capb_t(sbp_decode_ctx_t *ctx, sbp_msg_gnss_capb_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) { return false; }
-  if (!decode_sbp_gnss_capb_t(ctx, &msg->gc)) { return false; }
+bool decode_sbp_msg_gnss_capb_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_gnss_capb_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_nmct)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_capb_t(ctx, &msg->gc)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_gnss_capb_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_gnss_capb_t *msg) {
+s8 sbp_decode_sbp_msg_gnss_capb_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_gnss_capb_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -4995,27 +7912,38 @@ s8 sbp_decode_sbp_msg_gnss_capb_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gnss_capb_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gnss_capb_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_gnss_capb_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_gnss_capb_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_gnss_capb_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GNSS_CAPB, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_gnss_capb_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GNSS_CAPB, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_gnss_capb_t(const sbp_msg_gnss_capb_t *a, const sbp_msg_gnss_capb_t *b) {
+int sbp_cmp_sbp_msg_gnss_capb_t(const sbp_msg_gnss_capb_t *a,
+                                const sbp_msg_gnss_capb_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->t_nmct, &b->t_nmct);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_capb_t(&a->gc, &b->gc);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_group_delay_dep_a_t(const sbp_msg_group_delay_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_group_delay_dep_a_t(
+    const sbp_msg_group_delay_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_dep_t(&msg->t_op);
   packed_size += sbp_packed_size_u8(&msg->prn);
@@ -5026,18 +7954,32 @@ size_t sbp_packed_size_sbp_msg_group_delay_dep_a_t(const sbp_msg_group_delay_dep
   return packed_size;
 }
 
-bool encode_sbp_msg_group_delay_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_dep_a_t *msg)
-{
-  if (!encode_sbp_gps_time_dep_t(ctx, &msg->t_op)) { return false; }
-  if (!encode_u8(ctx, &msg->prn)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_s16(ctx, &msg->tgd)) { return false; }
-  if (!encode_s16(ctx, &msg->isc_l1ca)) { return false; }
-  if (!encode_s16(ctx, &msg->isc_l2c)) { return false; }
+bool encode_sbp_msg_group_delay_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_dep_a_t *msg) {
+  if (!encode_sbp_gps_time_dep_t(ctx, &msg->t_op)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->prn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->isc_l1ca)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->isc_l2c)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_group_delay_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_group_delay_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_group_delay_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_group_delay_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5051,18 +7993,32 @@ s8 sbp_encode_sbp_msg_group_delay_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_group_delay_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_group_delay_dep_a_t *msg)
-{
-  if (!decode_sbp_gps_time_dep_t(ctx, &msg->t_op)) { return false; }
-  if (!decode_u8(ctx, &msg->prn)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_s16(ctx, &msg->tgd)) { return false; }
-  if (!decode_s16(ctx, &msg->isc_l1ca)) { return false; }
-  if (!decode_s16(ctx, &msg->isc_l2c)) { return false; }
+bool decode_sbp_msg_group_delay_dep_a_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_group_delay_dep_a_t *msg) {
+  if (!decode_sbp_gps_time_dep_t(ctx, &msg->t_op)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->prn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->isc_l1ca)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->isc_l2c)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_group_delay_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_group_delay_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_group_delay_dep_a_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_group_delay_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5075,39 +8031,58 @@ s8 sbp_decode_sbp_msg_group_delay_dep_a_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_delay_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_group_delay_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_group_delay_dep_a_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_group_delay_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GROUP_DELAY_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_group_delay_dep_a_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GROUP_DELAY_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_group_delay_dep_a_t(const sbp_msg_group_delay_dep_a_t *a, const sbp_msg_group_delay_dep_a_t *b) {
+int sbp_cmp_sbp_msg_group_delay_dep_a_t(const sbp_msg_group_delay_dep_a_t *a,
+                                        const sbp_msg_group_delay_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_dep_t(&a->t_op, &b->t_op);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->prn, &b->prn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->isc_l1ca, &b->isc_l1ca);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->isc_l2c, &b->isc_l2c);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_group_delay_dep_b_t(const sbp_msg_group_delay_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_group_delay_dep_b_t(
+    const sbp_msg_group_delay_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->t_op);
   packed_size += sbp_packed_size_sbp_gnss_signal_dep_t(&msg->sid);
@@ -5118,18 +8093,32 @@ size_t sbp_packed_size_sbp_msg_group_delay_dep_b_t(const sbp_msg_group_delay_dep
   return packed_size;
 }
 
-bool encode_sbp_msg_group_delay_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_dep_b_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_op)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_s16(ctx, &msg->tgd)) { return false; }
-  if (!encode_s16(ctx, &msg->isc_l1ca)) { return false; }
-  if (!encode_s16(ctx, &msg->isc_l2c)) { return false; }
+bool encode_sbp_msg_group_delay_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_dep_b_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_op)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->isc_l1ca)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->isc_l2c)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_group_delay_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_group_delay_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_group_delay_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_group_delay_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5143,18 +8132,32 @@ s8 sbp_encode_sbp_msg_group_delay_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_group_delay_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_group_delay_dep_b_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_op)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_s16(ctx, &msg->tgd)) { return false; }
-  if (!decode_s16(ctx, &msg->isc_l1ca)) { return false; }
-  if (!decode_s16(ctx, &msg->isc_l2c)) { return false; }
+bool decode_sbp_msg_group_delay_dep_b_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_group_delay_dep_b_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_op)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->isc_l1ca)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->isc_l2c)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_group_delay_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_group_delay_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_group_delay_dep_b_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_group_delay_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5167,35 +8170,53 @@ s8 sbp_decode_sbp_msg_group_delay_dep_b_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_delay_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_group_delay_dep_b_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_group_delay_dep_b_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_group_delay_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GROUP_DELAY_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_group_delay_dep_b_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GROUP_DELAY_DEP_B, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_group_delay_dep_b_t(const sbp_msg_group_delay_dep_b_t *a, const sbp_msg_group_delay_dep_b_t *b) {
+int sbp_cmp_sbp_msg_group_delay_dep_b_t(const sbp_msg_group_delay_dep_b_t *a,
+                                        const sbp_msg_group_delay_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->t_op, &b->t_op);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->isc_l1ca, &b->isc_l1ca);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->isc_l2c, &b->isc_l2c);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -5210,18 +8231,32 @@ size_t sbp_packed_size_sbp_msg_group_delay_t(const sbp_msg_group_delay_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_group_delay_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_delay_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_op)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_s16(ctx, &msg->tgd)) { return false; }
-  if (!encode_s16(ctx, &msg->isc_l1ca)) { return false; }
-  if (!encode_s16(ctx, &msg->isc_l2c)) { return false; }
+bool encode_sbp_msg_group_delay_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_group_delay_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->t_op)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->isc_l1ca)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->isc_l2c)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_group_delay_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_group_delay_t *msg) {
+s8 sbp_encode_sbp_msg_group_delay_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_group_delay_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5235,18 +8270,32 @@ s8 sbp_encode_sbp_msg_group_delay_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_group_delay_t(sbp_decode_ctx_t *ctx, sbp_msg_group_delay_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_op)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_s16(ctx, &msg->tgd)) { return false; }
-  if (!decode_s16(ctx, &msg->isc_l1ca)) { return false; }
-  if (!decode_s16(ctx, &msg->isc_l2c)) { return false; }
+bool decode_sbp_msg_group_delay_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_group_delay_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->t_op)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->tgd)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->isc_l1ca)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->isc_l2c)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_group_delay_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_group_delay_t *msg) {
+s8 sbp_decode_sbp_msg_group_delay_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_group_delay_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5259,39 +8308,58 @@ s8 sbp_decode_sbp_msg_group_delay_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_delay_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_group_delay_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_group_delay_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_group_delay_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GROUP_DELAY, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_group_delay_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GROUP_DELAY, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_group_delay_t(const sbp_msg_group_delay_t *a, const sbp_msg_group_delay_t *b) {
+int sbp_cmp_sbp_msg_group_delay_t(const sbp_msg_group_delay_t *a,
+                                  const sbp_msg_group_delay_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->t_op, &b->t_op);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->tgd, &b->tgd);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->isc_l1ca, &b->isc_l1ca);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->isc_l2c, &b->isc_l2c);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_almanac_common_content_t(const sbp_almanac_common_content_t *msg) {
+size_t sbp_packed_size_sbp_almanac_common_content_t(
+    const sbp_almanac_common_content_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->toa);
@@ -5302,18 +8370,32 @@ size_t sbp_packed_size_sbp_almanac_common_content_t(const sbp_almanac_common_con
   return packed_size;
 }
 
-bool encode_sbp_almanac_common_content_t(sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toa)) { return false; }
-  if (!encode_double(ctx, &msg->ura)) { return false; }
-  if (!encode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->health_bits)) { return false; }
+bool encode_sbp_almanac_common_content_t(
+    sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toa)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_almanac_common_content_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_almanac_common_content_t *msg) {
+s8 sbp_encode_sbp_almanac_common_content_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_almanac_common_content_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5327,18 +8409,32 @@ s8 sbp_encode_sbp_almanac_common_content_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_almanac_common_content_t(sbp_decode_ctx_t *ctx, sbp_almanac_common_content_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toa)) { return false; }
-  if (!decode_double(ctx, &msg->ura)) { return false; }
-  if (!decode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->health_bits)) { return false; }
+bool decode_sbp_almanac_common_content_t(sbp_decode_ctx_t *ctx,
+                                         sbp_almanac_common_content_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toa)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_almanac_common_content_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_almanac_common_content_t *msg) {
+s8 sbp_decode_sbp_almanac_common_content_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_almanac_common_content_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5352,30 +8448,45 @@ s8 sbp_decode_sbp_almanac_common_content_t(const uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_almanac_common_content_t(const sbp_almanac_common_content_t *a, const sbp_almanac_common_content_t *b) {
+int sbp_cmp_sbp_almanac_common_content_t(
+    const sbp_almanac_common_content_t *a,
+    const sbp_almanac_common_content_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toa, &b->toa);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ura, &b->ura);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->fit_interval, &b->fit_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->health_bits, &b->health_bits);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_almanac_common_content_dep_t(const sbp_almanac_common_content_dep_t *msg) {
+size_t sbp_packed_size_sbp_almanac_common_content_dep_t(
+    const sbp_almanac_common_content_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gnss_signal_dep_t(&msg->sid);
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->toa);
@@ -5386,18 +8497,32 @@ size_t sbp_packed_size_sbp_almanac_common_content_dep_t(const sbp_almanac_common
   return packed_size;
 }
 
-bool encode_sbp_almanac_common_content_dep_t(sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_dep_t *msg)
-{
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toa)) { return false; }
-  if (!encode_double(ctx, &msg->ura)) { return false; }
-  if (!encode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->valid)) { return false; }
-  if (!encode_u8(ctx, &msg->health_bits)) { return false; }
+bool encode_sbp_almanac_common_content_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_almanac_common_content_dep_t *msg) {
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->toa)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_almanac_common_content_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_almanac_common_content_dep_t *msg) {
+s8 sbp_encode_sbp_almanac_common_content_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_almanac_common_content_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5411,18 +8536,32 @@ s8 sbp_encode_sbp_almanac_common_content_dep_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_almanac_common_content_dep_t(sbp_decode_ctx_t *ctx, sbp_almanac_common_content_dep_t *msg)
-{
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toa)) { return false; }
-  if (!decode_double(ctx, &msg->ura)) { return false; }
-  if (!decode_u32(ctx, &msg->fit_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->valid)) { return false; }
-  if (!decode_u8(ctx, &msg->health_bits)) { return false; }
+bool decode_sbp_almanac_common_content_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_almanac_common_content_dep_t *msg) {
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->toa)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ura)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->fit_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->valid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->health_bits)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_almanac_common_content_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_almanac_common_content_dep_t *msg) {
+s8 sbp_decode_sbp_almanac_common_content_dep_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_almanac_common_content_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5436,30 +8575,45 @@ s8 sbp_decode_sbp_almanac_common_content_dep_t(const uint8_t *buf, uint8_t len, 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_almanac_common_content_dep_t(const sbp_almanac_common_content_dep_t *a, const sbp_almanac_common_content_dep_t *b) {
+int sbp_cmp_sbp_almanac_common_content_dep_t(
+    const sbp_almanac_common_content_dep_t *a,
+    const sbp_almanac_common_content_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->toa, &b->toa);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ura, &b->ura);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->fit_interval, &b->fit_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->valid, &b->valid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->health_bits, &b->health_bits);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_almanac_gps_dep_t(const sbp_msg_almanac_gps_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_almanac_gps_dep_t(
+    const sbp_msg_almanac_gps_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_almanac_common_content_dep_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->m0);
@@ -5474,22 +8628,44 @@ size_t sbp_packed_size_sbp_msg_almanac_gps_dep_t(const sbp_msg_almanac_gps_dep_t
   return packed_size;
 }
 
-bool encode_sbp_msg_almanac_gps_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_gps_dep_t *msg)
-{
-  if (!encode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
+bool encode_sbp_msg_almanac_gps_dep_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_almanac_gps_dep_t *msg) {
+  if (!encode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_almanac_gps_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_almanac_gps_dep_t *msg) {
+s8 sbp_encode_sbp_msg_almanac_gps_dep_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_almanac_gps_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5503,22 +8679,44 @@ s8 sbp_encode_sbp_msg_almanac_gps_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_almanac_gps_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_gps_dep_t *msg)
-{
-  if (!decode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
+bool decode_sbp_msg_almanac_gps_dep_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_almanac_gps_dep_t *msg) {
+  if (!decode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_almanac_gps_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_almanac_gps_dep_t *msg) {
+s8 sbp_decode_sbp_msg_almanac_gps_dep_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_almanac_gps_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5531,47 +8729,73 @@ s8 sbp_decode_sbp_msg_almanac_gps_dep_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_gps_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_gps_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_almanac_gps_dep_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_almanac_gps_dep_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_almanac_gps_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ALMANAC_GPS_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_almanac_gps_dep_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ALMANAC_GPS_DEP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_almanac_gps_dep_t(const sbp_msg_almanac_gps_dep_t *a, const sbp_msg_almanac_gps_dep_t *b) {
+int sbp_cmp_sbp_msg_almanac_gps_dep_t(const sbp_msg_almanac_gps_dep_t *a,
+                                      const sbp_msg_almanac_gps_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_almanac_common_content_dep_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -5590,22 +8814,44 @@ size_t sbp_packed_size_sbp_msg_almanac_gps_t(const sbp_msg_almanac_gps_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_almanac_gps_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_gps_t *msg)
-{
-  if (!encode_sbp_almanac_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->m0)) { return false; }
-  if (!encode_double(ctx, &msg->ecc)) { return false; }
-  if (!encode_double(ctx, &msg->sqrta)) { return false; }
-  if (!encode_double(ctx, &msg->omega0)) { return false; }
-  if (!encode_double(ctx, &msg->omegadot)) { return false; }
-  if (!encode_double(ctx, &msg->w)) { return false; }
-  if (!encode_double(ctx, &msg->inc)) { return false; }
-  if (!encode_double(ctx, &msg->af0)) { return false; }
-  if (!encode_double(ctx, &msg->af1)) { return false; }
+bool encode_sbp_msg_almanac_gps_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_almanac_gps_t *msg) {
+  if (!encode_sbp_almanac_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->af1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_almanac_gps_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_almanac_gps_t *msg) {
+s8 sbp_encode_sbp_msg_almanac_gps_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_almanac_gps_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5619,22 +8865,44 @@ s8 sbp_encode_sbp_msg_almanac_gps_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_almanac_gps_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_gps_t *msg)
-{
-  if (!decode_sbp_almanac_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->m0)) { return false; }
-  if (!decode_double(ctx, &msg->ecc)) { return false; }
-  if (!decode_double(ctx, &msg->sqrta)) { return false; }
-  if (!decode_double(ctx, &msg->omega0)) { return false; }
-  if (!decode_double(ctx, &msg->omegadot)) { return false; }
-  if (!decode_double(ctx, &msg->w)) { return false; }
-  if (!decode_double(ctx, &msg->inc)) { return false; }
-  if (!decode_double(ctx, &msg->af0)) { return false; }
-  if (!decode_double(ctx, &msg->af1)) { return false; }
+bool decode_sbp_msg_almanac_gps_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_almanac_gps_t *msg) {
+  if (!decode_sbp_almanac_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->m0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->ecc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->sqrta)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omegadot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->inc)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af0)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->af1)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_almanac_gps_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_almanac_gps_t *msg) {
+s8 sbp_decode_sbp_msg_almanac_gps_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_almanac_gps_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5647,51 +8915,78 @@ s8 sbp_decode_sbp_msg_almanac_gps_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_gps_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_gps_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_almanac_gps_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_almanac_gps_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_almanac_gps_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ALMANAC_GPS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_almanac_gps_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ALMANAC_GPS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_almanac_gps_t(const sbp_msg_almanac_gps_t *a, const sbp_msg_almanac_gps_t *b) {
+int sbp_cmp_sbp_msg_almanac_gps_t(const sbp_msg_almanac_gps_t *a,
+                                  const sbp_msg_almanac_gps_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_almanac_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->m0, &b->m0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->ecc, &b->ecc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->sqrta, &b->sqrta);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega0, &b->omega0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omegadot, &b->omegadot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->inc, &b->inc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af0, &b->af0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->af1, &b->af1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_almanac_glo_dep_t(const sbp_msg_almanac_glo_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_almanac_glo_dep_t(
+    const sbp_msg_almanac_glo_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_almanac_common_content_dep_t(&msg->common);
   packed_size += sbp_packed_size_double(&msg->lambda_na);
@@ -5704,20 +8999,38 @@ size_t sbp_packed_size_sbp_msg_almanac_glo_dep_t(const sbp_msg_almanac_glo_dep_t
   return packed_size;
 }
 
-bool encode_sbp_msg_almanac_glo_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_glo_dep_t *msg)
-{
-  if (!encode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->lambda_na)) { return false; }
-  if (!encode_double(ctx, &msg->t_lambda_na)) { return false; }
-  if (!encode_double(ctx, &msg->i)) { return false; }
-  if (!encode_double(ctx, &msg->t)) { return false; }
-  if (!encode_double(ctx, &msg->t_dot)) { return false; }
-  if (!encode_double(ctx, &msg->epsilon)) { return false; }
-  if (!encode_double(ctx, &msg->omega)) { return false; }
+bool encode_sbp_msg_almanac_glo_dep_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_almanac_glo_dep_t *msg) {
+  if (!encode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lambda_na)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->t_lambda_na)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->i)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->t)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->t_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->epsilon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_almanac_glo_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_almanac_glo_dep_t *msg) {
+s8 sbp_encode_sbp_msg_almanac_glo_dep_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_almanac_glo_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5731,20 +9044,38 @@ s8 sbp_encode_sbp_msg_almanac_glo_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_almanac_glo_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_glo_dep_t *msg)
-{
-  if (!decode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->lambda_na)) { return false; }
-  if (!decode_double(ctx, &msg->t_lambda_na)) { return false; }
-  if (!decode_double(ctx, &msg->i)) { return false; }
-  if (!decode_double(ctx, &msg->t)) { return false; }
-  if (!decode_double(ctx, &msg->t_dot)) { return false; }
-  if (!decode_double(ctx, &msg->epsilon)) { return false; }
-  if (!decode_double(ctx, &msg->omega)) { return false; }
+bool decode_sbp_msg_almanac_glo_dep_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_almanac_glo_dep_t *msg) {
+  if (!decode_sbp_almanac_common_content_dep_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lambda_na)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->t_lambda_na)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->i)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->t)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->t_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->epsilon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_almanac_glo_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_almanac_glo_dep_t *msg) {
+s8 sbp_decode_sbp_msg_almanac_glo_dep_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_almanac_glo_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5757,41 +9088,63 @@ s8 sbp_decode_sbp_msg_almanac_glo_dep_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_glo_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_glo_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_almanac_glo_dep_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_almanac_glo_dep_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_almanac_glo_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ALMANAC_GLO_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_almanac_glo_dep_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ALMANAC_GLO_DEP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_almanac_glo_dep_t(const sbp_msg_almanac_glo_dep_t *a, const sbp_msg_almanac_glo_dep_t *b) {
+int sbp_cmp_sbp_msg_almanac_glo_dep_t(const sbp_msg_almanac_glo_dep_t *a,
+                                      const sbp_msg_almanac_glo_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_almanac_common_content_dep_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lambda_na, &b->lambda_na);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->t_lambda_na, &b->t_lambda_na);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->i, &b->i);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->t, &b->t);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->t_dot, &b->t_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->epsilon, &b->epsilon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega, &b->omega);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -5808,20 +9161,38 @@ size_t sbp_packed_size_sbp_msg_almanac_glo_t(const sbp_msg_almanac_glo_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_almanac_glo_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_glo_t *msg)
-{
-  if (!encode_sbp_almanac_common_content_t(ctx, &msg->common)) { return false; }
-  if (!encode_double(ctx, &msg->lambda_na)) { return false; }
-  if (!encode_double(ctx, &msg->t_lambda_na)) { return false; }
-  if (!encode_double(ctx, &msg->i)) { return false; }
-  if (!encode_double(ctx, &msg->t)) { return false; }
-  if (!encode_double(ctx, &msg->t_dot)) { return false; }
-  if (!encode_double(ctx, &msg->epsilon)) { return false; }
-  if (!encode_double(ctx, &msg->omega)) { return false; }
+bool encode_sbp_msg_almanac_glo_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_almanac_glo_t *msg) {
+  if (!encode_sbp_almanac_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->lambda_na)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->t_lambda_na)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->i)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->t)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->t_dot)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->epsilon)) {
+    return false;
+  }
+  if (!encode_double(ctx, &msg->omega)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_almanac_glo_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_almanac_glo_t *msg) {
+s8 sbp_encode_sbp_msg_almanac_glo_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_almanac_glo_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5835,20 +9206,38 @@ s8 sbp_encode_sbp_msg_almanac_glo_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_almanac_glo_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_glo_t *msg)
-{
-  if (!decode_sbp_almanac_common_content_t(ctx, &msg->common)) { return false; }
-  if (!decode_double(ctx, &msg->lambda_na)) { return false; }
-  if (!decode_double(ctx, &msg->t_lambda_na)) { return false; }
-  if (!decode_double(ctx, &msg->i)) { return false; }
-  if (!decode_double(ctx, &msg->t)) { return false; }
-  if (!decode_double(ctx, &msg->t_dot)) { return false; }
-  if (!decode_double(ctx, &msg->epsilon)) { return false; }
-  if (!decode_double(ctx, &msg->omega)) { return false; }
+bool decode_sbp_msg_almanac_glo_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_almanac_glo_t *msg) {
+  if (!decode_sbp_almanac_common_content_t(ctx, &msg->common)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->lambda_na)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->t_lambda_na)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->i)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->t)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->t_dot)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->epsilon)) {
+    return false;
+  }
+  if (!decode_double(ctx, &msg->omega)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_almanac_glo_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_almanac_glo_t *msg) {
+s8 sbp_decode_sbp_msg_almanac_glo_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_almanac_glo_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5861,41 +9250,63 @@ s8 sbp_decode_sbp_msg_almanac_glo_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_glo_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_glo_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_almanac_glo_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_almanac_glo_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_almanac_glo_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ALMANAC_GLO, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_almanac_glo_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ALMANAC_GLO, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_almanac_glo_t(const sbp_msg_almanac_glo_t *a, const sbp_msg_almanac_glo_t *b) {
+int sbp_cmp_sbp_msg_almanac_glo_t(const sbp_msg_almanac_glo_t *a,
+                                  const sbp_msg_almanac_glo_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_almanac_common_content_t(&a->common, &b->common);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->lambda_na, &b->lambda_na);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->t_lambda_na, &b->t_lambda_na);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->i, &b->i);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->t, &b->t);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->t_dot, &b->t_dot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->epsilon, &b->epsilon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_double(&a->omega, &b->omega);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -5909,17 +9320,29 @@ size_t sbp_packed_size_sbp_msg_glo_biases_t(const sbp_msg_glo_biases_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_glo_biases_t(sbp_encode_ctx_t *ctx, const sbp_msg_glo_biases_t *msg)
-{
-  if (!encode_u8(ctx, &msg->mask)) { return false; }
-  if (!encode_s16(ctx, &msg->l1ca_bias)) { return false; }
-  if (!encode_s16(ctx, &msg->l1p_bias)) { return false; }
-  if (!encode_s16(ctx, &msg->l2ca_bias)) { return false; }
-  if (!encode_s16(ctx, &msg->l2p_bias)) { return false; }
+bool encode_sbp_msg_glo_biases_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_glo_biases_t *msg) {
+  if (!encode_u8(ctx, &msg->mask)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->l1ca_bias)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->l1p_bias)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->l2ca_bias)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->l2p_bias)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_glo_biases_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_glo_biases_t *msg) {
+s8 sbp_encode_sbp_msg_glo_biases_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_glo_biases_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5933,17 +9356,28 @@ s8 sbp_encode_sbp_msg_glo_biases_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_glo_biases_t(sbp_decode_ctx_t *ctx, sbp_msg_glo_biases_t *msg)
-{
-  if (!decode_u8(ctx, &msg->mask)) { return false; }
-  if (!decode_s16(ctx, &msg->l1ca_bias)) { return false; }
-  if (!decode_s16(ctx, &msg->l1p_bias)) { return false; }
-  if (!decode_s16(ctx, &msg->l2ca_bias)) { return false; }
-  if (!decode_s16(ctx, &msg->l2p_bias)) { return false; }
+bool decode_sbp_msg_glo_biases_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_glo_biases_t *msg) {
+  if (!decode_u8(ctx, &msg->mask)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->l1ca_bias)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->l1p_bias)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->l2ca_bias)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->l2p_bias)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_glo_biases_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_glo_biases_t *msg) {
+s8 sbp_decode_sbp_msg_glo_biases_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_glo_biases_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -5956,32 +9390,48 @@ s8 sbp_decode_sbp_msg_glo_biases_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_glo_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_glo_biases_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_glo_biases_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_glo_biases_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_glo_biases_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GLO_BIASES, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_glo_biases_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GLO_BIASES, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_glo_biases_t(const sbp_msg_glo_biases_t *a, const sbp_msg_glo_biases_t *b) {
+int sbp_cmp_sbp_msg_glo_biases_t(const sbp_msg_glo_biases_t *a,
+                                 const sbp_msg_glo_biases_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->mask, &b->mask);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->l1ca_bias, &b->l1ca_bias);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->l1p_bias, &b->l1p_bias);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->l2ca_bias, &b->l2ca_bias);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->l2p_bias, &b->l2p_bias);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -5993,15 +9443,21 @@ size_t sbp_packed_size_sbp_sv_az_el_t(const sbp_sv_az_el_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_sv_az_el_t(sbp_encode_ctx_t *ctx, const sbp_sv_az_el_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->az)) { return false; }
-  if (!encode_s8(ctx, &msg->el)) { return false; }
+bool encode_sbp_sv_az_el_t(sbp_encode_ctx_t *ctx, const sbp_sv_az_el_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->az)) {
+    return false;
+  }
+  if (!encode_s8(ctx, &msg->el)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_sv_az_el_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_sv_az_el_t *msg) {
+s8 sbp_encode_sbp_sv_az_el_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                             const sbp_sv_az_el_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -6015,15 +9471,21 @@ s8 sbp_encode_sbp_sv_az_el_t(uint8_t *buf, uint8_t len, uint8_t *n_written, cons
   return SBP_OK;
 }
 
-bool decode_sbp_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_sv_az_el_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->az)) { return false; }
-  if (!decode_s8(ctx, &msg->el)) { return false; }
+bool decode_sbp_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_sv_az_el_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->az)) {
+    return false;
+  }
+  if (!decode_s8(ctx, &msg->el)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_sv_az_el_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_sv_az_el_t *msg) {
+s8 sbp_decode_sbp_sv_az_el_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                             sbp_sv_az_el_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -6039,15 +9501,21 @@ s8 sbp_decode_sbp_sv_az_el_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, s
 
 int sbp_cmp_sbp_sv_az_el_t(const sbp_sv_az_el_t *a, const sbp_sv_az_el_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->az, &b->az);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s8(&a->el, &b->el);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -6057,16 +9525,18 @@ size_t sbp_packed_size_sbp_msg_sv_az_el_t(const sbp_msg_sv_az_el_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx, const sbp_msg_sv_az_el_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_azel; i++)
-  {
-    if (!encode_sbp_sv_az_el_t(ctx, &msg->azel[i])) { return false; }
+bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_sv_az_el_t *msg) {
+  for (uint8_t i = 0; i < msg->n_azel; i++) {
+    if (!encode_sbp_sv_az_el_t(ctx, &msg->azel[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_sv_az_el_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_sv_az_el_t *msg) {
+s8 sbp_encode_sbp_msg_sv_az_el_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_sv_az_el_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -6080,16 +9550,19 @@ s8 sbp_encode_sbp_msg_sv_az_el_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_msg_sv_az_el_t *msg)
-{
-    msg->n_azel = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_sv_az_el_t(&msg->azel[0]));
+bool decode_sbp_msg_sv_az_el_t(sbp_decode_ctx_t *ctx, sbp_msg_sv_az_el_t *msg) {
+  msg->n_azel = (uint8_t)((ctx->buf_len - ctx->offset) /
+                          sbp_packed_size_sbp_sv_az_el_t(&msg->azel[0]));
   for (uint8_t i = 0; i < msg->n_azel; i++) {
-    if (!decode_sbp_sv_az_el_t(ctx, &msg->azel[i])) { return false; }
+    if (!decode_sbp_sv_az_el_t(ctx, &msg->azel[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_sv_az_el_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_sv_az_el_t *msg) {
+s8 sbp_decode_sbp_msg_sv_az_el_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_sv_az_el_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -6102,45 +9575,56 @@ s8 sbp_decode_sbp_msg_sv_az_el_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_sv_az_el_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sv_az_el_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_sv_az_el_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_sv_az_el_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_sv_az_el_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SV_AZ_EL, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_sv_az_el_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SV_AZ_EL, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_sv_az_el_t(const sbp_msg_sv_az_el_t *a, const sbp_msg_sv_az_el_t *b) {
+int sbp_cmp_sbp_msg_sv_az_el_t(const sbp_msg_sv_az_el_t *a,
+                               const sbp_msg_sv_az_el_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_azel, &b->n_azel);
-  for (uint8_t i = 0; i < a->n_azel && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_azel && ret == 0; i++) {
     ret = sbp_cmp_sbp_sv_az_el_t(&a->azel[i], &b->azel[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
 size_t sbp_packed_size_sbp_msg_osr_t(const sbp_msg_osr_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_observation_header_t(&msg->header);
-  packed_size += (msg->n_obs * sbp_packed_size_sbp_packed_osr_content_t(&msg->obs[0]));
+  packed_size +=
+      (msg->n_obs * sbp_packed_size_sbp_packed_osr_content_t(&msg->obs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_osr_t(sbp_encode_ctx_t *ctx, const sbp_msg_osr_t *msg)
-{
-  if (!encode_sbp_observation_header_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_obs; i++)
-  {
-    if (!encode_sbp_packed_osr_content_t(ctx, &msg->obs[i])) { return false; }
+bool encode_sbp_msg_osr_t(sbp_encode_ctx_t *ctx, const sbp_msg_osr_t *msg) {
+  if (!encode_sbp_observation_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_obs; i++) {
+    if (!encode_sbp_packed_osr_content_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_osr_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_osr_t *msg) {
+s8 sbp_encode_sbp_msg_osr_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                            const sbp_msg_osr_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -6154,17 +9638,23 @@ s8 sbp_encode_sbp_msg_osr_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const
   return SBP_OK;
 }
 
-bool decode_sbp_msg_osr_t(sbp_decode_ctx_t *ctx, sbp_msg_osr_t *msg)
-{
-  if (!decode_sbp_observation_header_t(ctx, &msg->header)) { return false; }
-    msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_packed_osr_content_t(&msg->obs[0]));
+bool decode_sbp_msg_osr_t(sbp_decode_ctx_t *ctx, sbp_msg_osr_t *msg) {
+  if (!decode_sbp_observation_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_obs =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_packed_osr_content_t(&msg->obs[0]));
   for (uint8_t i = 0; i < msg->n_obs; i++) {
-    if (!decode_sbp_packed_osr_content_t(ctx, &msg->obs[i])) { return false; }
+    if (!decode_sbp_packed_osr_content_t(ctx, &msg->obs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_osr_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_osr_t *msg) {
+s8 sbp_decode_sbp_msg_osr_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                            sbp_msg_osr_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -6177,26 +9667,33 @@ s8 sbp_decode_sbp_msg_osr_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_osr_t(struct sbp_state *s, u16 sender_id, const sbp_msg_osr_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_osr_t(struct sbp_state *s, u16 sender_id,
+                          const sbp_msg_osr_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_osr_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_OSR, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_osr_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_OSR, sender_id, payload_len, payload,
+                          write);
 }
 
 int sbp_cmp_sbp_msg_osr_t(const sbp_msg_osr_t *a, const sbp_msg_osr_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_observation_header_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
     ret = sbp_cmp_sbp_packed_osr_content_t(&a->obs[i], &b->obs[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/observation.c
+++ b/c/src/new/observation.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/observation.yaml
  * with generate.py. Please do not hand edit!
@@ -478,7 +466,7 @@ bool encode_sbp_msg_obs_t(sbp_encode_ctx_t *ctx, const sbp_msg_obs_t *msg) {
   if (!encode_sbp_observation_header_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_obs; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -530,6 +518,7 @@ s8 sbp_decode_sbp_msg_obs_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_obs_t(struct sbp_state *s, u16 sender_id,
                           const sbp_msg_obs_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -552,7 +541,7 @@ int sbp_cmp_sbp_msg_obs_t(const sbp_msg_obs_t *a, const sbp_msg_obs_t *b) {
   }
 
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_obs; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_t(&a->obs[i], &b->obs[i]);
   }
   if (ret != 0) {
@@ -629,6 +618,7 @@ s8 sbp_decode_sbp_msg_base_pos_llh_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_base_pos_llh_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_base_pos_llh_t *msg,
                                    sbp_write_fn_t write) {
@@ -732,6 +722,7 @@ s8 sbp_decode_sbp_msg_base_pos_ecef_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_base_pos_ecef_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_base_pos_ecef_t *msg,
                                     sbp_write_fn_t write) {
@@ -1357,6 +1348,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_e_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_gps_dep_e_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_gps_dep_e_t *msg, sbp_write_fn_t write) {
@@ -1702,6 +1694,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_f_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_gps_dep_f_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_gps_dep_f_t *msg, sbp_write_fn_t write) {
@@ -2046,6 +2039,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_gps_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gps_t *msg,
                                     sbp_write_fn_t write) {
@@ -2389,6 +2383,7 @@ s8 sbp_decode_sbp_msg_ephemeris_qzss_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_qzss_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_ephemeris_qzss_t *msg,
                                      sbp_write_fn_t write) {
@@ -2739,6 +2734,7 @@ s8 sbp_decode_sbp_msg_ephemeris_bds_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_bds_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_bds_t *msg,
                                     sbp_write_fn_t write) {
@@ -3094,6 +3090,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_gal_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_gal_dep_a_t *msg, sbp_write_fn_t write) {
@@ -3457,6 +3454,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_gal_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gal_t *msg,
                                     sbp_write_fn_t write) {
@@ -3620,17 +3618,17 @@ bool encode_sbp_msg_ephemeris_sbas_dep_a_t(
   if (!encode_sbp_ephemeris_common_content_dep_a_t(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3704,6 +3702,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_sbas_dep_a_t *msg, sbp_write_fn_t write) {
@@ -3728,21 +3727,21 @@ int sbp_cmp_sbp_msg_ephemeris_sbas_dep_a_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -3785,17 +3784,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_a_t(
   if (!encode_double(ctx, &msg->tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3863,6 +3862,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_glo_dep_a_t *msg, sbp_write_fn_t write) {
@@ -3897,21 +3897,21 @@ int sbp_cmp_sbp_msg_ephemeris_glo_dep_a_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -3938,17 +3938,17 @@ bool encode_sbp_msg_ephemeris_sbas_dep_b_t(
   if (!encode_sbp_ephemeris_common_content_dep_b_t(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4022,6 +4022,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_b_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_sbas_dep_b_t *msg, sbp_write_fn_t write) {
@@ -4046,21 +4047,21 @@ int sbp_cmp_sbp_msg_ephemeris_sbas_dep_b_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4096,17 +4097,17 @@ bool encode_sbp_msg_ephemeris_sbas_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_ephemeris_common_content_t(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_float(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_float(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4180,6 +4181,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_sbas_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_ephemeris_sbas_t *msg,
                                      sbp_write_fn_t write) {
@@ -4203,21 +4205,21 @@ int sbp_cmp_sbp_msg_ephemeris_sbas_t(const sbp_msg_ephemeris_sbas_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_float(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_float(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4260,17 +4262,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_b_t(
   if (!encode_double(ctx, &msg->tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4338,6 +4340,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_b_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_b_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_glo_dep_b_t *msg, sbp_write_fn_t write) {
@@ -4372,21 +4375,21 @@ int sbp_cmp_sbp_msg_ephemeris_glo_dep_b_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4424,17 +4427,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_c_t(
   if (!encode_double(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4511,6 +4514,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_c_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_c_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_glo_dep_c_t *msg, sbp_write_fn_t write) {
@@ -4550,21 +4554,21 @@ int sbp_cmp_sbp_msg_ephemeris_glo_dep_c_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4608,17 +4612,17 @@ bool encode_sbp_msg_ephemeris_glo_dep_d_t(
   if (!encode_double(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4701,6 +4705,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_d_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_d_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ephemeris_glo_dep_d_t *msg, sbp_write_fn_t write) {
@@ -4740,21 +4745,21 @@ int sbp_cmp_sbp_msg_ephemeris_glo_dep_d_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4802,17 +4807,17 @@ bool encode_sbp_msg_ephemeris_glo_t(sbp_encode_ctx_t *ctx,
   if (!encode_float(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_double(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_float(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4895,6 +4900,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_glo_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_glo_t *msg,
                                     sbp_write_fn_t write) {
@@ -4933,21 +4939,21 @@ int sbp_cmp_sbp_msg_ephemeris_glo_t(const sbp_msg_ephemeris_glo_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_double(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_float(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -5216,6 +5222,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_d_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_dep_d_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_d_t *msg,
                                       sbp_write_fn_t write) {
@@ -5610,6 +5617,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_dep_a_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_a_t *msg,
                                       sbp_write_fn_t write) {
@@ -5996,6 +6004,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_b_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_dep_b_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_b_t *msg,
                                       sbp_write_fn_t write) {
@@ -6401,6 +6410,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_c_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ephemeris_dep_c_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_c_t *msg,
                                       sbp_write_fn_t write) {
@@ -7081,7 +7091,7 @@ bool encode_sbp_msg_obs_dep_a_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_obs; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_dep_a_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -7134,6 +7144,7 @@ s8 sbp_decode_sbp_msg_obs_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_obs_dep_a_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_obs_dep_a_t *msg,
                                 sbp_write_fn_t write) {
@@ -7158,7 +7169,7 @@ int sbp_cmp_sbp_msg_obs_dep_a_t(const sbp_msg_obs_dep_a_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_obs; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_dep_a_t(&a->obs[i], &b->obs[i]);
   }
   if (ret != 0) {
@@ -7180,7 +7191,7 @@ bool encode_sbp_msg_obs_dep_b_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_obs; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_dep_b_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -7233,6 +7244,7 @@ s8 sbp_decode_sbp_msg_obs_dep_b_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_obs_dep_b_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_obs_dep_b_t *msg,
                                 sbp_write_fn_t write) {
@@ -7257,7 +7269,7 @@ int sbp_cmp_sbp_msg_obs_dep_b_t(const sbp_msg_obs_dep_b_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_obs; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_dep_b_t(&a->obs[i], &b->obs[i]);
   }
   if (ret != 0) {
@@ -7279,7 +7291,7 @@ bool encode_sbp_msg_obs_dep_c_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_observation_header_dep_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_obs; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
     if (!encode_sbp_packed_obs_content_dep_c_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -7332,6 +7344,7 @@ s8 sbp_decode_sbp_msg_obs_dep_c_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_obs_dep_c_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_obs_dep_c_t *msg,
                                 sbp_write_fn_t write) {
@@ -7356,7 +7369,7 @@ int sbp_cmp_sbp_msg_obs_dep_c_t(const sbp_msg_obs_dep_c_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_obs; i++) {
     ret = sbp_cmp_sbp_packed_obs_content_dep_c_t(&a->obs[i], &b->obs[i]);
   }
   if (ret != 0) {
@@ -7470,6 +7483,7 @@ s8 sbp_decode_sbp_msg_iono_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_iono_t(struct sbp_state *s, u16 sender_id,
                            const sbp_msg_iono_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -7594,6 +7608,7 @@ s8 sbp_decode_sbp_msg_sv_configuration_gps_dep_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_sv_configuration_gps_dep_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_sv_configuration_gps_dep_t *msg, sbp_write_fn_t write) {
@@ -7912,6 +7927,7 @@ s8 sbp_decode_sbp_msg_gnss_capb_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_gnss_capb_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_gnss_capb_t *msg,
                                 sbp_write_fn_t write) {
@@ -8031,6 +8047,7 @@ s8 sbp_decode_sbp_msg_group_delay_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_group_delay_dep_a_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_group_delay_dep_a_t *msg,
                                         sbp_write_fn_t write) {
@@ -8170,6 +8187,7 @@ s8 sbp_decode_sbp_msg_group_delay_dep_b_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_group_delay_dep_b_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_group_delay_dep_b_t *msg,
                                         sbp_write_fn_t write) {
@@ -8308,6 +8326,7 @@ s8 sbp_decode_sbp_msg_group_delay_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_group_delay_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_group_delay_t *msg,
                                   sbp_write_fn_t write) {
@@ -8729,6 +8748,7 @@ s8 sbp_decode_sbp_msg_almanac_gps_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_almanac_gps_dep_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_almanac_gps_dep_t *msg,
                                       sbp_write_fn_t write) {
@@ -8915,6 +8935,7 @@ s8 sbp_decode_sbp_msg_almanac_gps_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_almanac_gps_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_almanac_gps_t *msg,
                                   sbp_write_fn_t write) {
@@ -9088,6 +9109,7 @@ s8 sbp_decode_sbp_msg_almanac_glo_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_almanac_glo_dep_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_almanac_glo_dep_t *msg,
                                       sbp_write_fn_t write) {
@@ -9250,6 +9272,7 @@ s8 sbp_decode_sbp_msg_almanac_glo_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_almanac_glo_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_almanac_glo_t *msg,
                                   sbp_write_fn_t write) {
@@ -9390,6 +9413,7 @@ s8 sbp_decode_sbp_msg_glo_biases_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_glo_biases_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_glo_biases_t *msg,
                                  sbp_write_fn_t write) {
@@ -9527,7 +9551,7 @@ size_t sbp_packed_size_sbp_msg_sv_az_el_t(const sbp_msg_sv_az_el_t *msg) {
 
 bool encode_sbp_msg_sv_az_el_t(sbp_encode_ctx_t *ctx,
                                const sbp_msg_sv_az_el_t *msg) {
-  for (uint8_t i = 0; i < msg->n_azel; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_azel; i++) {
     if (!encode_sbp_sv_az_el_t(ctx, &msg->azel[i])) {
       return false;
     }
@@ -9575,6 +9599,7 @@ s8 sbp_decode_sbp_msg_sv_az_el_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_sv_az_el_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_sv_az_el_t *msg,
                                sbp_write_fn_t write) {
@@ -9594,7 +9619,7 @@ int sbp_cmp_sbp_msg_sv_az_el_t(const sbp_msg_sv_az_el_t *a,
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_azel, &b->n_azel);
-  for (uint8_t i = 0; i < a->n_azel && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_azel; i++) {
     ret = sbp_cmp_sbp_sv_az_el_t(&a->azel[i], &b->azel[i]);
   }
   if (ret != 0) {
@@ -9615,7 +9640,7 @@ bool encode_sbp_msg_osr_t(sbp_encode_ctx_t *ctx, const sbp_msg_osr_t *msg) {
   if (!encode_sbp_observation_header_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_obs; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_obs; i++) {
     if (!encode_sbp_packed_osr_content_t(ctx, &msg->obs[i])) {
       return false;
     }
@@ -9667,6 +9692,7 @@ s8 sbp_decode_sbp_msg_osr_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_osr_t(struct sbp_state *s, u16 sender_id,
                           const sbp_msg_osr_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -9689,7 +9715,7 @@ int sbp_cmp_sbp_msg_osr_t(const sbp_msg_osr_t *a, const sbp_msg_osr_t *b) {
   }
 
   ret = sbp_cmp_u8(&a->n_obs, &b->n_obs);
-  for (uint8_t i = 0; i < a->n_obs && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_obs; i++) {
     ret = sbp_cmp_sbp_packed_osr_content_t(&a->obs[i], &b->obs[i]);
   }
   if (ret != 0) {

--- a/c/src/new/orientation.c
+++ b/c/src/new/orientation.c
@@ -1,17 +1,35 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/orientation.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/orientation.h>
 #include <libsbp/internal/new/orientation.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/orientation.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_msg_baseline_heading_t(const sbp_msg_baseline_heading_t *msg) {
+size_t sbp_packed_size_sbp_msg_baseline_heading_t(
+    const sbp_msg_baseline_heading_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_u32(&msg->heading);
@@ -20,16 +38,26 @@ size_t sbp_packed_size_sbp_msg_baseline_heading_t(const sbp_msg_baseline_heading
   return packed_size;
 }
 
-bool encode_sbp_msg_baseline_heading_t(sbp_encode_ctx_t *ctx, const sbp_msg_baseline_heading_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u32(ctx, &msg->heading)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_baseline_heading_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_baseline_heading_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->heading)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_baseline_heading_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_baseline_heading_t *msg) {
+s8 sbp_encode_sbp_msg_baseline_heading_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_baseline_heading_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -43,16 +71,26 @@ s8 sbp_encode_sbp_msg_baseline_heading_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_baseline_heading_t(sbp_decode_ctx_t *ctx, sbp_msg_baseline_heading_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u32(ctx, &msg->heading)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_baseline_heading_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_baseline_heading_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->heading)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_baseline_heading_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_baseline_heading_t *msg) {
+s8 sbp_decode_sbp_msg_baseline_heading_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_baseline_heading_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -65,29 +103,43 @@ s8 sbp_decode_sbp_msg_baseline_heading_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_heading_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_heading_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_baseline_heading_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_baseline_heading_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_baseline_heading_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_BASELINE_HEADING, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_baseline_heading_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_BASELINE_HEADING, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_baseline_heading_t(const sbp_msg_baseline_heading_t *a, const sbp_msg_baseline_heading_t *b) {
+int sbp_cmp_sbp_msg_baseline_heading_t(const sbp_msg_baseline_heading_t *a,
+                                       const sbp_msg_baseline_heading_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->heading, &b->heading);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -106,22 +158,44 @@ size_t sbp_packed_size_sbp_msg_orient_quat_t(const sbp_msg_orient_quat_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_orient_quat_t(sbp_encode_ctx_t *ctx, const sbp_msg_orient_quat_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->w)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_float(ctx, &msg->w_accuracy)) { return false; }
-  if (!encode_float(ctx, &msg->x_accuracy)) { return false; }
-  if (!encode_float(ctx, &msg->y_accuracy)) { return false; }
-  if (!encode_float(ctx, &msg->z_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_orient_quat_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_orient_quat_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->w)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->w_accuracy)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->x_accuracy)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->y_accuracy)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->z_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_orient_quat_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_orient_quat_t *msg) {
+s8 sbp_encode_sbp_msg_orient_quat_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_orient_quat_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -135,22 +209,44 @@ s8 sbp_encode_sbp_msg_orient_quat_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_orient_quat_t(sbp_decode_ctx_t *ctx, sbp_msg_orient_quat_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->w)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_float(ctx, &msg->w_accuracy)) { return false; }
-  if (!decode_float(ctx, &msg->x_accuracy)) { return false; }
-  if (!decode_float(ctx, &msg->y_accuracy)) { return false; }
-  if (!decode_float(ctx, &msg->z_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_orient_quat_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_orient_quat_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->w)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->w_accuracy)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->x_accuracy)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->y_accuracy)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->z_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_orient_quat_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_orient_quat_t *msg) {
+s8 sbp_decode_sbp_msg_orient_quat_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_orient_quat_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -163,51 +259,78 @@ s8 sbp_decode_sbp_msg_orient_quat_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_orient_quat_t(struct sbp_state *s, u16 sender_id, const sbp_msg_orient_quat_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_orient_quat_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_orient_quat_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_orient_quat_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ORIENT_QUAT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_orient_quat_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ORIENT_QUAT, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_orient_quat_t(const sbp_msg_orient_quat_t *a, const sbp_msg_orient_quat_t *b) {
+int sbp_cmp_sbp_msg_orient_quat_t(const sbp_msg_orient_quat_t *a,
+                                  const sbp_msg_orient_quat_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->w, &b->w);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->w_accuracy, &b->w_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->x_accuracy, &b->x_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->y_accuracy, &b->y_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->z_accuracy, &b->z_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_orient_euler_t(const sbp_msg_orient_euler_t *msg) {
+size_t sbp_packed_size_sbp_msg_orient_euler_t(
+    const sbp_msg_orient_euler_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->roll);
@@ -220,20 +343,38 @@ size_t sbp_packed_size_sbp_msg_orient_euler_t(const sbp_msg_orient_euler_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_orient_euler_t(sbp_encode_ctx_t *ctx, const sbp_msg_orient_euler_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->roll)) { return false; }
-  if (!encode_s32(ctx, &msg->pitch)) { return false; }
-  if (!encode_s32(ctx, &msg->yaw)) { return false; }
-  if (!encode_float(ctx, &msg->roll_accuracy)) { return false; }
-  if (!encode_float(ctx, &msg->pitch_accuracy)) { return false; }
-  if (!encode_float(ctx, &msg->yaw_accuracy)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_orient_euler_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_orient_euler_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->roll)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->pitch)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->yaw)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->roll_accuracy)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->pitch_accuracy)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->yaw_accuracy)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_orient_euler_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_orient_euler_t *msg) {
+s8 sbp_encode_sbp_msg_orient_euler_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_orient_euler_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -247,20 +388,38 @@ s8 sbp_encode_sbp_msg_orient_euler_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_orient_euler_t(sbp_decode_ctx_t *ctx, sbp_msg_orient_euler_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->roll)) { return false; }
-  if (!decode_s32(ctx, &msg->pitch)) { return false; }
-  if (!decode_s32(ctx, &msg->yaw)) { return false; }
-  if (!decode_float(ctx, &msg->roll_accuracy)) { return false; }
-  if (!decode_float(ctx, &msg->pitch_accuracy)) { return false; }
-  if (!decode_float(ctx, &msg->yaw_accuracy)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_orient_euler_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_orient_euler_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->roll)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->pitch)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->yaw)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->roll_accuracy)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->pitch_accuracy)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->yaw_accuracy)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_orient_euler_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_orient_euler_t *msg) {
+s8 sbp_decode_sbp_msg_orient_euler_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_orient_euler_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -273,45 +432,68 @@ s8 sbp_decode_sbp_msg_orient_euler_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_orient_euler_t(struct sbp_state *s, u16 sender_id, const sbp_msg_orient_euler_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_orient_euler_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_orient_euler_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_orient_euler_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ORIENT_EULER, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_orient_euler_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ORIENT_EULER, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_orient_euler_t(const sbp_msg_orient_euler_t *a, const sbp_msg_orient_euler_t *b) {
+int sbp_cmp_sbp_msg_orient_euler_t(const sbp_msg_orient_euler_t *a,
+                                   const sbp_msg_orient_euler_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->roll, &b->roll);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->pitch, &b->pitch);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->yaw, &b->yaw);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->roll_accuracy, &b->roll_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->pitch_accuracy, &b->pitch_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->yaw_accuracy, &b->yaw_accuracy);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_angular_rate_t(const sbp_msg_angular_rate_t *msg) {
+size_t sbp_packed_size_sbp_msg_angular_rate_t(
+    const sbp_msg_angular_rate_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_s32(&msg->x);
@@ -321,17 +503,29 @@ size_t sbp_packed_size_sbp_msg_angular_rate_t(const sbp_msg_angular_rate_t *msg)
   return packed_size;
 }
 
-bool encode_sbp_msg_angular_rate_t(sbp_encode_ctx_t *ctx, const sbp_msg_angular_rate_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->x)) { return false; }
-  if (!encode_s32(ctx, &msg->y)) { return false; }
-  if (!encode_s32(ctx, &msg->z)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_angular_rate_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_angular_rate_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_angular_rate_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_angular_rate_t *msg) {
+s8 sbp_encode_sbp_msg_angular_rate_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_angular_rate_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -345,17 +539,29 @@ s8 sbp_encode_sbp_msg_angular_rate_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_angular_rate_t(sbp_decode_ctx_t *ctx, sbp_msg_angular_rate_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->x)) { return false; }
-  if (!decode_s32(ctx, &msg->y)) { return false; }
-  if (!decode_s32(ctx, &msg->z)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_angular_rate_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_angular_rate_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->x)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->y)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->z)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_angular_rate_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_angular_rate_t *msg) {
+s8 sbp_decode_sbp_msg_angular_rate_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_angular_rate_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -368,31 +574,47 @@ s8 sbp_decode_sbp_msg_angular_rate_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_angular_rate_t(struct sbp_state *s, u16 sender_id, const sbp_msg_angular_rate_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_angular_rate_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_angular_rate_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_angular_rate_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ANGULAR_RATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_angular_rate_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ANGULAR_RATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_angular_rate_t(const sbp_msg_angular_rate_t *a, const sbp_msg_angular_rate_t *b) {
+int sbp_cmp_sbp_msg_angular_rate_t(const sbp_msg_angular_rate_t *a,
+                                   const sbp_msg_angular_rate_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->x, &b->x);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->y, &b->y);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->z, &b->z);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/orientation.c
+++ b/c/src/new/orientation.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/orientation.yaml
  * with generate.py. Please do not hand edit!
@@ -103,6 +91,7 @@ s8 sbp_decode_sbp_msg_baseline_heading_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_baseline_heading_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_baseline_heading_t *msg,
                                        sbp_write_fn_t write) {
@@ -259,6 +248,7 @@ s8 sbp_decode_sbp_msg_orient_quat_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_orient_quat_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_orient_quat_t *msg,
                                   sbp_write_fn_t write) {
@@ -432,6 +422,7 @@ s8 sbp_decode_sbp_msg_orient_euler_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_orient_euler_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_orient_euler_t *msg,
                                    sbp_write_fn_t write) {
@@ -574,6 +565,7 @@ s8 sbp_decode_sbp_msg_angular_rate_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_angular_rate_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_angular_rate_t *msg,
                                    sbp_write_fn_t write) {

--- a/c/src/new/piksi.c
+++ b/c/src/new/piksi.c
@@ -608,7 +608,7 @@ size_t sbp_packed_size_sbp_msg_thread_state_t(
 
 bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_thread_state_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < 20; i++) {
+  for (uint8_t i = 0; i < 20; i++) {
     if (!encode_char(ctx, &msg->name[i])) {
       return false;
     }
@@ -2168,7 +2168,7 @@ size_t sbp_packed_size_sbp_msg_network_state_resp_t(
 
 bool encode_sbp_msg_network_state_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
+  for (uint8_t i = 0; i < 4; i++) {
     if (!encode_u8(ctx, &msg->ipv4_address[i])) {
       return false;
     }
@@ -2176,7 +2176,7 @@ bool encode_sbp_msg_network_state_resp_t(
   if (!encode_u8(ctx, &msg->ipv4_mask_size)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0; i < 16; i++) {
     if (!encode_u8(ctx, &msg->ipv6_address[i])) {
       return false;
     }
@@ -2190,7 +2190,7 @@ bool encode_sbp_msg_network_state_resp_t(
   if (!encode_u32(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0; i < 16; i++) {
     if (!encode_char(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2359,7 +2359,7 @@ bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0; i < 16; i++) {
     if (!encode_char(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2462,7 +2462,7 @@ size_t sbp_packed_size_sbp_msg_network_bandwidth_usage_t(
 
 bool encode_sbp_msg_network_bandwidth_usage_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_interfaces; i++) {
+  for (uint8_t i = 0; i < msg->n_interfaces; i++) {
     if (!encode_sbp_network_usage_t(ctx, &msg->interfaces[i])) {
       return false;
     }
@@ -2561,7 +2561,7 @@ bool encode_sbp_msg_cell_modem_status_t(
   if (!encode_float(ctx, &msg->signal_error_rate)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_reserved; i++) {
+  for (uint8_t i = 0; i < msg->n_reserved; i++) {
     if (!encode_u8(ctx, &msg->reserved[i])) {
       return false;
     }
@@ -2690,7 +2690,7 @@ bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx,
   if (!encode_float(ctx, &msg->amplitude_unit)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_amplitude_value; i++) {
+  for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
     if (!encode_u8(ctx, &msg->amplitude_value[i])) {
       return false;
     }
@@ -2851,7 +2851,7 @@ bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx,
   if (!encode_float(ctx, &msg->amplitude_unit)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_amplitude_value; i++) {
+  for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
     if (!encode_u8(ctx, &msg->amplitude_value[i])) {
       return false;
     }
@@ -2987,12 +2987,12 @@ size_t sbp_packed_size_sbp_msg_front_end_gain_t(
 
 bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_front_end_gain_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
+  for (uint8_t i = 0; i < 8; i++) {
     if (!encode_s8(ctx, &msg->rf_gain[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
+  for (uint8_t i = 0; i < 8; i++) {
     if (!encode_s8(ctx, &msg->if_gain[i])) {
       return false;
     }

--- a/c/src/new/piksi.c
+++ b/c/src/new/piksi.c
@@ -1,29 +1,47 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/piksi.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/piksi.h>
 #include <libsbp/internal/new/piksi.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/piksi.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_almanac_t(const sbp_msg_almanac_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_almanac_t(sbp_encode_ctx_t *ctx, const sbp_msg_almanac_t *msg)
-{
+bool encode_sbp_msg_almanac_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_almanac_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_almanac_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_almanac_t *msg) {
+s8 sbp_encode_sbp_msg_almanac_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_almanac_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -37,14 +55,14 @@ s8 sbp_encode_sbp_msg_almanac_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_almanac_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_almanac_t(sbp_decode_ctx_t *ctx, sbp_msg_almanac_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_almanac_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_almanac_t *msg) {
+s8 sbp_decode_sbp_msg_almanac_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_almanac_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -57,16 +75,22 @@ s8 sbp_decode_sbp_msg_almanac_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_almanac_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_almanac_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_almanac_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ALMANAC, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_almanac_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ALMANAC, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_almanac_t(const sbp_msg_almanac_t *a, const sbp_msg_almanac_t *b) {
+int sbp_cmp_sbp_msg_almanac_t(const sbp_msg_almanac_t *a,
+                              const sbp_msg_almanac_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
@@ -78,14 +102,15 @@ size_t sbp_packed_size_sbp_msg_set_time_t(const sbp_msg_set_time_t *msg) {
   return 0;
 }
 
-bool encode_sbp_msg_set_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_set_time_t *msg)
-{
+bool encode_sbp_msg_set_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_set_time_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_set_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_set_time_t *msg) {
+s8 sbp_encode_sbp_msg_set_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_set_time_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -99,14 +124,14 @@ s8 sbp_encode_sbp_msg_set_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_set_time_t(sbp_decode_ctx_t *ctx, sbp_msg_set_time_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_set_time_t(sbp_decode_ctx_t *ctx, sbp_msg_set_time_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_set_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_set_time_t *msg) {
+s8 sbp_decode_sbp_msg_set_time_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_set_time_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -119,16 +144,22 @@ s8 sbp_decode_sbp_msg_set_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_set_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_set_time_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_set_time_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_set_time_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_set_time_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SET_TIME, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_set_time_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SET_TIME, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_set_time_t(const sbp_msg_set_time_t *a, const sbp_msg_set_time_t *b) {
+int sbp_cmp_sbp_msg_set_time_t(const sbp_msg_set_time_t *a,
+                               const sbp_msg_set_time_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
@@ -141,13 +172,15 @@ size_t sbp_packed_size_sbp_msg_reset_t(const sbp_msg_reset_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_reset_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_t *msg)
-{
-  if (!encode_u32(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_reset_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_t *msg) {
+  if (!encode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_reset_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_reset_t *msg) {
+s8 sbp_encode_sbp_msg_reset_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                              const sbp_msg_reset_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -161,13 +194,15 @@ s8 sbp_encode_sbp_msg_reset_t(uint8_t *buf, uint8_t len, uint8_t *n_written, con
   return SBP_OK;
 }
 
-bool decode_sbp_msg_reset_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_t *msg)
-{
-  if (!decode_u32(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_reset_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_t *msg) {
+  if (!decode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_reset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_reset_t *msg) {
+s8 sbp_decode_sbp_msg_reset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                              sbp_msg_reset_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -180,20 +215,27 @@ s8 sbp_decode_sbp_msg_reset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_reset_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_reset_t(struct sbp_state *s, u16 sender_id,
+                            const sbp_msg_reset_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_reset_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_RESET, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_reset_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_RESET, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_reset_t(const sbp_msg_reset_t *a, const sbp_msg_reset_t *b) {
+int sbp_cmp_sbp_msg_reset_t(const sbp_msg_reset_t *a,
+                            const sbp_msg_reset_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -202,14 +244,15 @@ size_t sbp_packed_size_sbp_msg_reset_dep_t(const sbp_msg_reset_dep_t *msg) {
   return 0;
 }
 
-bool encode_sbp_msg_reset_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_dep_t *msg)
-{
+bool encode_sbp_msg_reset_dep_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_reset_dep_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_reset_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_reset_dep_t *msg) {
+s8 sbp_encode_sbp_msg_reset_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_reset_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -223,14 +266,15 @@ s8 sbp_encode_sbp_msg_reset_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_reset_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_dep_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_reset_dep_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_reset_dep_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_reset_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_reset_dep_t *msg) {
+s8 sbp_decode_sbp_msg_reset_dep_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_reset_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -243,16 +287,22 @@ s8 sbp_decode_sbp_msg_reset_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_reset_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_reset_dep_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_reset_dep_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_reset_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_RESET_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_reset_dep_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_RESET_DEP, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_reset_dep_t(const sbp_msg_reset_dep_t *a, const sbp_msg_reset_dep_t *b) {
+int sbp_cmp_sbp_msg_reset_dep_t(const sbp_msg_reset_dep_t *a,
+                                const sbp_msg_reset_dep_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
@@ -264,14 +314,16 @@ size_t sbp_packed_size_sbp_msg_cw_results_t(const sbp_msg_cw_results_t *msg) {
   return 0;
 }
 
-bool encode_sbp_msg_cw_results_t(sbp_encode_ctx_t *ctx, const sbp_msg_cw_results_t *msg)
-{
+bool encode_sbp_msg_cw_results_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_cw_results_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_cw_results_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_cw_results_t *msg) {
+s8 sbp_encode_sbp_msg_cw_results_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_cw_results_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -285,14 +337,15 @@ s8 sbp_encode_sbp_msg_cw_results_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_cw_results_t(sbp_decode_ctx_t *ctx, sbp_msg_cw_results_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_cw_results_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_cw_results_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_cw_results_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_cw_results_t *msg) {
+s8 sbp_decode_sbp_msg_cw_results_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_cw_results_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -305,16 +358,22 @@ s8 sbp_decode_sbp_msg_cw_results_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_cw_results_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cw_results_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_cw_results_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_cw_results_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_cw_results_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_CW_RESULTS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_cw_results_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_CW_RESULTS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_cw_results_t(const sbp_msg_cw_results_t *a, const sbp_msg_cw_results_t *b) {
+int sbp_cmp_sbp_msg_cw_results_t(const sbp_msg_cw_results_t *a,
+                                 const sbp_msg_cw_results_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
@@ -326,14 +385,15 @@ size_t sbp_packed_size_sbp_msg_cw_start_t(const sbp_msg_cw_start_t *msg) {
   return 0;
 }
 
-bool encode_sbp_msg_cw_start_t(sbp_encode_ctx_t *ctx, const sbp_msg_cw_start_t *msg)
-{
+bool encode_sbp_msg_cw_start_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_cw_start_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_cw_start_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_cw_start_t *msg) {
+s8 sbp_encode_sbp_msg_cw_start_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_cw_start_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -347,14 +407,14 @@ s8 sbp_encode_sbp_msg_cw_start_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_cw_start_t(sbp_decode_ctx_t *ctx, sbp_msg_cw_start_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_cw_start_t(sbp_decode_ctx_t *ctx, sbp_msg_cw_start_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_cw_start_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_cw_start_t *msg) {
+s8 sbp_decode_sbp_msg_cw_start_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_cw_start_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -367,35 +427,46 @@ s8 sbp_decode_sbp_msg_cw_start_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_cw_start_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cw_start_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_cw_start_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_cw_start_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_cw_start_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_CW_START, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_cw_start_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_CW_START, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_cw_start_t(const sbp_msg_cw_start_t *a, const sbp_msg_cw_start_t *b) {
+int sbp_cmp_sbp_msg_cw_start_t(const sbp_msg_cw_start_t *a,
+                               const sbp_msg_cw_start_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_reset_filters_t(const sbp_msg_reset_filters_t *msg) {
+size_t sbp_packed_size_sbp_msg_reset_filters_t(
+    const sbp_msg_reset_filters_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->filter);
   return packed_size;
 }
 
-bool encode_sbp_msg_reset_filters_t(sbp_encode_ctx_t *ctx, const sbp_msg_reset_filters_t *msg)
-{
-  if (!encode_u8(ctx, &msg->filter)) { return false; }
+bool encode_sbp_msg_reset_filters_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_reset_filters_t *msg) {
+  if (!encode_u8(ctx, &msg->filter)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_reset_filters_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_reset_filters_t *msg) {
+s8 sbp_encode_sbp_msg_reset_filters_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_reset_filters_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -409,13 +480,17 @@ s8 sbp_encode_sbp_msg_reset_filters_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_reset_filters_t(sbp_decode_ctx_t *ctx, sbp_msg_reset_filters_t *msg)
-{
-  if (!decode_u8(ctx, &msg->filter)) { return false; }
+bool decode_sbp_msg_reset_filters_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_reset_filters_t *msg) {
+  if (!decode_u8(ctx, &msg->filter)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_reset_filters_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_reset_filters_t *msg) {
+s8 sbp_decode_sbp_msg_reset_filters_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_reset_filters_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -428,36 +503,47 @@ s8 sbp_decode_sbp_msg_reset_filters_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_reset_filters_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_filters_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_reset_filters_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_reset_filters_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_reset_filters_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_RESET_FILTERS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_reset_filters_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_RESET_FILTERS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_reset_filters_t(const sbp_msg_reset_filters_t *a, const sbp_msg_reset_filters_t *b) {
+int sbp_cmp_sbp_msg_reset_filters_t(const sbp_msg_reset_filters_t *a,
+                                    const sbp_msg_reset_filters_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->filter, &b->filter);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_init_base_dep_t(const sbp_msg_init_base_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_init_base_dep_t(
+    const sbp_msg_init_base_dep_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_init_base_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_init_base_dep_t *msg)
-{
+bool encode_sbp_msg_init_base_dep_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_init_base_dep_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_init_base_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_init_base_dep_t *msg) {
+s8 sbp_encode_sbp_msg_init_base_dep_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_init_base_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -471,14 +557,16 @@ s8 sbp_encode_sbp_msg_init_base_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_init_base_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_init_base_dep_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_init_base_dep_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_init_base_dep_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_init_base_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_init_base_dep_t *msg) {
+s8 sbp_decode_sbp_msg_init_base_dep_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_init_base_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -491,42 +579,56 @@ s8 sbp_decode_sbp_msg_init_base_dep_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_init_base_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_init_base_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_init_base_dep_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_init_base_dep_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_init_base_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_INIT_BASE_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_init_base_dep_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_INIT_BASE_DEP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_init_base_dep_t(const sbp_msg_init_base_dep_t *a, const sbp_msg_init_base_dep_t *b) {
+int sbp_cmp_sbp_msg_init_base_dep_t(const sbp_msg_init_base_dep_t *a,
+                                    const sbp_msg_init_base_dep_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_thread_state_t(const sbp_msg_thread_state_t *msg) {
+size_t sbp_packed_size_sbp_msg_thread_state_t(
+    const sbp_msg_thread_state_t *msg) {
   size_t packed_size = 0;
-  packed_size += ( 20 * sbp_packed_size_char(&msg->name[0]));
+  packed_size += (20 * sbp_packed_size_char(&msg->name[0]));
   packed_size += sbp_packed_size_u16(&msg->cpu);
   packed_size += sbp_packed_size_u32(&msg->stack_free);
   return packed_size;
 }
 
-bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_thread_state_t *msg)
-{
-  for (uint8_t i = 0; i < 20; i++)
-  {
-    if (!encode_char(ctx, &msg->name[i])) { return false; }
+bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_thread_state_t *msg) {
+  for (uint8_t i = 0; i < 20; i++) {
+    if (!encode_char(ctx, &msg->name[i])) {
+      return false;
+    }
   }
-  if (!encode_u16(ctx, &msg->cpu)) { return false; }
-  if (!encode_u32(ctx, &msg->stack_free)) { return false; }
+  if (!encode_u16(ctx, &msg->cpu)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->stack_free)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_thread_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_thread_state_t *msg) {
+s8 sbp_encode_sbp_msg_thread_state_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_thread_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -540,17 +642,25 @@ s8 sbp_encode_sbp_msg_thread_state_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_thread_state_t(sbp_decode_ctx_t *ctx, sbp_msg_thread_state_t *msg)
-{
+bool decode_sbp_msg_thread_state_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_thread_state_t *msg) {
   for (uint8_t i = 0; i < 20; i++) {
-    if (!decode_char(ctx, &msg->name[i])) { return false; }
+    if (!decode_char(ctx, &msg->name[i])) {
+      return false;
+    }
   }
-  if (!decode_u16(ctx, &msg->cpu)) { return false; }
-  if (!decode_u32(ctx, &msg->stack_free)) { return false; }
+  if (!decode_u16(ctx, &msg->cpu)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->stack_free)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_thread_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_thread_state_t *msg) {
+s8 sbp_decode_sbp_msg_thread_state_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_thread_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -563,29 +673,40 @@ s8 sbp_decode_sbp_msg_thread_state_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_thread_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_thread_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_thread_state_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_thread_state_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_thread_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_THREAD_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_thread_state_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_THREAD_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_thread_state_t(const sbp_msg_thread_state_t *a, const sbp_msg_thread_state_t *b) {
+int sbp_cmp_sbp_msg_thread_state_t(const sbp_msg_thread_state_t *a,
+                                   const sbp_msg_thread_state_t *b) {
   int ret = 0;
-  
-  for (uint8_t i = 0; i < 20 && ret == 0; i++)
-  {
+
+  for (uint8_t i = 0; i < 20 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->name[i], &b->name[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->cpu, &b->cpu);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->stack_free, &b->stack_free);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -600,18 +721,31 @@ size_t sbp_packed_size_sbp_uart_channel_t(const sbp_uart_channel_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_uart_channel_t(sbp_encode_ctx_t *ctx, const sbp_uart_channel_t *msg)
-{
-  if (!encode_float(ctx, &msg->tx_throughput)) { return false; }
-  if (!encode_float(ctx, &msg->rx_throughput)) { return false; }
-  if (!encode_u16(ctx, &msg->crc_error_count)) { return false; }
-  if (!encode_u16(ctx, &msg->io_error_count)) { return false; }
-  if (!encode_u8(ctx, &msg->tx_buffer_level)) { return false; }
-  if (!encode_u8(ctx, &msg->rx_buffer_level)) { return false; }
+bool encode_sbp_uart_channel_t(sbp_encode_ctx_t *ctx,
+                               const sbp_uart_channel_t *msg) {
+  if (!encode_float(ctx, &msg->tx_throughput)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->rx_throughput)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->crc_error_count)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->io_error_count)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tx_buffer_level)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->rx_buffer_level)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_uart_channel_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_uart_channel_t *msg) {
+s8 sbp_encode_sbp_uart_channel_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_uart_channel_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -625,18 +759,30 @@ s8 sbp_encode_sbp_uart_channel_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_uart_channel_t(sbp_decode_ctx_t *ctx, sbp_uart_channel_t *msg)
-{
-  if (!decode_float(ctx, &msg->tx_throughput)) { return false; }
-  if (!decode_float(ctx, &msg->rx_throughput)) { return false; }
-  if (!decode_u16(ctx, &msg->crc_error_count)) { return false; }
-  if (!decode_u16(ctx, &msg->io_error_count)) { return false; }
-  if (!decode_u8(ctx, &msg->tx_buffer_level)) { return false; }
-  if (!decode_u8(ctx, &msg->rx_buffer_level)) { return false; }
+bool decode_sbp_uart_channel_t(sbp_decode_ctx_t *ctx, sbp_uart_channel_t *msg) {
+  if (!decode_float(ctx, &msg->tx_throughput)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->rx_throughput)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->crc_error_count)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->io_error_count)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tx_buffer_level)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->rx_buffer_level)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_uart_channel_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_uart_channel_t *msg) {
+s8 sbp_decode_sbp_uart_channel_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_uart_channel_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -650,26 +796,39 @@ s8 sbp_decode_sbp_uart_channel_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_uart_channel_t(const sbp_uart_channel_t *a, const sbp_uart_channel_t *b) {
+int sbp_cmp_sbp_uart_channel_t(const sbp_uart_channel_t *a,
+                               const sbp_uart_channel_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_float(&a->tx_throughput, &b->tx_throughput);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->rx_throughput, &b->rx_throughput);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->crc_error_count, &b->crc_error_count);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->io_error_count, &b->io_error_count);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tx_buffer_level, &b->tx_buffer_level);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->rx_buffer_level, &b->rx_buffer_level);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -682,16 +841,24 @@ size_t sbp_packed_size_sbp_period_t(const sbp_period_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_period_t(sbp_encode_ctx_t *ctx, const sbp_period_t *msg)
-{
-  if (!encode_s32(ctx, &msg->avg)) { return false; }
-  if (!encode_s32(ctx, &msg->pmin)) { return false; }
-  if (!encode_s32(ctx, &msg->pmax)) { return false; }
-  if (!encode_s32(ctx, &msg->current)) { return false; }
+bool encode_sbp_period_t(sbp_encode_ctx_t *ctx, const sbp_period_t *msg) {
+  if (!encode_s32(ctx, &msg->avg)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->pmin)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->pmax)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->current)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_period_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_period_t *msg) {
+s8 sbp_encode_sbp_period_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                           const sbp_period_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -705,16 +872,24 @@ s8 sbp_encode_sbp_period_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const 
   return SBP_OK;
 }
 
-bool decode_sbp_period_t(sbp_decode_ctx_t *ctx, sbp_period_t *msg)
-{
-  if (!decode_s32(ctx, &msg->avg)) { return false; }
-  if (!decode_s32(ctx, &msg->pmin)) { return false; }
-  if (!decode_s32(ctx, &msg->pmax)) { return false; }
-  if (!decode_s32(ctx, &msg->current)) { return false; }
+bool decode_sbp_period_t(sbp_decode_ctx_t *ctx, sbp_period_t *msg) {
+  if (!decode_s32(ctx, &msg->avg)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->pmin)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->pmax)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->current)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_period_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_period_t *msg) {
+s8 sbp_decode_sbp_period_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                           sbp_period_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -730,18 +905,26 @@ s8 sbp_decode_sbp_period_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp
 
 int sbp_cmp_sbp_period_t(const sbp_period_t *a, const sbp_period_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s32(&a->avg, &b->avg);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->pmin, &b->pmin);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->pmax, &b->pmax);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->current, &b->current);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -754,16 +937,24 @@ size_t sbp_packed_size_sbp_latency_t(const sbp_latency_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_latency_t(sbp_encode_ctx_t *ctx, const sbp_latency_t *msg)
-{
-  if (!encode_s32(ctx, &msg->avg)) { return false; }
-  if (!encode_s32(ctx, &msg->lmin)) { return false; }
-  if (!encode_s32(ctx, &msg->lmax)) { return false; }
-  if (!encode_s32(ctx, &msg->current)) { return false; }
+bool encode_sbp_latency_t(sbp_encode_ctx_t *ctx, const sbp_latency_t *msg) {
+  if (!encode_s32(ctx, &msg->avg)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->lmin)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->lmax)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->current)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_latency_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_latency_t *msg) {
+s8 sbp_encode_sbp_latency_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                            const sbp_latency_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -777,16 +968,24 @@ s8 sbp_encode_sbp_latency_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const
   return SBP_OK;
 }
 
-bool decode_sbp_latency_t(sbp_decode_ctx_t *ctx, sbp_latency_t *msg)
-{
-  if (!decode_s32(ctx, &msg->avg)) { return false; }
-  if (!decode_s32(ctx, &msg->lmin)) { return false; }
-  if (!decode_s32(ctx, &msg->lmax)) { return false; }
-  if (!decode_s32(ctx, &msg->current)) { return false; }
+bool decode_sbp_latency_t(sbp_decode_ctx_t *ctx, sbp_latency_t *msg) {
+  if (!decode_s32(ctx, &msg->avg)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->lmin)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->lmax)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->current)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_latency_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_latency_t *msg) {
+s8 sbp_decode_sbp_latency_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                            sbp_latency_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -802,18 +1001,26 @@ s8 sbp_decode_sbp_latency_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
 
 int sbp_cmp_sbp_latency_t(const sbp_latency_t *a, const sbp_latency_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s32(&a->avg, &b->avg);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->lmin, &b->lmin);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->lmax, &b->lmax);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->current, &b->current);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -827,17 +1034,29 @@ size_t sbp_packed_size_sbp_msg_uart_state_t(const sbp_msg_uart_state_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_uart_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_uart_state_t *msg)
-{
-  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_a)) { return false; }
-  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_b)) { return false; }
-  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) { return false; }
-  if (!encode_sbp_latency_t(ctx, &msg->latency)) { return false; }
-  if (!encode_sbp_period_t(ctx, &msg->obs_period)) { return false; }
+bool encode_sbp_msg_uart_state_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_uart_state_t *msg) {
+  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_a)) {
+    return false;
+  }
+  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_b)) {
+    return false;
+  }
+  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) {
+    return false;
+  }
+  if (!encode_sbp_latency_t(ctx, &msg->latency)) {
+    return false;
+  }
+  if (!encode_sbp_period_t(ctx, &msg->obs_period)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_uart_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_uart_state_t *msg) {
+s8 sbp_encode_sbp_msg_uart_state_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_uart_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -851,17 +1070,28 @@ s8 sbp_encode_sbp_msg_uart_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_uart_state_t(sbp_decode_ctx_t *ctx, sbp_msg_uart_state_t *msg)
-{
-  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_a)) { return false; }
-  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_b)) { return false; }
-  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) { return false; }
-  if (!decode_sbp_latency_t(ctx, &msg->latency)) { return false; }
-  if (!decode_sbp_period_t(ctx, &msg->obs_period)) { return false; }
+bool decode_sbp_msg_uart_state_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_uart_state_t *msg) {
+  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_a)) {
+    return false;
+  }
+  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_b)) {
+    return false;
+  }
+  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) {
+    return false;
+  }
+  if (!decode_sbp_latency_t(ctx, &msg->latency)) {
+    return false;
+  }
+  if (!decode_sbp_period_t(ctx, &msg->obs_period)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_uart_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_uart_state_t *msg) {
+s8 sbp_decode_sbp_msg_uart_state_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_uart_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -874,36 +1104,53 @@ s8 sbp_decode_sbp_msg_uart_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_uart_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_uart_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_uart_state_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_uart_state_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_uart_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_UART_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_uart_state_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_UART_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_uart_state_t(const sbp_msg_uart_state_t *a, const sbp_msg_uart_state_t *b) {
+int sbp_cmp_sbp_msg_uart_state_t(const sbp_msg_uart_state_t *a,
+                                 const sbp_msg_uart_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_uart_channel_t(&a->uart_a, &b->uart_a);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_uart_channel_t(&a->uart_b, &b->uart_b);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_uart_channel_t(&a->uart_ftdi, &b->uart_ftdi);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_latency_t(&a->latency, &b->latency);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_period_t(&a->obs_period, &b->obs_period);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_uart_state_depa_t(const sbp_msg_uart_state_depa_t *msg) {
+size_t sbp_packed_size_sbp_msg_uart_state_depa_t(
+    const sbp_msg_uart_state_depa_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_uart_channel_t(&msg->uart_a);
   packed_size += sbp_packed_size_sbp_uart_channel_t(&msg->uart_b);
@@ -912,16 +1159,26 @@ size_t sbp_packed_size_sbp_msg_uart_state_depa_t(const sbp_msg_uart_state_depa_t
   return packed_size;
 }
 
-bool encode_sbp_msg_uart_state_depa_t(sbp_encode_ctx_t *ctx, const sbp_msg_uart_state_depa_t *msg)
-{
-  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_a)) { return false; }
-  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_b)) { return false; }
-  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) { return false; }
-  if (!encode_sbp_latency_t(ctx, &msg->latency)) { return false; }
+bool encode_sbp_msg_uart_state_depa_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_uart_state_depa_t *msg) {
+  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_a)) {
+    return false;
+  }
+  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_b)) {
+    return false;
+  }
+  if (!encode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) {
+    return false;
+  }
+  if (!encode_sbp_latency_t(ctx, &msg->latency)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_uart_state_depa_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_uart_state_depa_t *msg) {
+s8 sbp_encode_sbp_msg_uart_state_depa_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_uart_state_depa_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -935,16 +1192,26 @@ s8 sbp_encode_sbp_msg_uart_state_depa_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_uart_state_depa_t(sbp_decode_ctx_t *ctx, sbp_msg_uart_state_depa_t *msg)
-{
-  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_a)) { return false; }
-  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_b)) { return false; }
-  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) { return false; }
-  if (!decode_sbp_latency_t(ctx, &msg->latency)) { return false; }
+bool decode_sbp_msg_uart_state_depa_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_uart_state_depa_t *msg) {
+  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_a)) {
+    return false;
+  }
+  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_b)) {
+    return false;
+  }
+  if (!decode_sbp_uart_channel_t(ctx, &msg->uart_ftdi)) {
+    return false;
+  }
+  if (!decode_sbp_latency_t(ctx, &msg->latency)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_uart_state_depa_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_uart_state_depa_t *msg) {
+s8 sbp_decode_sbp_msg_uart_state_depa_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_uart_state_depa_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -957,29 +1224,43 @@ s8 sbp_decode_sbp_msg_uart_state_depa_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_uart_state_depa_t(struct sbp_state *s, u16 sender_id, const sbp_msg_uart_state_depa_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_uart_state_depa_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_uart_state_depa_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_uart_state_depa_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_UART_STATE_DEPA, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_uart_state_depa_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_UART_STATE_DEPA, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_uart_state_depa_t(const sbp_msg_uart_state_depa_t *a, const sbp_msg_uart_state_depa_t *b) {
+int sbp_cmp_sbp_msg_uart_state_depa_t(const sbp_msg_uart_state_depa_t *a,
+                                      const sbp_msg_uart_state_depa_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_uart_channel_t(&a->uart_a, &b->uart_a);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_uart_channel_t(&a->uart_b, &b->uart_b);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_uart_channel_t(&a->uart_ftdi, &b->uart_ftdi);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_latency_t(&a->latency, &b->latency);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -989,13 +1270,16 @@ size_t sbp_packed_size_sbp_msg_iar_state_t(const sbp_msg_iar_state_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_iar_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_iar_state_t *msg)
-{
-  if (!encode_u32(ctx, &msg->num_hyps)) { return false; }
+bool encode_sbp_msg_iar_state_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_iar_state_t *msg) {
+  if (!encode_u32(ctx, &msg->num_hyps)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_iar_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_iar_state_t *msg) {
+s8 sbp_encode_sbp_msg_iar_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_iar_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1009,13 +1293,16 @@ s8 sbp_encode_sbp_msg_iar_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_iar_state_t(sbp_decode_ctx_t *ctx, sbp_msg_iar_state_t *msg)
-{
-  if (!decode_u32(ctx, &msg->num_hyps)) { return false; }
+bool decode_sbp_msg_iar_state_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_iar_state_t *msg) {
+  if (!decode_u32(ctx, &msg->num_hyps)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_iar_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_iar_state_t *msg) {
+s8 sbp_decode_sbp_msg_iar_state_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_iar_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1028,38 +1315,53 @@ s8 sbp_decode_sbp_msg_iar_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_iar_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_iar_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_iar_state_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_iar_state_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_iar_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_IAR_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_iar_state_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_IAR_STATE, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_iar_state_t(const sbp_msg_iar_state_t *a, const sbp_msg_iar_state_t *b) {
+int sbp_cmp_sbp_msg_iar_state_t(const sbp_msg_iar_state_t *a,
+                                const sbp_msg_iar_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->num_hyps, &b->num_hyps);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_mask_satellite_t(const sbp_msg_mask_satellite_t *msg) {
+size_t sbp_packed_size_sbp_msg_mask_satellite_t(
+    const sbp_msg_mask_satellite_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->mask);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   return packed_size;
 }
 
-bool encode_sbp_msg_mask_satellite_t(sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_t *msg)
-{
-  if (!encode_u8(ctx, &msg->mask)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_msg_mask_satellite_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_mask_satellite_t *msg) {
+  if (!encode_u8(ctx, &msg->mask)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_mask_satellite_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_mask_satellite_t *msg) {
+s8 sbp_encode_sbp_msg_mask_satellite_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_mask_satellite_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1073,14 +1375,20 @@ s8 sbp_encode_sbp_msg_mask_satellite_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_mask_satellite_t(sbp_decode_ctx_t *ctx, sbp_msg_mask_satellite_t *msg)
-{
-  if (!decode_u8(ctx, &msg->mask)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_mask_satellite_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_mask_satellite_t *msg) {
+  if (!decode_u8(ctx, &msg->mask)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_mask_satellite_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_mask_satellite_t *msg) {
+s8 sbp_decode_sbp_msg_mask_satellite_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_mask_satellite_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1093,41 +1401,58 @@ s8 sbp_decode_sbp_msg_mask_satellite_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_mask_satellite_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_mask_satellite_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_mask_satellite_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_mask_satellite_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_MASK_SATELLITE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_mask_satellite_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_MASK_SATELLITE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_mask_satellite_t(const sbp_msg_mask_satellite_t *a, const sbp_msg_mask_satellite_t *b) {
+int sbp_cmp_sbp_msg_mask_satellite_t(const sbp_msg_mask_satellite_t *a,
+                                     const sbp_msg_mask_satellite_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->mask, &b->mask);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_mask_satellite_dep_t(const sbp_msg_mask_satellite_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_mask_satellite_dep_t(
+    const sbp_msg_mask_satellite_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->mask);
   packed_size += sbp_packed_size_sbp_gnss_signal_dep_t(&msg->sid);
   return packed_size;
 }
 
-bool encode_sbp_msg_mask_satellite_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_dep_t *msg)
-{
-  if (!encode_u8(ctx, &msg->mask)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool encode_sbp_msg_mask_satellite_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_mask_satellite_dep_t *msg) {
+  if (!encode_u8(ctx, &msg->mask)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_mask_satellite_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_mask_satellite_dep_t *msg) {
+s8 sbp_encode_sbp_msg_mask_satellite_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_mask_satellite_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1141,14 +1466,20 @@ s8 sbp_encode_sbp_msg_mask_satellite_dep_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_mask_satellite_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_mask_satellite_dep_t *msg)
-{
-  if (!decode_u8(ctx, &msg->mask)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_mask_satellite_dep_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_mask_satellite_dep_t *msg) {
+  if (!decode_u8(ctx, &msg->mask)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_mask_satellite_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_mask_satellite_dep_t *msg) {
+s8 sbp_decode_sbp_msg_mask_satellite_dep_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_mask_satellite_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1161,27 +1492,39 @@ s8 sbp_decode_sbp_msg_mask_satellite_dep_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_mask_satellite_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_mask_satellite_dep_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_dep_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_mask_satellite_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_MASK_SATELLITE_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_mask_satellite_dep_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_MASK_SATELLITE_DEP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_mask_satellite_dep_t(const sbp_msg_mask_satellite_dep_t *a, const sbp_msg_mask_satellite_dep_t *b) {
+int sbp_cmp_sbp_msg_mask_satellite_dep_t(
+    const sbp_msg_mask_satellite_dep_t *a,
+    const sbp_msg_mask_satellite_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->mask, &b->mask);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_device_monitor_t(const sbp_msg_device_monitor_t *msg) {
+size_t sbp_packed_size_sbp_msg_device_monitor_t(
+    const sbp_msg_device_monitor_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s16(&msg->dev_vin);
   packed_size += sbp_packed_size_s16(&msg->cpu_vint);
@@ -1191,17 +1534,29 @@ size_t sbp_packed_size_sbp_msg_device_monitor_t(const sbp_msg_device_monitor_t *
   return packed_size;
 }
 
-bool encode_sbp_msg_device_monitor_t(sbp_encode_ctx_t *ctx, const sbp_msg_device_monitor_t *msg)
-{
-  if (!encode_s16(ctx, &msg->dev_vin)) { return false; }
-  if (!encode_s16(ctx, &msg->cpu_vint)) { return false; }
-  if (!encode_s16(ctx, &msg->cpu_vaux)) { return false; }
-  if (!encode_s16(ctx, &msg->cpu_temperature)) { return false; }
-  if (!encode_s16(ctx, &msg->fe_temperature)) { return false; }
+bool encode_sbp_msg_device_monitor_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_device_monitor_t *msg) {
+  if (!encode_s16(ctx, &msg->dev_vin)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->cpu_vint)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->cpu_vaux)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->cpu_temperature)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->fe_temperature)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_device_monitor_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_device_monitor_t *msg) {
+s8 sbp_encode_sbp_msg_device_monitor_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_device_monitor_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1215,17 +1570,29 @@ s8 sbp_encode_sbp_msg_device_monitor_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_device_monitor_t(sbp_decode_ctx_t *ctx, sbp_msg_device_monitor_t *msg)
-{
-  if (!decode_s16(ctx, &msg->dev_vin)) { return false; }
-  if (!decode_s16(ctx, &msg->cpu_vint)) { return false; }
-  if (!decode_s16(ctx, &msg->cpu_vaux)) { return false; }
-  if (!decode_s16(ctx, &msg->cpu_temperature)) { return false; }
-  if (!decode_s16(ctx, &msg->fe_temperature)) { return false; }
+bool decode_sbp_msg_device_monitor_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_device_monitor_t *msg) {
+  if (!decode_s16(ctx, &msg->dev_vin)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->cpu_vint)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->cpu_vaux)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->cpu_temperature)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->fe_temperature)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_device_monitor_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_device_monitor_t *msg) {
+s8 sbp_decode_sbp_msg_device_monitor_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_device_monitor_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1238,116 +1605,148 @@ s8 sbp_decode_sbp_msg_device_monitor_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_device_monitor_t(struct sbp_state *s, u16 sender_id, const sbp_msg_device_monitor_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_device_monitor_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_device_monitor_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_device_monitor_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_DEVICE_MONITOR, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_device_monitor_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_DEVICE_MONITOR, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_device_monitor_t(const sbp_msg_device_monitor_t *a, const sbp_msg_device_monitor_t *b) {
+int sbp_cmp_sbp_msg_device_monitor_t(const sbp_msg_device_monitor_t *a,
+                                     const sbp_msg_device_monitor_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s16(&a->dev_vin, &b->dev_vin);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->cpu_vint, &b->cpu_vint);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->cpu_vaux, &b->cpu_vaux);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->cpu_temperature, &b->cpu_temperature);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->fe_temperature, &b->fe_temperature);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_null_terminated_string_params_t sbp_msg_command_req_tcommand_params = 
-{
-  .max_packed_len = 251
-};
+static const sbp_null_terminated_string_params_t
+    sbp_msg_command_req_tcommand_params = {.max_packed_len = 251};
 
-  void sbp_msg_command_req_t_command_init(sbp_null_terminated_string_t *s)
-{
+void sbp_msg_command_req_t_command_init(sbp_null_terminated_string_t *s) {
   sbp_null_terminated_string_init(s, &sbp_msg_command_req_tcommand_params);
 }
 
-  bool sbp_msg_command_req_t_command_valid(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_valid(s, &sbp_msg_command_req_tcommand_params);
+bool sbp_msg_command_req_t_command_valid(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_valid(s,
+                                          &sbp_msg_command_req_tcommand_params);
 }
 
-  int sbp_msg_command_req_t_command_strcmp(const sbp_null_terminated_string_t *a, const sbp_null_terminated_string_t *b)
-{
-  return sbp_null_terminated_string_strcmp(a, b, &sbp_msg_command_req_tcommand_params);
+int sbp_msg_command_req_t_command_strcmp(
+    const sbp_null_terminated_string_t *a,
+    const sbp_null_terminated_string_t *b) {
+  return sbp_null_terminated_string_strcmp(
+      a, b, &sbp_msg_command_req_tcommand_params);
 }
 
-  uint8_t sbp_msg_command_req_t_command_packed_len(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_packed_len(s, &sbp_msg_command_req_tcommand_params);
+uint8_t sbp_msg_command_req_t_command_packed_len(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_packed_len(
+      s, &sbp_msg_command_req_tcommand_params);
 }
 
-  uint8_t sbp_msg_command_req_t_command_space_remaining(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_space_remaining(s, &sbp_msg_command_req_tcommand_params);
-      }
-  bool sbp_msg_command_req_t_command_set(sbp_null_terminated_string_t *s, const char *new_str)
-  {
-  return sbp_null_terminated_string_set(s, &sbp_msg_command_req_tcommand_params, new_str);
-  }
+uint8_t sbp_msg_command_req_t_command_space_remaining(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_space_remaining(
+      s, &sbp_msg_command_req_tcommand_params);
+}
+bool sbp_msg_command_req_t_command_set(sbp_null_terminated_string_t *s,
+                                       const char *new_str) {
+  return sbp_null_terminated_string_set(s, &sbp_msg_command_req_tcommand_params,
+                                        new_str);
+}
 
-  bool sbp_msg_command_req_t_command_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_command_req_t_command_printf(sbp_null_terminated_string_t *s,
+                                          const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(s, &sbp_msg_command_req_tcommand_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_command_req_t_command_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_null_terminated_string_vprintf(s, &sbp_msg_command_req_tcommand_params, fmt, ap);
-  }
-
-  bool sbp_msg_command_req_t_command_append_printf(sbp_null_terminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_append_vprintf(s, &sbp_msg_command_req_tcommand_params, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_command_req_tcommand_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_command_req_t_command_append_vprintf(sbp_null_terminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_null_terminated_string_append_vprintf(s, &sbp_msg_command_req_tcommand_params, fmt, ap);
+bool sbp_msg_command_req_t_command_vprintf(sbp_null_terminated_string_t *s,
+                                           const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_vprintf(
+      s, &sbp_msg_command_req_tcommand_params, fmt, ap);
 }
 
-  const char *sbp_msg_command_req_t_command_get(const sbp_null_terminated_string_t *s)
-{
-  return sbp_null_terminated_string_get(s, &sbp_msg_command_req_tcommand_params);
+bool sbp_msg_command_req_t_command_append_printf(
+    sbp_null_terminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_command_req_tcommand_params, fmt, ap);
+  va_end(ap);
+  return ret;
+}
+
+bool sbp_msg_command_req_t_command_append_vprintf(
+    sbp_null_terminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_null_terminated_string_append_vprintf(
+      s, &sbp_msg_command_req_tcommand_params, fmt, ap);
+}
+
+const char *sbp_msg_command_req_t_command_get(
+    const sbp_null_terminated_string_t *s) {
+  return sbp_null_terminated_string_get(s,
+                                        &sbp_msg_command_req_tcommand_params);
 }
 
 size_t sbp_packed_size_sbp_msg_command_req_t(const sbp_msg_command_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
-  packed_size += sbp_null_terminated_string_packed_len(&msg->command, &sbp_msg_command_req_tcommand_params);
+  packed_size += sbp_null_terminated_string_packed_len(
+      &msg->command, &sbp_msg_command_req_tcommand_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_command_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_command_req_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!sbp_null_terminated_string_pack(&msg->command, &sbp_msg_command_req_tcommand_params, ctx)) { return false; }
+bool encode_sbp_msg_command_req_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_command_req_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_pack(
+          &msg->command, &sbp_msg_command_req_tcommand_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_command_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_command_req_t *msg) {
+s8 sbp_encode_sbp_msg_command_req_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_command_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1361,14 +1760,21 @@ s8 sbp_encode_sbp_msg_command_req_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_command_req_t(sbp_decode_ctx_t *ctx, sbp_msg_command_req_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!sbp_null_terminated_string_unpack(&msg->command, &sbp_msg_command_req_tcommand_params, ctx)) { return false; }
+bool decode_sbp_msg_command_req_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_command_req_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!sbp_null_terminated_string_unpack(
+          &msg->command, &sbp_msg_command_req_tcommand_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_command_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_command_req_t *msg) {
+s8 sbp_decode_sbp_msg_command_req_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_command_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1381,41 +1787,59 @@ s8 sbp_decode_sbp_msg_command_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_command_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_command_req_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_command_req_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_command_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_COMMAND_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_command_req_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_COMMAND_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_command_req_t(const sbp_msg_command_req_t *a, const sbp_msg_command_req_t *b) {
+int sbp_cmp_sbp_msg_command_req_t(const sbp_msg_command_req_t *a,
+                                  const sbp_msg_command_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_null_terminated_string_strcmp(&a->command, &b->command, &sbp_msg_command_req_tcommand_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_null_terminated_string_strcmp(&a->command, &b->command,
+                                          &sbp_msg_command_req_tcommand_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_command_resp_t(const sbp_msg_command_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_command_resp_t(
+    const sbp_msg_command_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += sbp_packed_size_s32(&msg->code);
   return packed_size;
 }
 
-bool encode_sbp_msg_command_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_command_resp_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!encode_s32(ctx, &msg->code)) { return false; }
+bool encode_sbp_msg_command_resp_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_command_resp_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->code)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_command_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_command_resp_t *msg) {
+s8 sbp_encode_sbp_msg_command_resp_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_command_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1429,14 +1853,20 @@ s8 sbp_encode_sbp_msg_command_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_command_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_command_resp_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!decode_s32(ctx, &msg->code)) { return false; }
+bool decode_sbp_msg_command_resp_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_command_resp_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->code)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_command_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_command_resp_t *msg) {
+s8 sbp_decode_sbp_msg_command_resp_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_command_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1449,107 +1879,130 @@ s8 sbp_decode_sbp_msg_command_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_command_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_command_resp_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_command_resp_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_command_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_COMMAND_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_command_resp_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_COMMAND_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_command_resp_t(const sbp_msg_command_resp_t *a, const sbp_msg_command_resp_t *b) {
+int sbp_cmp_sbp_msg_command_resp_t(const sbp_msg_command_resp_t *a,
+                                   const sbp_msg_command_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->code, &b->code);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_command_output_tline_params = 
-{
-  .max_packed_len = 251
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_command_output_tline_params = {.max_packed_len = 251};
 
-  void sbp_msg_command_output_t_line_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_command_output_t_line_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_command_output_tline_params);
 }
 
-  bool sbp_msg_command_output_t_line_valid(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_command_output_t_line_valid(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_valid(s, &sbp_msg_command_output_tline_params);
 }
 
-  int sbp_msg_command_output_t_line_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_command_output_tline_params);
+int sbp_msg_command_output_t_line_strcmp(const sbp_unterminated_string_t *a,
+                                         const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(a, b,
+                                        &sbp_msg_command_output_tline_params);
 }
 
-  uint8_t sbp_msg_command_output_t_line_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_command_output_tline_params);
+uint8_t sbp_msg_command_output_t_line_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_command_output_tline_params);
 }
 
-  uint8_t sbp_msg_command_output_t_line_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_command_output_tline_params);
-      }
-  bool sbp_msg_command_output_t_line_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_command_output_tline_params, new_str);
-  }
+uint8_t sbp_msg_command_output_t_line_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_command_output_tline_params);
+}
+bool sbp_msg_command_output_t_line_set(sbp_unterminated_string_t *s,
+                                       const char *new_str) {
+  return sbp_unterminated_string_set(s, &sbp_msg_command_output_tline_params,
+                                     new_str);
+}
 
-  bool sbp_msg_command_output_t_line_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_command_output_t_line_printf(sbp_unterminated_string_t *s,
+                                          const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_command_output_tline_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_command_output_t_line_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_command_output_tline_params, fmt, ap);
-  }
-
-  bool sbp_msg_command_output_t_line_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_command_output_tline_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_command_output_tline_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_command_output_t_line_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_command_output_tline_params, fmt, ap);
+bool sbp_msg_command_output_t_line_vprintf(sbp_unterminated_string_t *s,
+                                           const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_command_output_tline_params, fmt, ap);
 }
 
-  const char *sbp_msg_command_output_t_line_get(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_command_output_t_line_append_printf(sbp_unterminated_string_t *s,
+                                                 const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_command_output_tline_params, fmt, ap);
+  va_end(ap);
+  return ret;
+}
+
+bool sbp_msg_command_output_t_line_append_vprintf(sbp_unterminated_string_t *s,
+                                                  const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_command_output_tline_params, fmt, ap);
+}
+
+const char *sbp_msg_command_output_t_line_get(
+    const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_get(s, &sbp_msg_command_output_tline_params);
 }
 
-size_t sbp_packed_size_sbp_msg_command_output_t(const sbp_msg_command_output_t *msg) {
+size_t sbp_packed_size_sbp_msg_command_output_t(
+    const sbp_msg_command_output_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u32(&msg->sequence);
-  packed_size += sbp_unterminated_string_packed_len(&msg->line, &sbp_msg_command_output_tline_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->line, &sbp_msg_command_output_tline_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_command_output_t(sbp_encode_ctx_t *ctx, const sbp_msg_command_output_t *msg)
-{
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->line, &sbp_msg_command_output_tline_params, ctx)) { return false; }
+bool encode_sbp_msg_command_output_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_command_output_t *msg) {
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->line, &sbp_msg_command_output_tline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_command_output_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_command_output_t *msg) {
+s8 sbp_encode_sbp_msg_command_output_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_command_output_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1563,14 +2016,21 @@ s8 sbp_encode_sbp_msg_command_output_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_command_output_t(sbp_decode_ctx_t *ctx, sbp_msg_command_output_t *msg)
-{
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->line, &sbp_msg_command_output_tline_params, ctx)) { return false; }
+bool decode_sbp_msg_command_output_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_command_output_t *msg) {
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->line, &sbp_msg_command_output_tline_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_command_output_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_command_output_t *msg) {
+s8 sbp_decode_sbp_msg_command_output_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_command_output_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1583,39 +2043,53 @@ s8 sbp_decode_sbp_msg_command_output_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_command_output_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_output_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_command_output_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_command_output_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_command_output_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_COMMAND_OUTPUT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_command_output_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_COMMAND_OUTPUT, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_command_output_t(const sbp_msg_command_output_t *a, const sbp_msg_command_output_t *b) {
+int sbp_cmp_sbp_msg_command_output_t(const sbp_msg_command_output_t *a,
+                                     const sbp_msg_command_output_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->line, &b->line, &sbp_msg_command_output_tline_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(&a->line, &b->line,
+                                       &sbp_msg_command_output_tline_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_network_state_req_t(const sbp_msg_network_state_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_network_state_req_t(
+    const sbp_msg_network_state_req_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_network_state_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_network_state_req_t *msg)
-{
+bool encode_sbp_msg_network_state_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_network_state_req_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_network_state_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_network_state_req_t *msg) {
+s8 sbp_encode_sbp_msg_network_state_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_network_state_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1629,14 +2103,16 @@ s8 sbp_encode_sbp_msg_network_state_req_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_network_state_req_t(sbp_decode_ctx_t *ctx, sbp_msg_network_state_req_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_network_state_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_network_state_req_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_network_state_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_network_state_req_t *msg) {
+s8 sbp_decode_sbp_msg_network_state_req_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_network_state_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1649,58 +2125,80 @@ s8 sbp_decode_sbp_msg_network_state_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_network_state_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_network_state_req_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_network_state_req_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_network_state_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_NETWORK_STATE_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_network_state_req_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_NETWORK_STATE_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_network_state_req_t(const sbp_msg_network_state_req_t *a, const sbp_msg_network_state_req_t *b) {
+int sbp_cmp_sbp_msg_network_state_req_t(const sbp_msg_network_state_req_t *a,
+                                        const sbp_msg_network_state_req_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_network_state_resp_t(const sbp_msg_network_state_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_network_state_resp_t(
+    const sbp_msg_network_state_resp_t *msg) {
   size_t packed_size = 0;
-  packed_size += ( 4 * sbp_packed_size_u8(&msg->ipv4_address[0]));
+  packed_size += (4 * sbp_packed_size_u8(&msg->ipv4_address[0]));
   packed_size += sbp_packed_size_u8(&msg->ipv4_mask_size);
-  packed_size += ( 16 * sbp_packed_size_u8(&msg->ipv6_address[0]));
+  packed_size += (16 * sbp_packed_size_u8(&msg->ipv6_address[0]));
   packed_size += sbp_packed_size_u8(&msg->ipv6_mask_size);
   packed_size += sbp_packed_size_u32(&msg->rx_bytes);
   packed_size += sbp_packed_size_u32(&msg->tx_bytes);
-  packed_size += ( 16 * sbp_packed_size_char(&msg->interface_name[0]));
+  packed_size += (16 * sbp_packed_size_char(&msg->interface_name[0]));
   packed_size += sbp_packed_size_u32(&msg->flags);
   return packed_size;
 }
 
-bool encode_sbp_msg_network_state_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg)
-{
-  for (uint8_t i = 0; i < 4; i++)
-  {
-    if (!encode_u8(ctx, &msg->ipv4_address[i])) { return false; }
+bool encode_sbp_msg_network_state_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg) {
+  for (uint8_t i = 0; i < 4; i++) {
+    if (!encode_u8(ctx, &msg->ipv4_address[i])) {
+      return false;
+    }
   }
-  if (!encode_u8(ctx, &msg->ipv4_mask_size)) { return false; }
-  for (uint8_t i = 0; i < 16; i++)
-  {
-    if (!encode_u8(ctx, &msg->ipv6_address[i])) { return false; }
+  if (!encode_u8(ctx, &msg->ipv4_mask_size)) {
+    return false;
   }
-  if (!encode_u8(ctx, &msg->ipv6_mask_size)) { return false; }
-  if (!encode_u32(ctx, &msg->rx_bytes)) { return false; }
-  if (!encode_u32(ctx, &msg->tx_bytes)) { return false; }
-  for (uint8_t i = 0; i < 16; i++)
-  {
-    if (!encode_char(ctx, &msg->interface_name[i])) { return false; }
+  for (uint8_t i = 0; i < 16; i++) {
+    if (!encode_u8(ctx, &msg->ipv6_address[i])) {
+      return false;
+    }
   }
-  if (!encode_u32(ctx, &msg->flags)) { return false; }
+  if (!encode_u8(ctx, &msg->ipv6_mask_size)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->rx_bytes)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tx_bytes)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 16; i++) {
+    if (!encode_char(ctx, &msg->interface_name[i])) {
+      return false;
+    }
+  }
+  if (!encode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_network_state_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_network_state_resp_t *msg) {
+s8 sbp_encode_sbp_msg_network_state_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_network_state_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1714,26 +2212,44 @@ s8 sbp_encode_sbp_msg_network_state_resp_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_network_state_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_network_state_resp_t *msg)
-{
+bool decode_sbp_msg_network_state_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_network_state_resp_t *msg) {
   for (uint8_t i = 0; i < 4; i++) {
-    if (!decode_u8(ctx, &msg->ipv4_address[i])) { return false; }
+    if (!decode_u8(ctx, &msg->ipv4_address[i])) {
+      return false;
+    }
   }
-  if (!decode_u8(ctx, &msg->ipv4_mask_size)) { return false; }
+  if (!decode_u8(ctx, &msg->ipv4_mask_size)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 16; i++) {
-    if (!decode_u8(ctx, &msg->ipv6_address[i])) { return false; }
+    if (!decode_u8(ctx, &msg->ipv6_address[i])) {
+      return false;
+    }
   }
-  if (!decode_u8(ctx, &msg->ipv6_mask_size)) { return false; }
-  if (!decode_u32(ctx, &msg->rx_bytes)) { return false; }
-  if (!decode_u32(ctx, &msg->tx_bytes)) { return false; }
+  if (!decode_u8(ctx, &msg->ipv6_mask_size)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->rx_bytes)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tx_bytes)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 16; i++) {
-    if (!decode_char(ctx, &msg->interface_name[i])) { return false; }
+    if (!decode_char(ctx, &msg->interface_name[i])) {
+      return false;
+    }
   }
-  if (!decode_u32(ctx, &msg->flags)) { return false; }
+  if (!decode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_network_state_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_network_state_resp_t *msg) {
+s8 sbp_decode_sbp_msg_network_state_resp_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_network_state_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1746,50 +2262,70 @@ s8 sbp_decode_sbp_msg_network_state_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_network_state_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_network_state_resp_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_resp_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_network_state_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_NETWORK_STATE_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_network_state_resp_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_NETWORK_STATE_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_network_state_resp_t(const sbp_msg_network_state_resp_t *a, const sbp_msg_network_state_resp_t *b) {
+int sbp_cmp_sbp_msg_network_state_resp_t(
+    const sbp_msg_network_state_resp_t *a,
+    const sbp_msg_network_state_resp_t *b) {
   int ret = 0;
-  
-  for (uint8_t i = 0; i < 4 && ret == 0; i++)
-  {
+
+  for (uint8_t i = 0; i < 4 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->ipv4_address[i], &b->ipv4_address[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->ipv4_mask_size, &b->ipv4_mask_size);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 16 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->ipv6_address[i], &b->ipv6_address[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->ipv6_mask_size, &b->ipv6_mask_size);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->rx_bytes, &b->rx_bytes);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tx_bytes, &b->tx_bytes);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 16 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->interface_name[i], &b->interface_name[i]);
   }
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -1799,24 +2335,34 @@ size_t sbp_packed_size_sbp_network_usage_t(const sbp_network_usage_t *msg) {
   packed_size += sbp_packed_size_u64(&msg->total_bytes);
   packed_size += sbp_packed_size_u32(&msg->rx_bytes);
   packed_size += sbp_packed_size_u32(&msg->tx_bytes);
-  packed_size += ( 16 * sbp_packed_size_char(&msg->interface_name[0]));
+  packed_size += (16 * sbp_packed_size_char(&msg->interface_name[0]));
   return packed_size;
 }
 
-bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx, const sbp_network_usage_t *msg)
-{
-  if (!encode_u64(ctx, &msg->duration)) { return false; }
-  if (!encode_u64(ctx, &msg->total_bytes)) { return false; }
-  if (!encode_u32(ctx, &msg->rx_bytes)) { return false; }
-  if (!encode_u32(ctx, &msg->tx_bytes)) { return false; }
-  for (uint8_t i = 0; i < 16; i++)
-  {
-    if (!encode_char(ctx, &msg->interface_name[i])) { return false; }
+bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx,
+                                const sbp_network_usage_t *msg) {
+  if (!encode_u64(ctx, &msg->duration)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->total_bytes)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->rx_bytes)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tx_bytes)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 16; i++) {
+    if (!encode_char(ctx, &msg->interface_name[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_network_usage_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_network_usage_t *msg) {
+s8 sbp_encode_sbp_network_usage_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_network_usage_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1830,19 +2376,30 @@ s8 sbp_encode_sbp_network_usage_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_network_usage_t(sbp_decode_ctx_t *ctx, sbp_network_usage_t *msg)
-{
-  if (!decode_u64(ctx, &msg->duration)) { return false; }
-  if (!decode_u64(ctx, &msg->total_bytes)) { return false; }
-  if (!decode_u32(ctx, &msg->rx_bytes)) { return false; }
-  if (!decode_u32(ctx, &msg->tx_bytes)) { return false; }
+bool decode_sbp_network_usage_t(sbp_decode_ctx_t *ctx,
+                                sbp_network_usage_t *msg) {
+  if (!decode_u64(ctx, &msg->duration)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->total_bytes)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->rx_bytes)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tx_bytes)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 16; i++) {
-    if (!decode_char(ctx, &msg->interface_name[i])) { return false; }
+    if (!decode_char(ctx, &msg->interface_name[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_network_usage_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_network_usage_t *msg) {
+s8 sbp_decode_sbp_network_usage_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_network_usage_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1856,45 +2413,60 @@ s8 sbp_decode_sbp_network_usage_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_network_usage_t(const sbp_network_usage_t *a, const sbp_network_usage_t *b) {
+int sbp_cmp_sbp_network_usage_t(const sbp_network_usage_t *a,
+                                const sbp_network_usage_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->duration, &b->duration);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->total_bytes, &b->total_bytes);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->rx_bytes, &b->rx_bytes);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tx_bytes, &b->tx_bytes);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 16 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
     ret = sbp_cmp_char(&a->interface_name[i], &b->interface_name[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_network_bandwidth_usage_t(const sbp_msg_network_bandwidth_usage_t *msg) {
+size_t sbp_packed_size_sbp_msg_network_bandwidth_usage_t(
+    const sbp_msg_network_bandwidth_usage_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_interfaces * sbp_packed_size_sbp_network_usage_t(&msg->interfaces[0]));
+  packed_size += (msg->n_interfaces *
+                  sbp_packed_size_sbp_network_usage_t(&msg->interfaces[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_network_bandwidth_usage_t(sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_interfaces; i++)
-  {
-    if (!encode_sbp_network_usage_t(ctx, &msg->interfaces[i])) { return false; }
+bool encode_sbp_msg_network_bandwidth_usage_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg) {
+  for (uint8_t i = 0; i < msg->n_interfaces; i++) {
+    if (!encode_sbp_network_usage_t(ctx, &msg->interfaces[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_network_bandwidth_usage_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_network_bandwidth_usage_t *msg) {
+s8 sbp_encode_sbp_msg_network_bandwidth_usage_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_network_bandwidth_usage_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1908,16 +2480,22 @@ s8 sbp_encode_sbp_msg_network_bandwidth_usage_t(uint8_t *buf, uint8_t len, uint8
   return SBP_OK;
 }
 
-bool decode_sbp_msg_network_bandwidth_usage_t(sbp_decode_ctx_t *ctx, sbp_msg_network_bandwidth_usage_t *msg)
-{
-    msg->n_interfaces = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_network_usage_t(&msg->interfaces[0]));
+bool decode_sbp_msg_network_bandwidth_usage_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_network_bandwidth_usage_t *msg) {
+  msg->n_interfaces =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_network_usage_t(&msg->interfaces[0]));
   for (uint8_t i = 0; i < msg->n_interfaces; i++) {
-    if (!decode_sbp_network_usage_t(ctx, &msg->interfaces[i])) { return false; }
+    if (!decode_sbp_network_usage_t(ctx, &msg->interfaces[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_network_bandwidth_usage_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_network_bandwidth_usage_t *msg) {
+s8 sbp_decode_sbp_msg_network_bandwidth_usage_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_network_bandwidth_usage_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1930,28 +2508,37 @@ s8 sbp_decode_sbp_msg_network_bandwidth_usage_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_network_bandwidth_usage_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_bandwidth_usage_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_network_bandwidth_usage_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_network_bandwidth_usage_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_network_bandwidth_usage_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_NETWORK_BANDWIDTH_USAGE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_network_bandwidth_usage_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_NETWORK_BANDWIDTH_USAGE, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_network_bandwidth_usage_t(const sbp_msg_network_bandwidth_usage_t *a, const sbp_msg_network_bandwidth_usage_t *b) {
+int sbp_cmp_sbp_msg_network_bandwidth_usage_t(
+    const sbp_msg_network_bandwidth_usage_t *a,
+    const sbp_msg_network_bandwidth_usage_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_interfaces, &b->n_interfaces);
-  for (uint8_t i = 0; i < a->n_interfaces && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_interfaces && ret == 0; i++) {
     ret = sbp_cmp_sbp_network_usage_t(&a->interfaces[i], &b->interfaces[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_cell_modem_status_t(const sbp_msg_cell_modem_status_t *msg) {
+size_t sbp_packed_size_sbp_msg_cell_modem_status_t(
+    const sbp_msg_cell_modem_status_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s8(&msg->signal_strength);
   packed_size += sbp_packed_size_float(&msg->signal_error_rate);
@@ -1959,18 +2546,25 @@ size_t sbp_packed_size_sbp_msg_cell_modem_status_t(const sbp_msg_cell_modem_stat
   return packed_size;
 }
 
-bool encode_sbp_msg_cell_modem_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_cell_modem_status_t *msg)
-{
-  if (!encode_s8(ctx, &msg->signal_strength)) { return false; }
-  if (!encode_float(ctx, &msg->signal_error_rate)) { return false; }
-  for (uint8_t i = 0; i < msg->n_reserved; i++)
-  {
-    if (!encode_u8(ctx, &msg->reserved[i])) { return false; }
+bool encode_sbp_msg_cell_modem_status_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_cell_modem_status_t *msg) {
+  if (!encode_s8(ctx, &msg->signal_strength)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->signal_error_rate)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_reserved; i++) {
+    if (!encode_u8(ctx, &msg->reserved[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_cell_modem_status_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_cell_modem_status_t *msg) {
+s8 sbp_encode_sbp_msg_cell_modem_status_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_cell_modem_status_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1984,18 +2578,27 @@ s8 sbp_encode_sbp_msg_cell_modem_status_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_cell_modem_status_t(sbp_decode_ctx_t *ctx, sbp_msg_cell_modem_status_t *msg)
-{
-  if (!decode_s8(ctx, &msg->signal_strength)) { return false; }
-  if (!decode_float(ctx, &msg->signal_error_rate)) { return false; }
-    msg->n_reserved = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->reserved[0]));
+bool decode_sbp_msg_cell_modem_status_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_cell_modem_status_t *msg) {
+  if (!decode_s8(ctx, &msg->signal_strength)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->signal_error_rate)) {
+    return false;
+  }
+  msg->n_reserved = (uint8_t)((ctx->buf_len - ctx->offset) /
+                              sbp_packed_size_u8(&msg->reserved[0]));
   for (uint8_t i = 0; i < msg->n_reserved; i++) {
-    if (!decode_u8(ctx, &msg->reserved[i])) { return false; }
+    if (!decode_u8(ctx, &msg->reserved[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_cell_modem_status_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_cell_modem_status_t *msg) {
+s8 sbp_decode_sbp_msg_cell_modem_status_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_cell_modem_status_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2008,30 +2611,41 @@ s8 sbp_decode_sbp_msg_cell_modem_status_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_cell_modem_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cell_modem_status_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_cell_modem_status_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_cell_modem_status_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_cell_modem_status_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_CELL_MODEM_STATUS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_cell_modem_status_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_CELL_MODEM_STATUS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_cell_modem_status_t(const sbp_msg_cell_modem_status_t *a, const sbp_msg_cell_modem_status_t *b) {
+int sbp_cmp_sbp_msg_cell_modem_status_t(const sbp_msg_cell_modem_status_t *a,
+                                        const sbp_msg_cell_modem_status_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s8(&a->signal_strength, &b->signal_strength);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->signal_error_rate, &b->signal_error_rate);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_reserved, &b->n_reserved);
-  for (uint8_t i = 0; i < a->n_reserved && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_reserved && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->reserved[i], &b->reserved[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -2043,26 +2657,42 @@ size_t sbp_packed_size_sbp_msg_specan_dep_t(const sbp_msg_specan_dep_t *msg) {
   packed_size += sbp_packed_size_float(&msg->freq_step);
   packed_size += sbp_packed_size_float(&msg->amplitude_ref);
   packed_size += sbp_packed_size_float(&msg->amplitude_unit);
-  packed_size += (msg->n_amplitude_value * sbp_packed_size_u8(&msg->amplitude_value[0]));
+  packed_size +=
+      (msg->n_amplitude_value * sbp_packed_size_u8(&msg->amplitude_value[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_specan_dep_t *msg)
-{
-  if (!encode_u16(ctx, &msg->channel_tag)) { return false; }
-  if (!encode_sbp_gps_time_dep_t(ctx, &msg->t)) { return false; }
-  if (!encode_float(ctx, &msg->freq_ref)) { return false; }
-  if (!encode_float(ctx, &msg->freq_step)) { return false; }
-  if (!encode_float(ctx, &msg->amplitude_ref)) { return false; }
-  if (!encode_float(ctx, &msg->amplitude_unit)) { return false; }
-  for (uint8_t i = 0; i < msg->n_amplitude_value; i++)
-  {
-    if (!encode_u8(ctx, &msg->amplitude_value[i])) { return false; }
+bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_specan_dep_t *msg) {
+  if (!encode_u16(ctx, &msg->channel_tag)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_dep_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->freq_ref)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->freq_step)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->amplitude_ref)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->amplitude_unit)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
+    if (!encode_u8(ctx, &msg->amplitude_value[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_specan_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_specan_dep_t *msg) {
+s8 sbp_encode_sbp_msg_specan_dep_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_specan_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2076,22 +2706,39 @@ s8 sbp_encode_sbp_msg_specan_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_specan_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_specan_dep_t *msg)
-{
-  if (!decode_u16(ctx, &msg->channel_tag)) { return false; }
-  if (!decode_sbp_gps_time_dep_t(ctx, &msg->t)) { return false; }
-  if (!decode_float(ctx, &msg->freq_ref)) { return false; }
-  if (!decode_float(ctx, &msg->freq_step)) { return false; }
-  if (!decode_float(ctx, &msg->amplitude_ref)) { return false; }
-  if (!decode_float(ctx, &msg->amplitude_unit)) { return false; }
-    msg->n_amplitude_value = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->amplitude_value[0]));
+bool decode_sbp_msg_specan_dep_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_specan_dep_t *msg) {
+  if (!decode_u16(ctx, &msg->channel_tag)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_dep_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->freq_ref)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->freq_step)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->amplitude_ref)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->amplitude_unit)) {
+    return false;
+  }
+  msg->n_amplitude_value =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_u8(&msg->amplitude_value[0]));
   for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
-    if (!decode_u8(ctx, &msg->amplitude_value[i])) { return false; }
+    if (!decode_u8(ctx, &msg->amplitude_value[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_specan_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_specan_dep_t *msg) {
+s8 sbp_decode_sbp_msg_specan_dep_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_specan_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2104,42 +2751,61 @@ s8 sbp_decode_sbp_msg_specan_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_specan_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_specan_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_specan_dep_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_specan_dep_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_specan_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SPECAN_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_specan_dep_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SPECAN_DEP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_specan_dep_t(const sbp_msg_specan_dep_t *a, const sbp_msg_specan_dep_t *b) {
+int sbp_cmp_sbp_msg_specan_dep_t(const sbp_msg_specan_dep_t *a,
+                                 const sbp_msg_specan_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->channel_tag, &b->channel_tag);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_dep_t(&a->t, &b->t);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->freq_ref, &b->freq_ref);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->freq_step, &b->freq_step);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->amplitude_ref, &b->amplitude_ref);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->amplitude_unit, &b->amplitude_unit);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_amplitude_value, &b->n_amplitude_value);
-  for (uint8_t i = 0; i < a->n_amplitude_value && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_amplitude_value && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->amplitude_value[i], &b->amplitude_value[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -2151,26 +2817,41 @@ size_t sbp_packed_size_sbp_msg_specan_t(const sbp_msg_specan_t *msg) {
   packed_size += sbp_packed_size_float(&msg->freq_step);
   packed_size += sbp_packed_size_float(&msg->amplitude_ref);
   packed_size += sbp_packed_size_float(&msg->amplitude_unit);
-  packed_size += (msg->n_amplitude_value * sbp_packed_size_u8(&msg->amplitude_value[0]));
+  packed_size +=
+      (msg->n_amplitude_value * sbp_packed_size_u8(&msg->amplitude_value[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx, const sbp_msg_specan_t *msg)
-{
-  if (!encode_u16(ctx, &msg->channel_tag)) { return false; }
-  if (!encode_sbp_sbp_gps_time_t(ctx, &msg->t)) { return false; }
-  if (!encode_float(ctx, &msg->freq_ref)) { return false; }
-  if (!encode_float(ctx, &msg->freq_step)) { return false; }
-  if (!encode_float(ctx, &msg->amplitude_ref)) { return false; }
-  if (!encode_float(ctx, &msg->amplitude_unit)) { return false; }
-  for (uint8_t i = 0; i < msg->n_amplitude_value; i++)
-  {
-    if (!encode_u8(ctx, &msg->amplitude_value[i])) { return false; }
+bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx,
+                             const sbp_msg_specan_t *msg) {
+  if (!encode_u16(ctx, &msg->channel_tag)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gps_time_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->freq_ref)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->freq_step)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->amplitude_ref)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->amplitude_unit)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
+    if (!encode_u8(ctx, &msg->amplitude_value[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_specan_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_specan_t *msg) {
+s8 sbp_encode_sbp_msg_specan_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                               const sbp_msg_specan_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2184,22 +2865,38 @@ s8 sbp_encode_sbp_msg_specan_t(uint8_t *buf, uint8_t len, uint8_t *n_written, co
   return SBP_OK;
 }
 
-bool decode_sbp_msg_specan_t(sbp_decode_ctx_t *ctx, sbp_msg_specan_t *msg)
-{
-  if (!decode_u16(ctx, &msg->channel_tag)) { return false; }
-  if (!decode_sbp_sbp_gps_time_t(ctx, &msg->t)) { return false; }
-  if (!decode_float(ctx, &msg->freq_ref)) { return false; }
-  if (!decode_float(ctx, &msg->freq_step)) { return false; }
-  if (!decode_float(ctx, &msg->amplitude_ref)) { return false; }
-  if (!decode_float(ctx, &msg->amplitude_unit)) { return false; }
-    msg->n_amplitude_value = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->amplitude_value[0]));
+bool decode_sbp_msg_specan_t(sbp_decode_ctx_t *ctx, sbp_msg_specan_t *msg) {
+  if (!decode_u16(ctx, &msg->channel_tag)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gps_time_t(ctx, &msg->t)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->freq_ref)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->freq_step)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->amplitude_ref)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->amplitude_unit)) {
+    return false;
+  }
+  msg->n_amplitude_value =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_u8(&msg->amplitude_value[0]));
   for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
-    if (!decode_u8(ctx, &msg->amplitude_value[i])) { return false; }
+    if (!decode_u8(ctx, &msg->amplitude_value[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_specan_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_specan_t *msg) {
+s8 sbp_decode_sbp_msg_specan_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                               sbp_msg_specan_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2212,66 +2909,90 @@ s8 sbp_decode_sbp_msg_specan_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_specan_t(struct sbp_state *s, u16 sender_id, const sbp_msg_specan_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_specan_t(struct sbp_state *s, u16 sender_id,
+                             const sbp_msg_specan_t *msg,
+                             sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_specan_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SPECAN, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_specan_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SPECAN, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_specan_t(const sbp_msg_specan_t *a, const sbp_msg_specan_t *b) {
+int sbp_cmp_sbp_msg_specan_t(const sbp_msg_specan_t *a,
+                             const sbp_msg_specan_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->channel_tag, &b->channel_tag);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gps_time_t(&a->t, &b->t);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->freq_ref, &b->freq_ref);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->freq_step, &b->freq_step);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->amplitude_ref, &b->amplitude_ref);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->amplitude_unit, &b->amplitude_unit);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_amplitude_value, &b->n_amplitude_value);
-  for (uint8_t i = 0; i < a->n_amplitude_value && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_amplitude_value && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->amplitude_value[i], &b->amplitude_value[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_front_end_gain_t(const sbp_msg_front_end_gain_t *msg) {
+size_t sbp_packed_size_sbp_msg_front_end_gain_t(
+    const sbp_msg_front_end_gain_t *msg) {
   size_t packed_size = 0;
-  packed_size += ( 8 * sbp_packed_size_s8(&msg->rf_gain[0]));
-  packed_size += ( 8 * sbp_packed_size_s8(&msg->if_gain[0]));
+  packed_size += (8 * sbp_packed_size_s8(&msg->rf_gain[0]));
+  packed_size += (8 * sbp_packed_size_s8(&msg->if_gain[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx, const sbp_msg_front_end_gain_t *msg)
-{
-  for (uint8_t i = 0; i < 8; i++)
-  {
-    if (!encode_s8(ctx, &msg->rf_gain[i])) { return false; }
+bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_front_end_gain_t *msg) {
+  for (uint8_t i = 0; i < 8; i++) {
+    if (!encode_s8(ctx, &msg->rf_gain[i])) {
+      return false;
+    }
   }
-  for (uint8_t i = 0; i < 8; i++)
-  {
-    if (!encode_s8(ctx, &msg->if_gain[i])) { return false; }
+  for (uint8_t i = 0; i < 8; i++) {
+    if (!encode_s8(ctx, &msg->if_gain[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_front_end_gain_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_front_end_gain_t *msg) {
+s8 sbp_encode_sbp_msg_front_end_gain_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_front_end_gain_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2285,18 +3006,24 @@ s8 sbp_encode_sbp_msg_front_end_gain_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_front_end_gain_t(sbp_decode_ctx_t *ctx, sbp_msg_front_end_gain_t *msg)
-{
+bool decode_sbp_msg_front_end_gain_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_front_end_gain_t *msg) {
   for (uint8_t i = 0; i < 8; i++) {
-    if (!decode_s8(ctx, &msg->rf_gain[i])) { return false; }
+    if (!decode_s8(ctx, &msg->rf_gain[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 8; i++) {
-    if (!decode_s8(ctx, &msg->if_gain[i])) { return false; }
+    if (!decode_s8(ctx, &msg->if_gain[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_front_end_gain_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_front_end_gain_t *msg) {
+s8 sbp_decode_sbp_msg_front_end_gain_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_front_end_gain_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2309,28 +3036,36 @@ s8 sbp_decode_sbp_msg_front_end_gain_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_front_end_gain_t(struct sbp_state *s, u16 sender_id, const sbp_msg_front_end_gain_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_front_end_gain_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_front_end_gain_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_front_end_gain_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_FRONT_END_GAIN, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_front_end_gain_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_FRONT_END_GAIN, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_front_end_gain_t(const sbp_msg_front_end_gain_t *a, const sbp_msg_front_end_gain_t *b) {
+int sbp_cmp_sbp_msg_front_end_gain_t(const sbp_msg_front_end_gain_t *a,
+                                     const sbp_msg_front_end_gain_t *b) {
   int ret = 0;
-  
-  for (uint8_t i = 0; i < 8 && ret == 0; i++)
-  {
+
+  for (uint8_t i = 0; i < 8 && ret == 0; i++) {
     ret = sbp_cmp_s8(&a->rf_gain[i], &b->rf_gain[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 8 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 8 && ret == 0; i++) {
     ret = sbp_cmp_s8(&a->if_gain[i], &b->if_gain[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/piksi.c
+++ b/c/src/new/piksi.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/piksi.yaml
  * with generate.py. Please do not hand edit!
@@ -75,6 +63,7 @@ s8 sbp_decode_sbp_msg_almanac_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_almanac_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_almanac_t *msg,
                               sbp_write_fn_t write) {
@@ -144,6 +133,7 @@ s8 sbp_decode_sbp_msg_set_time_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_set_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_set_time_t *msg,
                                sbp_write_fn_t write) {
@@ -215,6 +205,7 @@ s8 sbp_decode_sbp_msg_reset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_reset_t(struct sbp_state *s, u16 sender_id,
                             const sbp_msg_reset_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
@@ -287,6 +278,7 @@ s8 sbp_decode_sbp_msg_reset_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_reset_dep_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_reset_dep_t *msg,
                                 sbp_write_fn_t write) {
@@ -358,6 +350,7 @@ s8 sbp_decode_sbp_msg_cw_results_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_cw_results_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_cw_results_t *msg,
                                  sbp_write_fn_t write) {
@@ -427,6 +420,7 @@ s8 sbp_decode_sbp_msg_cw_start_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_cw_start_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_cw_start_t *msg,
                                sbp_write_fn_t write) {
@@ -503,6 +497,7 @@ s8 sbp_decode_sbp_msg_reset_filters_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_reset_filters_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_reset_filters_t *msg,
                                     sbp_write_fn_t write) {
@@ -579,6 +574,7 @@ s8 sbp_decode_sbp_msg_init_base_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_init_base_dep_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_init_base_dep_t *msg,
                                     sbp_write_fn_t write) {
@@ -612,7 +608,7 @@ size_t sbp_packed_size_sbp_msg_thread_state_t(
 
 bool encode_sbp_msg_thread_state_t(sbp_encode_ctx_t *ctx,
                                    const sbp_msg_thread_state_t *msg) {
-  for (uint8_t i = 0; i < 20; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 20; i++) {
     if (!encode_char(ctx, &msg->name[i])) {
       return false;
     }
@@ -673,6 +669,7 @@ s8 sbp_decode_sbp_msg_thread_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_thread_state_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_thread_state_t *msg,
                                    sbp_write_fn_t write) {
@@ -691,7 +688,7 @@ int sbp_cmp_sbp_msg_thread_state_t(const sbp_msg_thread_state_t *a,
                                    const sbp_msg_thread_state_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; i < 20 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 20; i++) {
     ret = sbp_cmp_char(&a->name[i], &b->name[i]);
   }
   if (ret != 0) {
@@ -1104,6 +1101,7 @@ s8 sbp_decode_sbp_msg_uart_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_uart_state_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_uart_state_t *msg,
                                  sbp_write_fn_t write) {
@@ -1224,6 +1222,7 @@ s8 sbp_decode_sbp_msg_uart_state_depa_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_uart_state_depa_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_uart_state_depa_t *msg,
                                       sbp_write_fn_t write) {
@@ -1315,6 +1314,7 @@ s8 sbp_decode_sbp_msg_iar_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_iar_state_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_iar_state_t *msg,
                                 sbp_write_fn_t write) {
@@ -1401,6 +1401,7 @@ s8 sbp_decode_sbp_msg_mask_satellite_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_mask_satellite_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_mask_satellite_t *msg,
                                      sbp_write_fn_t write) {
@@ -1492,6 +1493,7 @@ s8 sbp_decode_sbp_msg_mask_satellite_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_mask_satellite_dep_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_dep_t *msg,
     sbp_write_fn_t write) {
@@ -1605,6 +1607,7 @@ s8 sbp_decode_sbp_msg_device_monitor_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_device_monitor_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_device_monitor_t *msg,
                                      sbp_write_fn_t write) {
@@ -1787,6 +1790,7 @@ s8 sbp_decode_sbp_msg_command_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_command_req_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_command_req_t *msg,
                                   sbp_write_fn_t write) {
@@ -1810,8 +1814,7 @@ int sbp_cmp_sbp_msg_command_req_t(const sbp_msg_command_req_t *a,
     return ret;
   }
 
-  ret = sbp_null_terminated_string_strcmp(&a->command, &b->command,
-                                          &sbp_msg_command_req_tcommand_params);
+  ret = sbp_msg_command_req_t_command_strcmp(&a->command, &b->command);
   if (ret != 0) {
     return ret;
   }
@@ -1879,6 +1882,7 @@ s8 sbp_decode_sbp_msg_command_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_command_resp_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_command_resp_t *msg,
                                    sbp_write_fn_t write) {
@@ -2043,6 +2047,7 @@ s8 sbp_decode_sbp_msg_command_output_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_command_output_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_command_output_t *msg,
                                      sbp_write_fn_t write) {
@@ -2066,8 +2071,7 @@ int sbp_cmp_sbp_msg_command_output_t(const sbp_msg_command_output_t *a,
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(&a->line, &b->line,
-                                       &sbp_msg_command_output_tline_params);
+  ret = sbp_msg_command_output_t_line_strcmp(&a->line, &b->line);
   if (ret != 0) {
     return ret;
   }
@@ -2125,6 +2129,7 @@ s8 sbp_decode_sbp_msg_network_state_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_network_state_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_network_state_req_t *msg,
                                         sbp_write_fn_t write) {
@@ -2163,7 +2168,7 @@ size_t sbp_packed_size_sbp_msg_network_state_resp_t(
 
 bool encode_sbp_msg_network_state_resp_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg) {
-  for (uint8_t i = 0; i < 4; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
     if (!encode_u8(ctx, &msg->ipv4_address[i])) {
       return false;
     }
@@ -2171,7 +2176,7 @@ bool encode_sbp_msg_network_state_resp_t(
   if (!encode_u8(ctx, &msg->ipv4_mask_size)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     if (!encode_u8(ctx, &msg->ipv6_address[i])) {
       return false;
     }
@@ -2185,7 +2190,7 @@ bool encode_sbp_msg_network_state_resp_t(
   if (!encode_u32(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     if (!encode_char(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2262,6 +2267,7 @@ s8 sbp_decode_sbp_msg_network_state_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_network_state_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_resp_t *msg,
     sbp_write_fn_t write) {
@@ -2281,7 +2287,7 @@ int sbp_cmp_sbp_msg_network_state_resp_t(
     const sbp_msg_network_state_resp_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; i < 4 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
     ret = sbp_cmp_u8(&a->ipv4_address[i], &b->ipv4_address[i]);
   }
   if (ret != 0) {
@@ -2293,7 +2299,7 @@ int sbp_cmp_sbp_msg_network_state_resp_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     ret = sbp_cmp_u8(&a->ipv6_address[i], &b->ipv6_address[i]);
   }
   if (ret != 0) {
@@ -2315,7 +2321,7 @@ int sbp_cmp_sbp_msg_network_state_resp_t(
     return ret;
   }
 
-  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     ret = sbp_cmp_char(&a->interface_name[i], &b->interface_name[i]);
   }
   if (ret != 0) {
@@ -2353,7 +2359,7 @@ bool encode_sbp_network_usage_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     if (!encode_char(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2437,7 +2443,7 @@ int sbp_cmp_sbp_network_usage_t(const sbp_network_usage_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 16 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
     ret = sbp_cmp_char(&a->interface_name[i], &b->interface_name[i]);
   }
   if (ret != 0) {
@@ -2456,7 +2462,7 @@ size_t sbp_packed_size_sbp_msg_network_bandwidth_usage_t(
 
 bool encode_sbp_msg_network_bandwidth_usage_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_bandwidth_usage_t *msg) {
-  for (uint8_t i = 0; i < msg->n_interfaces; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_interfaces; i++) {
     if (!encode_sbp_network_usage_t(ctx, &msg->interfaces[i])) {
       return false;
     }
@@ -2508,6 +2514,7 @@ s8 sbp_decode_sbp_msg_network_bandwidth_usage_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_network_bandwidth_usage_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_network_bandwidth_usage_t *msg, sbp_write_fn_t write) {
@@ -2528,7 +2535,7 @@ int sbp_cmp_sbp_msg_network_bandwidth_usage_t(
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_interfaces, &b->n_interfaces);
-  for (uint8_t i = 0; i < a->n_interfaces && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_interfaces; i++) {
     ret = sbp_cmp_sbp_network_usage_t(&a->interfaces[i], &b->interfaces[i]);
   }
   if (ret != 0) {
@@ -2554,7 +2561,7 @@ bool encode_sbp_msg_cell_modem_status_t(
   if (!encode_float(ctx, &msg->signal_error_rate)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_reserved; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_reserved; i++) {
     if (!encode_u8(ctx, &msg->reserved[i])) {
       return false;
     }
@@ -2611,6 +2618,7 @@ s8 sbp_decode_sbp_msg_cell_modem_status_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_cell_modem_status_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_cell_modem_status_t *msg,
                                         sbp_write_fn_t write) {
@@ -2640,7 +2648,7 @@ int sbp_cmp_sbp_msg_cell_modem_status_t(const sbp_msg_cell_modem_status_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_reserved, &b->n_reserved);
-  for (uint8_t i = 0; i < a->n_reserved && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_reserved; i++) {
     ret = sbp_cmp_u8(&a->reserved[i], &b->reserved[i]);
   }
   if (ret != 0) {
@@ -2682,7 +2690,7 @@ bool encode_sbp_msg_specan_dep_t(sbp_encode_ctx_t *ctx,
   if (!encode_float(ctx, &msg->amplitude_unit)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_amplitude_value; i++) {
     if (!encode_u8(ctx, &msg->amplitude_value[i])) {
       return false;
     }
@@ -2751,6 +2759,7 @@ s8 sbp_decode_sbp_msg_specan_dep_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_specan_dep_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_specan_dep_t *msg,
                                  sbp_write_fn_t write) {
@@ -2800,7 +2809,7 @@ int sbp_cmp_sbp_msg_specan_dep_t(const sbp_msg_specan_dep_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_amplitude_value, &b->n_amplitude_value);
-  for (uint8_t i = 0; i < a->n_amplitude_value && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_amplitude_value; i++) {
     ret = sbp_cmp_u8(&a->amplitude_value[i], &b->amplitude_value[i]);
   }
   if (ret != 0) {
@@ -2842,7 +2851,7 @@ bool encode_sbp_msg_specan_t(sbp_encode_ctx_t *ctx,
   if (!encode_float(ctx, &msg->amplitude_unit)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_amplitude_value; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_amplitude_value; i++) {
     if (!encode_u8(ctx, &msg->amplitude_value[i])) {
       return false;
     }
@@ -2909,6 +2918,7 @@ s8 sbp_decode_sbp_msg_specan_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_specan_t(struct sbp_state *s, u16 sender_id,
                              const sbp_msg_specan_t *msg,
                              sbp_write_fn_t write) {
@@ -2958,7 +2968,7 @@ int sbp_cmp_sbp_msg_specan_t(const sbp_msg_specan_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_amplitude_value, &b->n_amplitude_value);
-  for (uint8_t i = 0; i < a->n_amplitude_value && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_amplitude_value; i++) {
     ret = sbp_cmp_u8(&a->amplitude_value[i], &b->amplitude_value[i]);
   }
   if (ret != 0) {
@@ -2977,12 +2987,12 @@ size_t sbp_packed_size_sbp_msg_front_end_gain_t(
 
 bool encode_sbp_msg_front_end_gain_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_front_end_gain_t *msg) {
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
     if (!encode_s8(ctx, &msg->rf_gain[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
     if (!encode_s8(ctx, &msg->if_gain[i])) {
       return false;
     }
@@ -3036,6 +3046,7 @@ s8 sbp_decode_sbp_msg_front_end_gain_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_front_end_gain_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_front_end_gain_t *msg,
                                      sbp_write_fn_t write) {
@@ -3054,14 +3065,14 @@ int sbp_cmp_sbp_msg_front_end_gain_t(const sbp_msg_front_end_gain_t *a,
                                      const sbp_msg_front_end_gain_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; i < 8 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
     ret = sbp_cmp_s8(&a->rf_gain[i], &b->rf_gain[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 8 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
     ret = sbp_cmp_s8(&a->if_gain[i], &b->if_gain[i]);
   }
   if (ret != 0) {

--- a/c/src/new/sbas.c
+++ b/c/src/new/sbas.c
@@ -1,38 +1,63 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/sbas.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/sbas.h>
 #include <libsbp/internal/new/sbas.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/sbas.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_sbas_raw_t(const sbp_msg_sbas_raw_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_u32(&msg->tow);
   packed_size += sbp_packed_size_u8(&msg->message_type);
-  packed_size += ( 27 * sbp_packed_size_u8(&msg->data[0]));
+  packed_size += (27 * sbp_packed_size_u8(&msg->data[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx, const sbp_msg_sbas_raw_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u8(ctx, &msg->message_type)) { return false; }
-  for (uint8_t i = 0; i < 27; i++)
-  {
-    if (!encode_u8(ctx, &msg->data[i])) { return false; }
+bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_sbas_raw_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->message_type)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 27; i++) {
+    if (!encode_u8(ctx, &msg->data[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_sbas_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_sbas_raw_t *msg) {
+s8 sbp_encode_sbp_msg_sbas_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_sbas_raw_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -46,18 +71,26 @@ s8 sbp_encode_sbp_msg_sbas_raw_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_sbas_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_sbas_raw_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u8(ctx, &msg->message_type)) { return false; }
+bool decode_sbp_msg_sbas_raw_t(sbp_decode_ctx_t *ctx, sbp_msg_sbas_raw_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->message_type)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 27; i++) {
-    if (!decode_u8(ctx, &msg->data[i])) { return false; }
+    if (!decode_u8(ctx, &msg->data[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_sbas_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_sbas_raw_t *msg) {
+s8 sbp_decode_sbp_msg_sbas_raw_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_sbas_raw_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -70,31 +103,44 @@ s8 sbp_decode_sbp_msg_sbas_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_sbas_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sbas_raw_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_sbas_raw_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_sbas_raw_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_sbas_raw_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SBAS_RAW, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_sbas_raw_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SBAS_RAW, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_sbas_raw_t(const sbp_msg_sbas_raw_t *a, const sbp_msg_sbas_raw_t *b) {
+int sbp_cmp_sbp_msg_sbas_raw_t(const sbp_msg_sbas_raw_t *a,
+                               const sbp_msg_sbas_raw_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->message_type, &b->message_type);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 27 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 27 && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->data[i], &b->data[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/sbas.c
+++ b/c/src/new/sbas.c
@@ -36,7 +36,7 @@ bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->message_type)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 27; i++) {
+  for (uint8_t i = 0; i < 27; i++) {
     if (!encode_u8(ctx, &msg->data[i])) {
       return false;
     }

--- a/c/src/new/sbas.c
+++ b/c/src/new/sbas.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/sbas.yaml
  * with generate.py. Please do not hand edit!
@@ -48,7 +36,7 @@ bool encode_sbp_msg_sbas_raw_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->message_type)) {
     return false;
   }
-  for (uint8_t i = 0; i < 27; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 27; i++) {
     if (!encode_u8(ctx, &msg->data[i])) {
       return false;
     }
@@ -103,6 +91,7 @@ s8 sbp_decode_sbp_msg_sbas_raw_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_sbas_raw_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_sbas_raw_t *msg,
                                sbp_write_fn_t write) {
@@ -136,7 +125,7 @@ int sbp_cmp_sbp_msg_sbas_raw_t(const sbp_msg_sbas_raw_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 27 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 27; i++) {
     ret = sbp_cmp_u8(&a->data[i], &b->data[i]);
   }
   if (ret != 0) {

--- a/c/src/new/settings.c
+++ b/c/src/new/settings.c
@@ -1,29 +1,49 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/settings.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/settings.h>
 #include <libsbp/internal/new/settings.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/settings.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_msg_settings_save_t(const sbp_msg_settings_save_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_save_t(
+    const sbp_msg_settings_save_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_settings_save_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_save_t *msg)
-{
+bool encode_sbp_msg_settings_save_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_settings_save_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_save_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_save_t *msg) {
+s8 sbp_encode_sbp_msg_settings_save_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_settings_save_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -37,14 +57,16 @@ s8 sbp_encode_sbp_msg_settings_save_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_save_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_save_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_settings_save_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_settings_save_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_save_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_save_t *msg) {
+s8 sbp_decode_sbp_msg_settings_save_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_settings_save_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -57,116 +79,138 @@ s8 sbp_decode_sbp_msg_settings_save_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_save_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_save_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_save_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_settings_save_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_save_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_SAVE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_save_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_SAVE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_save_t(const sbp_msg_settings_save_t *a, const sbp_msg_settings_save_t *b) {
+int sbp_cmp_sbp_msg_settings_save_t(const sbp_msg_settings_save_t *a,
+                                    const sbp_msg_settings_save_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_write_tsetting_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_write_tsetting_params = {.max_packed_len = 255};
 
-  void sbp_msg_settings_write_t_setting_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_settings_write_t_setting_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_settings_write_tsetting_params);
 }
 
-  bool sbp_msg_settings_write_t_setting_valid(const sbp_multipart_string_t *s)
-{
+bool sbp_msg_settings_write_t_setting_valid(const sbp_multipart_string_t *s) {
   return sbp_multipart_string_valid(s, &sbp_msg_settings_write_tsetting_params);
 }
 
-  int sbp_msg_settings_write_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_write_tsetting_params);
+int sbp_msg_settings_write_t_setting_strcmp(const sbp_multipart_string_t *a,
+                                            const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(a, b,
+                                     &sbp_msg_settings_write_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_write_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_write_tsetting_params);
+uint8_t sbp_msg_settings_write_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_write_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_write_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_write_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_write_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_write_tsetting_params);
+uint8_t sbp_msg_settings_write_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_write_tsetting_params);
+}
+uint8_t sbp_msg_settings_write_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_write_tsetting_params);
 }
 
-  bool sbp_msg_settings_write_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_write_tsetting_params, new_str);
+bool sbp_msg_settings_write_t_setting_add_section(sbp_multipart_string_t *s,
+                                                  const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_write_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_write_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_write_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_write_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
+bool sbp_msg_settings_write_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_write_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_write_tsetting_params, str);
+bool sbp_msg_settings_write_t_setting_append(sbp_multipart_string_t *s,
+                                             const char *str) {
+  return sbp_multipart_string_append(s, &sbp_msg_settings_write_tsetting_params,
+                                     str);
 }
 
-  bool sbp_msg_settings_write_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_write_t_setting_append_printf(sbp_multipart_string_t *s,
+                                                    const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_write_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
+bool sbp_msg_settings_write_t_setting_append_vprintf(sbp_multipart_string_t *s,
+                                                     const char *fmt,
+                                                     va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_write_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_write_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_write_tsetting_params, section);
+const char *sbp_msg_settings_write_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_write_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_write_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_write_tsetting_params, section);
+uint8_t sbp_msg_settings_write_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_write_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_write_t(const sbp_msg_settings_write_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_write_t(
+    const sbp_msg_settings_write_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_write_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_write_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_write_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_t *msg)
-{
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_write_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_write_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_settings_write_t *msg) {
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_write_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_write_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_write_t *msg) {
+s8 sbp_encode_sbp_msg_settings_write_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_settings_write_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -180,13 +224,18 @@ s8 sbp_encode_sbp_msg_settings_write_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_write_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_write_t *msg)
-{
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_write_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_write_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_settings_write_t *msg) {
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_write_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_write_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_write_t *msg) {
+s8 sbp_decode_sbp_msg_settings_write_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_settings_write_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -199,119 +248,147 @@ s8 sbp_decode_sbp_msg_settings_write_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_write_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_write_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_write_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_settings_write_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_write_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_WRITE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_write_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_WRITE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_write_t(const sbp_msg_settings_write_t *a, const sbp_msg_settings_write_t *b) {
+int sbp_cmp_sbp_msg_settings_write_t(const sbp_msg_settings_write_t *a,
+                                     const sbp_msg_settings_write_t *b) {
   int ret = 0;
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_write_tsetting_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                    &sbp_msg_settings_write_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_write_resp_tsetting_params = 
-{
-  .max_packed_len = 254
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_write_resp_tsetting_params = {.max_packed_len = 254};
 
-  void sbp_msg_settings_write_resp_t_setting_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_settings_write_resp_t_setting_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_settings_write_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_settings_write_resp_tsetting_params);
+bool sbp_msg_settings_write_resp_t_setting_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(
+      s, &sbp_msg_settings_write_resp_tsetting_params);
 }
 
-  int sbp_msg_settings_write_resp_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_write_resp_tsetting_params);
+int sbp_msg_settings_write_resp_t_setting_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_settings_write_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_write_resp_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_write_resp_tsetting_params);
+uint8_t sbp_msg_settings_write_resp_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_write_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_write_resp_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_write_resp_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_write_resp_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_write_resp_tsetting_params);
+uint8_t sbp_msg_settings_write_resp_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_write_resp_tsetting_params);
+}
+uint8_t sbp_msg_settings_write_resp_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_write_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_write_resp_tsetting_params, new_str);
+bool sbp_msg_settings_write_resp_t_setting_add_section(
+    sbp_multipart_string_t *s, const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_write_resp_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_write_resp_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_write_resp_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_write_resp_tsetting_params, str);
+bool sbp_msg_settings_write_resp_t_setting_append(sbp_multipart_string_t *s,
+                                                  const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_settings_write_resp_tsetting_params, str);
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_write_resp_t_setting_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_write_resp_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_write_resp_t_setting_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_write_resp_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_write_resp_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_write_resp_tsetting_params, section);
+const char *sbp_msg_settings_write_resp_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_write_resp_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_write_resp_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_write_resp_tsetting_params, section);
+uint8_t sbp_msg_settings_write_resp_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_write_resp_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_write_resp_t(const sbp_msg_settings_write_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_write_resp_t(
+    const sbp_msg_settings_write_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->status);
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_write_resp_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_write_resp_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_write_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_resp_t *msg)
-{
-  if (!encode_u8(ctx, &msg->status)) { return false; }
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_write_resp_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_write_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_resp_t *msg) {
+  if (!encode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_write_resp_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_write_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_write_resp_t *msg) {
+s8 sbp_encode_sbp_msg_settings_write_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_write_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -325,14 +402,21 @@ s8 sbp_encode_sbp_msg_settings_write_resp_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_write_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_write_resp_t *msg)
-{
-  if (!decode_u8(ctx, &msg->status)) { return false; }
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_write_resp_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_write_resp_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_settings_write_resp_t *msg) {
+  if (!decode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_write_resp_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_write_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_write_resp_t *msg) {
+s8 sbp_decode_sbp_msg_settings_write_resp_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_settings_write_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -345,120 +429,149 @@ s8 sbp_decode_sbp_msg_settings_write_resp_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_write_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_write_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_write_resp_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_settings_write_resp_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_write_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_WRITE_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_write_resp_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_WRITE_RESP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_write_resp_t(const sbp_msg_settings_write_resp_t *a, const sbp_msg_settings_write_resp_t *b) {
+int sbp_cmp_sbp_msg_settings_write_resp_t(
+    const sbp_msg_settings_write_resp_t *a,
+    const sbp_msg_settings_write_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->status, &b->status);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_write_resp_tsetting_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_multipart_string_strcmp(
+      &a->setting, &b->setting, &sbp_msg_settings_write_resp_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_read_req_tsetting_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_read_req_tsetting_params = {.max_packed_len = 255};
 
-  void sbp_msg_settings_read_req_t_setting_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_settings_read_req_t_setting_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_settings_read_req_tsetting_params);
 }
 
-  bool sbp_msg_settings_read_req_t_setting_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_settings_read_req_tsetting_params);
+bool sbp_msg_settings_read_req_t_setting_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(s,
+                                    &sbp_msg_settings_read_req_tsetting_params);
 }
 
-  int sbp_msg_settings_read_req_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_read_req_tsetting_params);
+int sbp_msg_settings_read_req_t_setting_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_settings_read_req_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_read_req_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_read_req_tsetting_params);
+uint8_t sbp_msg_settings_read_req_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_read_req_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_read_req_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_read_req_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_read_req_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_read_req_tsetting_params);
+uint8_t sbp_msg_settings_read_req_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_read_req_tsetting_params);
+}
+uint8_t sbp_msg_settings_read_req_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_read_req_tsetting_params);
 }
 
-  bool sbp_msg_settings_read_req_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_read_req_tsetting_params, new_str);
+bool sbp_msg_settings_read_req_t_setting_add_section(sbp_multipart_string_t *s,
+                                                     const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_read_req_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_read_req_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_read_req_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_read_req_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
+bool sbp_msg_settings_read_req_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_read_req_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_read_req_tsetting_params, str);
+bool sbp_msg_settings_read_req_t_setting_append(sbp_multipart_string_t *s,
+                                                const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_settings_read_req_tsetting_params, str);
 }
 
-  bool sbp_msg_settings_read_req_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_read_req_t_setting_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_read_req_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
+bool sbp_msg_settings_read_req_t_setting_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_read_req_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_read_req_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_read_req_tsetting_params, section);
+const char *sbp_msg_settings_read_req_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_read_req_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_read_req_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_read_req_tsetting_params, section);
+uint8_t sbp_msg_settings_read_req_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_read_req_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_read_req_t(const sbp_msg_settings_read_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_read_req_t(
+    const sbp_msg_settings_read_req_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_read_req_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_read_req_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_read_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_req_t *msg)
-{
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_read_req_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_read_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_req_t *msg) {
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_read_req_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_read_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_read_req_t *msg) {
+s8 sbp_encode_sbp_msg_settings_read_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_read_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -472,13 +585,18 @@ s8 sbp_encode_sbp_msg_settings_read_req_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_read_req_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_req_t *msg)
-{
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_read_req_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_read_req_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_settings_read_req_t *msg) {
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_read_req_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_read_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_read_req_t *msg) {
+s8 sbp_decode_sbp_msg_settings_read_req_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_settings_read_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -491,117 +609,143 @@ s8 sbp_decode_sbp_msg_settings_read_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_read_req_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_settings_read_req_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_read_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_read_req_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_REQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_read_req_t(const sbp_msg_settings_read_req_t *a, const sbp_msg_settings_read_req_t *b) {
+int sbp_cmp_sbp_msg_settings_read_req_t(const sbp_msg_settings_read_req_t *a,
+                                        const sbp_msg_settings_read_req_t *b) {
   int ret = 0;
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_read_req_tsetting_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                    &sbp_msg_settings_read_req_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_read_resp_tsetting_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_read_resp_tsetting_params = {.max_packed_len = 255};
 
-  void sbp_msg_settings_read_resp_t_setting_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_settings_read_resp_t_setting_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_settings_read_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_settings_read_resp_tsetting_params);
+bool sbp_msg_settings_read_resp_t_setting_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(
+      s, &sbp_msg_settings_read_resp_tsetting_params);
 }
 
-  int sbp_msg_settings_read_resp_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_read_resp_tsetting_params);
+int sbp_msg_settings_read_resp_t_setting_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_settings_read_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_read_resp_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_read_resp_tsetting_params);
+uint8_t sbp_msg_settings_read_resp_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_read_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_read_resp_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_read_resp_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_read_resp_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_read_resp_tsetting_params);
+uint8_t sbp_msg_settings_read_resp_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_read_resp_tsetting_params);
+}
+uint8_t sbp_msg_settings_read_resp_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_read_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_read_resp_tsetting_params, new_str);
+bool sbp_msg_settings_read_resp_t_setting_add_section(sbp_multipart_string_t *s,
+                                                      const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_read_resp_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_read_resp_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_read_resp_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_read_resp_tsetting_params, str);
+bool sbp_msg_settings_read_resp_t_setting_append(sbp_multipart_string_t *s,
+                                                 const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_settings_read_resp_tsetting_params, str);
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_read_resp_t_setting_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_read_resp_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_read_resp_t_setting_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_read_resp_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_read_resp_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_read_resp_tsetting_params, section);
+const char *sbp_msg_settings_read_resp_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_read_resp_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_read_resp_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_read_resp_tsetting_params, section);
+uint8_t sbp_msg_settings_read_resp_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_read_resp_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_read_resp_t(const sbp_msg_settings_read_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_read_resp_t(
+    const sbp_msg_settings_read_resp_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_read_resp_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_read_resp_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_read_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_resp_t *msg)
-{
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_read_resp_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_read_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_resp_t *msg) {
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_read_resp_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_read_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_read_resp_t *msg) {
+s8 sbp_encode_sbp_msg_settings_read_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_read_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -615,13 +759,18 @@ s8 sbp_encode_sbp_msg_settings_read_resp_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_read_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_resp_t *msg)
-{
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_read_resp_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_read_resp_t(sbp_decode_ctx_t *ctx,
+                                         sbp_msg_settings_read_resp_t *msg) {
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_read_resp_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_read_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_read_resp_t *msg) {
+s8 sbp_decode_sbp_msg_settings_read_resp_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_msg_settings_read_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -634,36 +783,51 @@ s8 sbp_decode_sbp_msg_settings_read_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_read_resp_t(
+    struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_resp_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_read_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_read_resp_t(payload, sizeof(payload),
+                                                   &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_RESP, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_read_resp_t(const sbp_msg_settings_read_resp_t *a, const sbp_msg_settings_read_resp_t *b) {
+int sbp_cmp_sbp_msg_settings_read_resp_t(
+    const sbp_msg_settings_read_resp_t *a,
+    const sbp_msg_settings_read_resp_t *b) {
   int ret = 0;
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_read_resp_tsetting_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_multipart_string_strcmp(
+      &a->setting, &b->setting, &sbp_msg_settings_read_resp_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_settings_read_by_index_req_t(const sbp_msg_settings_read_by_index_req_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_read_by_index_req_t(
+    const sbp_msg_settings_read_by_index_req_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->index);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_read_by_index_req_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_req_t *msg)
-{
-  if (!encode_u16(ctx, &msg->index)) { return false; }
+bool encode_sbp_msg_settings_read_by_index_req_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_req_t *msg) {
+  if (!encode_u16(ctx, &msg->index)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_read_by_index_req_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_read_by_index_req_t *msg) {
+s8 sbp_encode_sbp_msg_settings_read_by_index_req_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_read_by_index_req_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -677,13 +841,17 @@ s8 sbp_encode_sbp_msg_settings_read_by_index_req_t(uint8_t *buf, uint8_t len, ui
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_read_by_index_req_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_req_t *msg)
-{
-  if (!decode_u16(ctx, &msg->index)) { return false; }
+bool decode_sbp_msg_settings_read_by_index_req_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_req_t *msg) {
+  if (!decode_u16(ctx, &msg->index)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_read_by_index_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_read_by_index_req_t *msg) {
+s8 sbp_decode_sbp_msg_settings_read_by_index_req_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_settings_read_by_index_req_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -696,119 +864,151 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_req_t(const uint8_t *buf, uint8_t l
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_by_index_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_req_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_read_by_index_req_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_settings_read_by_index_req_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_read_by_index_req_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_BY_INDEX_REQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_read_by_index_req_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_BY_INDEX_REQ, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_read_by_index_req_t(const sbp_msg_settings_read_by_index_req_t *a, const sbp_msg_settings_read_by_index_req_t *b) {
+int sbp_cmp_sbp_msg_settings_read_by_index_req_t(
+    const sbp_msg_settings_read_by_index_req_t *a,
+    const sbp_msg_settings_read_by_index_req_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->index, &b->index);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_read_by_index_resp_tsetting_params = 
-{
-  .max_packed_len = 253
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_read_by_index_resp_tsetting_params = {.max_packed_len =
+                                                               253};
 
-  void sbp_msg_settings_read_by_index_resp_t_setting_init(sbp_multipart_string_t *s)
-{
-  sbp_multipart_string_init(s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+void sbp_msg_settings_read_by_index_resp_t_setting_init(
+    sbp_multipart_string_t *s) {
+  sbp_multipart_string_init(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+bool sbp_msg_settings_read_by_index_resp_t_setting_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
 }
 
-  int sbp_msg_settings_read_by_index_resp_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+int sbp_msg_settings_read_by_index_resp_t_setting_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_settings_read_by_index_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_read_by_index_resp_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+uint8_t sbp_msg_settings_read_by_index_resp_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_read_by_index_resp_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_read_by_index_resp_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+uint8_t sbp_msg_settings_read_by_index_resp_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+}
+uint8_t sbp_msg_settings_read_by_index_resp_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, new_str);
+bool sbp_msg_settings_read_by_index_resp_t_setting_add_section(
+    sbp_multipart_string_t *s, const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_read_by_index_resp_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_read_by_index_resp_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, str);
+bool sbp_msg_settings_read_by_index_resp_t_setting_append(
+    sbp_multipart_string_t *s, const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, str);
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_read_by_index_resp_t_setting_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_read_by_index_resp_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_read_by_index_resp_t_setting_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_read_by_index_resp_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, section);
+const char *sbp_msg_settings_read_by_index_resp_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_read_by_index_resp_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_read_by_index_resp_tsetting_params, section);
+uint8_t sbp_msg_settings_read_by_index_resp_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_read_by_index_resp_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_read_by_index_resp_t(const sbp_msg_settings_read_by_index_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_read_by_index_resp_t(
+    const sbp_msg_settings_read_by_index_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->index);
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_read_by_index_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_resp_t *msg)
-{
-  if (!encode_u16(ctx, &msg->index)) { return false; }
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_read_by_index_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_resp_t *msg) {
+  if (!encode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_read_by_index_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_read_by_index_resp_t *msg) {
+s8 sbp_encode_sbp_msg_settings_read_by_index_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_read_by_index_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -822,14 +1022,22 @@ s8 sbp_encode_sbp_msg_settings_read_by_index_resp_t(uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_read_by_index_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_resp_t *msg)
-{
-  if (!decode_u16(ctx, &msg->index)) { return false; }
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_read_by_index_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_resp_t *msg) {
+  if (!decode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_read_by_index_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_read_by_index_resp_t *msg) {
+s8 sbp_decode_sbp_msg_settings_read_by_index_resp_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_settings_read_by_index_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -842,39 +1050,55 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_resp_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_by_index_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_read_by_index_resp_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_settings_read_by_index_resp_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_read_by_index_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_read_by_index_resp_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_read_by_index_resp_t(const sbp_msg_settings_read_by_index_resp_t *a, const sbp_msg_settings_read_by_index_resp_t *b) {
+int sbp_cmp_sbp_msg_settings_read_by_index_resp_t(
+    const sbp_msg_settings_read_by_index_resp_t *a,
+    const sbp_msg_settings_read_by_index_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_read_by_index_resp_tsetting_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_multipart_string_strcmp(
+      &a->setting, &b->setting,
+      &sbp_msg_settings_read_by_index_resp_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_settings_read_by_index_done_t(const sbp_msg_settings_read_by_index_done_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_read_by_index_done_t(
+    const sbp_msg_settings_read_by_index_done_t *msg) {
   (void)msg;
   return 0;
 }
 
-bool encode_sbp_msg_settings_read_by_index_done_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_done_t *msg)
-{
+bool encode_sbp_msg_settings_read_by_index_done_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_by_index_done_t *msg) {
   (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_read_by_index_done_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_read_by_index_done_t *msg) {
+s8 sbp_encode_sbp_msg_settings_read_by_index_done_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_read_by_index_done_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -888,14 +1112,16 @@ s8 sbp_encode_sbp_msg_settings_read_by_index_done_t(uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_read_by_index_done_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_done_t *msg)
-{
-    (void)ctx;
+bool decode_sbp_msg_settings_read_by_index_done_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_read_by_index_done_t *msg) {
+  (void)ctx;
   (void)msg;
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_read_by_index_done_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_read_by_index_done_t *msg) {
+s8 sbp_decode_sbp_msg_settings_read_by_index_done_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_settings_read_by_index_done_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -908,116 +1134,140 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_done_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_by_index_done_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_done_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_read_by_index_done_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_settings_read_by_index_done_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_read_by_index_done_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_BY_INDEX_DONE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_read_by_index_done_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_READ_BY_INDEX_DONE, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_read_by_index_done_t(const sbp_msg_settings_read_by_index_done_t *a, const sbp_msg_settings_read_by_index_done_t *b) {
+int sbp_cmp_sbp_msg_settings_read_by_index_done_t(
+    const sbp_msg_settings_read_by_index_done_t *a,
+    const sbp_msg_settings_read_by_index_done_t *b) {
   (void)a;
   (void)b;
   int ret = 0;
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_register_tsetting_params = 
-{
-  .max_packed_len = 255
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_register_tsetting_params = {.max_packed_len = 255};
 
-  void sbp_msg_settings_register_t_setting_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_settings_register_t_setting_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_settings_register_tsetting_params);
 }
 
-  bool sbp_msg_settings_register_t_setting_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_settings_register_tsetting_params);
+bool sbp_msg_settings_register_t_setting_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(s,
+                                    &sbp_msg_settings_register_tsetting_params);
 }
 
-  int sbp_msg_settings_register_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_register_tsetting_params);
+int sbp_msg_settings_register_t_setting_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_settings_register_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_register_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_register_tsetting_params);
+uint8_t sbp_msg_settings_register_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_register_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_register_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_register_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_register_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_register_tsetting_params);
+uint8_t sbp_msg_settings_register_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_register_tsetting_params);
+}
+uint8_t sbp_msg_settings_register_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_register_tsetting_params);
 }
 
-  bool sbp_msg_settings_register_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_register_tsetting_params, new_str);
+bool sbp_msg_settings_register_t_setting_add_section(sbp_multipart_string_t *s,
+                                                     const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_register_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_register_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_register_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_register_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
+bool sbp_msg_settings_register_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_register_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_register_tsetting_params, str);
+bool sbp_msg_settings_register_t_setting_append(sbp_multipart_string_t *s,
+                                                const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_settings_register_tsetting_params, str);
 }
 
-  bool sbp_msg_settings_register_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_register_t_setting_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_register_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
+bool sbp_msg_settings_register_t_setting_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_register_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_register_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_register_tsetting_params, section);
+const char *sbp_msg_settings_register_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_register_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_register_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_register_tsetting_params, section);
+uint8_t sbp_msg_settings_register_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_register_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_register_t(const sbp_msg_settings_register_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_register_t(
+    const sbp_msg_settings_register_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_register_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_register_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_register_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_t *msg)
-{
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_register_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_register_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_t *msg) {
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_register_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_register_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_register_t *msg) {
+s8 sbp_encode_sbp_msg_settings_register_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_register_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1031,13 +1281,18 @@ s8 sbp_encode_sbp_msg_settings_register_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_register_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_register_t *msg)
-{
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_register_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_register_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_settings_register_t *msg) {
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_register_tsetting_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_register_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_register_t *msg) {
+s8 sbp_decode_sbp_msg_settings_register_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_settings_register_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1050,119 +1305,148 @@ s8 sbp_decode_sbp_msg_settings_register_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_register_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_register_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_register_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_settings_register_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_register_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_REGISTER, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_register_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_REGISTER, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_register_t(const sbp_msg_settings_register_t *a, const sbp_msg_settings_register_t *b) {
+int sbp_cmp_sbp_msg_settings_register_t(const sbp_msg_settings_register_t *a,
+                                        const sbp_msg_settings_register_t *b) {
   int ret = 0;
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_register_tsetting_params);
-  if (ret != 0) { return ret; }
+
+  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                    &sbp_msg_settings_register_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_multipart_string_params_t sbp_msg_settings_register_resp_tsetting_params = 
-{
-  .max_packed_len = 254
-};
+static const sbp_multipart_string_params_t
+    sbp_msg_settings_register_resp_tsetting_params = {.max_packed_len = 254};
 
-  void sbp_msg_settings_register_resp_t_setting_init(sbp_multipart_string_t *s)
-{
+void sbp_msg_settings_register_resp_t_setting_init(sbp_multipart_string_t *s) {
   sbp_multipart_string_init(s, &sbp_msg_settings_register_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_valid(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_valid(s, &sbp_msg_settings_register_resp_tsetting_params);
+bool sbp_msg_settings_register_resp_t_setting_valid(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_valid(
+      s, &sbp_msg_settings_register_resp_tsetting_params);
 }
 
-  int sbp_msg_settings_register_resp_t_setting_strcmp(const sbp_multipart_string_t *a, const sbp_multipart_string_t *b)
-{
-  return sbp_multipart_string_strcmp(a, b, &sbp_msg_settings_register_resp_tsetting_params);
+int sbp_msg_settings_register_resp_t_setting_strcmp(
+    const sbp_multipart_string_t *a, const sbp_multipart_string_t *b) {
+  return sbp_multipart_string_strcmp(
+      a, b, &sbp_msg_settings_register_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_register_resp_t_setting_packed_len(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_packed_len(s, &sbp_msg_settings_register_resp_tsetting_params);
+uint8_t sbp_msg_settings_register_resp_t_setting_packed_len(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_packed_len(
+      s, &sbp_msg_settings_register_resp_tsetting_params);
 }
 
-  uint8_t sbp_msg_settings_register_resp_t_setting_space_remaining(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_space_remaining(s, &sbp_msg_settings_register_resp_tsetting_params);
-      }
-  uint8_t sbp_msg_settings_register_resp_t_setting_count_sections(const sbp_multipart_string_t *s)
-{
-  return sbp_multipart_string_count_sections(s, &sbp_msg_settings_register_resp_tsetting_params);
+uint8_t sbp_msg_settings_register_resp_t_setting_space_remaining(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_space_remaining(
+      s, &sbp_msg_settings_register_resp_tsetting_params);
+}
+uint8_t sbp_msg_settings_register_resp_t_setting_count_sections(
+    const sbp_multipart_string_t *s) {
+  return sbp_multipart_string_count_sections(
+      s, &sbp_msg_settings_register_resp_tsetting_params);
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_add_section(sbp_multipart_string_t *s, const char *new_str)
-{
-  return sbp_multipart_string_add_section(s, &sbp_msg_settings_register_resp_tsetting_params, new_str);
+bool sbp_msg_settings_register_resp_t_setting_add_section(
+    sbp_multipart_string_t *s, const char *new_str) {
+  return sbp_multipart_string_add_section(
+      s, &sbp_msg_settings_register_resp_tsetting_params, new_str);
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_add_section_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_register_resp_t_setting_add_section_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_add_section_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_add_section_vprintf(s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_register_resp_t_setting_add_section_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_add_section_vprintf(
+      s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_append(sbp_multipart_string_t *s, const char *str)
-{
-  return sbp_multipart_string_append(s, &sbp_msg_settings_register_resp_tsetting_params, str);
+bool sbp_msg_settings_register_resp_t_setting_append(sbp_multipart_string_t *s,
+                                                     const char *str) {
+  return sbp_multipart_string_append(
+      s, &sbp_msg_settings_register_resp_tsetting_params, str);
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_append_printf(sbp_multipart_string_t *s, const char *fmt, ...) 
-{
+bool sbp_msg_settings_register_resp_t_setting_append_printf(
+    sbp_multipart_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_settings_register_resp_t_setting_append_vprintf(sbp_multipart_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_multipart_string_append_vprintf(s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
+bool sbp_msg_settings_register_resp_t_setting_append_vprintf(
+    sbp_multipart_string_t *s, const char *fmt, va_list ap) {
+  return sbp_multipart_string_append_vprintf(
+      s, &sbp_msg_settings_register_resp_tsetting_params, fmt, ap);
 }
 
-  const char *sbp_msg_settings_register_resp_t_setting_get_section(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_get_section(s, &sbp_msg_settings_register_resp_tsetting_params, section);
+const char *sbp_msg_settings_register_resp_t_setting_get_section(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_get_section(
+      s, &sbp_msg_settings_register_resp_tsetting_params, section);
 }
 
-  uint8_t sbp_msg_settings_register_resp_t_setting_section_strlen(const sbp_multipart_string_t *s, uint8_t section)
-{
-  return sbp_multipart_string_section_strlen(s, &sbp_msg_settings_register_resp_tsetting_params, section);
+uint8_t sbp_msg_settings_register_resp_t_setting_section_strlen(
+    const sbp_multipart_string_t *s, uint8_t section) {
+  return sbp_multipart_string_section_strlen(
+      s, &sbp_msg_settings_register_resp_tsetting_params, section);
 }
 
-size_t sbp_packed_size_sbp_msg_settings_register_resp_t(const sbp_msg_settings_register_resp_t *msg) {
+size_t sbp_packed_size_sbp_msg_settings_register_resp_t(
+    const sbp_msg_settings_register_resp_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->status);
-  packed_size += sbp_multipart_string_packed_len(&msg->setting, &sbp_msg_settings_register_resp_tsetting_params);
+  packed_size += sbp_multipart_string_packed_len(
+      &msg->setting, &sbp_msg_settings_register_resp_tsetting_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_settings_register_resp_t(sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_resp_t *msg)
-{
-  if (!encode_u8(ctx, &msg->status)) { return false; }
-  if (!sbp_multipart_string_pack(&msg->setting, &sbp_msg_settings_register_resp_tsetting_params, ctx)) { return false; }
+bool encode_sbp_msg_settings_register_resp_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_resp_t *msg) {
+  if (!encode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!sbp_multipart_string_pack(
+          &msg->setting, &sbp_msg_settings_register_resp_tsetting_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_settings_register_resp_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_settings_register_resp_t *msg) {
+s8 sbp_encode_sbp_msg_settings_register_resp_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_settings_register_resp_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1176,14 +1460,22 @@ s8 sbp_encode_sbp_msg_settings_register_resp_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_settings_register_resp_t(sbp_decode_ctx_t *ctx, sbp_msg_settings_register_resp_t *msg)
-{
-  if (!decode_u8(ctx, &msg->status)) { return false; }
-  if (!sbp_multipart_string_unpack(&msg->setting, &sbp_msg_settings_register_resp_tsetting_params, ctx)) { return false; }
+bool decode_sbp_msg_settings_register_resp_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_settings_register_resp_t *msg) {
+  if (!decode_u8(ctx, &msg->status)) {
+    return false;
+  }
+  if (!sbp_multipart_string_unpack(
+          &msg->setting, &sbp_msg_settings_register_resp_tsetting_params,
+          ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_settings_register_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_settings_register_resp_t *msg) {
+s8 sbp_decode_sbp_msg_settings_register_resp_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_settings_register_resp_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1196,22 +1488,35 @@ s8 sbp_decode_sbp_msg_settings_register_resp_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_register_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_register_resp_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_settings_register_resp_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_settings_register_resp_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_settings_register_resp_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SETTINGS_REGISTER_RESP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_settings_register_resp_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SETTINGS_REGISTER_RESP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_settings_register_resp_t(const sbp_msg_settings_register_resp_t *a, const sbp_msg_settings_register_resp_t *b) {
+int sbp_cmp_sbp_msg_settings_register_resp_t(
+    const sbp_msg_settings_register_resp_t *a,
+    const sbp_msg_settings_register_resp_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->status, &b->status);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting, &sbp_msg_settings_register_resp_tsetting_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_multipart_string_strcmp(
+      &a->setting, &b->setting,
+      &sbp_msg_settings_register_resp_tsetting_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/settings.c
+++ b/c/src/new/settings.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/settings.yaml
  * with generate.py. Please do not hand edit!
@@ -79,6 +67,7 @@ s8 sbp_decode_sbp_msg_settings_save_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_save_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_settings_save_t *msg,
                                     sbp_write_fn_t write) {
@@ -248,6 +237,7 @@ s8 sbp_decode_sbp_msg_settings_write_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_write_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_settings_write_t *msg,
                                      sbp_write_fn_t write) {
@@ -266,8 +256,7 @@ int sbp_cmp_sbp_msg_settings_write_t(const sbp_msg_settings_write_t *a,
                                      const sbp_msg_settings_write_t *b) {
   int ret = 0;
 
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting,
-                                    &sbp_msg_settings_write_tsetting_params);
+  ret = sbp_msg_settings_write_t_setting_strcmp(&a->setting, &b->setting);
   if (ret != 0) {
     return ret;
   }
@@ -429,6 +418,7 @@ s8 sbp_decode_sbp_msg_settings_write_resp_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_write_resp_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_settings_write_resp_t *msg, sbp_write_fn_t write) {
@@ -453,8 +443,7 @@ int sbp_cmp_sbp_msg_settings_write_resp_t(
     return ret;
   }
 
-  ret = sbp_multipart_string_strcmp(
-      &a->setting, &b->setting, &sbp_msg_settings_write_resp_tsetting_params);
+  ret = sbp_msg_settings_write_resp_t_setting_strcmp(&a->setting, &b->setting);
   if (ret != 0) {
     return ret;
   }
@@ -609,6 +598,7 @@ s8 sbp_decode_sbp_msg_settings_read_req_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_read_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_settings_read_req_t *msg,
                                         sbp_write_fn_t write) {
@@ -627,8 +617,7 @@ int sbp_cmp_sbp_msg_settings_read_req_t(const sbp_msg_settings_read_req_t *a,
                                         const sbp_msg_settings_read_req_t *b) {
   int ret = 0;
 
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting,
-                                    &sbp_msg_settings_read_req_tsetting_params);
+  ret = sbp_msg_settings_read_req_t_setting_strcmp(&a->setting, &b->setting);
   if (ret != 0) {
     return ret;
   }
@@ -783,6 +772,7 @@ s8 sbp_decode_sbp_msg_settings_read_resp_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_read_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_resp_t *msg,
     sbp_write_fn_t write) {
@@ -802,8 +792,7 @@ int sbp_cmp_sbp_msg_settings_read_resp_t(
     const sbp_msg_settings_read_resp_t *b) {
   int ret = 0;
 
-  ret = sbp_multipart_string_strcmp(
-      &a->setting, &b->setting, &sbp_msg_settings_read_resp_tsetting_params);
+  ret = sbp_msg_settings_read_resp_t_setting_strcmp(&a->setting, &b->setting);
   if (ret != 0) {
     return ret;
   }
@@ -864,6 +853,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_req_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_read_by_index_req_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_settings_read_by_index_req_t *msg, sbp_write_fn_t write) {
@@ -1050,6 +1040,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_resp_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_read_by_index_resp_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_settings_read_by_index_resp_t *msg, sbp_write_fn_t write) {
@@ -1074,9 +1065,8 @@ int sbp_cmp_sbp_msg_settings_read_by_index_resp_t(
     return ret;
   }
 
-  ret = sbp_multipart_string_strcmp(
-      &a->setting, &b->setting,
-      &sbp_msg_settings_read_by_index_resp_tsetting_params);
+  ret = sbp_msg_settings_read_by_index_resp_t_setting_strcmp(&a->setting,
+                                                             &b->setting);
   if (ret != 0) {
     return ret;
   }
@@ -1134,6 +1124,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_done_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_read_by_index_done_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_settings_read_by_index_done_t *msg, sbp_write_fn_t write) {
@@ -1305,6 +1296,7 @@ s8 sbp_decode_sbp_msg_settings_register_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_register_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_settings_register_t *msg,
                                         sbp_write_fn_t write) {
@@ -1323,8 +1315,7 @@ int sbp_cmp_sbp_msg_settings_register_t(const sbp_msg_settings_register_t *a,
                                         const sbp_msg_settings_register_t *b) {
   int ret = 0;
 
-  ret = sbp_multipart_string_strcmp(&a->setting, &b->setting,
-                                    &sbp_msg_settings_register_tsetting_params);
+  ret = sbp_msg_settings_register_t_setting_strcmp(&a->setting, &b->setting);
   if (ret != 0) {
     return ret;
   }
@@ -1488,6 +1479,7 @@ s8 sbp_decode_sbp_msg_settings_register_resp_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_settings_register_resp_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_settings_register_resp_t *msg, sbp_write_fn_t write) {
@@ -1512,9 +1504,8 @@ int sbp_cmp_sbp_msg_settings_register_resp_t(
     return ret;
   }
 
-  ret = sbp_multipart_string_strcmp(
-      &a->setting, &b->setting,
-      &sbp_msg_settings_register_resp_tsetting_params);
+  ret =
+      sbp_msg_settings_register_resp_t_setting_strcmp(&a->setting, &b->setting);
   if (ret != 0) {
     return ret;
   }

--- a/c/src/new/solution_meta.c
+++ b/c/src/new/solution_meta.c
@@ -136,7 +136,7 @@ bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->last_used_gnss_vel_tow)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_sol_in; i++) {
+  for (uint8_t i = 0; i < msg->n_sol_in; i++) {
     if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
       return false;
     }
@@ -314,7 +314,7 @@ bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->age_gnss)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_sol_in; i++) {
+  for (uint8_t i = 0; i < msg->n_sol_in; i++) {
     if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
       return false;
     }

--- a/c/src/new/solution_meta.c
+++ b/c/src/new/solution_meta.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/solution_meta.yaml
  * with generate.py. Please do not hand edit!
@@ -148,7 +136,7 @@ bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->last_used_gnss_vel_tow)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_sol_in; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_sol_in; i++) {
     if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
       return false;
     }
@@ -224,6 +212,7 @@ s8 sbp_decode_sbp_msg_soln_meta_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_soln_meta_dep_a_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_soln_meta_dep_a_t *msg,
                                       sbp_write_fn_t write) {
@@ -283,7 +272,7 @@ int sbp_cmp_sbp_msg_soln_meta_dep_a_t(const sbp_msg_soln_meta_dep_a_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_sol_in, &b->n_sol_in);
-  for (uint8_t i = 0; i < a->n_sol_in && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_sol_in; i++) {
     ret = sbp_cmp_sbp_solution_input_type_t(&a->sol_in[i], &b->sol_in[i]);
   }
   if (ret != 0) {
@@ -325,7 +314,7 @@ bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->age_gnss)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_sol_in; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_sol_in; i++) {
     if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
       return false;
     }
@@ -393,6 +382,7 @@ s8 sbp_decode_sbp_msg_soln_meta_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_soln_meta_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_soln_meta_t *msg,
                                 sbp_write_fn_t write) {
@@ -442,7 +432,7 @@ int sbp_cmp_sbp_msg_soln_meta_t(const sbp_msg_soln_meta_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_sol_in, &b->n_sol_in);
-  for (uint8_t i = 0; i < a->n_sol_in && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_sol_in; i++) {
     ret = sbp_cmp_sbp_solution_input_type_t(&a->sol_in[i], &b->sol_in[i]);
   }
   if (ret != 0) {

--- a/c/src/new/solution_meta.c
+++ b/c/src/new/solution_meta.c
@@ -1,31 +1,55 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/solution_meta.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/solution_meta.h>
 #include <libsbp/internal/new/solution_meta.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/solution_meta.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_solution_input_type_t(const sbp_solution_input_type_t *msg) {
+size_t sbp_packed_size_sbp_solution_input_type_t(
+    const sbp_solution_input_type_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->sensor_type);
   packed_size += sbp_packed_size_u8(&msg->flags);
   return packed_size;
 }
 
-bool encode_sbp_solution_input_type_t(sbp_encode_ctx_t *ctx, const sbp_solution_input_type_t *msg)
-{
-  if (!encode_u8(ctx, &msg->sensor_type)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_solution_input_type_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_solution_input_type_t *msg) {
+  if (!encode_u8(ctx, &msg->sensor_type)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_solution_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_solution_input_type_t *msg) {
+s8 sbp_encode_sbp_solution_input_type_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_solution_input_type_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -39,14 +63,20 @@ s8 sbp_encode_sbp_solution_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_solution_input_type_t(sbp_decode_ctx_t *ctx, sbp_solution_input_type_t *msg)
-{
-  if (!decode_u8(ctx, &msg->sensor_type)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_solution_input_type_t(sbp_decode_ctx_t *ctx,
+                                      sbp_solution_input_type_t *msg) {
+  if (!decode_u8(ctx, &msg->sensor_type)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_solution_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_solution_input_type_t *msg) {
+s8 sbp_decode_sbp_solution_input_type_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_solution_input_type_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -60,18 +90,24 @@ s8 sbp_decode_sbp_solution_input_type_t(const uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_solution_input_type_t(const sbp_solution_input_type_t *a, const sbp_solution_input_type_t *b) {
+int sbp_cmp_sbp_solution_input_type_t(const sbp_solution_input_type_t *a,
+                                      const sbp_solution_input_type_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->sensor_type, &b->sensor_type);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_soln_meta_dep_a_t(const sbp_msg_soln_meta_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_soln_meta_dep_a_t(
+    const sbp_msg_soln_meta_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->pdop);
   packed_size += sbp_packed_size_u16(&msg->hdop);
@@ -81,28 +117,48 @@ size_t sbp_packed_size_sbp_msg_soln_meta_dep_a_t(const sbp_msg_soln_meta_dep_a_t
   packed_size += sbp_packed_size_u8(&msg->alignment_status);
   packed_size += sbp_packed_size_u32(&msg->last_used_gnss_pos_tow);
   packed_size += sbp_packed_size_u32(&msg->last_used_gnss_vel_tow);
-  packed_size += (msg->n_sol_in * sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
+  packed_size += (msg->n_sol_in *
+                  sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_soln_meta_dep_a_t *msg)
-{
-  if (!encode_u16(ctx, &msg->pdop)) { return false; }
-  if (!encode_u16(ctx, &msg->hdop)) { return false; }
-  if (!encode_u16(ctx, &msg->vdop)) { return false; }
-  if (!encode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!encode_u16(ctx, &msg->age_corrections)) { return false; }
-  if (!encode_u8(ctx, &msg->alignment_status)) { return false; }
-  if (!encode_u32(ctx, &msg->last_used_gnss_pos_tow)) { return false; }
-  if (!encode_u32(ctx, &msg->last_used_gnss_vel_tow)) { return false; }
-  for (uint8_t i = 0; i < msg->n_sol_in; i++)
-  {
-    if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) { return false; }
+bool encode_sbp_msg_soln_meta_dep_a_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_soln_meta_dep_a_t *msg) {
+  if (!encode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->age_corrections)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->alignment_status)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->last_used_gnss_pos_tow)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->last_used_gnss_vel_tow)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_sol_in; i++) {
+    if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_soln_meta_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_soln_meta_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_soln_meta_dep_a_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_soln_meta_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -116,24 +172,46 @@ s8 sbp_encode_sbp_msg_soln_meta_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_soln_meta_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_soln_meta_dep_a_t *msg)
-{
-  if (!decode_u16(ctx, &msg->pdop)) { return false; }
-  if (!decode_u16(ctx, &msg->hdop)) { return false; }
-  if (!decode_u16(ctx, &msg->vdop)) { return false; }
-  if (!decode_u8(ctx, &msg->n_sats)) { return false; }
-  if (!decode_u16(ctx, &msg->age_corrections)) { return false; }
-  if (!decode_u8(ctx, &msg->alignment_status)) { return false; }
-  if (!decode_u32(ctx, &msg->last_used_gnss_pos_tow)) { return false; }
-  if (!decode_u32(ctx, &msg->last_used_gnss_vel_tow)) { return false; }
-    msg->n_sol_in = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
+bool decode_sbp_msg_soln_meta_dep_a_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_soln_meta_dep_a_t *msg) {
+  if (!decode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->age_corrections)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->alignment_status)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->last_used_gnss_pos_tow)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->last_used_gnss_vel_tow)) {
+    return false;
+  }
+  msg->n_sol_in =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
   for (uint8_t i = 0; i < msg->n_sol_in; i++) {
-    if (!decode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) { return false; }
+    if (!decode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_soln_meta_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_soln_meta_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_soln_meta_dep_a_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_soln_meta_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -146,48 +224,71 @@ s8 sbp_decode_sbp_msg_soln_meta_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_soln_meta_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_soln_meta_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_soln_meta_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_soln_meta_dep_a_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_soln_meta_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SOLN_META_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_soln_meta_dep_a_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SOLN_META_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_soln_meta_dep_a_t(const sbp_msg_soln_meta_dep_a_t *a, const sbp_msg_soln_meta_dep_a_t *b) {
+int sbp_cmp_sbp_msg_soln_meta_dep_a_t(const sbp_msg_soln_meta_dep_a_t *a,
+                                      const sbp_msg_soln_meta_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->pdop, &b->pdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hdop, &b->hdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vdop, &b->vdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sats, &b->n_sats);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->age_corrections, &b->age_corrections);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->alignment_status, &b->alignment_status);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->last_used_gnss_pos_tow, &b->last_used_gnss_pos_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->last_used_gnss_vel_tow, &b->last_used_gnss_vel_tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sol_in, &b->n_sol_in);
-  for (uint8_t i = 0; i < a->n_sol_in && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_sol_in && ret == 0; i++) {
     ret = sbp_cmp_sbp_solution_input_type_t(&a->sol_in[i], &b->sol_in[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -199,26 +300,41 @@ size_t sbp_packed_size_sbp_msg_soln_meta_t(const sbp_msg_soln_meta_t *msg) {
   packed_size += sbp_packed_size_u16(&msg->vdop);
   packed_size += sbp_packed_size_u16(&msg->age_corrections);
   packed_size += sbp_packed_size_u32(&msg->age_gnss);
-  packed_size += (msg->n_sol_in * sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
+  packed_size += (msg->n_sol_in *
+                  sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx, const sbp_msg_soln_meta_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u16(ctx, &msg->pdop)) { return false; }
-  if (!encode_u16(ctx, &msg->hdop)) { return false; }
-  if (!encode_u16(ctx, &msg->vdop)) { return false; }
-  if (!encode_u16(ctx, &msg->age_corrections)) { return false; }
-  if (!encode_u32(ctx, &msg->age_gnss)) { return false; }
-  for (uint8_t i = 0; i < msg->n_sol_in; i++)
-  {
-    if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) { return false; }
+bool encode_sbp_msg_soln_meta_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_soln_meta_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->age_corrections)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->age_gnss)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_sol_in; i++) {
+    if (!encode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_soln_meta_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_soln_meta_t *msg) {
+s8 sbp_encode_sbp_msg_soln_meta_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_soln_meta_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -232,22 +348,39 @@ s8 sbp_encode_sbp_msg_soln_meta_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_soln_meta_t(sbp_decode_ctx_t *ctx, sbp_msg_soln_meta_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u16(ctx, &msg->pdop)) { return false; }
-  if (!decode_u16(ctx, &msg->hdop)) { return false; }
-  if (!decode_u16(ctx, &msg->vdop)) { return false; }
-  if (!decode_u16(ctx, &msg->age_corrections)) { return false; }
-  if (!decode_u32(ctx, &msg->age_gnss)) { return false; }
-    msg->n_sol_in = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
+bool decode_sbp_msg_soln_meta_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_soln_meta_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->pdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->hdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->vdop)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->age_corrections)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->age_gnss)) {
+    return false;
+  }
+  msg->n_sol_in =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_solution_input_type_t(&msg->sol_in[0]));
   for (uint8_t i = 0; i < msg->n_sol_in; i++) {
-    if (!decode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) { return false; }
+    if (!decode_sbp_solution_input_type_t(ctx, &msg->sol_in[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_soln_meta_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_soln_meta_t *msg) {
+s8 sbp_decode_sbp_msg_soln_meta_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_soln_meta_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -260,42 +393,61 @@ s8 sbp_decode_sbp_msg_soln_meta_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_soln_meta_t(struct sbp_state *s, u16 sender_id, const sbp_msg_soln_meta_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_soln_meta_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_soln_meta_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_soln_meta_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SOLN_META, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_soln_meta_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SOLN_META, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_soln_meta_t(const sbp_msg_soln_meta_t *a, const sbp_msg_soln_meta_t *b) {
+int sbp_cmp_sbp_msg_soln_meta_t(const sbp_msg_soln_meta_t *a,
+                                const sbp_msg_soln_meta_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->pdop, &b->pdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->hdop, &b->hdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->vdop, &b->vdop);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->age_corrections, &b->age_corrections);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->age_gnss, &b->age_gnss);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_sol_in, &b->n_sol_in);
-  for (uint8_t i = 0; i < a->n_sol_in && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_sol_in && ret == 0; i++) {
     ret = sbp_cmp_sbp_solution_input_type_t(&a->sol_in[i], &b->sol_in[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -305,13 +457,17 @@ size_t sbp_packed_size_sbp_gnss_input_type_t(const sbp_gnss_input_type_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_gnss_input_type_t(sbp_encode_ctx_t *ctx, const sbp_gnss_input_type_t *msg)
-{
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_gnss_input_type_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_gnss_input_type_t *msg) {
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gnss_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gnss_input_type_t *msg) {
+s8 sbp_encode_sbp_gnss_input_type_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_gnss_input_type_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -325,13 +481,17 @@ s8 sbp_encode_sbp_gnss_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_gnss_input_type_t(sbp_decode_ctx_t *ctx, sbp_gnss_input_type_t *msg)
-{
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_gnss_input_type_t(sbp_decode_ctx_t *ctx,
+                                  sbp_gnss_input_type_t *msg) {
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gnss_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gnss_input_type_t *msg) {
+s8 sbp_decode_sbp_gnss_input_type_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_gnss_input_type_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -345,11 +505,14 @@ s8 sbp_decode_sbp_gnss_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gnss_input_type_t(const sbp_gnss_input_type_t *a, const sbp_gnss_input_type_t *b) {
+int sbp_cmp_sbp_gnss_input_type_t(const sbp_gnss_input_type_t *a,
+                                  const sbp_gnss_input_type_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -359,13 +522,17 @@ size_t sbp_packed_size_sbp_imu_input_type_t(const sbp_imu_input_type_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_imu_input_type_t(sbp_encode_ctx_t *ctx, const sbp_imu_input_type_t *msg)
-{
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_imu_input_type_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_imu_input_type_t *msg) {
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_imu_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_imu_input_type_t *msg) {
+s8 sbp_encode_sbp_imu_input_type_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_imu_input_type_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -379,13 +546,16 @@ s8 sbp_encode_sbp_imu_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_imu_input_type_t(sbp_decode_ctx_t *ctx, sbp_imu_input_type_t *msg)
-{
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_imu_input_type_t(sbp_decode_ctx_t *ctx,
+                                 sbp_imu_input_type_t *msg) {
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_imu_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_imu_input_type_t *msg) {
+s8 sbp_decode_sbp_imu_input_type_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_imu_input_type_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -399,11 +569,14 @@ s8 sbp_decode_sbp_imu_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_imu_input_type_t(const sbp_imu_input_type_t *a, const sbp_imu_input_type_t *b) {
+int sbp_cmp_sbp_imu_input_type_t(const sbp_imu_input_type_t *a,
+                                 const sbp_imu_input_type_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -413,13 +586,17 @@ size_t sbp_packed_size_sbp_odo_input_type_t(const sbp_odo_input_type_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_odo_input_type_t(sbp_encode_ctx_t *ctx, const sbp_odo_input_type_t *msg)
-{
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_odo_input_type_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_odo_input_type_t *msg) {
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_odo_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_odo_input_type_t *msg) {
+s8 sbp_encode_sbp_odo_input_type_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_odo_input_type_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -433,13 +610,16 @@ s8 sbp_encode_sbp_odo_input_type_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_odo_input_type_t(sbp_decode_ctx_t *ctx, sbp_odo_input_type_t *msg)
-{
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_odo_input_type_t(sbp_decode_ctx_t *ctx,
+                                 sbp_odo_input_type_t *msg) {
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_odo_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_odo_input_type_t *msg) {
+s8 sbp_decode_sbp_odo_input_type_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_odo_input_type_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -453,10 +633,13 @@ s8 sbp_decode_sbp_odo_input_type_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_odo_input_type_t(const sbp_odo_input_type_t *a, const sbp_odo_input_type_t *b) {
+int sbp_cmp_sbp_odo_input_type_t(const sbp_odo_input_type_t *a,
+                                 const sbp_odo_input_type_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/ssr.c
+++ b/c/src/new/ssr.c
@@ -1,31 +1,55 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/ssr.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/ssr.h>
 #include <libsbp/internal/new/ssr.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/new/ssr.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_code_biases_content_t(const sbp_code_biases_content_t *msg) {
+size_t sbp_packed_size_sbp_code_biases_content_t(
+    const sbp_code_biases_content_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->code);
   packed_size += sbp_packed_size_s16(&msg->value);
   return packed_size;
 }
 
-bool encode_sbp_code_biases_content_t(sbp_encode_ctx_t *ctx, const sbp_code_biases_content_t *msg)
-{
-  if (!encode_u8(ctx, &msg->code)) { return false; }
-  if (!encode_s16(ctx, &msg->value)) { return false; }
+bool encode_sbp_code_biases_content_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_code_biases_content_t *msg) {
+  if (!encode_u8(ctx, &msg->code)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->value)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_code_biases_content_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_code_biases_content_t *msg) {
+s8 sbp_encode_sbp_code_biases_content_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_code_biases_content_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -39,14 +63,20 @@ s8 sbp_encode_sbp_code_biases_content_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_code_biases_content_t(sbp_decode_ctx_t *ctx, sbp_code_biases_content_t *msg)
-{
-  if (!decode_u8(ctx, &msg->code)) { return false; }
-  if (!decode_s16(ctx, &msg->value)) { return false; }
+bool decode_sbp_code_biases_content_t(sbp_decode_ctx_t *ctx,
+                                      sbp_code_biases_content_t *msg) {
+  if (!decode_u8(ctx, &msg->code)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->value)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_code_biases_content_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_code_biases_content_t *msg) {
+s8 sbp_decode_sbp_code_biases_content_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_code_biases_content_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -60,18 +90,24 @@ s8 sbp_decode_sbp_code_biases_content_t(const uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_code_biases_content_t(const sbp_code_biases_content_t *a, const sbp_code_biases_content_t *b) {
+int sbp_cmp_sbp_code_biases_content_t(const sbp_code_biases_content_t *a,
+                                      const sbp_code_biases_content_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->code, &b->code);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->value, &b->value);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_phase_biases_content_t(const sbp_phase_biases_content_t *msg) {
+size_t sbp_packed_size_sbp_phase_biases_content_t(
+    const sbp_phase_biases_content_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->code);
   packed_size += sbp_packed_size_u8(&msg->integer_indicator);
@@ -81,17 +117,29 @@ size_t sbp_packed_size_sbp_phase_biases_content_t(const sbp_phase_biases_content
   return packed_size;
 }
 
-bool encode_sbp_phase_biases_content_t(sbp_encode_ctx_t *ctx, const sbp_phase_biases_content_t *msg)
-{
-  if (!encode_u8(ctx, &msg->code)) { return false; }
-  if (!encode_u8(ctx, &msg->integer_indicator)) { return false; }
-  if (!encode_u8(ctx, &msg->widelane_integer_indicator)) { return false; }
-  if (!encode_u8(ctx, &msg->discontinuity_counter)) { return false; }
-  if (!encode_s32(ctx, &msg->bias)) { return false; }
+bool encode_sbp_phase_biases_content_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_phase_biases_content_t *msg) {
+  if (!encode_u8(ctx, &msg->code)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->integer_indicator)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->widelane_integer_indicator)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->discontinuity_counter)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->bias)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_phase_biases_content_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_phase_biases_content_t *msg) {
+s8 sbp_encode_sbp_phase_biases_content_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_phase_biases_content_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -105,17 +153,29 @@ s8 sbp_encode_sbp_phase_biases_content_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_phase_biases_content_t(sbp_decode_ctx_t *ctx, sbp_phase_biases_content_t *msg)
-{
-  if (!decode_u8(ctx, &msg->code)) { return false; }
-  if (!decode_u8(ctx, &msg->integer_indicator)) { return false; }
-  if (!decode_u8(ctx, &msg->widelane_integer_indicator)) { return false; }
-  if (!decode_u8(ctx, &msg->discontinuity_counter)) { return false; }
-  if (!decode_s32(ctx, &msg->bias)) { return false; }
+bool decode_sbp_phase_biases_content_t(sbp_decode_ctx_t *ctx,
+                                       sbp_phase_biases_content_t *msg) {
+  if (!decode_u8(ctx, &msg->code)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->integer_indicator)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->widelane_integer_indicator)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->discontinuity_counter)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->bias)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_phase_biases_content_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_phase_biases_content_t *msg) {
+s8 sbp_decode_sbp_phase_biases_content_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_phase_biases_content_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -129,23 +189,35 @@ s8 sbp_decode_sbp_phase_biases_content_t(const uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_phase_biases_content_t(const sbp_phase_biases_content_t *a, const sbp_phase_biases_content_t *b) {
+int sbp_cmp_sbp_phase_biases_content_t(const sbp_phase_biases_content_t *a,
+                                       const sbp_phase_biases_content_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->code, &b->code);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->integer_indicator, &b->integer_indicator);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u8(&a->widelane_integer_indicator, &b->widelane_integer_indicator);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_u8(&a->widelane_integer_indicator,
+                   &b->widelane_integer_indicator);
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->discontinuity_counter, &b->discontinuity_counter);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->bias, &b->bias);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -161,19 +233,34 @@ size_t sbp_packed_size_sbp_stec_header_t(const sbp_stec_header_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_stec_header_t(sbp_encode_ctx_t *ctx, const sbp_stec_header_t *msg)
-{
-  if (!encode_u16(ctx, &msg->tile_set_id)) { return false; }
-  if (!encode_u16(ctx, &msg->tile_id)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->num_msgs)) { return false; }
-  if (!encode_u8(ctx, &msg->seq_num)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_atmo)) { return false; }
+bool encode_sbp_stec_header_t(sbp_encode_ctx_t *ctx,
+                              const sbp_stec_header_t *msg) {
+  if (!encode_u16(ctx, &msg->tile_set_id)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->tile_id)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_stec_header_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_stec_header_t *msg) {
+s8 sbp_encode_sbp_stec_header_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_stec_header_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -187,19 +274,33 @@ s8 sbp_encode_sbp_stec_header_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_stec_header_t(sbp_decode_ctx_t *ctx, sbp_stec_header_t *msg)
-{
-  if (!decode_u16(ctx, &msg->tile_set_id)) { return false; }
-  if (!decode_u16(ctx, &msg->tile_id)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->num_msgs)) { return false; }
-  if (!decode_u8(ctx, &msg->seq_num)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_atmo)) { return false; }
+bool decode_sbp_stec_header_t(sbp_decode_ctx_t *ctx, sbp_stec_header_t *msg) {
+  if (!decode_u16(ctx, &msg->tile_set_id)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->tile_id)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_stec_header_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_stec_header_t *msg) {
+s8 sbp_decode_sbp_stec_header_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_stec_header_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -213,33 +314,49 @@ s8 sbp_decode_sbp_stec_header_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_stec_header_t(const sbp_stec_header_t *a, const sbp_stec_header_t *b) {
+int sbp_cmp_sbp_stec_header_t(const sbp_stec_header_t *a,
+                              const sbp_stec_header_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->tile_set_id, &b->tile_set_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->tile_id, &b->tile_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->num_msgs, &b->num_msgs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->seq_num, &b->seq_num);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_atmo, &b->iod_atmo);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_gridded_correction_header_t(const sbp_gridded_correction_header_t *msg) {
+size_t sbp_packed_size_sbp_gridded_correction_header_t(
+    const sbp_gridded_correction_header_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->tile_set_id);
   packed_size += sbp_packed_size_u16(&msg->tile_id);
@@ -252,20 +369,38 @@ size_t sbp_packed_size_sbp_gridded_correction_header_t(const sbp_gridded_correct
   return packed_size;
 }
 
-bool encode_sbp_gridded_correction_header_t(sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_t *msg)
-{
-  if (!encode_u16(ctx, &msg->tile_set_id)) { return false; }
-  if (!encode_u16(ctx, &msg->tile_id)) { return false; }
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_u16(ctx, &msg->num_msgs)) { return false; }
-  if (!encode_u16(ctx, &msg->seq_num)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_atmo)) { return false; }
-  if (!encode_u8(ctx, &msg->tropo_quality_indicator)) { return false; }
+bool encode_sbp_gridded_correction_header_t(
+    sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_t *msg) {
+  if (!encode_u16(ctx, &msg->tile_set_id)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->tile_id)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tropo_quality_indicator)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gridded_correction_header_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gridded_correction_header_t *msg) {
+s8 sbp_encode_sbp_gridded_correction_header_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_gridded_correction_header_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -279,20 +414,38 @@ s8 sbp_encode_sbp_gridded_correction_header_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_gridded_correction_header_t(sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_t *msg)
-{
-  if (!decode_u16(ctx, &msg->tile_set_id)) { return false; }
-  if (!decode_u16(ctx, &msg->tile_id)) { return false; }
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_u16(ctx, &msg->num_msgs)) { return false; }
-  if (!decode_u16(ctx, &msg->seq_num)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_atmo)) { return false; }
-  if (!decode_u8(ctx, &msg->tropo_quality_indicator)) { return false; }
+bool decode_sbp_gridded_correction_header_t(
+    sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_t *msg) {
+  if (!decode_u16(ctx, &msg->tile_set_id)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->tile_id)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tropo_quality_indicator)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gridded_correction_header_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gridded_correction_header_t *msg) {
+s8 sbp_decode_sbp_gridded_correction_header_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_gridded_correction_header_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -306,55 +459,81 @@ s8 sbp_decode_sbp_gridded_correction_header_t(const uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gridded_correction_header_t(const sbp_gridded_correction_header_t *a, const sbp_gridded_correction_header_t *b) {
+int sbp_cmp_sbp_gridded_correction_header_t(
+    const sbp_gridded_correction_header_t *a,
+    const sbp_gridded_correction_header_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->tile_set_id, &b->tile_set_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->tile_id, &b->tile_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->num_msgs, &b->num_msgs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->seq_num, &b->seq_num);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_atmo, &b->iod_atmo);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tropo_quality_indicator, &b->tropo_quality_indicator);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_stec_sat_element_t(const sbp_stec_sat_element_t *msg) {
+size_t sbp_packed_size_sbp_stec_sat_element_t(
+    const sbp_stec_sat_element_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sv_id_t(&msg->sv_id);
   packed_size += sbp_packed_size_u8(&msg->stec_quality_indicator);
-  packed_size += ( 4 * sbp_packed_size_s16(&msg->stec_coeff[0]));
+  packed_size += (4 * sbp_packed_size_s16(&msg->stec_coeff[0]));
   return packed_size;
 }
 
-bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx, const sbp_stec_sat_element_t *msg)
-{
-  if (!encode_sbp_sv_id_t(ctx, &msg->sv_id)) { return false; }
-  if (!encode_u8(ctx, &msg->stec_quality_indicator)) { return false; }
-  for (uint8_t i = 0; i < 4; i++)
-  {
-    if (!encode_s16(ctx, &msg->stec_coeff[i])) { return false; }
+bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_stec_sat_element_t *msg) {
+  if (!encode_sbp_sv_id_t(ctx, &msg->sv_id)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->stec_quality_indicator)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 4; i++) {
+    if (!encode_s16(ctx, &msg->stec_coeff[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_stec_sat_element_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_stec_sat_element_t *msg) {
+s8 sbp_encode_sbp_stec_sat_element_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_stec_sat_element_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -368,17 +547,25 @@ s8 sbp_encode_sbp_stec_sat_element_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_stec_sat_element_t(sbp_decode_ctx_t *ctx, sbp_stec_sat_element_t *msg)
-{
-  if (!decode_sbp_sv_id_t(ctx, &msg->sv_id)) { return false; }
-  if (!decode_u8(ctx, &msg->stec_quality_indicator)) { return false; }
+bool decode_sbp_stec_sat_element_t(sbp_decode_ctx_t *ctx,
+                                   sbp_stec_sat_element_t *msg) {
+  if (!decode_sbp_sv_id_t(ctx, &msg->sv_id)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->stec_quality_indicator)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 4; i++) {
-    if (!decode_s16(ctx, &msg->stec_coeff[i])) { return false; }
+    if (!decode_s16(ctx, &msg->stec_coeff[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_stec_sat_element_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_stec_sat_element_t *msg) {
+s8 sbp_decode_sbp_stec_sat_element_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_stec_sat_element_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -392,38 +579,52 @@ s8 sbp_decode_sbp_stec_sat_element_t(const uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_stec_sat_element_t(const sbp_stec_sat_element_t *a, const sbp_stec_sat_element_t *b) {
+int sbp_cmp_sbp_stec_sat_element_t(const sbp_stec_sat_element_t *a,
+                                   const sbp_stec_sat_element_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sv_id_t(&a->sv_id, &b->sv_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->stec_quality_indicator, &b->stec_quality_indicator);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 4 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 4 && ret == 0; i++) {
     ret = sbp_cmp_s16(&a->stec_coeff[i], &b->stec_coeff[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tropospheric_delay_correction_no_std_t(const sbp_tropospheric_delay_correction_no_std_t *msg) {
+size_t sbp_packed_size_sbp_tropospheric_delay_correction_no_std_t(
+    const sbp_tropospheric_delay_correction_no_std_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s16(&msg->hydro);
   packed_size += sbp_packed_size_s8(&msg->wet);
   return packed_size;
 }
 
-bool encode_sbp_tropospheric_delay_correction_no_std_t(sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_no_std_t *msg)
-{
-  if (!encode_s16(ctx, &msg->hydro)) { return false; }
-  if (!encode_s8(ctx, &msg->wet)) { return false; }
+bool encode_sbp_tropospheric_delay_correction_no_std_t(
+    sbp_encode_ctx_t *ctx,
+    const sbp_tropospheric_delay_correction_no_std_t *msg) {
+  if (!encode_s16(ctx, &msg->hydro)) {
+    return false;
+  }
+  if (!encode_s8(ctx, &msg->wet)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tropospheric_delay_correction_no_std_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tropospheric_delay_correction_no_std_t *msg) {
+s8 sbp_encode_sbp_tropospheric_delay_correction_no_std_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tropospheric_delay_correction_no_std_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -437,14 +638,20 @@ s8 sbp_encode_sbp_tropospheric_delay_correction_no_std_t(uint8_t *buf, uint8_t l
   return SBP_OK;
 }
 
-bool decode_sbp_tropospheric_delay_correction_no_std_t(sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_no_std_t *msg)
-{
-  if (!decode_s16(ctx, &msg->hydro)) { return false; }
-  if (!decode_s8(ctx, &msg->wet)) { return false; }
+bool decode_sbp_tropospheric_delay_correction_no_std_t(
+    sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_no_std_t *msg) {
+  if (!decode_s16(ctx, &msg->hydro)) {
+    return false;
+  }
+  if (!decode_s8(ctx, &msg->wet)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tropospheric_delay_correction_no_std_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tropospheric_delay_correction_no_std_t *msg) {
+s8 sbp_decode_sbp_tropospheric_delay_correction_no_std_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_tropospheric_delay_correction_no_std_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -458,18 +665,25 @@ s8 sbp_decode_sbp_tropospheric_delay_correction_no_std_t(const uint8_t *buf, uin
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tropospheric_delay_correction_no_std_t(const sbp_tropospheric_delay_correction_no_std_t *a, const sbp_tropospheric_delay_correction_no_std_t *b) {
+int sbp_cmp_sbp_tropospheric_delay_correction_no_std_t(
+    const sbp_tropospheric_delay_correction_no_std_t *a,
+    const sbp_tropospheric_delay_correction_no_std_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s16(&a->hydro, &b->hydro);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s8(&a->wet, &b->wet);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tropospheric_delay_correction_t(const sbp_tropospheric_delay_correction_t *msg) {
+size_t sbp_packed_size_sbp_tropospheric_delay_correction_t(
+    const sbp_tropospheric_delay_correction_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s16(&msg->hydro);
   packed_size += sbp_packed_size_s8(&msg->wet);
@@ -477,15 +691,23 @@ size_t sbp_packed_size_sbp_tropospheric_delay_correction_t(const sbp_tropospheri
   return packed_size;
 }
 
-bool encode_sbp_tropospheric_delay_correction_t(sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_t *msg)
-{
-  if (!encode_s16(ctx, &msg->hydro)) { return false; }
-  if (!encode_s8(ctx, &msg->wet)) { return false; }
-  if (!encode_u8(ctx, &msg->stddev)) { return false; }
+bool encode_sbp_tropospheric_delay_correction_t(
+    sbp_encode_ctx_t *ctx, const sbp_tropospheric_delay_correction_t *msg) {
+  if (!encode_s16(ctx, &msg->hydro)) {
+    return false;
+  }
+  if (!encode_s8(ctx, &msg->wet)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->stddev)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tropospheric_delay_correction_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tropospheric_delay_correction_t *msg) {
+s8 sbp_encode_sbp_tropospheric_delay_correction_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tropospheric_delay_correction_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -499,15 +721,23 @@ s8 sbp_encode_sbp_tropospheric_delay_correction_t(uint8_t *buf, uint8_t len, uin
   return SBP_OK;
 }
 
-bool decode_sbp_tropospheric_delay_correction_t(sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_t *msg)
-{
-  if (!decode_s16(ctx, &msg->hydro)) { return false; }
-  if (!decode_s8(ctx, &msg->wet)) { return false; }
-  if (!decode_u8(ctx, &msg->stddev)) { return false; }
+bool decode_sbp_tropospheric_delay_correction_t(
+    sbp_decode_ctx_t *ctx, sbp_tropospheric_delay_correction_t *msg) {
+  if (!decode_s16(ctx, &msg->hydro)) {
+    return false;
+  }
+  if (!decode_s8(ctx, &msg->wet)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->stddev)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tropospheric_delay_correction_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tropospheric_delay_correction_t *msg) {
+s8 sbp_decode_sbp_tropospheric_delay_correction_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_tropospheric_delay_correction_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -521,35 +751,50 @@ s8 sbp_decode_sbp_tropospheric_delay_correction_t(const uint8_t *buf, uint8_t le
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tropospheric_delay_correction_t(const sbp_tropospheric_delay_correction_t *a, const sbp_tropospheric_delay_correction_t *b) {
+int sbp_cmp_sbp_tropospheric_delay_correction_t(
+    const sbp_tropospheric_delay_correction_t *a,
+    const sbp_tropospheric_delay_correction_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s16(&a->hydro, &b->hydro);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s8(&a->wet, &b->wet);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->stddev, &b->stddev);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_stec_residual_no_std_t(const sbp_stec_residual_no_std_t *msg) {
+size_t sbp_packed_size_sbp_stec_residual_no_std_t(
+    const sbp_stec_residual_no_std_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sv_id_t(&msg->sv_id);
   packed_size += sbp_packed_size_s16(&msg->residual);
   return packed_size;
 }
 
-bool encode_sbp_stec_residual_no_std_t(sbp_encode_ctx_t *ctx, const sbp_stec_residual_no_std_t *msg)
-{
-  if (!encode_sbp_sv_id_t(ctx, &msg->sv_id)) { return false; }
-  if (!encode_s16(ctx, &msg->residual)) { return false; }
+bool encode_sbp_stec_residual_no_std_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_stec_residual_no_std_t *msg) {
+  if (!encode_sbp_sv_id_t(ctx, &msg->sv_id)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->residual)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_stec_residual_no_std_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_stec_residual_no_std_t *msg) {
+s8 sbp_encode_sbp_stec_residual_no_std_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_stec_residual_no_std_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -563,14 +808,20 @@ s8 sbp_encode_sbp_stec_residual_no_std_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_stec_residual_no_std_t(sbp_decode_ctx_t *ctx, sbp_stec_residual_no_std_t *msg)
-{
-  if (!decode_sbp_sv_id_t(ctx, &msg->sv_id)) { return false; }
-  if (!decode_s16(ctx, &msg->residual)) { return false; }
+bool decode_sbp_stec_residual_no_std_t(sbp_decode_ctx_t *ctx,
+                                       sbp_stec_residual_no_std_t *msg) {
+  if (!decode_sbp_sv_id_t(ctx, &msg->sv_id)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->residual)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_stec_residual_no_std_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_stec_residual_no_std_t *msg) {
+s8 sbp_decode_sbp_stec_residual_no_std_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_stec_residual_no_std_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -584,14 +835,19 @@ s8 sbp_decode_sbp_stec_residual_no_std_t(const uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_stec_residual_no_std_t(const sbp_stec_residual_no_std_t *a, const sbp_stec_residual_no_std_t *b) {
+int sbp_cmp_sbp_stec_residual_no_std_t(const sbp_stec_residual_no_std_t *a,
+                                       const sbp_stec_residual_no_std_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sv_id_t(&a->sv_id, &b->sv_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->residual, &b->residual);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -603,15 +859,22 @@ size_t sbp_packed_size_sbp_stec_residual_t(const sbp_stec_residual_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_stec_residual_t(sbp_encode_ctx_t *ctx, const sbp_stec_residual_t *msg)
-{
-  if (!encode_sbp_sv_id_t(ctx, &msg->sv_id)) { return false; }
-  if (!encode_s16(ctx, &msg->residual)) { return false; }
-  if (!encode_u8(ctx, &msg->stddev)) { return false; }
+bool encode_sbp_stec_residual_t(sbp_encode_ctx_t *ctx,
+                                const sbp_stec_residual_t *msg) {
+  if (!encode_sbp_sv_id_t(ctx, &msg->sv_id)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->residual)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->stddev)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_stec_residual_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_stec_residual_t *msg) {
+s8 sbp_encode_sbp_stec_residual_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_stec_residual_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -625,15 +888,22 @@ s8 sbp_encode_sbp_stec_residual_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_stec_residual_t(sbp_decode_ctx_t *ctx, sbp_stec_residual_t *msg)
-{
-  if (!decode_sbp_sv_id_t(ctx, &msg->sv_id)) { return false; }
-  if (!decode_s16(ctx, &msg->residual)) { return false; }
-  if (!decode_u8(ctx, &msg->stddev)) { return false; }
+bool decode_sbp_stec_residual_t(sbp_decode_ctx_t *ctx,
+                                sbp_stec_residual_t *msg) {
+  if (!decode_sbp_sv_id_t(ctx, &msg->sv_id)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->residual)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->stddev)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_stec_residual_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_stec_residual_t *msg) {
+s8 sbp_decode_sbp_stec_residual_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_stec_residual_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -647,21 +917,29 @@ s8 sbp_decode_sbp_stec_residual_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_stec_residual_t(const sbp_stec_residual_t *a, const sbp_stec_residual_t *b) {
+int sbp_cmp_sbp_stec_residual_t(const sbp_stec_residual_t *a,
+                                const sbp_stec_residual_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sv_id_t(&a->sv_id, &b->sv_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->residual, &b->residual);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->stddev, &b->stddev);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_orbit_clock_t(const sbp_msg_ssr_orbit_clock_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_orbit_clock_t(
+    const sbp_msg_ssr_orbit_clock_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->time);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
@@ -680,26 +958,56 @@ size_t sbp_packed_size_sbp_msg_ssr_orbit_clock_t(const sbp_msg_ssr_orbit_clock_t
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_orbit_clock_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_ssr)) { return false; }
-  if (!encode_u32(ctx, &msg->iod)) { return false; }
-  if (!encode_s32(ctx, &msg->radial)) { return false; }
-  if (!encode_s32(ctx, &msg->along)) { return false; }
-  if (!encode_s32(ctx, &msg->cross)) { return false; }
-  if (!encode_s32(ctx, &msg->dot_radial)) { return false; }
-  if (!encode_s32(ctx, &msg->dot_along)) { return false; }
-  if (!encode_s32(ctx, &msg->dot_cross)) { return false; }
-  if (!encode_s32(ctx, &msg->c0)) { return false; }
-  if (!encode_s32(ctx, &msg->c1)) { return false; }
-  if (!encode_s32(ctx, &msg->c2)) { return false; }
+bool encode_sbp_msg_ssr_orbit_clock_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ssr_orbit_clock_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->iod)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->radial)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->along)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cross)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->dot_radial)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->dot_along)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->dot_cross)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->c0)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->c1)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->c2)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_orbit_clock_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_orbit_clock_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_orbit_clock_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_ssr_orbit_clock_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -713,26 +1021,56 @@ s8 sbp_encode_sbp_msg_ssr_orbit_clock_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_orbit_clock_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_ssr)) { return false; }
-  if (!decode_u32(ctx, &msg->iod)) { return false; }
-  if (!decode_s32(ctx, &msg->radial)) { return false; }
-  if (!decode_s32(ctx, &msg->along)) { return false; }
-  if (!decode_s32(ctx, &msg->cross)) { return false; }
-  if (!decode_s32(ctx, &msg->dot_radial)) { return false; }
-  if (!decode_s32(ctx, &msg->dot_along)) { return false; }
-  if (!decode_s32(ctx, &msg->dot_cross)) { return false; }
-  if (!decode_s32(ctx, &msg->c0)) { return false; }
-  if (!decode_s32(ctx, &msg->c1)) { return false; }
-  if (!decode_s32(ctx, &msg->c2)) { return false; }
+bool decode_sbp_msg_ssr_orbit_clock_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ssr_orbit_clock_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->iod)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->radial)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->along)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cross)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->dot_radial)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->dot_along)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->dot_cross)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->c0)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->c1)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->c2)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_orbit_clock_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_orbit_clock_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_orbit_clock_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_ssr_orbit_clock_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -745,86 +1083,133 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_orbit_clock_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_orbit_clock_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_ssr_orbit_clock_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_orbit_clock_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_ORBIT_CLOCK, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_orbit_clock_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_ORBIT_CLOCK, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_orbit_clock_t(const sbp_msg_ssr_orbit_clock_t *a, const sbp_msg_ssr_orbit_clock_t *b) {
+int sbp_cmp_sbp_msg_ssr_orbit_clock_t(const sbp_msg_ssr_orbit_clock_t *a,
+                                      const sbp_msg_ssr_orbit_clock_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_ssr, &b->iod_ssr);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->iod, &b->iod);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->radial, &b->radial);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->along, &b->along);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cross, &b->cross);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->dot_radial, &b->dot_radial);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->dot_along, &b->dot_along);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->dot_cross, &b->dot_cross);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->c0, &b->c0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->c1, &b->c1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->c2, &b->c2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_code_biases_t(const sbp_msg_ssr_code_biases_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_code_biases_t(
+    const sbp_msg_ssr_code_biases_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->time);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_u8(&msg->update_interval);
   packed_size += sbp_packed_size_u8(&msg->iod_ssr);
-  packed_size += (msg->n_biases * sbp_packed_size_sbp_code_biases_content_t(&msg->biases[0]));
+  packed_size += (msg->n_biases *
+                  sbp_packed_size_sbp_code_biases_content_t(&msg->biases[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_code_biases_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_ssr)) { return false; }
-  for (uint8_t i = 0; i < msg->n_biases; i++)
-  {
-    if (!encode_sbp_code_biases_content_t(ctx, &msg->biases[i])) { return false; }
+bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx,
+                                      const sbp_msg_ssr_code_biases_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_biases; i++) {
+    if (!encode_sbp_code_biases_content_t(ctx, &msg->biases[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_code_biases_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_code_biases_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_code_biases_t(uint8_t *buf, uint8_t len,
+                                        uint8_t *n_written,
+                                        const sbp_msg_ssr_code_biases_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -838,20 +1223,34 @@ s8 sbp_encode_sbp_msg_ssr_code_biases_t(uint8_t *buf, uint8_t len, uint8_t *n_wr
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_code_biases_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_code_biases_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_ssr)) { return false; }
-    msg->n_biases = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_code_biases_content_t(&msg->biases[0]));
+bool decode_sbp_msg_ssr_code_biases_t(sbp_decode_ctx_t *ctx,
+                                      sbp_msg_ssr_code_biases_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  msg->n_biases =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_code_biases_content_t(&msg->biases[0]));
   for (uint8_t i = 0; i < msg->n_biases; i++) {
-    if (!decode_sbp_code_biases_content_t(ctx, &msg->biases[i])) { return false; }
+    if (!decode_sbp_code_biases_content_t(ctx, &msg->biases[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_code_biases_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_code_biases_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_code_biases_t(const uint8_t *buf, uint8_t len,
+                                        uint8_t *n_read,
+                                        sbp_msg_ssr_code_biases_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -864,40 +1263,56 @@ s8 sbp_decode_sbp_msg_ssr_code_biases_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_code_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_code_biases_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_code_biases_t(struct sbp_state *s, u16 sender_id,
+                                      const sbp_msg_ssr_code_biases_t *msg,
+                                      sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_code_biases_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_CODE_BIASES, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_code_biases_t(payload, sizeof(payload),
+                                                &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_CODE_BIASES, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_code_biases_t(const sbp_msg_ssr_code_biases_t *a, const sbp_msg_ssr_code_biases_t *b) {
+int sbp_cmp_sbp_msg_ssr_code_biases_t(const sbp_msg_ssr_code_biases_t *a,
+                                      const sbp_msg_ssr_code_biases_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_ssr, &b->iod_ssr);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_biases, &b->n_biases);
-  for (uint8_t i = 0; i < a->n_biases && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_biases && ret == 0; i++) {
     ret = sbp_cmp_sbp_code_biases_content_t(&a->biases[i], &b->biases[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_phase_biases_t(const sbp_msg_ssr_phase_biases_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_phase_biases_t(
+    const sbp_msg_ssr_phase_biases_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->time);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
@@ -907,28 +1322,48 @@ size_t sbp_packed_size_sbp_msg_ssr_phase_biases_t(const sbp_msg_ssr_phase_biases
   packed_size += sbp_packed_size_u8(&msg->mw_consistency);
   packed_size += sbp_packed_size_u16(&msg->yaw);
   packed_size += sbp_packed_size_s8(&msg->yaw_rate);
-  packed_size += (msg->n_biases * sbp_packed_size_sbp_phase_biases_content_t(&msg->biases[0]));
+  packed_size += (msg->n_biases *
+                  sbp_packed_size_sbp_phase_biases_content_t(&msg->biases[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_phase_biases_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_ssr)) { return false; }
-  if (!encode_u8(ctx, &msg->dispersive_bias)) { return false; }
-  if (!encode_u8(ctx, &msg->mw_consistency)) { return false; }
-  if (!encode_u16(ctx, &msg->yaw)) { return false; }
-  if (!encode_s8(ctx, &msg->yaw_rate)) { return false; }
-  for (uint8_t i = 0; i < msg->n_biases; i++)
-  {
-    if (!encode_sbp_phase_biases_content_t(ctx, &msg->biases[i])) { return false; }
+bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_ssr_phase_biases_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->dispersive_bias)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->mw_consistency)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->yaw)) {
+    return false;
+  }
+  if (!encode_s8(ctx, &msg->yaw_rate)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_biases; i++) {
+    if (!encode_sbp_phase_biases_content_t(ctx, &msg->biases[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_phase_biases_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_phase_biases_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_phase_biases_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_phase_biases_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -942,24 +1377,46 @@ s8 sbp_encode_sbp_msg_ssr_phase_biases_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_phase_biases_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_phase_biases_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_ssr)) { return false; }
-  if (!decode_u8(ctx, &msg->dispersive_bias)) { return false; }
-  if (!decode_u8(ctx, &msg->mw_consistency)) { return false; }
-  if (!decode_u16(ctx, &msg->yaw)) { return false; }
-  if (!decode_s8(ctx, &msg->yaw_rate)) { return false; }
-    msg->n_biases = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_phase_biases_content_t(&msg->biases[0]));
+bool decode_sbp_msg_ssr_phase_biases_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_ssr_phase_biases_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->dispersive_bias)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->mw_consistency)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->yaw)) {
+    return false;
+  }
+  if (!decode_s8(ctx, &msg->yaw_rate)) {
+    return false;
+  }
+  msg->n_biases =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_phase_biases_content_t(&msg->biases[0]));
   for (uint8_t i = 0; i < msg->n_biases; i++) {
-    if (!decode_sbp_phase_biases_content_t(ctx, &msg->biases[i])) { return false; }
+    if (!decode_sbp_phase_biases_content_t(ctx, &msg->biases[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_phase_biases_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_phase_biases_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_phase_biases_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_ssr_phase_biases_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -972,69 +1429,99 @@ s8 sbp_decode_sbp_msg_ssr_phase_biases_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_phase_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_phase_biases_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_phase_biases_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_ssr_phase_biases_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_phase_biases_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_PHASE_BIASES, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_phase_biases_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_PHASE_BIASES, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_phase_biases_t(const sbp_msg_ssr_phase_biases_t *a, const sbp_msg_ssr_phase_biases_t *b) {
+int sbp_cmp_sbp_msg_ssr_phase_biases_t(const sbp_msg_ssr_phase_biases_t *a,
+                                       const sbp_msg_ssr_phase_biases_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_ssr, &b->iod_ssr);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->dispersive_bias, &b->dispersive_bias);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->mw_consistency, &b->mw_consistency);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->yaw, &b->yaw);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s8(&a->yaw_rate, &b->yaw_rate);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_biases, &b->n_biases);
-  for (uint8_t i = 0; i < a->n_biases && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_biases && ret == 0; i++) {
     ret = sbp_cmp_sbp_phase_biases_content_t(&a->biases[i], &b->biases[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_stec_correction_t(const sbp_msg_ssr_stec_correction_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_stec_correction_t(
+    const sbp_msg_ssr_stec_correction_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_stec_header_t(&msg->header);
-  packed_size += (msg->n_stec_sat_list * sbp_packed_size_sbp_stec_sat_element_t(&msg->stec_sat_list[0]));
+  packed_size += (msg->n_stec_sat_list * sbp_packed_size_sbp_stec_sat_element_t(
+                                             &msg->stec_sat_list[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_stec_correction_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_t *msg)
-{
-  if (!encode_sbp_stec_header_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++)
-  {
-    if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) { return false; }
+bool encode_sbp_msg_ssr_stec_correction_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_t *msg) {
+  if (!encode_sbp_stec_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
+    if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_stec_correction_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_stec_correction_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_stec_correction_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_stec_correction_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1048,17 +1535,25 @@ s8 sbp_encode_sbp_msg_ssr_stec_correction_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_stec_correction_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_t *msg)
-{
-  if (!decode_sbp_stec_header_t(ctx, &msg->header)) { return false; }
-    msg->n_stec_sat_list = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_stec_sat_element_t(&msg->stec_sat_list[0]));
+bool decode_sbp_msg_ssr_stec_correction_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ssr_stec_correction_t *msg) {
+  if (!decode_sbp_stec_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_stec_sat_list =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_stec_sat_element_t(&msg->stec_sat_list[0]));
   for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
-    if (!decode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) { return false; }
+    if (!decode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_stec_correction_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_stec_correction_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_stec_correction_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_stec_correction_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1071,52 +1566,76 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_stec_correction_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_stec_correction_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_stec_correction_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_stec_correction_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_stec_correction_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_STEC_CORRECTION, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_stec_correction_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_STEC_CORRECTION, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_stec_correction_t(const sbp_msg_ssr_stec_correction_t *a, const sbp_msg_ssr_stec_correction_t *b) {
+int sbp_cmp_sbp_msg_ssr_stec_correction_t(
+    const sbp_msg_ssr_stec_correction_t *a,
+    const sbp_msg_ssr_stec_correction_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_stec_header_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u8(&a->n_stec_sat_list, &b->n_stec_sat_list);
-  for (uint8_t i = 0; i < a->n_stec_sat_list && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_stec_sat_element_t(&a->stec_sat_list[i], &b->stec_sat_list[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_u8(&a->n_stec_sat_list, &b->n_stec_sat_list);
+  for (uint8_t i = 0; i < a->n_stec_sat_list && ret == 0; i++) {
+    ret = sbp_cmp_sbp_stec_sat_element_t(&a->stec_sat_list[i],
+                                         &b->stec_sat_list[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_gridded_correction_t(const sbp_msg_ssr_gridded_correction_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_gridded_correction_t(
+    const sbp_msg_ssr_gridded_correction_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gridded_correction_header_t(&msg->header);
   packed_size += sbp_packed_size_u16(&msg->index);
-  packed_size += sbp_packed_size_sbp_tropospheric_delay_correction_t(&msg->tropo_delay_correction);
-  packed_size += (msg->n_stec_residuals * sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
+  packed_size += sbp_packed_size_sbp_tropospheric_delay_correction_t(
+      &msg->tropo_delay_correction);
+  packed_size += (msg->n_stec_residuals *
+                  sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_gridded_correction_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_t *msg)
-{
-  if (!encode_sbp_gridded_correction_header_t(ctx, &msg->header)) { return false; }
-  if (!encode_u16(ctx, &msg->index)) { return false; }
-  if (!encode_sbp_tropospheric_delay_correction_t(ctx, &msg->tropo_delay_correction)) { return false; }
-  for (uint8_t i = 0; i < msg->n_stec_residuals; i++)
-  {
-    if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) { return false; }
+bool encode_sbp_msg_ssr_gridded_correction_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_t *msg) {
+  if (!encode_sbp_gridded_correction_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!encode_sbp_tropospheric_delay_correction_t(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+    if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_gridded_correction_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_gridded_correction_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_gridded_correction_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_gridded_correction_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1130,19 +1649,32 @@ s8 sbp_encode_sbp_msg_ssr_gridded_correction_t(uint8_t *buf, uint8_t len, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_gridded_correction_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_t *msg)
-{
-  if (!decode_sbp_gridded_correction_header_t(ctx, &msg->header)) { return false; }
-  if (!decode_u16(ctx, &msg->index)) { return false; }
-  if (!decode_sbp_tropospheric_delay_correction_t(ctx, &msg->tropo_delay_correction)) { return false; }
-    msg->n_stec_residuals = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
+bool decode_sbp_msg_ssr_gridded_correction_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_t *msg) {
+  if (!decode_sbp_gridded_correction_header_t(ctx, &msg->header)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!decode_sbp_tropospheric_delay_correction_t(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  msg->n_stec_residuals =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
   for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
-    if (!decode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) { return false; }
+    if (!decode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_gridded_correction_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_gridded_correction_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_gridded_correction_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_gridded_correction_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1155,37 +1687,54 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_gridded_correction_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_gridded_correction_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_gridded_correction_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_gridded_correction_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_gridded_correction_t(payload, sizeof(payload),
+                                                       &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_gridded_correction_t(const sbp_msg_ssr_gridded_correction_t *a, const sbp_msg_ssr_gridded_correction_t *b) {
+int sbp_cmp_sbp_msg_ssr_gridded_correction_t(
+    const sbp_msg_ssr_gridded_correction_t *a,
+    const sbp_msg_ssr_gridded_correction_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gridded_correction_header_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u16(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_sbp_tropospheric_delay_correction_t(&a->tropo_delay_correction, &b->tropo_delay_correction);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
-  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_stec_residual_t(&a->stec_residuals[i], &b->stec_residuals[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_u16(&a->index, &b->index);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_sbp_tropospheric_delay_correction_t(&a->tropo_delay_correction,
+                                                    &b->tropo_delay_correction);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
+  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++) {
+    ret = sbp_cmp_sbp_stec_residual_t(&a->stec_residuals[i],
+                                      &b->stec_residuals[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_tile_definition_t(const sbp_msg_ssr_tile_definition_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_tile_definition_t(
+    const sbp_msg_ssr_tile_definition_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->tile_set_id);
   packed_size += sbp_packed_size_u16(&msg->tile_id);
@@ -1199,21 +1748,41 @@ size_t sbp_packed_size_sbp_msg_ssr_tile_definition_t(const sbp_msg_ssr_tile_defi
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_tile_definition_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_tile_definition_t *msg)
-{
-  if (!encode_u16(ctx, &msg->tile_set_id)) { return false; }
-  if (!encode_u16(ctx, &msg->tile_id)) { return false; }
-  if (!encode_s16(ctx, &msg->corner_nw_lat)) { return false; }
-  if (!encode_s16(ctx, &msg->corner_nw_lon)) { return false; }
-  if (!encode_u16(ctx, &msg->spacing_lat)) { return false; }
-  if (!encode_u16(ctx, &msg->spacing_lon)) { return false; }
-  if (!encode_u16(ctx, &msg->rows)) { return false; }
-  if (!encode_u16(ctx, &msg->cols)) { return false; }
-  if (!encode_u64(ctx, &msg->bitmask)) { return false; }
+bool encode_sbp_msg_ssr_tile_definition_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_tile_definition_t *msg) {
+  if (!encode_u16(ctx, &msg->tile_set_id)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->tile_id)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->corner_nw_lat)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->corner_nw_lon)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->spacing_lat)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->spacing_lon)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->rows)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->cols)) {
+    return false;
+  }
+  if (!encode_u64(ctx, &msg->bitmask)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_tile_definition_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_tile_definition_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_tile_definition_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_tile_definition_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1227,21 +1796,41 @@ s8 sbp_encode_sbp_msg_ssr_tile_definition_t(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_tile_definition_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_tile_definition_t *msg)
-{
-  if (!decode_u16(ctx, &msg->tile_set_id)) { return false; }
-  if (!decode_u16(ctx, &msg->tile_id)) { return false; }
-  if (!decode_s16(ctx, &msg->corner_nw_lat)) { return false; }
-  if (!decode_s16(ctx, &msg->corner_nw_lon)) { return false; }
-  if (!decode_u16(ctx, &msg->spacing_lat)) { return false; }
-  if (!decode_u16(ctx, &msg->spacing_lon)) { return false; }
-  if (!decode_u16(ctx, &msg->rows)) { return false; }
-  if (!decode_u16(ctx, &msg->cols)) { return false; }
-  if (!decode_u64(ctx, &msg->bitmask)) { return false; }
+bool decode_sbp_msg_ssr_tile_definition_t(sbp_decode_ctx_t *ctx,
+                                          sbp_msg_ssr_tile_definition_t *msg) {
+  if (!decode_u16(ctx, &msg->tile_set_id)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->tile_id)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->corner_nw_lat)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->corner_nw_lon)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->spacing_lat)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->spacing_lon)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->rows)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->cols)) {
+    return false;
+  }
+  if (!decode_u64(ctx, &msg->bitmask)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_tile_definition_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_tile_definition_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_tile_definition_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_tile_definition_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1254,44 +1843,69 @@ s8 sbp_decode_sbp_msg_ssr_tile_definition_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_tile_definition_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_tile_definition_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_tile_definition_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_tile_definition_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_tile_definition_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_TILE_DEFINITION, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_tile_definition_t(payload, sizeof(payload),
+                                                    &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_TILE_DEFINITION, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_tile_definition_t(const sbp_msg_ssr_tile_definition_t *a, const sbp_msg_ssr_tile_definition_t *b) {
+int sbp_cmp_sbp_msg_ssr_tile_definition_t(
+    const sbp_msg_ssr_tile_definition_t *a,
+    const sbp_msg_ssr_tile_definition_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->tile_set_id, &b->tile_set_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->tile_id, &b->tile_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->corner_nw_lat, &b->corner_nw_lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->corner_nw_lon, &b->corner_nw_lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->spacing_lat, &b->spacing_lat);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->spacing_lon, &b->spacing_lon);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->rows, &b->rows);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->cols, &b->cols);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u64(&a->bitmask, &b->bitmask);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -1300,28 +1914,37 @@ size_t sbp_packed_size_sbp_satellite_apc_t(const sbp_satellite_apc_t *msg) {
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_u8(&msg->sat_info);
   packed_size += sbp_packed_size_u16(&msg->svn);
-  packed_size += ( 3 * sbp_packed_size_s16(&msg->pco[0]));
-  packed_size += ( 21 * sbp_packed_size_s8(&msg->pcv[0]));
+  packed_size += (3 * sbp_packed_size_s16(&msg->pco[0]));
+  packed_size += (21 * sbp_packed_size_s8(&msg->pcv[0]));
   return packed_size;
 }
 
-bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx, const sbp_satellite_apc_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->sat_info)) { return false; }
-  if (!encode_u16(ctx, &msg->svn)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_s16(ctx, &msg->pco[i])) { return false; }
+bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx,
+                                const sbp_satellite_apc_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
   }
-  for (uint8_t i = 0; i < 21; i++)
-  {
-    if (!encode_s8(ctx, &msg->pcv[i])) { return false; }
+  if (!encode_u8(ctx, &msg->sat_info)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->svn)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_s16(ctx, &msg->pco[i])) {
+      return false;
+    }
+  }
+  for (uint8_t i = 0; i < 21; i++) {
+    if (!encode_s8(ctx, &msg->pcv[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_satellite_apc_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_satellite_apc_t *msg) {
+s8 sbp_encode_sbp_satellite_apc_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_satellite_apc_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1335,21 +1958,32 @@ s8 sbp_encode_sbp_satellite_apc_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_satellite_apc_t(sbp_decode_ctx_t *ctx, sbp_satellite_apc_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->sat_info)) { return false; }
-  if (!decode_u16(ctx, &msg->svn)) { return false; }
+bool decode_sbp_satellite_apc_t(sbp_decode_ctx_t *ctx,
+                                sbp_satellite_apc_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->sat_info)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->svn)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_s16(ctx, &msg->pco[i])) { return false; }
+    if (!decode_s16(ctx, &msg->pco[i])) {
+      return false;
+    }
   }
   for (uint8_t i = 0; i < 21; i++) {
-    if (!decode_s8(ctx, &msg->pcv[i])) { return false; }
+    if (!decode_s8(ctx, &msg->pcv[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_satellite_apc_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_satellite_apc_t *msg) {
+s8 sbp_decode_sbp_satellite_apc_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_satellite_apc_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1363,48 +1997,62 @@ s8 sbp_decode_sbp_satellite_apc_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_satellite_apc_t(const sbp_satellite_apc_t *a, const sbp_satellite_apc_t *b) {
+int sbp_cmp_sbp_satellite_apc_t(const sbp_satellite_apc_t *a,
+                                const sbp_satellite_apc_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->sat_info, &b->sat_info);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->svn, &b->svn);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
     ret = sbp_cmp_s16(&a->pco[i], &b->pco[i]);
   }
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 21 && ret == 0; i++)
-  {
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 21 && ret == 0; i++) {
     ret = sbp_cmp_s8(&a->pcv[i], &b->pcv[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_satellite_apc_t(const sbp_msg_ssr_satellite_apc_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_satellite_apc_t(
+    const sbp_msg_ssr_satellite_apc_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_apc * sbp_packed_size_sbp_satellite_apc_t(&msg->apc[0]));
+  packed_size +=
+      (msg->n_apc * sbp_packed_size_sbp_satellite_apc_t(&msg->apc[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_satellite_apc_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_satellite_apc_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_apc; i++)
-  {
-    if (!encode_sbp_satellite_apc_t(ctx, &msg->apc[i])) { return false; }
+bool encode_sbp_msg_ssr_satellite_apc_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_satellite_apc_t *msg) {
+  for (uint8_t i = 0; i < msg->n_apc; i++) {
+    if (!encode_sbp_satellite_apc_t(ctx, &msg->apc[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_satellite_apc_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_satellite_apc_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_satellite_apc_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_satellite_apc_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1418,16 +2066,21 @@ s8 sbp_encode_sbp_msg_ssr_satellite_apc_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_satellite_apc_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_satellite_apc_t *msg)
-{
-    msg->n_apc = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_satellite_apc_t(&msg->apc[0]));
+bool decode_sbp_msg_ssr_satellite_apc_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_ssr_satellite_apc_t *msg) {
+  msg->n_apc = (uint8_t)((ctx->buf_len - ctx->offset) /
+                         sbp_packed_size_sbp_satellite_apc_t(&msg->apc[0]));
   for (uint8_t i = 0; i < msg->n_apc; i++) {
-    if (!decode_sbp_satellite_apc_t(ctx, &msg->apc[i])) { return false; }
+    if (!decode_sbp_satellite_apc_t(ctx, &msg->apc[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_satellite_apc_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_satellite_apc_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_satellite_apc_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_ssr_satellite_apc_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1440,28 +2093,36 @@ s8 sbp_decode_sbp_msg_ssr_satellite_apc_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_satellite_apc_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_satellite_apc_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_satellite_apc_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_ssr_satellite_apc_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_satellite_apc_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_SATELLITE_APC, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_satellite_apc_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_SATELLITE_APC, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_satellite_apc_t(const sbp_msg_ssr_satellite_apc_t *a, const sbp_msg_ssr_satellite_apc_t *b) {
+int sbp_cmp_sbp_msg_ssr_satellite_apc_t(const sbp_msg_ssr_satellite_apc_t *a,
+                                        const sbp_msg_ssr_satellite_apc_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_apc, &b->n_apc);
-  for (uint8_t i = 0; i < a->n_apc && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_apc && ret == 0; i++) {
     ret = sbp_cmp_sbp_satellite_apc_t(&a->apc[i], &b->apc[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_orbit_clock_dep_a_t(const sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_orbit_clock_dep_a_t(
+    const sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->time);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
@@ -1480,26 +2141,56 @@ size_t sbp_packed_size_sbp_msg_ssr_orbit_clock_dep_a_t(const sbp_msg_ssr_orbit_c
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_orbit_clock_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_dep_a_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_ssr)) { return false; }
-  if (!encode_u8(ctx, &msg->iod)) { return false; }
-  if (!encode_s32(ctx, &msg->radial)) { return false; }
-  if (!encode_s32(ctx, &msg->along)) { return false; }
-  if (!encode_s32(ctx, &msg->cross)) { return false; }
-  if (!encode_s32(ctx, &msg->dot_radial)) { return false; }
-  if (!encode_s32(ctx, &msg->dot_along)) { return false; }
-  if (!encode_s32(ctx, &msg->dot_cross)) { return false; }
-  if (!encode_s32(ctx, &msg->c0)) { return false; }
-  if (!encode_s32(ctx, &msg->c1)) { return false; }
-  if (!encode_s32(ctx, &msg->c2)) { return false; }
+bool encode_sbp_msg_ssr_orbit_clock_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->radial)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->along)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->cross)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->dot_radial)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->dot_along)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->dot_cross)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->c0)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->c1)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->c2)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1513,26 +2204,56 @@ s8 sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_orbit_clock_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_dep_a_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_ssr)) { return false; }
-  if (!decode_u8(ctx, &msg->iod)) { return false; }
-  if (!decode_s32(ctx, &msg->radial)) { return false; }
-  if (!decode_s32(ctx, &msg->along)) { return false; }
-  if (!decode_s32(ctx, &msg->cross)) { return false; }
-  if (!decode_s32(ctx, &msg->dot_radial)) { return false; }
-  if (!decode_s32(ctx, &msg->dot_along)) { return false; }
-  if (!decode_s32(ctx, &msg->dot_cross)) { return false; }
-  if (!decode_s32(ctx, &msg->c0)) { return false; }
-  if (!decode_s32(ctx, &msg->c1)) { return false; }
-  if (!decode_s32(ctx, &msg->c2)) { return false; }
+bool decode_sbp_msg_ssr_orbit_clock_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->radial)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->along)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->cross)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->dot_radial)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->dot_along)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->dot_cross)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->c0)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->c1)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->c2)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_orbit_clock_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1545,63 +2266,99 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_orbit_clock_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_ORBIT_CLOCK_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_orbit_clock_dep_a_t(payload, sizeof(payload),
+                                                      &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_ORBIT_CLOCK_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_orbit_clock_dep_a_t(const sbp_msg_ssr_orbit_clock_dep_a_t *a, const sbp_msg_ssr_orbit_clock_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ssr_orbit_clock_dep_a_t(
+    const sbp_msg_ssr_orbit_clock_dep_a_t *a,
+    const sbp_msg_ssr_orbit_clock_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_ssr, &b->iod_ssr);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod, &b->iod);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->radial, &b->radial);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->along, &b->along);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->cross, &b->cross);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->dot_radial, &b->dot_radial);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->dot_along, &b->dot_along);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->dot_cross, &b->dot_cross);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->c0, &b->c0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->c1, &b->c1);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->c2, &b->c2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_stec_header_dep_a_t(const sbp_stec_header_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_stec_header_dep_a_t(
+    const sbp_stec_header_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->time);
   packed_size += sbp_packed_size_u8(&msg->num_msgs);
@@ -1611,17 +2368,29 @@ size_t sbp_packed_size_sbp_stec_header_dep_a_t(const sbp_stec_header_dep_a_t *ms
   return packed_size;
 }
 
-bool encode_sbp_stec_header_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_stec_header_dep_a_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->num_msgs)) { return false; }
-  if (!encode_u8(ctx, &msg->seq_num)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_atmo)) { return false; }
+bool encode_sbp_stec_header_dep_a_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_stec_header_dep_a_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_stec_header_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_stec_header_dep_a_t *msg) {
+s8 sbp_encode_sbp_stec_header_dep_a_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_stec_header_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1635,17 +2404,29 @@ s8 sbp_encode_sbp_stec_header_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_stec_header_dep_a_t(sbp_decode_ctx_t *ctx, sbp_stec_header_dep_a_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->num_msgs)) { return false; }
-  if (!decode_u8(ctx, &msg->seq_num)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_atmo)) { return false; }
+bool decode_sbp_stec_header_dep_a_t(sbp_decode_ctx_t *ctx,
+                                    sbp_stec_header_dep_a_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_stec_header_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_stec_header_dep_a_t *msg) {
+s8 sbp_decode_sbp_stec_header_dep_a_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_stec_header_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1659,27 +2440,39 @@ s8 sbp_decode_sbp_stec_header_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_stec_header_dep_a_t(const sbp_stec_header_dep_a_t *a, const sbp_stec_header_dep_a_t *b) {
+int sbp_cmp_sbp_stec_header_dep_a_t(const sbp_stec_header_dep_a_t *a,
+                                    const sbp_stec_header_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->num_msgs, &b->num_msgs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->seq_num, &b->seq_num);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_atmo, &b->iod_atmo);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_gridded_correction_header_dep_a_t(const sbp_gridded_correction_header_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_gridded_correction_header_dep_a_t(
+    const sbp_gridded_correction_header_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_gps_time_sec_t(&msg->time);
   packed_size += sbp_packed_size_u16(&msg->num_msgs);
@@ -1690,18 +2483,32 @@ size_t sbp_packed_size_sbp_gridded_correction_header_dep_a_t(const sbp_gridded_c
   return packed_size;
 }
 
-bool encode_sbp_gridded_correction_header_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_dep_a_t *msg)
-{
-  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!encode_u16(ctx, &msg->num_msgs)) { return false; }
-  if (!encode_u16(ctx, &msg->seq_num)) { return false; }
-  if (!encode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!encode_u8(ctx, &msg->iod_atmo)) { return false; }
-  if (!encode_u8(ctx, &msg->tropo_quality_indicator)) { return false; }
+bool encode_sbp_gridded_correction_header_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_gridded_correction_header_dep_a_t *msg) {
+  if (!encode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tropo_quality_indicator)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_gridded_correction_header_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_gridded_correction_header_dep_a_t *msg) {
+s8 sbp_encode_sbp_gridded_correction_header_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_gridded_correction_header_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1715,18 +2522,32 @@ s8 sbp_encode_sbp_gridded_correction_header_dep_a_t(uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-bool decode_sbp_gridded_correction_header_dep_a_t(sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_dep_a_t *msg)
-{
-  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) { return false; }
-  if (!decode_u16(ctx, &msg->num_msgs)) { return false; }
-  if (!decode_u16(ctx, &msg->seq_num)) { return false; }
-  if (!decode_u8(ctx, &msg->update_interval)) { return false; }
-  if (!decode_u8(ctx, &msg->iod_atmo)) { return false; }
-  if (!decode_u8(ctx, &msg->tropo_quality_indicator)) { return false; }
+bool decode_sbp_gridded_correction_header_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_gridded_correction_header_dep_a_t *msg) {
+  if (!decode_sbp_gps_time_sec_t(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->seq_num)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->update_interval)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->iod_atmo)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tropo_quality_indicator)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_gridded_correction_header_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_gridded_correction_header_dep_a_t *msg) {
+s8 sbp_decode_sbp_gridded_correction_header_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_gridded_correction_header_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1740,30 +2561,45 @@ s8 sbp_decode_sbp_gridded_correction_header_dep_a_t(const uint8_t *buf, uint8_t 
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_gridded_correction_header_dep_a_t(const sbp_gridded_correction_header_dep_a_t *a, const sbp_gridded_correction_header_dep_a_t *b) {
+int sbp_cmp_sbp_gridded_correction_header_dep_a_t(
+    const sbp_gridded_correction_header_dep_a_t *a,
+    const sbp_gridded_correction_header_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gps_time_sec_t(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->num_msgs, &b->num_msgs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->seq_num, &b->seq_num);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->update_interval, &b->update_interval);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->iod_atmo, &b->iod_atmo);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tropo_quality_indicator, &b->tropo_quality_indicator);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_grid_definition_header_dep_a_t(const sbp_grid_definition_header_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_grid_definition_header_dep_a_t(
+    const sbp_grid_definition_header_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->region_size_inverse);
   packed_size += sbp_packed_size_u16(&msg->area_width);
@@ -1774,18 +2610,32 @@ size_t sbp_packed_size_sbp_grid_definition_header_dep_a_t(const sbp_grid_definit
   return packed_size;
 }
 
-bool encode_sbp_grid_definition_header_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_grid_definition_header_dep_a_t *msg)
-{
-  if (!encode_u8(ctx, &msg->region_size_inverse)) { return false; }
-  if (!encode_u16(ctx, &msg->area_width)) { return false; }
-  if (!encode_u16(ctx, &msg->lat_nw_corner_enc)) { return false; }
-  if (!encode_u16(ctx, &msg->lon_nw_corner_enc)) { return false; }
-  if (!encode_u8(ctx, &msg->num_msgs)) { return false; }
-  if (!encode_u8(ctx, &msg->seq_num)) { return false; }
+bool encode_sbp_grid_definition_header_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_grid_definition_header_dep_a_t *msg) {
+  if (!encode_u8(ctx, &msg->region_size_inverse)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->area_width)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lat_nw_corner_enc)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lon_nw_corner_enc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->seq_num)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_grid_definition_header_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_grid_definition_header_dep_a_t *msg) {
+s8 sbp_encode_sbp_grid_definition_header_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_grid_definition_header_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1799,18 +2649,32 @@ s8 sbp_encode_sbp_grid_definition_header_dep_a_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_grid_definition_header_dep_a_t(sbp_decode_ctx_t *ctx, sbp_grid_definition_header_dep_a_t *msg)
-{
-  if (!decode_u8(ctx, &msg->region_size_inverse)) { return false; }
-  if (!decode_u16(ctx, &msg->area_width)) { return false; }
-  if (!decode_u16(ctx, &msg->lat_nw_corner_enc)) { return false; }
-  if (!decode_u16(ctx, &msg->lon_nw_corner_enc)) { return false; }
-  if (!decode_u8(ctx, &msg->num_msgs)) { return false; }
-  if (!decode_u8(ctx, &msg->seq_num)) { return false; }
+bool decode_sbp_grid_definition_header_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_grid_definition_header_dep_a_t *msg) {
+  if (!decode_u8(ctx, &msg->region_size_inverse)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->area_width)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lat_nw_corner_enc)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lon_nw_corner_enc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->num_msgs)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->seq_num)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_grid_definition_header_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_grid_definition_header_dep_a_t *msg) {
+s8 sbp_decode_sbp_grid_definition_header_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_grid_definition_header_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1824,47 +2688,68 @@ s8 sbp_decode_sbp_grid_definition_header_dep_a_t(const uint8_t *buf, uint8_t len
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_grid_definition_header_dep_a_t(const sbp_grid_definition_header_dep_a_t *a, const sbp_grid_definition_header_dep_a_t *b) {
+int sbp_cmp_sbp_grid_definition_header_dep_a_t(
+    const sbp_grid_definition_header_dep_a_t *a,
+    const sbp_grid_definition_header_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->region_size_inverse, &b->region_size_inverse);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->area_width, &b->area_width);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lat_nw_corner_enc, &b->lat_nw_corner_enc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lon_nw_corner_enc, &b->lon_nw_corner_enc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->num_msgs, &b->num_msgs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->seq_num, &b->seq_num);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_stec_correction_dep_a_t(const sbp_msg_ssr_stec_correction_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_stec_correction_dep_a_t(
+    const sbp_msg_ssr_stec_correction_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_stec_header_dep_a_t(&msg->header);
-  packed_size += (msg->n_stec_sat_list * sbp_packed_size_sbp_stec_sat_element_t(&msg->stec_sat_list[0]));
+  packed_size += (msg->n_stec_sat_list * sbp_packed_size_sbp_stec_sat_element_t(
+                                             &msg->stec_sat_list[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_stec_correction_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_dep_a_t *msg)
-{
-  if (!encode_sbp_stec_header_dep_a_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++)
-  {
-    if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) { return false; }
+bool encode_sbp_msg_ssr_stec_correction_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_stec_correction_dep_a_t *msg) {
+  if (!encode_sbp_stec_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
+    if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_stec_correction_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_stec_correction_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1878,17 +2763,25 @@ s8 sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(uint8_t *buf, uint8_t len, uin
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_stec_correction_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_dep_a_t *msg)
-{
-  if (!decode_sbp_stec_header_dep_a_t(ctx, &msg->header)) { return false; }
-    msg->n_stec_sat_list = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_stec_sat_element_t(&msg->stec_sat_list[0]));
+bool decode_sbp_msg_ssr_stec_correction_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_dep_a_t *msg) {
+  if (!decode_sbp_stec_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_stec_sat_list =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_stec_sat_element_t(&msg->stec_sat_list[0]));
   for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
-    if (!decode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) { return false; }
+    if (!decode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_stec_correction_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_stec_correction_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1901,52 +2794,79 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(const uint8_t *buf, uint8_t le
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_stec_correction_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_stec_correction_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_STEC_CORRECTION_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_stec_correction_dep_a_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_STEC_CORRECTION_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_stec_correction_dep_a_t(const sbp_msg_ssr_stec_correction_dep_a_t *a, const sbp_msg_ssr_stec_correction_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ssr_stec_correction_dep_a_t(
+    const sbp_msg_ssr_stec_correction_dep_a_t *a,
+    const sbp_msg_ssr_stec_correction_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_stec_header_dep_a_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u8(&a->n_stec_sat_list, &b->n_stec_sat_list);
-  for (uint8_t i = 0; i < a->n_stec_sat_list && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_stec_sat_element_t(&a->stec_sat_list[i], &b->stec_sat_list[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_u8(&a->n_stec_sat_list, &b->n_stec_sat_list);
+  for (uint8_t i = 0; i < a->n_stec_sat_list && ret == 0; i++) {
+    ret = sbp_cmp_sbp_stec_sat_element_t(&a->stec_sat_list[i],
+                                         &b->stec_sat_list[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_gridded_correction_header_dep_a_t(&msg->header);
+  packed_size +=
+      sbp_packed_size_sbp_gridded_correction_header_dep_a_t(&msg->header);
   packed_size += sbp_packed_size_u16(&msg->index);
-  packed_size += sbp_packed_size_sbp_tropospheric_delay_correction_no_std_t(&msg->tropo_delay_correction);
-  packed_size += (msg->n_stec_residuals * sbp_packed_size_sbp_stec_residual_no_std_t(&msg->stec_residuals[0]));
+  packed_size += sbp_packed_size_sbp_tropospheric_delay_correction_no_std_t(
+      &msg->tropo_delay_correction);
+  packed_size +=
+      (msg->n_stec_residuals *
+       sbp_packed_size_sbp_stec_residual_no_std_t(&msg->stec_residuals[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg)
-{
-  if (!encode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) { return false; }
-  if (!encode_u16(ctx, &msg->index)) { return false; }
-  if (!encode_sbp_tropospheric_delay_correction_no_std_t(ctx, &msg->tropo_delay_correction)) { return false; }
-  for (uint8_t i = 0; i < msg->n_stec_residuals; i++)
-  {
-    if (!encode_sbp_stec_residual_no_std_t(ctx, &msg->stec_residuals[i])) { return false; }
+bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    sbp_encode_ctx_t *ctx,
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
+  if (!encode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!encode_sbp_tropospheric_delay_correction_no_std_t(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+    if (!encode_sbp_stec_residual_no_std_t(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1960,19 +2880,32 @@ s8 sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(uint8_t *buf, uint8_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg)
-{
-  if (!decode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) { return false; }
-  if (!decode_u16(ctx, &msg->index)) { return false; }
-  if (!decode_sbp_tropospheric_delay_correction_no_std_t(ctx, &msg->tropo_delay_correction)) { return false; }
-    msg->n_stec_residuals = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_stec_residual_no_std_t(&msg->stec_residuals[0]));
+bool decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
+  if (!decode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!decode_sbp_tropospheric_delay_correction_no_std_t(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  msg->n_stec_residuals = (uint8_t)(
+      (ctx->buf_len - ctx->offset) /
+      sbp_packed_size_sbp_stec_residual_no_std_t(&msg->stec_residuals[0]));
   for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
-    if (!decode_sbp_stec_residual_no_std_t(ctx, &msg->stec_residuals[i])) { return false; }
+    if (!decode_sbp_stec_residual_no_std_t(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1985,58 +2918,89 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(const uint8_t *buf, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg,
+    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A,
+                          sender_id, payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *a, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *a,
+    const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gridded_correction_header_dep_a_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u16(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_sbp_tropospheric_delay_correction_no_std_t(&a->tropo_delay_correction, &b->tropo_delay_correction);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
-  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_stec_residual_no_std_t(&a->stec_residuals[i], &b->stec_residuals[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_u16(&a->index, &b->index);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_sbp_tropospheric_delay_correction_no_std_t(
+      &a->tropo_delay_correction, &b->tropo_delay_correction);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
+  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++) {
+    ret = sbp_cmp_sbp_stec_residual_no_std_t(&a->stec_residuals[i],
+                                             &b->stec_residuals[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_gridded_correction_dep_a_t(const sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_gridded_correction_dep_a_t(
+    const sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_gridded_correction_header_dep_a_t(&msg->header);
+  packed_size +=
+      sbp_packed_size_sbp_gridded_correction_header_dep_a_t(&msg->header);
   packed_size += sbp_packed_size_u16(&msg->index);
-  packed_size += sbp_packed_size_sbp_tropospheric_delay_correction_t(&msg->tropo_delay_correction);
-  packed_size += (msg->n_stec_residuals * sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
+  packed_size += sbp_packed_size_sbp_tropospheric_delay_correction_t(
+      &msg->tropo_delay_correction);
+  packed_size += (msg->n_stec_residuals *
+                  sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_a_t *msg)
-{
-  if (!encode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) { return false; }
-  if (!encode_u16(ctx, &msg->index)) { return false; }
-  if (!encode_sbp_tropospheric_delay_correction_t(ctx, &msg->tropo_delay_correction)) { return false; }
-  for (uint8_t i = 0; i < msg->n_stec_residuals; i++)
-  {
-    if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) { return false; }
+bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
+  if (!encode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!encode_sbp_tropospheric_delay_correction_t(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+    if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2050,19 +3014,32 @@ s8 sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(uint8_t *buf, uint8_t len, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_gridded_correction_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_a_t *msg)
-{
-  if (!decode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) { return false; }
-  if (!decode_u16(ctx, &msg->index)) { return false; }
-  if (!decode_sbp_tropospheric_delay_correction_t(ctx, &msg->tropo_delay_correction)) { return false; }
-    msg->n_stec_residuals = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
+bool decode_sbp_msg_ssr_gridded_correction_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
+  if (!decode_sbp_gridded_correction_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->index)) {
+    return false;
+  }
+  if (!decode_sbp_tropospheric_delay_correction_t(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  msg->n_stec_residuals =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_stec_residual_t(&msg->stec_residuals[0]));
   for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
-    if (!decode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) { return false; }
+    if (!decode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_gridded_correction_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2075,54 +3052,77 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(const uint8_t *buf, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_gridded_correction_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_gridded_correction_dep_a_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_gridded_correction_dep_a_t(const sbp_msg_ssr_gridded_correction_dep_a_t *a, const sbp_msg_ssr_gridded_correction_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ssr_gridded_correction_dep_a_t(
+    const sbp_msg_ssr_gridded_correction_dep_a_t *a,
+    const sbp_msg_ssr_gridded_correction_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_gridded_correction_header_dep_a_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u16(&a->index, &b->index);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_sbp_tropospheric_delay_correction_t(&a->tropo_delay_correction, &b->tropo_delay_correction);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
-  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_stec_residual_t(&a->stec_residuals[i], &b->stec_residuals[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_u16(&a->index, &b->index);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_sbp_tropospheric_delay_correction_t(&a->tropo_delay_correction,
+                                                    &b->tropo_delay_correction);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
+  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++) {
+    ret = sbp_cmp_sbp_stec_residual_t(&a->stec_residuals[i],
+                                      &b->stec_residuals[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_ssr_grid_definition_dep_a_t(const sbp_msg_ssr_grid_definition_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_ssr_grid_definition_dep_a_t(
+    const sbp_msg_ssr_grid_definition_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += sbp_packed_size_sbp_grid_definition_header_dep_a_t(&msg->header);
+  packed_size +=
+      sbp_packed_size_sbp_grid_definition_header_dep_a_t(&msg->header);
   packed_size += (msg->n_rle_list * sbp_packed_size_u8(&msg->rle_list[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_ssr_grid_definition_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_ssr_grid_definition_dep_a_t *msg)
-{
-  if (!encode_sbp_grid_definition_header_dep_a_t(ctx, &msg->header)) { return false; }
-  for (uint8_t i = 0; i < msg->n_rle_list; i++)
-  {
-    if (!encode_u8(ctx, &msg->rle_list[i])) { return false; }
+bool encode_sbp_msg_ssr_grid_definition_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_grid_definition_dep_a_t *msg) {
+  if (!encode_sbp_grid_definition_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_rle_list; i++) {
+    if (!encode_u8(ctx, &msg->rle_list[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ssr_grid_definition_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_grid_definition_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2136,17 +3136,24 @@ s8 sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(uint8_t *buf, uint8_t len, uin
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ssr_grid_definition_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_ssr_grid_definition_dep_a_t *msg)
-{
-  if (!decode_sbp_grid_definition_header_dep_a_t(ctx, &msg->header)) { return false; }
-    msg->n_rle_list = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->rle_list[0]));
+bool decode_sbp_msg_ssr_grid_definition_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_grid_definition_dep_a_t *msg) {
+  if (!decode_sbp_grid_definition_header_dep_a_t(ctx, &msg->header)) {
+    return false;
+  }
+  msg->n_rle_list = (uint8_t)((ctx->buf_len - ctx->offset) /
+                              sbp_packed_size_u8(&msg->rle_list[0]));
   for (uint8_t i = 0; i < msg->n_rle_list; i++) {
-    if (!decode_u8(ctx, &msg->rle_list[i])) { return false; }
+    if (!decode_u8(ctx, &msg->rle_list[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ssr_grid_definition_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_grid_definition_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -2159,26 +3166,36 @@ s8 sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(const uint8_t *buf, uint8_t le
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_grid_definition_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_ssr_grid_definition_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_SSR_GRID_DEFINITION_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ssr_grid_definition_dep_a_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_GRID_DEFINITION_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_ssr_grid_definition_dep_a_t(const sbp_msg_ssr_grid_definition_dep_a_t *a, const sbp_msg_ssr_grid_definition_dep_a_t *b) {
+int sbp_cmp_sbp_msg_ssr_grid_definition_dep_a_t(
+    const sbp_msg_ssr_grid_definition_dep_a_t *a,
+    const sbp_msg_ssr_grid_definition_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_grid_definition_header_dep_a_t(&a->header, &b->header);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_rle_list, &b->n_rle_list);
-  for (uint8_t i = 0; i < a->n_rle_list && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_rle_list && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->rle_list[i], &b->rle_list[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/ssr.c
+++ b/c/src/new/ssr.c
@@ -511,7 +511,7 @@ bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->stec_quality_indicator)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
+  for (uint8_t i = 0; i < 4; i++) {
     if (!encode_s16(ctx, &msg->stec_coeff[i])) {
       return false;
     }
@@ -1188,7 +1188,7 @@ bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->iod_ssr)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_biases; i++) {
+  for (uint8_t i = 0; i < msg->n_biases; i++) {
     if (!encode_sbp_code_biases_content_t(ctx, &msg->biases[i])) {
       return false;
     }
@@ -1343,7 +1343,7 @@ bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx,
   if (!encode_s8(ctx, &msg->yaw_rate)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_biases; i++) {
+  for (uint8_t i = 0; i < msg->n_biases; i++) {
     if (!encode_sbp_phase_biases_content_t(ctx, &msg->biases[i])) {
       return false;
     }
@@ -1502,7 +1502,7 @@ bool encode_sbp_msg_ssr_stec_correction_t(
   if (!encode_sbp_stec_header_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_sat_list; i++) {
+  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
     if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
       return false;
     }
@@ -1617,7 +1617,7 @@ bool encode_sbp_msg_ssr_gridded_correction_t(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_residuals; i++) {
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
     if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
       return false;
     }
@@ -1924,12 +1924,12 @@ bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx,
   if (!encode_u16(ctx, &msg->svn)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_s16(ctx, &msg->pco[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; ret == 0 && i < 21; i++) {
+  for (uint8_t i = 0; i < 21; i++) {
     if (!encode_s8(ctx, &msg->pcv[i])) {
       return false;
     }
@@ -2036,7 +2036,7 @@ size_t sbp_packed_size_sbp_msg_ssr_satellite_apc_t(
 
 bool encode_sbp_msg_ssr_satellite_apc_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_satellite_apc_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_apc; i++) {
+  for (uint8_t i = 0; i < msg->n_apc; i++) {
     if (!encode_sbp_satellite_apc_t(ctx, &msg->apc[i])) {
       return false;
     }
@@ -2735,7 +2735,7 @@ bool encode_sbp_msg_ssr_stec_correction_dep_a_t(
   if (!encode_sbp_stec_header_dep_a_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_sat_list; i++) {
+  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
     if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
       return false;
     }
@@ -2853,7 +2853,7 @@ bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_residuals; i++) {
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
     if (!encode_sbp_stec_residual_no_std_t(ctx, &msg->stec_residuals[i])) {
       return false;
     }
@@ -2988,7 +2988,7 @@ bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_residuals; i++) {
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
     if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
       return false;
     }
@@ -3111,7 +3111,7 @@ bool encode_sbp_msg_ssr_grid_definition_dep_a_t(
   if (!encode_sbp_grid_definition_header_dep_a_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_rle_list; i++) {
+  for (uint8_t i = 0; i < msg->n_rle_list; i++) {
     if (!encode_u8(ctx, &msg->rle_list[i])) {
       return false;
     }

--- a/c/src/new/ssr.c
+++ b/c/src/new/ssr.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/ssr.yaml
  * with generate.py. Please do not hand edit!
@@ -523,7 +511,7 @@ bool encode_sbp_stec_sat_element_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->stec_quality_indicator)) {
     return false;
   }
-  for (uint8_t i = 0; i < 4; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
     if (!encode_s16(ctx, &msg->stec_coeff[i])) {
       return false;
     }
@@ -593,7 +581,7 @@ int sbp_cmp_sbp_stec_sat_element_t(const sbp_stec_sat_element_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 4 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
     ret = sbp_cmp_s16(&a->stec_coeff[i], &b->stec_coeff[i]);
   }
   if (ret != 0) {
@@ -1083,6 +1071,7 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_orbit_clock_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ssr_orbit_clock_t *msg,
                                       sbp_write_fn_t write) {
@@ -1199,7 +1188,7 @@ bool encode_sbp_msg_ssr_code_biases_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->iod_ssr)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_biases; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_biases; i++) {
     if (!encode_sbp_code_biases_content_t(ctx, &msg->biases[i])) {
       return false;
     }
@@ -1263,6 +1252,7 @@ s8 sbp_decode_sbp_msg_ssr_code_biases_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_code_biases_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ssr_code_biases_t *msg,
                                       sbp_write_fn_t write) {
@@ -1302,7 +1292,7 @@ int sbp_cmp_sbp_msg_ssr_code_biases_t(const sbp_msg_ssr_code_biases_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_biases, &b->n_biases);
-  for (uint8_t i = 0; i < a->n_biases && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_biases; i++) {
     ret = sbp_cmp_sbp_code_biases_content_t(&a->biases[i], &b->biases[i]);
   }
   if (ret != 0) {
@@ -1353,7 +1343,7 @@ bool encode_sbp_msg_ssr_phase_biases_t(sbp_encode_ctx_t *ctx,
   if (!encode_s8(ctx, &msg->yaw_rate)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_biases; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_biases; i++) {
     if (!encode_sbp_phase_biases_content_t(ctx, &msg->biases[i])) {
       return false;
     }
@@ -1429,6 +1419,7 @@ s8 sbp_decode_sbp_msg_ssr_phase_biases_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_phase_biases_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_ssr_phase_biases_t *msg,
                                        sbp_write_fn_t write) {
@@ -1488,7 +1479,7 @@ int sbp_cmp_sbp_msg_ssr_phase_biases_t(const sbp_msg_ssr_phase_biases_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_biases, &b->n_biases);
-  for (uint8_t i = 0; i < a->n_biases && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_biases; i++) {
     ret = sbp_cmp_sbp_phase_biases_content_t(&a->biases[i], &b->biases[i]);
   }
   if (ret != 0) {
@@ -1511,7 +1502,7 @@ bool encode_sbp_msg_ssr_stec_correction_t(
   if (!encode_sbp_stec_header_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_sat_list; i++) {
     if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
       return false;
     }
@@ -1566,6 +1557,7 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_stec_correction_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_stec_correction_t *msg, sbp_write_fn_t write) {
@@ -1591,7 +1583,7 @@ int sbp_cmp_sbp_msg_ssr_stec_correction_t(
   }
 
   ret = sbp_cmp_u8(&a->n_stec_sat_list, &b->n_stec_sat_list);
-  for (uint8_t i = 0; i < a->n_stec_sat_list && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_stec_sat_list; i++) {
     ret = sbp_cmp_sbp_stec_sat_element_t(&a->stec_sat_list[i],
                                          &b->stec_sat_list[i]);
   }
@@ -1625,7 +1617,7 @@ bool encode_sbp_msg_ssr_gridded_correction_t(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_residuals; i++) {
     if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
       return false;
     }
@@ -1687,6 +1679,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_gridded_correction_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_gridded_correction_t *msg, sbp_write_fn_t write) {
@@ -1723,7 +1716,7 @@ int sbp_cmp_sbp_msg_ssr_gridded_correction_t(
   }
 
   ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
-  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_stec_residuals; i++) {
     ret = sbp_cmp_sbp_stec_residual_t(&a->stec_residuals[i],
                                       &b->stec_residuals[i]);
   }
@@ -1843,6 +1836,7 @@ s8 sbp_decode_sbp_msg_ssr_tile_definition_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_tile_definition_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_tile_definition_t *msg, sbp_write_fn_t write) {
@@ -1930,12 +1924,12 @@ bool encode_sbp_satellite_apc_t(sbp_encode_ctx_t *ctx,
   if (!encode_u16(ctx, &msg->svn)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_s16(ctx, &msg->pco[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 21; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 21; i++) {
     if (!encode_s8(ctx, &msg->pcv[i])) {
       return false;
     }
@@ -2016,14 +2010,14 @@ int sbp_cmp_sbp_satellite_apc_t(const sbp_satellite_apc_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_s16(&a->pco[i], &b->pco[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; i < 21 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 21; i++) {
     ret = sbp_cmp_s8(&a->pcv[i], &b->pcv[i]);
   }
   if (ret != 0) {
@@ -2042,7 +2036,7 @@ size_t sbp_packed_size_sbp_msg_ssr_satellite_apc_t(
 
 bool encode_sbp_msg_ssr_satellite_apc_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_ssr_satellite_apc_t *msg) {
-  for (uint8_t i = 0; i < msg->n_apc; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_apc; i++) {
     if (!encode_sbp_satellite_apc_t(ctx, &msg->apc[i])) {
       return false;
     }
@@ -2093,6 +2087,7 @@ s8 sbp_decode_sbp_msg_ssr_satellite_apc_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_satellite_apc_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_ssr_satellite_apc_t *msg,
                                         sbp_write_fn_t write) {
@@ -2112,7 +2107,7 @@ int sbp_cmp_sbp_msg_ssr_satellite_apc_t(const sbp_msg_ssr_satellite_apc_t *a,
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_apc, &b->n_apc);
-  for (uint8_t i = 0; i < a->n_apc && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_apc; i++) {
     ret = sbp_cmp_sbp_satellite_apc_t(&a->apc[i], &b->apc[i]);
   }
   if (ret != 0) {
@@ -2266,6 +2261,7 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_orbit_clock_dep_a_t *msg, sbp_write_fn_t write) {
@@ -2739,7 +2735,7 @@ bool encode_sbp_msg_ssr_stec_correction_dep_a_t(
   if (!encode_sbp_stec_header_dep_a_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_sat_list; i++) {
     if (!encode_sbp_stec_sat_element_t(ctx, &msg->stec_sat_list[i])) {
       return false;
     }
@@ -2794,6 +2790,7 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_stec_correction_dep_a_t *msg, sbp_write_fn_t write) {
@@ -2819,7 +2816,7 @@ int sbp_cmp_sbp_msg_ssr_stec_correction_dep_a_t(
   }
 
   ret = sbp_cmp_u8(&a->n_stec_sat_list, &b->n_stec_sat_list);
-  for (uint8_t i = 0; i < a->n_stec_sat_list && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_stec_sat_list; i++) {
     ret = sbp_cmp_sbp_stec_sat_element_t(&a->stec_sat_list[i],
                                          &b->stec_sat_list[i]);
   }
@@ -2856,7 +2853,7 @@ bool encode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_residuals; i++) {
     if (!encode_sbp_stec_residual_no_std_t(ctx, &msg->stec_residuals[i])) {
       return false;
     }
@@ -2918,6 +2915,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg,
@@ -2955,7 +2953,7 @@ int sbp_cmp_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
   }
 
   ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
-  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_stec_residuals; i++) {
     ret = sbp_cmp_sbp_stec_residual_no_std_t(&a->stec_residuals[i],
                                              &b->stec_residuals[i]);
   }
@@ -2990,7 +2988,7 @@ bool encode_sbp_msg_ssr_gridded_correction_dep_a_t(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_stec_residuals; i++) {
     if (!encode_sbp_stec_residual_t(ctx, &msg->stec_residuals[i])) {
       return false;
     }
@@ -3052,6 +3050,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_gridded_correction_dep_a_t *msg, sbp_write_fn_t write) {
@@ -3088,7 +3087,7 @@ int sbp_cmp_sbp_msg_ssr_gridded_correction_dep_a_t(
   }
 
   ret = sbp_cmp_u8(&a->n_stec_residuals, &b->n_stec_residuals);
-  for (uint8_t i = 0; i < a->n_stec_residuals && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_stec_residuals; i++) {
     ret = sbp_cmp_sbp_stec_residual_t(&a->stec_residuals[i],
                                       &b->stec_residuals[i]);
   }
@@ -3112,7 +3111,7 @@ bool encode_sbp_msg_ssr_grid_definition_dep_a_t(
   if (!encode_sbp_grid_definition_header_dep_a_t(ctx, &msg->header)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_rle_list; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_rle_list; i++) {
     if (!encode_u8(ctx, &msg->rle_list[i])) {
       return false;
     }
@@ -3166,6 +3165,7 @@ s8 sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_grid_definition_dep_a_t *msg, sbp_write_fn_t write) {
@@ -3191,7 +3191,7 @@ int sbp_cmp_sbp_msg_ssr_grid_definition_dep_a_t(
   }
 
   ret = sbp_cmp_u8(&a->n_rle_list, &b->n_rle_list);
-  for (uint8_t i = 0; i < a->n_rle_list && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_rle_list; i++) {
     ret = sbp_cmp_u8(&a->rle_list[i], &b->rle_list[i]);
   }
   if (ret != 0) {

--- a/c/src/new/system.c
+++ b/c/src/new/system.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/system.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/system.h>
-#include <libsbp/internal/new/system.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/internal/new/system.h>
+#include <libsbp/new/system.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_startup_t(const sbp_msg_startup_t *msg) {
   size_t packed_size = 0;
@@ -19,15 +36,22 @@ size_t sbp_packed_size_sbp_msg_startup_t(const sbp_msg_startup_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_startup_t(sbp_encode_ctx_t *ctx, const sbp_msg_startup_t *msg)
-{
-  if (!encode_u8(ctx, &msg->cause)) { return false; }
-  if (!encode_u8(ctx, &msg->startup_type)) { return false; }
-  if (!encode_u16(ctx, &msg->reserved)) { return false; }
+bool encode_sbp_msg_startup_t(sbp_encode_ctx_t *ctx,
+                              const sbp_msg_startup_t *msg) {
+  if (!encode_u8(ctx, &msg->cause)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->startup_type)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_startup_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_startup_t *msg) {
+s8 sbp_encode_sbp_msg_startup_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                const sbp_msg_startup_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -41,15 +65,21 @@ s8 sbp_encode_sbp_msg_startup_t(uint8_t *buf, uint8_t len, uint8_t *n_written, c
   return SBP_OK;
 }
 
-bool decode_sbp_msg_startup_t(sbp_decode_ctx_t *ctx, sbp_msg_startup_t *msg)
-{
-  if (!decode_u8(ctx, &msg->cause)) { return false; }
-  if (!decode_u8(ctx, &msg->startup_type)) { return false; }
-  if (!decode_u16(ctx, &msg->reserved)) { return false; }
+bool decode_sbp_msg_startup_t(sbp_decode_ctx_t *ctx, sbp_msg_startup_t *msg) {
+  if (!decode_u8(ctx, &msg->cause)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->startup_type)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->reserved)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_startup_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_startup_t *msg) {
+s8 sbp_decode_sbp_msg_startup_t(const uint8_t *buf, uint8_t len,
+                                uint8_t *n_read, sbp_msg_startup_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -62,114 +92,143 @@ s8 sbp_decode_sbp_msg_startup_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_startup_t(struct sbp_state *s, u16 sender_id, const sbp_msg_startup_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_startup_t(struct sbp_state *s, u16 sender_id,
+                              const sbp_msg_startup_t *msg,
+                              sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_startup_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_STARTUP, sender_id, payload_len, payload, write);
+  s8 ret =
+      sbp_encode_sbp_msg_startup_t(payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_STARTUP, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_startup_t(const sbp_msg_startup_t *a, const sbp_msg_startup_t *b) {
+int sbp_cmp_sbp_msg_startup_t(const sbp_msg_startup_t *a,
+                              const sbp_msg_startup_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->cause, &b->cause);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->startup_type, &b->startup_type);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->reserved, &b->reserved);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_dgnss_status_tsource_params = 
-{
-  .max_packed_len = 251
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_dgnss_status_tsource_params = {.max_packed_len = 251};
 
-  void sbp_msg_dgnss_status_t_source_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_dgnss_status_t_source_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_dgnss_status_tsource_params);
 }
 
-  bool sbp_msg_dgnss_status_t_source_valid(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_dgnss_status_t_source_valid(const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_valid(s, &sbp_msg_dgnss_status_tsource_params);
 }
 
-  int sbp_msg_dgnss_status_t_source_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_dgnss_status_tsource_params);
+int sbp_msg_dgnss_status_t_source_strcmp(const sbp_unterminated_string_t *a,
+                                         const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(a, b,
+                                        &sbp_msg_dgnss_status_tsource_params);
 }
 
-  uint8_t sbp_msg_dgnss_status_t_source_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_dgnss_status_tsource_params);
+uint8_t sbp_msg_dgnss_status_t_source_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_dgnss_status_tsource_params);
 }
 
-  uint8_t sbp_msg_dgnss_status_t_source_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_dgnss_status_tsource_params);
-      }
-  bool sbp_msg_dgnss_status_t_source_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_dgnss_status_tsource_params, new_str);
-  }
+uint8_t sbp_msg_dgnss_status_t_source_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_dgnss_status_tsource_params);
+}
+bool sbp_msg_dgnss_status_t_source_set(sbp_unterminated_string_t *s,
+                                       const char *new_str) {
+  return sbp_unterminated_string_set(s, &sbp_msg_dgnss_status_tsource_params,
+                                     new_str);
+}
 
-  bool sbp_msg_dgnss_status_t_source_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_dgnss_status_t_source_printf(sbp_unterminated_string_t *s,
+                                          const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_dgnss_status_t_source_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
-  }
-
-  bool sbp_msg_dgnss_status_t_source_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_dgnss_status_t_source_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
+bool sbp_msg_dgnss_status_t_source_vprintf(sbp_unterminated_string_t *s,
+                                           const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
 }
 
-  const char *sbp_msg_dgnss_status_t_source_get(const sbp_unterminated_string_t *s)
-{
+bool sbp_msg_dgnss_status_t_source_append_printf(sbp_unterminated_string_t *s,
+                                                 const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
+  va_end(ap);
+  return ret;
+}
+
+bool sbp_msg_dgnss_status_t_source_append_vprintf(sbp_unterminated_string_t *s,
+                                                  const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_dgnss_status_tsource_params, fmt, ap);
+}
+
+const char *sbp_msg_dgnss_status_t_source_get(
+    const sbp_unterminated_string_t *s) {
   return sbp_unterminated_string_get(s, &sbp_msg_dgnss_status_tsource_params);
 }
 
-size_t sbp_packed_size_sbp_msg_dgnss_status_t(const sbp_msg_dgnss_status_t *msg) {
+size_t sbp_packed_size_sbp_msg_dgnss_status_t(
+    const sbp_msg_dgnss_status_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->flags);
   packed_size += sbp_packed_size_u16(&msg->latency);
   packed_size += sbp_packed_size_u8(&msg->num_signals);
-  packed_size += sbp_unterminated_string_packed_len(&msg->source, &sbp_msg_dgnss_status_tsource_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->source, &sbp_msg_dgnss_status_tsource_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_dgnss_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_dgnss_status_t *msg)
-{
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_u16(ctx, &msg->latency)) { return false; }
-  if (!encode_u8(ctx, &msg->num_signals)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->source, &sbp_msg_dgnss_status_tsource_params, ctx)) { return false; }
+bool encode_sbp_msg_dgnss_status_t(sbp_encode_ctx_t *ctx,
+                                   const sbp_msg_dgnss_status_t *msg) {
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->latency)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->num_signals)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->source, &sbp_msg_dgnss_status_tsource_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_dgnss_status_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_dgnss_status_t *msg) {
+s8 sbp_encode_sbp_msg_dgnss_status_t(uint8_t *buf, uint8_t len,
+                                     uint8_t *n_written,
+                                     const sbp_msg_dgnss_status_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -183,16 +242,27 @@ s8 sbp_encode_sbp_msg_dgnss_status_t(uint8_t *buf, uint8_t len, uint8_t *n_writt
   return SBP_OK;
 }
 
-bool decode_sbp_msg_dgnss_status_t(sbp_decode_ctx_t *ctx, sbp_msg_dgnss_status_t *msg)
-{
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_u16(ctx, &msg->latency)) { return false; }
-  if (!decode_u8(ctx, &msg->num_signals)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->source, &sbp_msg_dgnss_status_tsource_params, ctx)) { return false; }
+bool decode_sbp_msg_dgnss_status_t(sbp_decode_ctx_t *ctx,
+                                   sbp_msg_dgnss_status_t *msg) {
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->latency)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->num_signals)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->source, &sbp_msg_dgnss_status_tsource_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_dgnss_status_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_dgnss_status_t *msg) {
+s8 sbp_decode_sbp_msg_dgnss_status_t(const uint8_t *buf, uint8_t len,
+                                     uint8_t *n_read,
+                                     sbp_msg_dgnss_status_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -205,29 +275,44 @@ s8 sbp_decode_sbp_msg_dgnss_status_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_dgnss_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dgnss_status_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_dgnss_status_t(struct sbp_state *s, u16 sender_id,
+                                   const sbp_msg_dgnss_status_t *msg,
+                                   sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_dgnss_status_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_DGNSS_STATUS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_dgnss_status_t(payload, sizeof(payload),
+                                             &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_DGNSS_STATUS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_dgnss_status_t(const sbp_msg_dgnss_status_t *a, const sbp_msg_dgnss_status_t *b) {
+int sbp_cmp_sbp_msg_dgnss_status_t(const sbp_msg_dgnss_status_t *a,
+                                   const sbp_msg_dgnss_status_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->latency, &b->latency);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->num_signals, &b->num_signals);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->source, &b->source, &sbp_msg_dgnss_status_tsource_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(&a->source, &b->source,
+                                       &sbp_msg_dgnss_status_tsource_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -237,13 +322,16 @@ size_t sbp_packed_size_sbp_msg_heartbeat_t(const sbp_msg_heartbeat_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_heartbeat_t(sbp_encode_ctx_t *ctx, const sbp_msg_heartbeat_t *msg)
-{
-  if (!encode_u32(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_heartbeat_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_heartbeat_t *msg) {
+  if (!encode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_heartbeat_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_heartbeat_t *msg) {
+s8 sbp_encode_sbp_msg_heartbeat_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_heartbeat_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -257,13 +345,16 @@ s8 sbp_encode_sbp_msg_heartbeat_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_heartbeat_t(sbp_decode_ctx_t *ctx, sbp_msg_heartbeat_t *msg)
-{
-  if (!decode_u32(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_heartbeat_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_heartbeat_t *msg) {
+  if (!decode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_heartbeat_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_heartbeat_t *msg) {
+s8 sbp_decode_sbp_msg_heartbeat_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_heartbeat_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -276,24 +367,33 @@ s8 sbp_decode_sbp_msg_heartbeat_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_heartbeat_t(struct sbp_state *s, u16 sender_id, const sbp_msg_heartbeat_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_heartbeat_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_heartbeat_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_heartbeat_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_HEARTBEAT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_heartbeat_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_HEARTBEAT, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_heartbeat_t(const sbp_msg_heartbeat_t *a, const sbp_msg_heartbeat_t *b) {
+int sbp_cmp_sbp_msg_heartbeat_t(const sbp_msg_heartbeat_t *a,
+                                const sbp_msg_heartbeat_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_sub_system_report_t(const sbp_sub_system_report_t *msg) {
+size_t sbp_packed_size_sbp_sub_system_report_t(
+    const sbp_sub_system_report_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->component);
   packed_size += sbp_packed_size_u8(&msg->generic);
@@ -301,15 +401,23 @@ size_t sbp_packed_size_sbp_sub_system_report_t(const sbp_sub_system_report_t *ms
   return packed_size;
 }
 
-bool encode_sbp_sub_system_report_t(sbp_encode_ctx_t *ctx, const sbp_sub_system_report_t *msg)
-{
-  if (!encode_u16(ctx, &msg->component)) { return false; }
-  if (!encode_u8(ctx, &msg->generic)) { return false; }
-  if (!encode_u8(ctx, &msg->specific)) { return false; }
+bool encode_sbp_sub_system_report_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_sub_system_report_t *msg) {
+  if (!encode_u16(ctx, &msg->component)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->generic)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->specific)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_sub_system_report_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_sub_system_report_t *msg) {
+s8 sbp_encode_sbp_sub_system_report_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_sub_system_report_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -323,15 +431,23 @@ s8 sbp_encode_sbp_sub_system_report_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_sub_system_report_t(sbp_decode_ctx_t *ctx, sbp_sub_system_report_t *msg)
-{
-  if (!decode_u16(ctx, &msg->component)) { return false; }
-  if (!decode_u8(ctx, &msg->generic)) { return false; }
-  if (!decode_u8(ctx, &msg->specific)) { return false; }
+bool decode_sbp_sub_system_report_t(sbp_decode_ctx_t *ctx,
+                                    sbp_sub_system_report_t *msg) {
+  if (!decode_u16(ctx, &msg->component)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->generic)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->specific)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_sub_system_report_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_sub_system_report_t *msg) {
+s8 sbp_decode_sbp_sub_system_report_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_sub_system_report_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -345,44 +461,64 @@ s8 sbp_decode_sbp_sub_system_report_t(const uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_sub_system_report_t(const sbp_sub_system_report_t *a, const sbp_sub_system_report_t *b) {
+int sbp_cmp_sbp_sub_system_report_t(const sbp_sub_system_report_t *a,
+                                    const sbp_sub_system_report_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->component, &b->component);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->generic, &b->generic);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->specific, &b->specific);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_status_report_t(const sbp_msg_status_report_t *msg) {
+size_t sbp_packed_size_sbp_msg_status_report_t(
+    const sbp_msg_status_report_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u16(&msg->reporting_system);
   packed_size += sbp_packed_size_u16(&msg->sbp_version);
   packed_size += sbp_packed_size_u32(&msg->sequence);
   packed_size += sbp_packed_size_u32(&msg->uptime);
-  packed_size += (msg->n_status * sbp_packed_size_sbp_sub_system_report_t(&msg->status[0]));
+  packed_size += (msg->n_status *
+                  sbp_packed_size_sbp_sub_system_report_t(&msg->status[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx, const sbp_msg_status_report_t *msg)
-{
-  if (!encode_u16(ctx, &msg->reporting_system)) { return false; }
-  if (!encode_u16(ctx, &msg->sbp_version)) { return false; }
-  if (!encode_u32(ctx, &msg->sequence)) { return false; }
-  if (!encode_u32(ctx, &msg->uptime)) { return false; }
-  for (uint8_t i = 0; i < msg->n_status; i++)
-  {
-    if (!encode_sbp_sub_system_report_t(ctx, &msg->status[i])) { return false; }
+bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_msg_status_report_t *msg) {
+  if (!encode_u16(ctx, &msg->reporting_system)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->sbp_version)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->uptime)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_status; i++) {
+    if (!encode_sbp_sub_system_report_t(ctx, &msg->status[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_status_report_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_status_report_t *msg) {
+s8 sbp_encode_sbp_msg_status_report_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_msg_status_report_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -396,20 +532,34 @@ s8 sbp_encode_sbp_msg_status_report_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_msg_status_report_t(sbp_decode_ctx_t *ctx, sbp_msg_status_report_t *msg)
-{
-  if (!decode_u16(ctx, &msg->reporting_system)) { return false; }
-  if (!decode_u16(ctx, &msg->sbp_version)) { return false; }
-  if (!decode_u32(ctx, &msg->sequence)) { return false; }
-  if (!decode_u32(ctx, &msg->uptime)) { return false; }
-    msg->n_status = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_sub_system_report_t(&msg->status[0]));
+bool decode_sbp_msg_status_report_t(sbp_decode_ctx_t *ctx,
+                                    sbp_msg_status_report_t *msg) {
+  if (!decode_u16(ctx, &msg->reporting_system)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->sbp_version)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->sequence)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->uptime)) {
+    return false;
+  }
+  msg->n_status =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_sub_system_report_t(&msg->status[0]));
   for (uint8_t i = 0; i < msg->n_status; i++) {
-    if (!decode_sbp_sub_system_report_t(ctx, &msg->status[i])) { return false; }
+    if (!decode_sbp_sub_system_report_t(ctx, &msg->status[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_status_report_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_status_report_t *msg) {
+s8 sbp_decode_sbp_msg_status_report_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_msg_status_report_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -422,36 +572,51 @@ s8 sbp_decode_sbp_msg_status_report_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_status_report_t(struct sbp_state *s, u16 sender_id, const sbp_msg_status_report_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_status_report_t(struct sbp_state *s, u16 sender_id,
+                                    const sbp_msg_status_report_t *msg,
+                                    sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_status_report_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_STATUS_REPORT, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_status_report_t(payload, sizeof(payload),
+                                              &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_STATUS_REPORT, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_status_report_t(const sbp_msg_status_report_t *a, const sbp_msg_status_report_t *b) {
+int sbp_cmp_sbp_msg_status_report_t(const sbp_msg_status_report_t *a,
+                                    const sbp_msg_status_report_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u16(&a->reporting_system, &b->reporting_system);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->sbp_version, &b->sbp_version);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->sequence, &b->sequence);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->uptime, &b->uptime);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_status, &b->n_status);
-  for (uint8_t i = 0; i < a->n_status && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_status && ret == 0; i++) {
     ret = sbp_cmp_sbp_sub_system_report_t(&a->status[i], &b->status[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -461,13 +626,17 @@ size_t sbp_packed_size_sbp_msg_ins_status_t(const sbp_msg_ins_status_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_ins_status_t(sbp_encode_ctx_t *ctx, const sbp_msg_ins_status_t *msg)
-{
-  if (!encode_u32(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_ins_status_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_ins_status_t *msg) {
+  if (!encode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ins_status_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ins_status_t *msg) {
+s8 sbp_encode_sbp_msg_ins_status_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_ins_status_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -481,13 +650,16 @@ s8 sbp_encode_sbp_msg_ins_status_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ins_status_t(sbp_decode_ctx_t *ctx, sbp_msg_ins_status_t *msg)
-{
-  if (!decode_u32(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_ins_status_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_ins_status_t *msg) {
+  if (!decode_u32(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ins_status_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ins_status_t *msg) {
+s8 sbp_decode_sbp_msg_ins_status_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_ins_status_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -500,104 +672,128 @@ s8 sbp_decode_sbp_msg_ins_status_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ins_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ins_status_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ins_status_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_ins_status_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ins_status_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_INS_STATUS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ins_status_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_INS_STATUS, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ins_status_t(const sbp_msg_ins_status_t *a, const sbp_msg_ins_status_t *b) {
+int sbp_cmp_sbp_msg_ins_status_t(const sbp_msg_ins_status_t *a,
+                                 const sbp_msg_ins_status_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_csac_telemetry_ttelemetry_params = 
-{
-  .max_packed_len = 254
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_csac_telemetry_ttelemetry_params = {.max_packed_len = 254};
 
-  void sbp_msg_csac_telemetry_t_telemetry_init(sbp_unterminated_string_t *s)
-{
+void sbp_msg_csac_telemetry_t_telemetry_init(sbp_unterminated_string_t *s) {
   sbp_unterminated_string_init(s, &sbp_msg_csac_telemetry_ttelemetry_params);
 }
 
-  bool sbp_msg_csac_telemetry_t_telemetry_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_csac_telemetry_ttelemetry_params);
+bool sbp_msg_csac_telemetry_t_telemetry_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params);
 }
 
-  int sbp_msg_csac_telemetry_t_telemetry_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_csac_telemetry_ttelemetry_params);
+int sbp_msg_csac_telemetry_t_telemetry_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_csac_telemetry_ttelemetry_params);
 }
 
-  uint8_t sbp_msg_csac_telemetry_t_telemetry_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_csac_telemetry_ttelemetry_params);
+uint8_t sbp_msg_csac_telemetry_t_telemetry_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params);
 }
 
-  uint8_t sbp_msg_csac_telemetry_t_telemetry_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_csac_telemetry_ttelemetry_params);
-      }
-  bool sbp_msg_csac_telemetry_t_telemetry_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_csac_telemetry_ttelemetry_params, new_str);
-  }
+uint8_t sbp_msg_csac_telemetry_t_telemetry_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params);
+}
+bool sbp_msg_csac_telemetry_t_telemetry_set(sbp_unterminated_string_t *s,
+                                            const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params, new_str);
+}
 
-  bool sbp_msg_csac_telemetry_t_telemetry_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_csac_telemetry_t_telemetry_printf(sbp_unterminated_string_t *s,
+                                               const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_csac_telemetry_t_telemetry_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
-  }
-
-  bool sbp_msg_csac_telemetry_t_telemetry_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_csac_telemetry_t_telemetry_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
+bool sbp_msg_csac_telemetry_t_telemetry_vprintf(sbp_unterminated_string_t *s,
+                                                const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
 }
 
-  const char *sbp_msg_csac_telemetry_t_telemetry_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_csac_telemetry_ttelemetry_params);
+bool sbp_msg_csac_telemetry_t_telemetry_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_csac_telemetry_t(const sbp_msg_csac_telemetry_t *msg) {
+bool sbp_msg_csac_telemetry_t_telemetry_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_csac_telemetry_ttelemetry_params, fmt, ap);
+}
+
+const char *sbp_msg_csac_telemetry_t_telemetry_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(s,
+                                     &sbp_msg_csac_telemetry_ttelemetry_params);
+}
+
+size_t sbp_packed_size_sbp_msg_csac_telemetry_t(
+    const sbp_msg_csac_telemetry_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->id);
-  packed_size += sbp_unterminated_string_packed_len(&msg->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_csac_telemetry_t(sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_t *msg)
-{
-  if (!encode_u8(ctx, &msg->id)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params, ctx)) { return false; }
+bool encode_sbp_msg_csac_telemetry_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_csac_telemetry_t *msg) {
+  if (!encode_u8(ctx, &msg->id)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_csac_telemetry_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_csac_telemetry_t *msg) {
+s8 sbp_encode_sbp_msg_csac_telemetry_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_csac_telemetry_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -611,14 +807,21 @@ s8 sbp_encode_sbp_msg_csac_telemetry_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_csac_telemetry_t(sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_t *msg)
-{
-  if (!decode_u8(ctx, &msg->id)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params, ctx)) { return false; }
+bool decode_sbp_msg_csac_telemetry_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_csac_telemetry_t *msg) {
+  if (!decode_u8(ctx, &msg->id)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_csac_telemetry_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_csac_telemetry_t *msg) {
+s8 sbp_decode_sbp_msg_csac_telemetry_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_csac_telemetry_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -631,107 +834,139 @@ s8 sbp_decode_sbp_msg_csac_telemetry_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_csac_telemetry_t(struct sbp_state *s, u16 sender_id, const sbp_msg_csac_telemetry_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_csac_telemetry_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_csac_telemetry_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_csac_telemetry_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_CSAC_TELEMETRY, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_csac_telemetry_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_CSAC_TELEMETRY, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_csac_telemetry_t(const sbp_msg_csac_telemetry_t *a, const sbp_msg_csac_telemetry_t *b) {
+int sbp_cmp_sbp_msg_csac_telemetry_t(const sbp_msg_csac_telemetry_t *a,
+                                     const sbp_msg_csac_telemetry_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->id, &b->id);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->telemetry, &b->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->telemetry, &b->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
-static const sbp_unterminated_string_params_t sbp_msg_csac_telemetry_labels_ttelemetry_labels_params = 
-{
-  .max_packed_len = 254
-};
+static const sbp_unterminated_string_params_t
+    sbp_msg_csac_telemetry_labels_ttelemetry_labels_params = {.max_packed_len =
+                                                                  254};
 
-  void sbp_msg_csac_telemetry_labels_t_telemetry_labels_init(sbp_unterminated_string_t *s)
-{
-  sbp_unterminated_string_init(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+void sbp_msg_csac_telemetry_labels_t_telemetry_labels_init(
+    sbp_unterminated_string_t *s) {
+  sbp_unterminated_string_init(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
 }
 
-  bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_valid(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_valid(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_valid(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_valid(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
 }
 
-  int sbp_msg_csac_telemetry_labels_t_telemetry_labels_strcmp(const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b)
-{
-  return sbp_unterminated_string_strcmp(a, b, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+int sbp_msg_csac_telemetry_labels_t_telemetry_labels_strcmp(
+    const sbp_unterminated_string_t *a, const sbp_unterminated_string_t *b) {
+  return sbp_unterminated_string_strcmp(
+      a, b, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
 }
 
-  uint8_t sbp_msg_csac_telemetry_labels_t_telemetry_labels_packed_len(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_packed_len(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+uint8_t sbp_msg_csac_telemetry_labels_t_telemetry_labels_packed_len(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_packed_len(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
 }
 
-  uint8_t sbp_msg_csac_telemetry_labels_t_telemetry_labels_space_remaining(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_space_remaining(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
-      }
-  bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_set(sbp_unterminated_string_t *s, const char *new_str)
-  {
-  return sbp_unterminated_string_set(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, new_str);
-  }
+uint8_t sbp_msg_csac_telemetry_labels_t_telemetry_labels_space_remaining(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_space_remaining(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+}
+bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_set(
+    sbp_unterminated_string_t *s, const char *new_str) {
+  return sbp_unterminated_string_set(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, new_str);
+}
 
-  bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-  {
+bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_unterminated_string_vprintf(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
-  }
-
-  bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_append_printf(sbp_unterminated_string_t *s, const char *fmt, ...) 
-{
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_append_vprintf(sbp_unterminated_string_t *s, const char *fmt, va_list ap)
-{
-  return sbp_unterminated_string_append_vprintf(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
+bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_vprintf(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
 }
 
-  const char *sbp_msg_csac_telemetry_labels_t_telemetry_labels_get(const sbp_unterminated_string_t *s)
-{
-  return sbp_unterminated_string_get(s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_append_printf(
+    sbp_unterminated_string_t *s, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_csac_telemetry_labels_t(const sbp_msg_csac_telemetry_labels_t *msg) {
+bool sbp_msg_csac_telemetry_labels_t_telemetry_labels_append_vprintf(
+    sbp_unterminated_string_t *s, const char *fmt, va_list ap) {
+  return sbp_unterminated_string_append_vprintf(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, fmt, ap);
+}
+
+const char *sbp_msg_csac_telemetry_labels_t_telemetry_labels_get(
+    const sbp_unterminated_string_t *s) {
+  return sbp_unterminated_string_get(
+      s, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+}
+
+size_t sbp_packed_size_sbp_msg_csac_telemetry_labels_t(
+    const sbp_msg_csac_telemetry_labels_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->id);
-  packed_size += sbp_unterminated_string_packed_len(&msg->telemetry_labels, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+  packed_size += sbp_unterminated_string_packed_len(
+      &msg->telemetry_labels,
+      &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
   return packed_size;
 }
 
-bool encode_sbp_msg_csac_telemetry_labels_t(sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_labels_t *msg)
-{
-  if (!encode_u8(ctx, &msg->id)) { return false; }
-  if (!sbp_unterminated_string_pack(&msg->telemetry_labels, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, ctx)) { return false; }
+bool encode_sbp_msg_csac_telemetry_labels_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_csac_telemetry_labels_t *msg) {
+  if (!encode_u8(ctx, &msg->id)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_pack(
+          &msg->telemetry_labels,
+          &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_csac_telemetry_labels_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_csac_telemetry_labels_t *msg) {
+s8 sbp_encode_sbp_msg_csac_telemetry_labels_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_csac_telemetry_labels_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -745,14 +980,22 @@ s8 sbp_encode_sbp_msg_csac_telemetry_labels_t(uint8_t *buf, uint8_t len, uint8_t
   return SBP_OK;
 }
 
-bool decode_sbp_msg_csac_telemetry_labels_t(sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_labels_t *msg)
-{
-  if (!decode_u8(ctx, &msg->id)) { return false; }
-  if (!sbp_unterminated_string_unpack(&msg->telemetry_labels, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, ctx)) { return false; }
+bool decode_sbp_msg_csac_telemetry_labels_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_csac_telemetry_labels_t *msg) {
+  if (!decode_u8(ctx, &msg->id)) {
+    return false;
+  }
+  if (!sbp_unterminated_string_unpack(
+          &msg->telemetry_labels,
+          &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params, ctx)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_csac_telemetry_labels_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_csac_telemetry_labels_t *msg) {
+s8 sbp_decode_sbp_msg_csac_telemetry_labels_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_csac_telemetry_labels_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -765,23 +1008,36 @@ s8 sbp_decode_sbp_msg_csac_telemetry_labels_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_csac_telemetry_labels_t(struct sbp_state *s, u16 sender_id, const sbp_msg_csac_telemetry_labels_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_csac_telemetry_labels_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_csac_telemetry_labels_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_csac_telemetry_labels_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_CSAC_TELEMETRY_LABELS, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_csac_telemetry_labels_t(payload, sizeof(payload),
+                                                      &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_CSAC_TELEMETRY_LABELS, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_csac_telemetry_labels_t(const sbp_msg_csac_telemetry_labels_t *a, const sbp_msg_csac_telemetry_labels_t *b) {
+int sbp_cmp_sbp_msg_csac_telemetry_labels_t(
+    const sbp_msg_csac_telemetry_labels_t *a,
+    const sbp_msg_csac_telemetry_labels_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->id, &b->id);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_unterminated_string_strcmp(&a->telemetry_labels, &b->telemetry_labels, &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_unterminated_string_strcmp(
+      &a->telemetry_labels, &b->telemetry_labels,
+      &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -797,19 +1053,35 @@ size_t sbp_packed_size_sbp_msg_ins_updates_t(const sbp_msg_ins_updates_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_ins_updates_t(sbp_encode_ctx_t *ctx, const sbp_msg_ins_updates_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_u8(ctx, &msg->gnsspos)) { return false; }
-  if (!encode_u8(ctx, &msg->gnssvel)) { return false; }
-  if (!encode_u8(ctx, &msg->wheelticks)) { return false; }
-  if (!encode_u8(ctx, &msg->speed)) { return false; }
-  if (!encode_u8(ctx, &msg->nhc)) { return false; }
-  if (!encode_u8(ctx, &msg->zerovel)) { return false; }
+bool encode_sbp_msg_ins_updates_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_ins_updates_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->gnsspos)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->gnssvel)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->wheelticks)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->speed)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->nhc)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->zerovel)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_ins_updates_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_ins_updates_t *msg) {
+s8 sbp_encode_sbp_msg_ins_updates_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_ins_updates_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -823,19 +1095,35 @@ s8 sbp_encode_sbp_msg_ins_updates_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_ins_updates_t(sbp_decode_ctx_t *ctx, sbp_msg_ins_updates_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_u8(ctx, &msg->gnsspos)) { return false; }
-  if (!decode_u8(ctx, &msg->gnssvel)) { return false; }
-  if (!decode_u8(ctx, &msg->wheelticks)) { return false; }
-  if (!decode_u8(ctx, &msg->speed)) { return false; }
-  if (!decode_u8(ctx, &msg->nhc)) { return false; }
-  if (!decode_u8(ctx, &msg->zerovel)) { return false; }
+bool decode_sbp_msg_ins_updates_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_ins_updates_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->gnsspos)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->gnssvel)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->wheelticks)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->speed)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->nhc)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->zerovel)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_ins_updates_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_ins_updates_t *msg) {
+s8 sbp_decode_sbp_msg_ins_updates_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_ins_updates_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -848,42 +1136,63 @@ s8 sbp_decode_sbp_msg_ins_updates_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ins_updates_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ins_updates_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_ins_updates_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_ins_updates_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_ins_updates_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_INS_UPDATES, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_ins_updates_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_INS_UPDATES, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_ins_updates_t(const sbp_msg_ins_updates_t *a, const sbp_msg_ins_updates_t *b) {
+int sbp_cmp_sbp_msg_ins_updates_t(const sbp_msg_ins_updates_t *a,
+                                  const sbp_msg_ins_updates_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->gnsspos, &b->gnsspos);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->gnssvel, &b->gnssvel);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->wheelticks, &b->wheelticks);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->speed, &b->speed);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->nhc, &b->nhc);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->zerovel, &b->zerovel);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_gnss_time_offset_t(const sbp_msg_gnss_time_offset_t *msg) {
+size_t sbp_packed_size_sbp_msg_gnss_time_offset_t(
+    const sbp_msg_gnss_time_offset_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s16(&msg->weeks);
   packed_size += sbp_packed_size_s32(&msg->milliseconds);
@@ -892,16 +1201,26 @@ size_t sbp_packed_size_sbp_msg_gnss_time_offset_t(const sbp_msg_gnss_time_offset
   return packed_size;
 }
 
-bool encode_sbp_msg_gnss_time_offset_t(sbp_encode_ctx_t *ctx, const sbp_msg_gnss_time_offset_t *msg)
-{
-  if (!encode_s16(ctx, &msg->weeks)) { return false; }
-  if (!encode_s32(ctx, &msg->milliseconds)) { return false; }
-  if (!encode_s16(ctx, &msg->microseconds)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_gnss_time_offset_t(sbp_encode_ctx_t *ctx,
+                                       const sbp_msg_gnss_time_offset_t *msg) {
+  if (!encode_s16(ctx, &msg->weeks)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->milliseconds)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->microseconds)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_gnss_time_offset_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_gnss_time_offset_t *msg) {
+s8 sbp_encode_sbp_msg_gnss_time_offset_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_gnss_time_offset_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -915,16 +1234,26 @@ s8 sbp_encode_sbp_msg_gnss_time_offset_t(uint8_t *buf, uint8_t len, uint8_t *n_w
   return SBP_OK;
 }
 
-bool decode_sbp_msg_gnss_time_offset_t(sbp_decode_ctx_t *ctx, sbp_msg_gnss_time_offset_t *msg)
-{
-  if (!decode_s16(ctx, &msg->weeks)) { return false; }
-  if (!decode_s32(ctx, &msg->milliseconds)) { return false; }
-  if (!decode_s16(ctx, &msg->microseconds)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_gnss_time_offset_t(sbp_decode_ctx_t *ctx,
+                                       sbp_msg_gnss_time_offset_t *msg) {
+  if (!decode_s16(ctx, &msg->weeks)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->milliseconds)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->microseconds)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_gnss_time_offset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_gnss_time_offset_t *msg) {
+s8 sbp_decode_sbp_msg_gnss_time_offset_t(const uint8_t *buf, uint8_t len,
+                                         uint8_t *n_read,
+                                         sbp_msg_gnss_time_offset_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -937,29 +1266,43 @@ s8 sbp_decode_sbp_msg_gnss_time_offset_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gnss_time_offset_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gnss_time_offset_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_gnss_time_offset_t(struct sbp_state *s, u16 sender_id,
+                                       const sbp_msg_gnss_time_offset_t *msg,
+                                       sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_gnss_time_offset_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GNSS_TIME_OFFSET, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_gnss_time_offset_t(payload, sizeof(payload),
+                                                 &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GNSS_TIME_OFFSET, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_gnss_time_offset_t(const sbp_msg_gnss_time_offset_t *a, const sbp_msg_gnss_time_offset_t *b) {
+int sbp_cmp_sbp_msg_gnss_time_offset_t(const sbp_msg_gnss_time_offset_t *a,
+                                       const sbp_msg_gnss_time_offset_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s16(&a->weeks, &b->weeks);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->milliseconds, &b->milliseconds);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->microseconds, &b->microseconds);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -970,14 +1313,19 @@ size_t sbp_packed_size_sbp_msg_pps_time_t(const sbp_msg_pps_time_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_pps_time_t(sbp_encode_ctx_t *ctx, const sbp_msg_pps_time_t *msg)
-{
-  if (!encode_u64(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_pps_time_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_pps_time_t *msg) {
+  if (!encode_u64(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_pps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_pps_time_t *msg) {
+s8 sbp_encode_sbp_msg_pps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_pps_time_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -991,14 +1339,18 @@ s8 sbp_encode_sbp_msg_pps_time_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_pps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_pps_time_t *msg)
-{
-  if (!decode_u64(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_pps_time_t(sbp_decode_ctx_t *ctx, sbp_msg_pps_time_t *msg) {
+  if (!decode_u64(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_pps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_pps_time_t *msg) {
+s8 sbp_decode_sbp_msg_pps_time_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_pps_time_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1011,23 +1363,33 @@ s8 sbp_decode_sbp_msg_pps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pps_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pps_time_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_pps_time_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_pps_time_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_pps_time_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_PPS_TIME, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_pps_time_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_PPS_TIME, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_pps_time_t(const sbp_msg_pps_time_t *a, const sbp_msg_pps_time_t *b) {
+int sbp_cmp_sbp_msg_pps_time_t(const sbp_msg_pps_time_t *a,
+                               const sbp_msg_pps_time_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -1040,19 +1402,28 @@ size_t sbp_packed_size_sbp_msg_group_meta_t(const sbp_msg_group_meta_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx, const sbp_msg_group_meta_t *msg)
-{
-  if (!encode_u8(ctx, &msg->group_id)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_u8(ctx, &msg->n_group_msgs)) { return false; }
-  for (uint8_t i = 0; i < msg->n_group_msgs; i++)
-  {
-    if (!encode_u16(ctx, &msg->group_msgs[i])) { return false; }
+bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx,
+                                 const sbp_msg_group_meta_t *msg) {
+  if (!encode_u8(ctx, &msg->group_id)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->n_group_msgs)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < msg->n_group_msgs; i++) {
+    if (!encode_u16(ctx, &msg->group_msgs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_group_meta_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_group_meta_t *msg) {
+s8 sbp_encode_sbp_msg_group_meta_t(uint8_t *buf, uint8_t len,
+                                   uint8_t *n_written,
+                                   const sbp_msg_group_meta_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1066,19 +1437,29 @@ s8 sbp_encode_sbp_msg_group_meta_t(uint8_t *buf, uint8_t len, uint8_t *n_written
   return SBP_OK;
 }
 
-bool decode_sbp_msg_group_meta_t(sbp_decode_ctx_t *ctx, sbp_msg_group_meta_t *msg)
-{
-  if (!decode_u8(ctx, &msg->group_id)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_u8(ctx, &msg->n_group_msgs)) { return false; }
-    msg->n_group_msgs = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u16(&msg->group_msgs[0]));
+bool decode_sbp_msg_group_meta_t(sbp_decode_ctx_t *ctx,
+                                 sbp_msg_group_meta_t *msg) {
+  if (!decode_u8(ctx, &msg->group_id)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->n_group_msgs)) {
+    return false;
+  }
+  msg->n_group_msgs = (uint8_t)((ctx->buf_len - ctx->offset) /
+                                sbp_packed_size_u16(&msg->group_msgs[0]));
   for (uint8_t i = 0; i < msg->n_group_msgs; i++) {
-    if (!decode_u16(ctx, &msg->group_msgs[i])) { return false; }
+    if (!decode_u16(ctx, &msg->group_msgs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_group_meta_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_group_meta_t *msg) {
+s8 sbp_decode_sbp_msg_group_meta_t(const uint8_t *buf, uint8_t len,
+                                   uint8_t *n_read, sbp_msg_group_meta_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1091,32 +1472,45 @@ s8 sbp_decode_sbp_msg_group_meta_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_meta_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_meta_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_group_meta_t(struct sbp_state *s, u16 sender_id,
+                                 const sbp_msg_group_meta_t *msg,
+                                 sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_group_meta_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_GROUP_META, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_group_meta_t(payload, sizeof(payload),
+                                           &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_GROUP_META, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_group_meta_t(const sbp_msg_group_meta_t *a, const sbp_msg_group_meta_t *b) {
+int sbp_cmp_sbp_msg_group_meta_t(const sbp_msg_group_meta_t *a,
+                                 const sbp_msg_group_meta_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->group_id, &b->group_id);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_group_msgs, &b->n_group_msgs);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->n_group_msgs, &b->n_group_msgs);
-  for (uint8_t i = 0; i < a->n_group_msgs && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_group_msgs && ret == 0; i++) {
     ret = sbp_cmp_u16(&a->group_msgs[i], &b->group_msgs[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/system.c
+++ b/c/src/new/system.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/system.yaml
  * with generate.py. Please do not hand edit!
@@ -92,6 +80,7 @@ s8 sbp_decode_sbp_msg_startup_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_startup_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_startup_t *msg,
                               sbp_write_fn_t write) {
@@ -275,6 +264,7 @@ s8 sbp_decode_sbp_msg_dgnss_status_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_dgnss_status_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_dgnss_status_t *msg,
                                    sbp_write_fn_t write) {
@@ -308,8 +298,7 @@ int sbp_cmp_sbp_msg_dgnss_status_t(const sbp_msg_dgnss_status_t *a,
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(&a->source, &b->source,
-                                       &sbp_msg_dgnss_status_tsource_params);
+  ret = sbp_msg_dgnss_status_t_source_strcmp(&a->source, &b->source);
   if (ret != 0) {
     return ret;
   }
@@ -367,6 +356,7 @@ s8 sbp_decode_sbp_msg_heartbeat_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_heartbeat_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_heartbeat_t *msg,
                                 sbp_write_fn_t write) {
@@ -508,7 +498,7 @@ bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->uptime)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_status; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_status; i++) {
     if (!encode_sbp_sub_system_report_t(ctx, &msg->status[i])) {
       return false;
     }
@@ -572,6 +562,7 @@ s8 sbp_decode_sbp_msg_status_report_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_status_report_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_status_report_t *msg,
                                     sbp_write_fn_t write) {
@@ -611,7 +602,7 @@ int sbp_cmp_sbp_msg_status_report_t(const sbp_msg_status_report_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_status, &b->n_status);
-  for (uint8_t i = 0; i < a->n_status && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_status; i++) {
     ret = sbp_cmp_sbp_sub_system_report_t(&a->status[i], &b->status[i]);
   }
   if (ret != 0) {
@@ -672,6 +663,7 @@ s8 sbp_decode_sbp_msg_ins_status_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ins_status_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_ins_status_t *msg,
                                  sbp_write_fn_t write) {
@@ -834,6 +826,7 @@ s8 sbp_decode_sbp_msg_csac_telemetry_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_csac_telemetry_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_csac_telemetry_t *msg,
                                      sbp_write_fn_t write) {
@@ -857,8 +850,7 @@ int sbp_cmp_sbp_msg_csac_telemetry_t(const sbp_msg_csac_telemetry_t *a,
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->telemetry, &b->telemetry, &sbp_msg_csac_telemetry_ttelemetry_params);
+  ret = sbp_msg_csac_telemetry_t_telemetry_strcmp(&a->telemetry, &b->telemetry);
   if (ret != 0) {
     return ret;
   }
@@ -1008,6 +1000,7 @@ s8 sbp_decode_sbp_msg_csac_telemetry_labels_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_csac_telemetry_labels_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_csac_telemetry_labels_t *msg, sbp_write_fn_t write) {
@@ -1032,9 +1025,8 @@ int sbp_cmp_sbp_msg_csac_telemetry_labels_t(
     return ret;
   }
 
-  ret = sbp_unterminated_string_strcmp(
-      &a->telemetry_labels, &b->telemetry_labels,
-      &sbp_msg_csac_telemetry_labels_ttelemetry_labels_params);
+  ret = sbp_msg_csac_telemetry_labels_t_telemetry_labels_strcmp(
+      &a->telemetry_labels, &b->telemetry_labels);
   if (ret != 0) {
     return ret;
   }
@@ -1136,6 +1128,7 @@ s8 sbp_decode_sbp_msg_ins_updates_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_ins_updates_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_ins_updates_t *msg,
                                   sbp_write_fn_t write) {
@@ -1266,6 +1259,7 @@ s8 sbp_decode_sbp_msg_gnss_time_offset_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_gnss_time_offset_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_gnss_time_offset_t *msg,
                                        sbp_write_fn_t write) {
@@ -1363,6 +1357,7 @@ s8 sbp_decode_sbp_msg_pps_time_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_pps_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_pps_time_t *msg,
                                sbp_write_fn_t write) {
@@ -1413,7 +1408,7 @@ bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->n_group_msgs)) {
     return false;
   }
-  for (uint8_t i = 0; i < msg->n_group_msgs; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_group_msgs; i++) {
     if (!encode_u16(ctx, &msg->group_msgs[i])) {
       return false;
     }
@@ -1472,6 +1467,7 @@ s8 sbp_decode_sbp_msg_group_meta_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_group_meta_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_group_meta_t *msg,
                                  sbp_write_fn_t write) {
@@ -1506,7 +1502,7 @@ int sbp_cmp_sbp_msg_group_meta_t(const sbp_msg_group_meta_t *a,
   }
 
   ret = sbp_cmp_u8(&a->n_group_msgs, &b->n_group_msgs);
-  for (uint8_t i = 0; i < a->n_group_msgs && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_group_msgs; i++) {
     ret = sbp_cmp_u16(&a->group_msgs[i], &b->group_msgs[i]);
   }
   if (ret != 0) {

--- a/c/src/new/system.c
+++ b/c/src/new/system.c
@@ -498,7 +498,7 @@ bool encode_sbp_msg_status_report_t(sbp_encode_ctx_t *ctx,
   if (!encode_u32(ctx, &msg->uptime)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_status; i++) {
+  for (uint8_t i = 0; i < msg->n_status; i++) {
     if (!encode_sbp_sub_system_report_t(ctx, &msg->status[i])) {
       return false;
     }
@@ -1408,7 +1408,7 @@ bool encode_sbp_msg_group_meta_t(sbp_encode_ctx_t *ctx,
   if (!encode_u8(ctx, &msg->n_group_msgs)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < msg->n_group_msgs; i++) {
+  for (uint8_t i = 0; i < msg->n_group_msgs; i++) {
     if (!encode_u16(ctx, &msg->group_msgs[i])) {
       return false;
     }

--- a/c/src/new/tracking.c
+++ b/c/src/new/tracking.c
@@ -1,17 +1,35 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/tracking.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/tracking.h>
-#include <libsbp/internal/new/tracking.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/internal/new/tracking.h>
+#include <libsbp/new/tracking.h>
+#include <libsbp/sbp.h>
 
-size_t sbp_packed_size_sbp_msg_tracking_state_detailed_dep_a_t(const sbp_msg_tracking_state_detailed_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_state_detailed_dep_a_t(
+    const sbp_msg_tracking_state_detailed_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u64(&msg->recv_time);
   packed_size += sbp_packed_size_sbp_sbp_gps_time_t(&msg->tot);
@@ -37,33 +55,77 @@ size_t sbp_packed_size_sbp_msg_tracking_state_detailed_dep_a_t(const sbp_msg_tra
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_state_detailed_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_a_t *msg)
-{
-  if (!encode_u64(ctx, &msg->recv_time)) { return false; }
-  if (!encode_sbp_sbp_gps_time_t(ctx, &msg->tot)) { return false; }
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_u16(ctx, &msg->P_std)) { return false; }
-  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
-  if (!encode_u16(ctx, &msg->lock)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_s32(ctx, &msg->doppler)) { return false; }
-  if (!encode_u16(ctx, &msg->doppler_std)) { return false; }
-  if (!encode_u32(ctx, &msg->uptime)) { return false; }
-  if (!encode_s16(ctx, &msg->clock_offset)) { return false; }
-  if (!encode_s16(ctx, &msg->clock_drift)) { return false; }
-  if (!encode_u16(ctx, &msg->corr_spacing)) { return false; }
-  if (!encode_s8(ctx, &msg->acceleration)) { return false; }
-  if (!encode_u8(ctx, &msg->sync_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->tow_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->track_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->nav_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->pset_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->misc_flags)) { return false; }
+bool encode_sbp_msg_tracking_state_detailed_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_a_t *msg) {
+  if (!encode_u64(ctx, &msg->recv_time)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gps_time_t(ctx, &msg->tot)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->P_std)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->doppler)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->doppler_std)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->uptime)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->clock_offset)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->clock_drift)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->corr_spacing)) {
+    return false;
+  }
+  if (!encode_s8(ctx, &msg->acceleration)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->sync_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tow_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->track_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->nav_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pset_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->misc_flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_state_detailed_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_tracking_state_detailed_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -77,33 +139,77 @@ s8 sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(uint8_t *buf, uint8_t len,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_state_detailed_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_a_t *msg)
-{
-  if (!decode_u64(ctx, &msg->recv_time)) { return false; }
-  if (!decode_sbp_sbp_gps_time_t(ctx, &msg->tot)) { return false; }
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_u16(ctx, &msg->P_std)) { return false; }
-  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
-  if (!decode_u16(ctx, &msg->lock)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_s32(ctx, &msg->doppler)) { return false; }
-  if (!decode_u16(ctx, &msg->doppler_std)) { return false; }
-  if (!decode_u32(ctx, &msg->uptime)) { return false; }
-  if (!decode_s16(ctx, &msg->clock_offset)) { return false; }
-  if (!decode_s16(ctx, &msg->clock_drift)) { return false; }
-  if (!decode_u16(ctx, &msg->corr_spacing)) { return false; }
-  if (!decode_s8(ctx, &msg->acceleration)) { return false; }
-  if (!decode_u8(ctx, &msg->sync_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->tow_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->track_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->nav_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->pset_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->misc_flags)) { return false; }
+bool decode_sbp_msg_tracking_state_detailed_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_a_t *msg) {
+  if (!decode_u64(ctx, &msg->recv_time)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gps_time_t(ctx, &msg->tot)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->P_std)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->doppler)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->doppler_std)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->uptime)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->clock_offset)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->clock_drift)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->corr_spacing)) {
+    return false;
+  }
+  if (!decode_s8(ctx, &msg->acceleration)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->sync_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tow_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->track_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->nav_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pset_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->misc_flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_state_detailed_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_tracking_state_detailed_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -116,84 +222,134 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(const uint8_t *buf, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_detailed_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_tracking_state_detailed_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DETAILED_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_state_detailed_dep_a_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DETAILED_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_state_detailed_dep_a_t(const sbp_msg_tracking_state_detailed_dep_a_t *a, const sbp_msg_tracking_state_detailed_dep_a_t *b) {
+int sbp_cmp_sbp_msg_tracking_state_detailed_dep_a_t(
+    const sbp_msg_tracking_state_detailed_dep_a_t *a,
+    const sbp_msg_tracking_state_detailed_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->recv_time, &b->recv_time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gps_time_t(&a->tot, &b->tot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->P_std, &b->P_std);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->doppler, &b->doppler);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->doppler_std, &b->doppler_std);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->uptime, &b->uptime);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->clock_offset, &b->clock_offset);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->clock_drift, &b->clock_drift);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->corr_spacing, &b->corr_spacing);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s8(&a->acceleration, &b->acceleration);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->sync_flags, &b->sync_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tow_flags, &b->tow_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->track_flags, &b->track_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->nav_flags, &b->nav_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pset_flags, &b->pset_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->misc_flags, &b->misc_flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_tracking_state_detailed_dep_t(const sbp_msg_tracking_state_detailed_dep_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_state_detailed_dep_t(
+    const sbp_msg_tracking_state_detailed_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u64(&msg->recv_time);
   packed_size += sbp_packed_size_sbp_gps_time_dep_t(&msg->tot);
@@ -219,33 +375,77 @@ size_t sbp_packed_size_sbp_msg_tracking_state_detailed_dep_t(const sbp_msg_track
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_state_detailed_dep_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_t *msg)
-{
-  if (!encode_u64(ctx, &msg->recv_time)) { return false; }
-  if (!encode_sbp_gps_time_dep_t(ctx, &msg->tot)) { return false; }
-  if (!encode_u32(ctx, &msg->P)) { return false; }
-  if (!encode_u16(ctx, &msg->P_std)) { return false; }
-  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
-  if (!encode_u16(ctx, &msg->lock)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_s32(ctx, &msg->doppler)) { return false; }
-  if (!encode_u16(ctx, &msg->doppler_std)) { return false; }
-  if (!encode_u32(ctx, &msg->uptime)) { return false; }
-  if (!encode_s16(ctx, &msg->clock_offset)) { return false; }
-  if (!encode_s16(ctx, &msg->clock_drift)) { return false; }
-  if (!encode_u16(ctx, &msg->corr_spacing)) { return false; }
-  if (!encode_s8(ctx, &msg->acceleration)) { return false; }
-  if (!encode_u8(ctx, &msg->sync_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->tow_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->track_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->nav_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->pset_flags)) { return false; }
-  if (!encode_u8(ctx, &msg->misc_flags)) { return false; }
+bool encode_sbp_msg_tracking_state_detailed_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_detailed_dep_t *msg) {
+  if (!encode_u64(ctx, &msg->recv_time)) {
+    return false;
+  }
+  if (!encode_sbp_gps_time_dep_t(ctx, &msg->tot)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->P_std)) {
+    return false;
+  }
+  if (!encode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->doppler)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->doppler_std)) {
+    return false;
+  }
+  if (!encode_u32(ctx, &msg->uptime)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->clock_offset)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->clock_drift)) {
+    return false;
+  }
+  if (!encode_u16(ctx, &msg->corr_spacing)) {
+    return false;
+  }
+  if (!encode_s8(ctx, &msg->acceleration)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->sync_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->tow_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->track_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->nav_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->pset_flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->misc_flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_state_detailed_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_state_detailed_dep_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_state_detailed_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_tracking_state_detailed_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -259,33 +459,77 @@ s8 sbp_encode_sbp_msg_tracking_state_detailed_dep_t(uint8_t *buf, uint8_t len, u
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_state_detailed_dep_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_t *msg)
-{
-  if (!decode_u64(ctx, &msg->recv_time)) { return false; }
-  if (!decode_sbp_gps_time_dep_t(ctx, &msg->tot)) { return false; }
-  if (!decode_u32(ctx, &msg->P)) { return false; }
-  if (!decode_u16(ctx, &msg->P_std)) { return false; }
-  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
-  if (!decode_u16(ctx, &msg->lock)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_s32(ctx, &msg->doppler)) { return false; }
-  if (!decode_u16(ctx, &msg->doppler_std)) { return false; }
-  if (!decode_u32(ctx, &msg->uptime)) { return false; }
-  if (!decode_s16(ctx, &msg->clock_offset)) { return false; }
-  if (!decode_s16(ctx, &msg->clock_drift)) { return false; }
-  if (!decode_u16(ctx, &msg->corr_spacing)) { return false; }
-  if (!decode_s8(ctx, &msg->acceleration)) { return false; }
-  if (!decode_u8(ctx, &msg->sync_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->tow_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->track_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->nav_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->pset_flags)) { return false; }
-  if (!decode_u8(ctx, &msg->misc_flags)) { return false; }
+bool decode_sbp_msg_tracking_state_detailed_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_detailed_dep_t *msg) {
+  if (!decode_u64(ctx, &msg->recv_time)) {
+    return false;
+  }
+  if (!decode_sbp_gps_time_dep_t(ctx, &msg->tot)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->P)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->P_std)) {
+    return false;
+  }
+  if (!decode_sbp_carrier_phase_t(ctx, &msg->L)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->lock)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->doppler)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->doppler_std)) {
+    return false;
+  }
+  if (!decode_u32(ctx, &msg->uptime)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->clock_offset)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->clock_drift)) {
+    return false;
+  }
+  if (!decode_u16(ctx, &msg->corr_spacing)) {
+    return false;
+  }
+  if (!decode_s8(ctx, &msg->acceleration)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->sync_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->tow_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->track_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->nav_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->pset_flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->misc_flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_state_detailed_dep_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_tracking_state_detailed_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -298,84 +542,134 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_detailed_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_detailed_dep_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_state_detailed_dep_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_tracking_state_detailed_dep_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_state_detailed_dep_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DETAILED_DEP, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_state_detailed_dep_t(
+      payload, sizeof(payload), &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DETAILED_DEP, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_state_detailed_dep_t(const sbp_msg_tracking_state_detailed_dep_t *a, const sbp_msg_tracking_state_detailed_dep_t *b) {
+int sbp_cmp_sbp_msg_tracking_state_detailed_dep_t(
+    const sbp_msg_tracking_state_detailed_dep_t *a,
+    const sbp_msg_tracking_state_detailed_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->recv_time, &b->recv_time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gps_time_dep_t(&a->tot, &b->tot);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->P, &b->P);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->P_std, &b->P_std);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_carrier_phase_t(&a->L, &b->L);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->lock, &b->lock);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->doppler, &b->doppler);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->doppler_std, &b->doppler_std);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u32(&a->uptime, &b->uptime);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->clock_offset, &b->clock_offset);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->clock_drift, &b->clock_drift);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u16(&a->corr_spacing, &b->corr_spacing);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s8(&a->acceleration, &b->acceleration);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->sync_flags, &b->sync_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->tow_flags, &b->tow_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->track_flags, &b->track_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->nav_flags, &b->nav_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->pset_flags, &b->pset_flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->misc_flags, &b->misc_flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tracking_channel_state_t(const sbp_tracking_channel_state_t *msg) {
+size_t sbp_packed_size_sbp_tracking_channel_state_t(
+    const sbp_tracking_channel_state_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
   packed_size += sbp_packed_size_u8(&msg->fcn);
@@ -383,15 +677,23 @@ size_t sbp_packed_size_sbp_tracking_channel_state_t(const sbp_tracking_channel_s
   return packed_size;
 }
 
-bool encode_sbp_tracking_channel_state_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!encode_u8(ctx, &msg->fcn)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
+bool encode_sbp_tracking_channel_state_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tracking_channel_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tracking_channel_state_t *msg) {
+s8 sbp_encode_sbp_tracking_channel_state_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tracking_channel_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -405,15 +707,23 @@ s8 sbp_encode_sbp_tracking_channel_state_t(uint8_t *buf, uint8_t len, uint8_t *n
   return SBP_OK;
 }
 
-bool decode_sbp_tracking_channel_state_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  if (!decode_u8(ctx, &msg->fcn)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
+bool decode_sbp_tracking_channel_state_t(sbp_decode_ctx_t *ctx,
+                                         sbp_tracking_channel_state_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->fcn)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tracking_channel_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tracking_channel_state_t *msg) {
+s8 sbp_decode_sbp_tracking_channel_state_t(const uint8_t *buf, uint8_t len,
+                                           uint8_t *n_read,
+                                           sbp_tracking_channel_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -427,36 +737,49 @@ s8 sbp_decode_sbp_tracking_channel_state_t(const uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tracking_channel_state_t(const sbp_tracking_channel_state_t *a, const sbp_tracking_channel_state_t *b) {
+int sbp_cmp_sbp_tracking_channel_state_t(
+    const sbp_tracking_channel_state_t *a,
+    const sbp_tracking_channel_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->fcn, &b->fcn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_tracking_state_t(const sbp_msg_tracking_state_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_state_t(
+    const sbp_msg_tracking_state_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_states * sbp_packed_size_sbp_tracking_channel_state_t(&msg->states[0]));
+  packed_size += (msg->n_states * sbp_packed_size_sbp_tracking_channel_state_t(
+                                      &msg->states[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_states; i++)
-  {
-    if (!encode_sbp_tracking_channel_state_t(ctx, &msg->states[i])) { return false; }
+bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx,
+                                     const sbp_msg_tracking_state_t *msg) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
+    if (!encode_sbp_tracking_channel_state_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_state_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_state_t(uint8_t *buf, uint8_t len,
+                                       uint8_t *n_written,
+                                       const sbp_msg_tracking_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -470,16 +793,22 @@ s8 sbp_encode_sbp_msg_tracking_state_t(uint8_t *buf, uint8_t len, uint8_t *n_wri
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_state_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_t *msg)
-{
-    msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_tracking_channel_state_t(&msg->states[0]));
+bool decode_sbp_msg_tracking_state_t(sbp_decode_ctx_t *ctx,
+                                     sbp_msg_tracking_state_t *msg) {
+  msg->n_states =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_tracking_channel_state_t(&msg->states[0]));
   for (uint8_t i = 0; i < msg->n_states; i++) {
-    if (!decode_sbp_tracking_channel_state_t(ctx, &msg->states[i])) { return false; }
+    if (!decode_sbp_tracking_channel_state_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_state_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_state_t(const uint8_t *buf, uint8_t len,
+                                       uint8_t *n_read,
+                                       sbp_msg_tracking_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -492,42 +821,56 @@ s8 sbp_decode_sbp_msg_tracking_state_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_state_t(struct sbp_state *s, u16 sender_id,
+                                     const sbp_msg_tracking_state_t *msg,
+                                     sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_state_t(payload, sizeof(payload),
+                                               &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_state_t(const sbp_msg_tracking_state_t *a, const sbp_msg_tracking_state_t *b) {
+int sbp_cmp_sbp_msg_tracking_state_t(const sbp_msg_tracking_state_t *a,
+                                     const sbp_msg_tracking_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
     ret = sbp_cmp_sbp_tracking_channel_state_t(&a->states[i], &b->states[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_measurement_state_t(const sbp_measurement_state_t *msg) {
+size_t sbp_packed_size_sbp_measurement_state_t(
+    const sbp_measurement_state_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->mesid);
   packed_size += sbp_packed_size_u8(&msg->cn0);
   return packed_size;
 }
 
-bool encode_sbp_measurement_state_t(sbp_encode_ctx_t *ctx, const sbp_measurement_state_t *msg)
-{
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->mesid)) { return false; }
-  if (!encode_u8(ctx, &msg->cn0)) { return false; }
+bool encode_sbp_measurement_state_t(sbp_encode_ctx_t *ctx,
+                                    const sbp_measurement_state_t *msg) {
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->mesid)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_measurement_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_measurement_state_t *msg) {
+s8 sbp_encode_sbp_measurement_state_t(uint8_t *buf, uint8_t len,
+                                      uint8_t *n_written,
+                                      const sbp_measurement_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -541,14 +884,20 @@ s8 sbp_encode_sbp_measurement_state_t(uint8_t *buf, uint8_t len, uint8_t *n_writ
   return SBP_OK;
 }
 
-bool decode_sbp_measurement_state_t(sbp_decode_ctx_t *ctx, sbp_measurement_state_t *msg)
-{
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->mesid)) { return false; }
-  if (!decode_u8(ctx, &msg->cn0)) { return false; }
+bool decode_sbp_measurement_state_t(sbp_decode_ctx_t *ctx,
+                                    sbp_measurement_state_t *msg) {
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->mesid)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_measurement_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_measurement_state_t *msg) {
+s8 sbp_decode_sbp_measurement_state_t(const uint8_t *buf, uint8_t len,
+                                      uint8_t *n_read,
+                                      sbp_measurement_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -562,33 +911,43 @@ s8 sbp_decode_sbp_measurement_state_t(const uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_measurement_state_t(const sbp_measurement_state_t *a, const sbp_measurement_state_t *b) {
+int sbp_cmp_sbp_measurement_state_t(const sbp_measurement_state_t *a,
+                                    const sbp_measurement_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->mesid, &b->mesid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_measurement_state_t(const sbp_msg_measurement_state_t *msg) {
+size_t sbp_packed_size_sbp_msg_measurement_state_t(
+    const sbp_msg_measurement_state_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_states * sbp_packed_size_sbp_measurement_state_t(&msg->states[0]));
+  packed_size += (msg->n_states *
+                  sbp_packed_size_sbp_measurement_state_t(&msg->states[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_measurement_state_t(sbp_encode_ctx_t *ctx, const sbp_msg_measurement_state_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_states; i++)
-  {
-    if (!encode_sbp_measurement_state_t(ctx, &msg->states[i])) { return false; }
+bool encode_sbp_msg_measurement_state_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_measurement_state_t *msg) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
+    if (!encode_sbp_measurement_state_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_measurement_state_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_measurement_state_t *msg) {
+s8 sbp_encode_sbp_msg_measurement_state_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_measurement_state_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -602,16 +961,22 @@ s8 sbp_encode_sbp_msg_measurement_state_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_measurement_state_t(sbp_decode_ctx_t *ctx, sbp_msg_measurement_state_t *msg)
-{
-    msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_measurement_state_t(&msg->states[0]));
+bool decode_sbp_msg_measurement_state_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_measurement_state_t *msg) {
+  msg->n_states =
+      (uint8_t)((ctx->buf_len - ctx->offset) /
+                sbp_packed_size_sbp_measurement_state_t(&msg->states[0]));
   for (uint8_t i = 0; i < msg->n_states; i++) {
-    if (!decode_sbp_measurement_state_t(ctx, &msg->states[i])) { return false; }
+    if (!decode_sbp_measurement_state_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_measurement_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_measurement_state_t *msg) {
+s8 sbp_decode_sbp_msg_measurement_state_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_measurement_state_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -624,42 +989,56 @@ s8 sbp_decode_sbp_msg_measurement_state_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_measurement_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_measurement_state_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_measurement_state_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_measurement_state_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_measurement_state_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_MEASUREMENT_STATE, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_measurement_state_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_MEASUREMENT_STATE, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_measurement_state_t(const sbp_msg_measurement_state_t *a, const sbp_msg_measurement_state_t *b) {
+int sbp_cmp_sbp_msg_measurement_state_t(const sbp_msg_measurement_state_t *a,
+                                        const sbp_msg_measurement_state_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
     ret = sbp_cmp_sbp_measurement_state_t(&a->states[i], &b->states[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tracking_channel_correlation_t(const sbp_tracking_channel_correlation_t *msg) {
+size_t sbp_packed_size_sbp_tracking_channel_correlation_t(
+    const sbp_tracking_channel_correlation_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s16(&msg->I);
   packed_size += sbp_packed_size_s16(&msg->Q);
   return packed_size;
 }
 
-bool encode_sbp_tracking_channel_correlation_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_t *msg)
-{
-  if (!encode_s16(ctx, &msg->I)) { return false; }
-  if (!encode_s16(ctx, &msg->Q)) { return false; }
+bool encode_sbp_tracking_channel_correlation_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_t *msg) {
+  if (!encode_s16(ctx, &msg->I)) {
+    return false;
+  }
+  if (!encode_s16(ctx, &msg->Q)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tracking_channel_correlation_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tracking_channel_correlation_t *msg) {
+s8 sbp_encode_sbp_tracking_channel_correlation_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tracking_channel_correlation_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -673,14 +1052,20 @@ s8 sbp_encode_sbp_tracking_channel_correlation_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_tracking_channel_correlation_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_t *msg)
-{
-  if (!decode_s16(ctx, &msg->I)) { return false; }
-  if (!decode_s16(ctx, &msg->Q)) { return false; }
+bool decode_sbp_tracking_channel_correlation_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_t *msg) {
+  if (!decode_s16(ctx, &msg->I)) {
+    return false;
+  }
+  if (!decode_s16(ctx, &msg->Q)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tracking_channel_correlation_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tracking_channel_correlation_t *msg) {
+s8 sbp_decode_sbp_tracking_channel_correlation_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_tracking_channel_correlation_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -694,14 +1079,20 @@ s8 sbp_decode_sbp_tracking_channel_correlation_t(const uint8_t *buf, uint8_t len
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tracking_channel_correlation_t(const sbp_tracking_channel_correlation_t *a, const sbp_tracking_channel_correlation_t *b) {
+int sbp_cmp_sbp_tracking_channel_correlation_t(
+    const sbp_tracking_channel_correlation_t *a,
+    const sbp_tracking_channel_correlation_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s16(&a->I, &b->I);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s16(&a->Q, &b->Q);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -709,22 +1100,30 @@ size_t sbp_packed_size_sbp_msg_tracking_iq_t(const sbp_msg_tracking_iq_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->channel);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
-  packed_size += ( 3 * sbp_packed_size_sbp_tracking_channel_correlation_t(&msg->corrs[0]));
+  packed_size +=
+      (3 * sbp_packed_size_sbp_tracking_channel_correlation_t(&msg->corrs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_t *msg)
-{
-  if (!encode_u8(ctx, &msg->channel)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_sbp_tracking_channel_correlation_t(ctx, &msg->corrs[i])) { return false; }
+bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx,
+                                  const sbp_msg_tracking_iq_t *msg) {
+  if (!encode_u8(ctx, &msg->channel)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_sbp_tracking_channel_correlation_t(ctx, &msg->corrs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_iq_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_iq_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_iq_t(uint8_t *buf, uint8_t len,
+                                    uint8_t *n_written,
+                                    const sbp_msg_tracking_iq_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -738,17 +1137,25 @@ s8 sbp_encode_sbp_msg_tracking_iq_t(uint8_t *buf, uint8_t len, uint8_t *n_writte
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_iq_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_iq_t *msg)
-{
-  if (!decode_u8(ctx, &msg->channel)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_tracking_iq_t(sbp_decode_ctx_t *ctx,
+                                  sbp_msg_tracking_iq_t *msg) {
+  if (!decode_u8(ctx, &msg->channel)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_sbp_tracking_channel_correlation_t(ctx, &msg->corrs[i])) { return false; }
+    if (!decode_sbp_tracking_channel_correlation_t(ctx, &msg->corrs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_iq_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_iq_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_iq_t(const uint8_t *buf, uint8_t len,
+                                    uint8_t *n_read,
+                                    sbp_msg_tracking_iq_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -761,47 +1168,66 @@ s8 sbp_decode_sbp_msg_tracking_iq_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_iq_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_iq_t(struct sbp_state *s, u16 sender_id,
+                                  const sbp_msg_tracking_iq_t *msg,
+                                  sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_iq_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_IQ, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_iq_t(payload, sizeof(payload),
+                                            &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_IQ, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_iq_t(const sbp_msg_tracking_iq_t *a, const sbp_msg_tracking_iq_t *b) {
+int sbp_cmp_sbp_msg_tracking_iq_t(const sbp_msg_tracking_iq_t *a,
+                                  const sbp_msg_tracking_iq_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->channel, &b->channel);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_tracking_channel_correlation_t(&a->corrs[i], &b->corrs[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+    ret =
+        sbp_cmp_sbp_tracking_channel_correlation_t(&a->corrs[i], &b->corrs[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tracking_channel_correlation_dep_t(const sbp_tracking_channel_correlation_dep_t *msg) {
+size_t sbp_packed_size_sbp_tracking_channel_correlation_dep_t(
+    const sbp_tracking_channel_correlation_dep_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_s32(&msg->I);
   packed_size += sbp_packed_size_s32(&msg->Q);
   return packed_size;
 }
 
-bool encode_sbp_tracking_channel_correlation_dep_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_dep_t *msg)
-{
-  if (!encode_s32(ctx, &msg->I)) { return false; }
-  if (!encode_s32(ctx, &msg->Q)) { return false; }
+bool encode_sbp_tracking_channel_correlation_dep_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_correlation_dep_t *msg) {
+  if (!encode_s32(ctx, &msg->I)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->Q)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tracking_channel_correlation_dep_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tracking_channel_correlation_dep_t *msg) {
+s8 sbp_encode_sbp_tracking_channel_correlation_dep_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tracking_channel_correlation_dep_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -815,14 +1241,20 @@ s8 sbp_encode_sbp_tracking_channel_correlation_dep_t(uint8_t *buf, uint8_t len, 
   return SBP_OK;
 }
 
-bool decode_sbp_tracking_channel_correlation_dep_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_dep_t *msg)
-{
-  if (!decode_s32(ctx, &msg->I)) { return false; }
-  if (!decode_s32(ctx, &msg->Q)) { return false; }
+bool decode_sbp_tracking_channel_correlation_dep_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_correlation_dep_t *msg) {
+  if (!decode_s32(ctx, &msg->I)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->Q)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tracking_channel_correlation_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tracking_channel_correlation_dep_t *msg) {
+s8 sbp_decode_sbp_tracking_channel_correlation_dep_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_tracking_channel_correlation_dep_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -836,37 +1268,52 @@ s8 sbp_decode_sbp_tracking_channel_correlation_dep_t(const uint8_t *buf, uint8_t
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tracking_channel_correlation_dep_t(const sbp_tracking_channel_correlation_dep_t *a, const sbp_tracking_channel_correlation_dep_t *b) {
+int sbp_cmp_sbp_tracking_channel_correlation_dep_t(
+    const sbp_tracking_channel_correlation_dep_t *a,
+    const sbp_tracking_channel_correlation_dep_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_s32(&a->I, &b->I);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->Q, &b->Q);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_tracking_iq_dep_b_t(const sbp_msg_tracking_iq_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_iq_dep_b_t(
+    const sbp_msg_tracking_iq_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->channel);
   packed_size += sbp_packed_size_sbp_sbp_gnss_signal_t(&msg->sid);
-  packed_size += ( 3 * sbp_packed_size_sbp_tracking_channel_correlation_dep_t(&msg->corrs[0]));
+  packed_size += (3 * sbp_packed_size_sbp_tracking_channel_correlation_dep_t(
+                          &msg->corrs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_iq_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_dep_b_t *msg)
-{
-  if (!encode_u8(ctx, &msg->channel)) { return false; }
-  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) { return false; }
+bool encode_sbp_msg_tracking_iq_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_dep_b_t *msg) {
+  if (!encode_u8(ctx, &msg->channel)) {
+    return false;
+  }
+  if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_iq_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_iq_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_iq_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_tracking_iq_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -880,17 +1327,25 @@ s8 sbp_encode_sbp_msg_tracking_iq_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_iq_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_iq_dep_b_t *msg)
-{
-  if (!decode_u8(ctx, &msg->channel)) { return false; }
-  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_tracking_iq_dep_b_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_tracking_iq_dep_b_t *msg) {
+  if (!decode_u8(ctx, &msg->channel)) {
+    return false;
+  }
+  if (!decode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) { return false; }
+    if (!decode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_iq_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_iq_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_iq_dep_b_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_tracking_iq_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -903,52 +1358,73 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_b_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_iq_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_iq_dep_b_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_tracking_iq_dep_b_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_iq_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_IQ_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_iq_dep_b_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_IQ_DEP_B, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_iq_dep_b_t(const sbp_msg_tracking_iq_dep_b_t *a, const sbp_msg_tracking_iq_dep_b_t *b) {
+int sbp_cmp_sbp_msg_tracking_iq_dep_b_t(const sbp_msg_tracking_iq_dep_b_t *a,
+                                        const sbp_msg_tracking_iq_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->channel, &b->channel);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_tracking_channel_correlation_dep_t(&a->corrs[i], &b->corrs[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_sbp_sbp_gnss_signal_t(&a->sid, &b->sid);
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+    ret = sbp_cmp_sbp_tracking_channel_correlation_dep_t(&a->corrs[i],
+                                                         &b->corrs[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_tracking_iq_dep_a_t(const sbp_msg_tracking_iq_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_iq_dep_a_t(
+    const sbp_msg_tracking_iq_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->channel);
   packed_size += sbp_packed_size_sbp_gnss_signal_dep_t(&msg->sid);
-  packed_size += ( 3 * sbp_packed_size_sbp_tracking_channel_correlation_dep_t(&msg->corrs[0]));
+  packed_size += (3 * sbp_packed_size_sbp_tracking_channel_correlation_dep_t(
+                          &msg->corrs[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_iq_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_dep_a_t *msg)
-{
-  if (!encode_u8(ctx, &msg->channel)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  for (uint8_t i = 0; i < 3; i++)
-  {
-    if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) { return false; }
+bool encode_sbp_msg_tracking_iq_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_iq_dep_a_t *msg) {
+  if (!encode_u8(ctx, &msg->channel)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  for (uint8_t i = 0; i < 3; i++) {
+    if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_iq_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_iq_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_iq_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_tracking_iq_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -962,17 +1438,25 @@ s8 sbp_encode_sbp_msg_tracking_iq_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_iq_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_iq_dep_a_t *msg)
-{
-  if (!decode_u8(ctx, &msg->channel)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
+bool decode_sbp_msg_tracking_iq_dep_a_t(sbp_decode_ctx_t *ctx,
+                                        sbp_msg_tracking_iq_dep_a_t *msg) {
+  if (!decode_u8(ctx, &msg->channel)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
   for (uint8_t i = 0; i < 3; i++) {
-    if (!decode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) { return false; }
+    if (!decode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_iq_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_iq_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_iq_dep_a_t(const uint8_t *buf, uint8_t len,
+                                          uint8_t *n_read,
+                                          sbp_msg_tracking_iq_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -985,33 +1469,46 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_a_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_iq_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_iq_dep_a_t(struct sbp_state *s, u16 sender_id,
+                                        const sbp_msg_tracking_iq_dep_a_t *msg,
+                                        sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_iq_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_IQ_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_iq_dep_a_t(payload, sizeof(payload),
+                                                  &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_IQ_DEP_A, sender_id, payload_len,
+                          payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_iq_dep_a_t(const sbp_msg_tracking_iq_dep_a_t *a, const sbp_msg_tracking_iq_dep_a_t *b) {
+int sbp_cmp_sbp_msg_tracking_iq_dep_a_t(const sbp_msg_tracking_iq_dep_a_t *a,
+                                        const sbp_msg_tracking_iq_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->channel, &b->channel);
-  if (ret != 0) { return ret; }
-  
-  ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
-  for (uint8_t i = 0; i < 3 && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_tracking_channel_correlation_dep_t(&a->corrs[i], &b->corrs[i]);
+  if (ret != 0) {
+    return ret;
   }
-  if (ret != 0) { return ret; }
+
+  ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
+  if (ret != 0) {
+    return ret;
+  }
+
+  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+    ret = sbp_cmp_sbp_tracking_channel_correlation_dep_t(&a->corrs[i],
+                                                         &b->corrs[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tracking_channel_state_dep_a_t(const sbp_tracking_channel_state_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_tracking_channel_state_dep_a_t(
+    const sbp_tracking_channel_state_dep_a_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->state);
   packed_size += sbp_packed_size_u8(&msg->prn);
@@ -1019,15 +1516,23 @@ size_t sbp_packed_size_sbp_tracking_channel_state_dep_a_t(const sbp_tracking_cha
   return packed_size;
 }
 
-bool encode_sbp_tracking_channel_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_a_t *msg)
-{
-  if (!encode_u8(ctx, &msg->state)) { return false; }
-  if (!encode_u8(ctx, &msg->prn)) { return false; }
-  if (!encode_float(ctx, &msg->cn0)) { return false; }
+bool encode_sbp_tracking_channel_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_a_t *msg) {
+  if (!encode_u8(ctx, &msg->state)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->prn)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tracking_channel_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tracking_channel_state_dep_a_t *msg) {
+s8 sbp_encode_sbp_tracking_channel_state_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tracking_channel_state_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1041,15 +1546,23 @@ s8 sbp_encode_sbp_tracking_channel_state_dep_a_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_tracking_channel_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_a_t *msg)
-{
-  if (!decode_u8(ctx, &msg->state)) { return false; }
-  if (!decode_u8(ctx, &msg->prn)) { return false; }
-  if (!decode_float(ctx, &msg->cn0)) { return false; }
+bool decode_sbp_tracking_channel_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_a_t *msg) {
+  if (!decode_u8(ctx, &msg->state)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->prn)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tracking_channel_state_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tracking_channel_state_dep_a_t *msg) {
+s8 sbp_decode_sbp_tracking_channel_state_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_tracking_channel_state_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1063,36 +1576,50 @@ s8 sbp_decode_sbp_tracking_channel_state_dep_a_t(const uint8_t *buf, uint8_t len
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tracking_channel_state_dep_a_t(const sbp_tracking_channel_state_dep_a_t *a, const sbp_tracking_channel_state_dep_a_t *b) {
+int sbp_cmp_sbp_tracking_channel_state_dep_a_t(
+    const sbp_tracking_channel_state_dep_a_t *a,
+    const sbp_tracking_channel_state_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->state, &b->state);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->prn, &b->prn);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_tracking_state_dep_a_t(const sbp_msg_tracking_state_dep_a_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_state_dep_a_t(
+    const sbp_msg_tracking_state_dep_a_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_states * sbp_packed_size_sbp_tracking_channel_state_dep_a_t(&msg->states[0]));
+  packed_size +=
+      (msg->n_states *
+       sbp_packed_size_sbp_tracking_channel_state_dep_a_t(&msg->states[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_state_dep_a_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_states; i++)
-  {
-    if (!encode_sbp_tracking_channel_state_dep_a_t(ctx, &msg->states[i])) { return false; }
+bool encode_sbp_msg_tracking_state_dep_a_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
+    if (!encode_sbp_tracking_channel_state_dep_a_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_state_dep_a_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_state_dep_a_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_tracking_state_dep_a_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1106,16 +1633,22 @@ s8 sbp_encode_sbp_msg_tracking_state_dep_a_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_state_dep_a_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_a_t *msg)
-{
-    msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_tracking_channel_state_dep_a_t(&msg->states[0]));
+bool decode_sbp_msg_tracking_state_dep_a_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_a_t *msg) {
+  msg->n_states = (uint8_t)(
+      (ctx->buf_len - ctx->offset) /
+      sbp_packed_size_sbp_tracking_channel_state_dep_a_t(&msg->states[0]));
   for (uint8_t i = 0; i < msg->n_states; i++) {
-    if (!decode_sbp_tracking_channel_state_dep_a_t(ctx, &msg->states[i])) { return false; }
+    if (!decode_sbp_tracking_channel_state_dep_a_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_state_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_state_dep_a_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_state_dep_a_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_tracking_state_dep_a_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1128,28 +1661,38 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_a_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_dep_a_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_state_dep_a_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_tracking_state_dep_a_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_state_dep_a_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DEP_A, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_state_dep_a_t(payload, sizeof(payload),
+                                                     &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DEP_A, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_state_dep_a_t(const sbp_msg_tracking_state_dep_a_t *a, const sbp_msg_tracking_state_dep_a_t *b) {
+int sbp_cmp_sbp_msg_tracking_state_dep_a_t(
+    const sbp_msg_tracking_state_dep_a_t *a,
+    const sbp_msg_tracking_state_dep_a_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_tracking_channel_state_dep_a_t(&a->states[i], &b->states[i]);
+  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
+    ret = sbp_cmp_sbp_tracking_channel_state_dep_a_t(&a->states[i],
+                                                     &b->states[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_tracking_channel_state_dep_b_t(const sbp_tracking_channel_state_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_tracking_channel_state_dep_b_t(
+    const sbp_tracking_channel_state_dep_b_t *msg) {
   size_t packed_size = 0;
   packed_size += sbp_packed_size_u8(&msg->state);
   packed_size += sbp_packed_size_sbp_gnss_signal_dep_t(&msg->sid);
@@ -1157,15 +1700,23 @@ size_t sbp_packed_size_sbp_tracking_channel_state_dep_b_t(const sbp_tracking_cha
   return packed_size;
 }
 
-bool encode_sbp_tracking_channel_state_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_b_t *msg)
-{
-  if (!encode_u8(ctx, &msg->state)) { return false; }
-  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!encode_float(ctx, &msg->cn0)) { return false; }
+bool encode_sbp_tracking_channel_state_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_tracking_channel_state_dep_b_t *msg) {
+  if (!encode_u8(ctx, &msg->state)) {
+    return false;
+  }
+  if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!encode_float(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_tracking_channel_state_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_tracking_channel_state_dep_b_t *msg) {
+s8 sbp_encode_sbp_tracking_channel_state_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_tracking_channel_state_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1179,15 +1730,23 @@ s8 sbp_encode_sbp_tracking_channel_state_dep_b_t(uint8_t *buf, uint8_t len, uint
   return SBP_OK;
 }
 
-bool decode_sbp_tracking_channel_state_dep_b_t(sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_b_t *msg)
-{
-  if (!decode_u8(ctx, &msg->state)) { return false; }
-  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) { return false; }
-  if (!decode_float(ctx, &msg->cn0)) { return false; }
+bool decode_sbp_tracking_channel_state_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_tracking_channel_state_dep_b_t *msg) {
+  if (!decode_u8(ctx, &msg->state)) {
+    return false;
+  }
+  if (!decode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
+    return false;
+  }
+  if (!decode_float(ctx, &msg->cn0)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_tracking_channel_state_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_tracking_channel_state_dep_b_t *msg) {
+s8 sbp_decode_sbp_tracking_channel_state_dep_b_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_tracking_channel_state_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1201,36 +1760,50 @@ s8 sbp_decode_sbp_tracking_channel_state_dep_b_t(const uint8_t *buf, uint8_t len
   return SBP_OK;
 }
 
-int sbp_cmp_sbp_tracking_channel_state_dep_b_t(const sbp_tracking_channel_state_dep_b_t *a, const sbp_tracking_channel_state_dep_b_t *b) {
+int sbp_cmp_sbp_tracking_channel_state_dep_b_t(
+    const sbp_tracking_channel_state_dep_b_t *a,
+    const sbp_tracking_channel_state_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->state, &b->state);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_sbp_gnss_signal_dep_t(&a->sid, &b->sid);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_float(&a->cn0, &b->cn0);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
-size_t sbp_packed_size_sbp_msg_tracking_state_dep_b_t(const sbp_msg_tracking_state_dep_b_t *msg) {
+size_t sbp_packed_size_sbp_msg_tracking_state_dep_b_t(
+    const sbp_msg_tracking_state_dep_b_t *msg) {
   size_t packed_size = 0;
-  packed_size += (msg->n_states * sbp_packed_size_sbp_tracking_channel_state_dep_b_t(&msg->states[0]));
+  packed_size +=
+      (msg->n_states *
+       sbp_packed_size_sbp_tracking_channel_state_dep_b_t(&msg->states[0]));
   return packed_size;
 }
 
-bool encode_sbp_msg_tracking_state_dep_b_t(sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_states; i++)
-  {
-    if (!encode_sbp_tracking_channel_state_dep_b_t(ctx, &msg->states[i])) { return false; }
+bool encode_sbp_msg_tracking_state_dep_b_t(
+    sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
+    if (!encode_sbp_tracking_channel_state_dep_b_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_tracking_state_dep_b_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_tracking_state_dep_b_t *msg) {
+s8 sbp_encode_sbp_msg_tracking_state_dep_b_t(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_tracking_state_dep_b_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1244,16 +1817,22 @@ s8 sbp_encode_sbp_msg_tracking_state_dep_b_t(uint8_t *buf, uint8_t len, uint8_t 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_tracking_state_dep_b_t(sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_b_t *msg)
-{
-    msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_sbp_tracking_channel_state_dep_b_t(&msg->states[0]));
+bool decode_sbp_msg_tracking_state_dep_b_t(
+    sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_b_t *msg) {
+  msg->n_states = (uint8_t)(
+      (ctx->buf_len - ctx->offset) /
+      sbp_packed_size_sbp_tracking_channel_state_dep_b_t(&msg->states[0]));
   for (uint8_t i = 0; i < msg->n_states; i++) {
-    if (!decode_sbp_tracking_channel_state_dep_b_t(ctx, &msg->states[i])) { return false; }
+    if (!decode_sbp_tracking_channel_state_dep_b_t(ctx, &msg->states[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_tracking_state_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_tracking_state_dep_b_t *msg) {
+s8 sbp_decode_sbp_msg_tracking_state_dep_b_t(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_tracking_state_dep_b_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -1266,23 +1845,32 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_b_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_dep_b_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_tracking_state_dep_b_t(
+    struct sbp_state *s, u16 sender_id,
+    const sbp_msg_tracking_state_dep_b_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_tracking_state_dep_b_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DEP_B, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_tracking_state_dep_b_t(payload, sizeof(payload),
+                                                     &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_TRACKING_STATE_DEP_B, sender_id,
+                          payload_len, payload, write);
 }
 
-int sbp_cmp_sbp_msg_tracking_state_dep_b_t(const sbp_msg_tracking_state_dep_b_t *a, const sbp_msg_tracking_state_dep_b_t *b) {
+int sbp_cmp_sbp_msg_tracking_state_dep_b_t(
+    const sbp_msg_tracking_state_dep_b_t *a,
+    const sbp_msg_tracking_state_dep_b_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++)
-  {
-    ret = sbp_cmp_sbp_tracking_channel_state_dep_b_t(&a->states[i], &b->states[i]);
+  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
+    ret = sbp_cmp_sbp_tracking_channel_state_dep_b_t(&a->states[i],
+                                                     &b->states[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/tracking.c
+++ b/c/src/new/tracking.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/tracking.yaml
  * with generate.py. Please do not hand edit!
@@ -222,6 +210,7 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_tracking_state_detailed_dep_a_t *msg, sbp_write_fn_t write) {
@@ -542,6 +531,7 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_state_detailed_dep_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_tracking_state_detailed_dep_t *msg, sbp_write_fn_t write) {
@@ -769,7 +759,7 @@ size_t sbp_packed_size_sbp_msg_tracking_state_t(
 
 bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_tracking_state_t *msg) {
-  for (uint8_t i = 0; i < msg->n_states; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
     if (!encode_sbp_tracking_channel_state_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -821,6 +811,7 @@ s8 sbp_decode_sbp_msg_tracking_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_state_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_tracking_state_t *msg,
                                      sbp_write_fn_t write) {
@@ -840,7 +831,7 @@ int sbp_cmp_sbp_msg_tracking_state_t(const sbp_msg_tracking_state_t *a,
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_states; i++) {
     ret = sbp_cmp_sbp_tracking_channel_state_t(&a->states[i], &b->states[i]);
   }
   if (ret != 0) {
@@ -937,7 +928,7 @@ size_t sbp_packed_size_sbp_msg_measurement_state_t(
 
 bool encode_sbp_msg_measurement_state_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_measurement_state_t *msg) {
-  for (uint8_t i = 0; i < msg->n_states; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
     if (!encode_sbp_measurement_state_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -989,6 +980,7 @@ s8 sbp_decode_sbp_msg_measurement_state_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_measurement_state_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_measurement_state_t *msg,
                                         sbp_write_fn_t write) {
@@ -1008,7 +1000,7 @@ int sbp_cmp_sbp_msg_measurement_state_t(const sbp_msg_measurement_state_t *a,
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_states; i++) {
     ret = sbp_cmp_sbp_measurement_state_t(&a->states[i], &b->states[i]);
   }
   if (ret != 0) {
@@ -1113,7 +1105,7 @@ bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_sbp_tracking_channel_correlation_t(ctx, &msg->corrs[i])) {
       return false;
     }
@@ -1168,6 +1160,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_iq_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_tracking_iq_t *msg,
                                   sbp_write_fn_t write) {
@@ -1196,7 +1189,7 @@ int sbp_cmp_sbp_msg_tracking_iq_t(const sbp_msg_tracking_iq_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret =
         sbp_cmp_sbp_tracking_channel_correlation_t(&a->corrs[i], &b->corrs[i]);
   }
@@ -1303,7 +1296,7 @@ bool encode_sbp_msg_tracking_iq_dep_b_t(
   if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
       return false;
     }
@@ -1358,6 +1351,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_b_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_iq_dep_b_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_tracking_iq_dep_b_t *msg,
                                         sbp_write_fn_t write) {
@@ -1386,7 +1380,7 @@ int sbp_cmp_sbp_msg_tracking_iq_dep_b_t(const sbp_msg_tracking_iq_dep_b_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_sbp_tracking_channel_correlation_dep_t(&a->corrs[i],
                                                          &b->corrs[i]);
   }
@@ -1414,7 +1408,7 @@ bool encode_sbp_msg_tracking_iq_dep_a_t(
   if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
       return false;
     }
@@ -1469,6 +1463,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_a_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_iq_dep_a_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_tracking_iq_dep_a_t *msg,
                                         sbp_write_fn_t write) {
@@ -1497,7 +1492,7 @@ int sbp_cmp_sbp_msg_tracking_iq_dep_a_t(const sbp_msg_tracking_iq_dep_a_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; i < 3 && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
     ret = sbp_cmp_sbp_tracking_channel_correlation_dep_t(&a->corrs[i],
                                                          &b->corrs[i]);
   }
@@ -1609,7 +1604,7 @@ size_t sbp_packed_size_sbp_msg_tracking_state_dep_a_t(
 
 bool encode_sbp_msg_tracking_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg) {
-  for (uint8_t i = 0; i < msg->n_states; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
     if (!encode_sbp_tracking_channel_state_dep_a_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -1661,6 +1656,7 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_a_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_tracking_state_dep_a_t *msg, sbp_write_fn_t write) {
@@ -1681,7 +1677,7 @@ int sbp_cmp_sbp_msg_tracking_state_dep_a_t(
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_states; i++) {
     ret = sbp_cmp_sbp_tracking_channel_state_dep_a_t(&a->states[i],
                                                      &b->states[i]);
   }
@@ -1793,7 +1789,7 @@ size_t sbp_packed_size_sbp_msg_tracking_state_dep_b_t(
 
 bool encode_sbp_msg_tracking_state_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg) {
-  for (uint8_t i = 0; i < msg->n_states; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
     if (!encode_sbp_tracking_channel_state_dep_b_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -1845,6 +1841,7 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_b_t(
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_tracking_state_dep_b_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_tracking_state_dep_b_t *msg, sbp_write_fn_t write) {
@@ -1865,7 +1862,7 @@ int sbp_cmp_sbp_msg_tracking_state_dep_b_t(
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_states, &b->n_states);
-  for (uint8_t i = 0; i < a->n_states && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_states; i++) {
     ret = sbp_cmp_sbp_tracking_channel_state_dep_b_t(&a->states[i],
                                                      &b->states[i]);
   }

--- a/c/src/new/tracking.c
+++ b/c/src/new/tracking.c
@@ -759,7 +759,7 @@ size_t sbp_packed_size_sbp_msg_tracking_state_t(
 
 bool encode_sbp_msg_tracking_state_t(sbp_encode_ctx_t *ctx,
                                      const sbp_msg_tracking_state_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
     if (!encode_sbp_tracking_channel_state_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -928,7 +928,7 @@ size_t sbp_packed_size_sbp_msg_measurement_state_t(
 
 bool encode_sbp_msg_measurement_state_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_measurement_state_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
     if (!encode_sbp_measurement_state_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -1105,7 +1105,7 @@ bool encode_sbp_msg_tracking_iq_t(sbp_encode_ctx_t *ctx,
   if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_sbp_tracking_channel_correlation_t(ctx, &msg->corrs[i])) {
       return false;
     }
@@ -1296,7 +1296,7 @@ bool encode_sbp_msg_tracking_iq_dep_b_t(
   if (!encode_sbp_sbp_gnss_signal_t(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
       return false;
     }
@@ -1408,7 +1408,7 @@ bool encode_sbp_msg_tracking_iq_dep_a_t(
   if (!encode_sbp_gnss_signal_dep_t(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++) {
     if (!encode_sbp_tracking_channel_correlation_dep_t(ctx, &msg->corrs[i])) {
       return false;
     }
@@ -1604,7 +1604,7 @@ size_t sbp_packed_size_sbp_msg_tracking_state_dep_a_t(
 
 bool encode_sbp_msg_tracking_state_dep_a_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_a_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
     if (!encode_sbp_tracking_channel_state_dep_a_t(ctx, &msg->states[i])) {
       return false;
     }
@@ -1789,7 +1789,7 @@ size_t sbp_packed_size_sbp_msg_tracking_state_dep_b_t(
 
 bool encode_sbp_msg_tracking_state_dep_b_t(
     sbp_encode_ctx_t *ctx, const sbp_msg_tracking_state_dep_b_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_states; i++) {
+  for (uint8_t i = 0; i < msg->n_states; i++) {
     if (!encode_sbp_tracking_channel_state_dep_b_t(ctx, &msg->states[i])) {
       return false;
     }

--- a/c/src/new/user.c
+++ b/c/src/new/user.c
@@ -24,7 +24,7 @@ size_t sbp_packed_size_sbp_msg_user_data_t(const sbp_msg_user_data_t *msg) {
 
 bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_user_data_t *msg) {
-  for (uint8_t i = 0; ret == 0 && i < msg->n_contents; i++) {
+  for (uint8_t i = 0; i < msg->n_contents; i++) {
     if (!encode_u8(ctx, &msg->contents[i])) {
       return false;
     }

--- a/c/src/new/user.c
+++ b/c/src/new/user.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/user.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/user.h>
-#include <libsbp/internal/new/user.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/internal/new/user.h>
+#include <libsbp/new/user.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_user_data_t(const sbp_msg_user_data_t *msg) {
   size_t packed_size = 0;
@@ -17,16 +34,18 @@ size_t sbp_packed_size_sbp_msg_user_data_t(const sbp_msg_user_data_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx, const sbp_msg_user_data_t *msg)
-{
-  for (uint8_t i = 0; i < msg->n_contents; i++)
-  {
-    if (!encode_u8(ctx, &msg->contents[i])) { return false; }
+bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_user_data_t *msg) {
+  for (uint8_t i = 0; i < msg->n_contents; i++) {
+    if (!encode_u8(ctx, &msg->contents[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_user_data_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_user_data_t *msg) {
+s8 sbp_encode_sbp_msg_user_data_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_user_data_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -40,16 +59,20 @@ s8 sbp_encode_sbp_msg_user_data_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_user_data_t(sbp_decode_ctx_t *ctx, sbp_msg_user_data_t *msg)
-{
-    msg->n_contents = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_u8(&msg->contents[0]));
+bool decode_sbp_msg_user_data_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_user_data_t *msg) {
+  msg->n_contents = (uint8_t)((ctx->buf_len - ctx->offset) /
+                              sbp_packed_size_u8(&msg->contents[0]));
   for (uint8_t i = 0; i < msg->n_contents; i++) {
-    if (!decode_u8(ctx, &msg->contents[i])) { return false; }
+    if (!decode_u8(ctx, &msg->contents[i])) {
+      return false;
+    }
   }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_user_data_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_user_data_t *msg) {
+s8 sbp_decode_sbp_msg_user_data_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_user_data_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -62,23 +85,30 @@ s8 sbp_decode_sbp_msg_user_data_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_user_data_t(struct sbp_state *s, u16 sender_id, const sbp_msg_user_data_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_user_data_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_user_data_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_user_data_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_USER_DATA, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_user_data_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_USER_DATA, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_user_data_t(const sbp_msg_user_data_t *a, const sbp_msg_user_data_t *b) {
+int sbp_cmp_sbp_msg_user_data_t(const sbp_msg_user_data_t *a,
+                                const sbp_msg_user_data_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u8(&a->n_contents, &b->n_contents);
-  for (uint8_t i = 0; i < a->n_contents && ret == 0; i++)
-  {
+  for (uint8_t i = 0; i < a->n_contents && ret == 0; i++) {
     ret = sbp_cmp_u8(&a->contents[i], &b->contents[i]);
   }
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/user.c
+++ b/c/src/new/user.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/user.yaml
  * with generate.py. Please do not hand edit!
@@ -36,7 +24,7 @@ size_t sbp_packed_size_sbp_msg_user_data_t(const sbp_msg_user_data_t *msg) {
 
 bool encode_sbp_msg_user_data_t(sbp_encode_ctx_t *ctx,
                                 const sbp_msg_user_data_t *msg) {
-  for (uint8_t i = 0; i < msg->n_contents; i++) {
+  for (uint8_t i = 0; ret == 0 && i < msg->n_contents; i++) {
     if (!encode_u8(ctx, &msg->contents[i])) {
       return false;
     }
@@ -85,6 +73,7 @@ s8 sbp_decode_sbp_msg_user_data_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_user_data_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_user_data_t *msg,
                                 sbp_write_fn_t write) {
@@ -104,7 +93,7 @@ int sbp_cmp_sbp_msg_user_data_t(const sbp_msg_user_data_t *a,
   int ret = 0;
 
   ret = sbp_cmp_u8(&a->n_contents, &b->n_contents);
-  for (uint8_t i = 0; i < a->n_contents && ret == 0; i++) {
+  for (uint8_t i = 0; ret == 0 && i < a->n_contents; i++) {
     ret = sbp_cmp_u8(&a->contents[i], &b->contents[i]);
   }
   if (ret != 0) {

--- a/c/src/new/vehicle.c
+++ b/c/src/new/vehicle.c
@@ -1,15 +1,32 @@
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
-#include <libsbp/sbp.h>
+/*****************************************************************************
+ * Automatically generated from yaml/swiftnav/sbp/vehicle.yaml
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <libsbp/internal/new/common.h>
-#include <libsbp/new/vehicle.h>
-#include <libsbp/internal/new/vehicle.h>
+#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/multipart.h>
 #include <libsbp/internal/new/string/null_terminated.h>
-#include <libsbp/internal/new/string/double_null_terminated.h>
 #include <libsbp/internal/new/string/unterminated.h>
+#include <libsbp/internal/new/vehicle.h>
+#include <libsbp/new/vehicle.h>
+#include <libsbp/sbp.h>
 
 size_t sbp_packed_size_sbp_msg_odometry_t(const sbp_msg_odometry_t *msg) {
   size_t packed_size = 0;
@@ -19,15 +36,22 @@ size_t sbp_packed_size_sbp_msg_odometry_t(const sbp_msg_odometry_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_odometry_t(sbp_encode_ctx_t *ctx, const sbp_msg_odometry_t *msg)
-{
-  if (!encode_u32(ctx, &msg->tow)) { return false; }
-  if (!encode_s32(ctx, &msg->velocity)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
+bool encode_sbp_msg_odometry_t(sbp_encode_ctx_t *ctx,
+                               const sbp_msg_odometry_t *msg) {
+  if (!encode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->velocity)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_odometry_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_odometry_t *msg) {
+s8 sbp_encode_sbp_msg_odometry_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                 const sbp_msg_odometry_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -41,15 +65,21 @@ s8 sbp_encode_sbp_msg_odometry_t(uint8_t *buf, uint8_t len, uint8_t *n_written, 
   return SBP_OK;
 }
 
-bool decode_sbp_msg_odometry_t(sbp_decode_ctx_t *ctx, sbp_msg_odometry_t *msg)
-{
-  if (!decode_u32(ctx, &msg->tow)) { return false; }
-  if (!decode_s32(ctx, &msg->velocity)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
+bool decode_sbp_msg_odometry_t(sbp_decode_ctx_t *ctx, sbp_msg_odometry_t *msg) {
+  if (!decode_u32(ctx, &msg->tow)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->velocity)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_odometry_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_odometry_t *msg) {
+s8 sbp_decode_sbp_msg_odometry_t(const uint8_t *buf, uint8_t len,
+                                 uint8_t *n_read, sbp_msg_odometry_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -62,26 +92,38 @@ s8 sbp_decode_sbp_msg_odometry_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_odometry_t(struct sbp_state *s, u16 sender_id, const sbp_msg_odometry_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_odometry_t(struct sbp_state *s, u16 sender_id,
+                               const sbp_msg_odometry_t *msg,
+                               sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_odometry_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_ODOMETRY, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_odometry_t(payload, sizeof(payload), &payload_len,
+                                         msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_ODOMETRY, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_odometry_t(const sbp_msg_odometry_t *a, const sbp_msg_odometry_t *b) {
+int sbp_cmp_sbp_msg_odometry_t(const sbp_msg_odometry_t *a,
+                               const sbp_msg_odometry_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u32(&a->tow, &b->tow);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->velocity, &b->velocity);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }
 
@@ -94,16 +136,25 @@ size_t sbp_packed_size_sbp_msg_wheeltick_t(const sbp_msg_wheeltick_t *msg) {
   return packed_size;
 }
 
-bool encode_sbp_msg_wheeltick_t(sbp_encode_ctx_t *ctx, const sbp_msg_wheeltick_t *msg)
-{
-  if (!encode_u64(ctx, &msg->time)) { return false; }
-  if (!encode_u8(ctx, &msg->flags)) { return false; }
-  if (!encode_u8(ctx, &msg->source)) { return false; }
-  if (!encode_s32(ctx, &msg->ticks)) { return false; }
+bool encode_sbp_msg_wheeltick_t(sbp_encode_ctx_t *ctx,
+                                const sbp_msg_wheeltick_t *msg) {
+  if (!encode_u64(ctx, &msg->time)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!encode_u8(ctx, &msg->source)) {
+    return false;
+  }
+  if (!encode_s32(ctx, &msg->ticks)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_encode_sbp_msg_wheeltick_t(uint8_t *buf, uint8_t len, uint8_t *n_written, const sbp_msg_wheeltick_t *msg) {
+s8 sbp_encode_sbp_msg_wheeltick_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                                  const sbp_msg_wheeltick_t *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -117,16 +168,25 @@ s8 sbp_encode_sbp_msg_wheeltick_t(uint8_t *buf, uint8_t len, uint8_t *n_written,
   return SBP_OK;
 }
 
-bool decode_sbp_msg_wheeltick_t(sbp_decode_ctx_t *ctx, sbp_msg_wheeltick_t *msg)
-{
-  if (!decode_u64(ctx, &msg->time)) { return false; }
-  if (!decode_u8(ctx, &msg->flags)) { return false; }
-  if (!decode_u8(ctx, &msg->source)) { return false; }
-  if (!decode_s32(ctx, &msg->ticks)) { return false; }
+bool decode_sbp_msg_wheeltick_t(sbp_decode_ctx_t *ctx,
+                                sbp_msg_wheeltick_t *msg) {
+  if (!decode_u64(ctx, &msg->time)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->flags)) {
+    return false;
+  }
+  if (!decode_u8(ctx, &msg->source)) {
+    return false;
+  }
+  if (!decode_s32(ctx, &msg->ticks)) {
+    return false;
+  }
   return true;
 }
 
-s8 sbp_decode_sbp_msg_wheeltick_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sbp_msg_wheeltick_t *msg) {
+s8 sbp_decode_sbp_msg_wheeltick_t(const uint8_t *buf, uint8_t len,
+                                  uint8_t *n_read, sbp_msg_wheeltick_t *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
@@ -139,28 +199,42 @@ s8 sbp_decode_sbp_msg_wheeltick_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_wheeltick_t(struct sbp_state *s, u16 sender_id, const sbp_msg_wheeltick_t *msg, sbp_write_fn_t write)
-{
+s8 sbp_send_sbp_msg_wheeltick_t(struct sbp_state *s, u16 sender_id,
+                                const sbp_msg_wheeltick_t *msg,
+                                sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_sbp_msg_wheeltick_t(payload, sizeof(payload), &payload_len, msg);
-  if (ret != SBP_OK) { return ret; }
-  return sbp_payload_send(s, SBP_MSG_WHEELTICK, sender_id, payload_len, payload, write);
+  s8 ret = sbp_encode_sbp_msg_wheeltick_t(payload, sizeof(payload),
+                                          &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_WHEELTICK, sender_id, payload_len, payload,
+                          write);
 }
 
-int sbp_cmp_sbp_msg_wheeltick_t(const sbp_msg_wheeltick_t *a, const sbp_msg_wheeltick_t *b) {
+int sbp_cmp_sbp_msg_wheeltick_t(const sbp_msg_wheeltick_t *a,
+                                const sbp_msg_wheeltick_t *b) {
   int ret = 0;
-  
+
   ret = sbp_cmp_u64(&a->time, &b->time);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->flags, &b->flags);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_u8(&a->source, &b->source);
-  if (ret != 0) { return ret; }
-  
+  if (ret != 0) {
+    return ret;
+  }
+
   ret = sbp_cmp_s32(&a->ticks, &b->ticks);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
   return ret;
 }

--- a/c/src/new/vehicle.c
+++ b/c/src/new/vehicle.c
@@ -1,15 +1,3 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/swiftnav/sbp/vehicle.yaml
  * with generate.py. Please do not hand edit!
@@ -92,6 +80,7 @@ s8 sbp_decode_sbp_msg_odometry_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_odometry_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_odometry_t *msg,
                                sbp_write_fn_t write) {
@@ -199,6 +188,7 @@ s8 sbp_decode_sbp_msg_wheeltick_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
+
 s8 sbp_send_sbp_msg_wheeltick_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_wheeltick_t *msg,
                                 sbp_write_fn_t write) {

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_private_template.h
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_private_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Copyright (C) 2015-2021 Swift Navigation Inc.
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_UNPACKED_(((pkg_name|upper)))_PRIVATE_H
-#define LIBSBP_UNPACKED_(((pkg_name|upper)))_PRIVATE_H
+#ifndef LIBSBP_INTERNAL_NEW_(((pkg_name|upper)))_H
+#define LIBSBP_INTERNAL_NEW_(((pkg_name|upper)))_H
 
 #include <stdbool.h>
 
@@ -32,7 +32,22 @@
 
 ((*- for m in msgs *))
 
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool encode_(((m.name|convert_unpacked)))(sbp_encode_ctx_t *ctx, const (((m.name|convert_unpacked))) *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool decode_(((m.name|convert_unpacked)))(sbp_decode_ctx_t *ctx, (((m.name|convert_unpacked))) *msg);
 
 ((*- endfor *))

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_private_template.h
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_private_template.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/(((filepath)))
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
 #ifndef LIBSBP_UNPACKED_(((pkg_name|upper)))_PRIVATE_H
 #define LIBSBP_UNPACKED_(((pkg_name|upper)))_PRIVATE_H
 

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -197,7 +197,7 @@ bool encode_(((msg_type)))(sbp_encode_ctx_t *ctx, const (((msg_type))) *msg)
   ((*- else *))
   ((*- set max_loop = "msg->" + f.size_fn *))
   ((*- endif *))
-  for (uint8_t i = 0; ret == 0 && i < (((max_loop))); i++)
+  for (uint8_t i = 0; i < (((max_loop))); i++)
   {
     if (!encode_(((basetype)))(ctx, &(((field)))[i])) { return false; }
   }

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2015-2018 Swift Navigation Inc.
+ * Contact: https://support.swiftnav.com
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*****************************************************************************
+ * Automatically generated from yaml/(((filepath)))
+ * with generate.py. Please do not hand edit!
+ *****************************************************************************/
+
+
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -1,20 +1,7 @@
-/*
- * Copyright (C) 2015-2018 Swift Navigation Inc.
- * Contact: https://support.swiftnav.com
- *
- * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
- *
- * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
- * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
- */
-
 /*****************************************************************************
  * Automatically generated from yaml/(((filepath)))
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
-
 
 #include <stdint.h>
 #include <stddef.h>
@@ -30,161 +17,167 @@
 #include <libsbp/internal/new/string/unterminated.h>
 
 ((*- for m in msgs *))
+((*- set msg_type = m.name|convert_unpacked *))
                                                                                                               
 ((*- for f in m.fields *))
 ((*- if f.packing == "packed-string" *))
 ((*- set params = m.name|convert_unpacked + f.name + "_params" *))
-static const sbp_(((f.encoding)))_string_params_t (((params))) = 
+((*- set string_prefix = "sbp_" + f.encoding + "_string" *))
+((*- set string_type = string_prefix + "_t" *))
+((*- set field_prefix = msg_type + "_" + f.name *))
+static const (((string_prefix)))_params_t (((params))) = 
 {
   .max_packed_len = (((f.max_items)))
 };
 
-  void (((m.name|convert_unpacked)))_(((f.name)))_init(sbp_(((f.encoding)))_string_t *s)
+void (((field_prefix)))_init( (((-string_type))) *s)
 {
-  sbp_(((f.encoding)))_string_init(s, &(((params))));
+  (((string_prefix)))_init(s, &(((params))));
 }
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_valid(const sbp_(((f.encoding)))_string_t *s)
+bool (((field_prefix)))_valid(const (((string_type))) *s)
 {
-  return sbp_(((f.encoding)))_string_valid(s, &(((params))));
+  return (((string_prefix)))_valid(s, &(((params))));
 }
 
-  int (((m.name|convert_unpacked)))_(((f.name)))_strcmp(const sbp_(((f.encoding)))_string_t *a, const sbp_(((f.encoding)))_string_t *b)
+int (((field_prefix)))_strcmp(const (((string_type))) *a, const (((string_type))) *b)
 {
-  return sbp_(((f.encoding)))_string_strcmp(a, b, &(((params))));
+  return (((string_prefix)))_strcmp(a, b, &(((params))));
 }
 
-  uint8_t (((m.name|convert_unpacked)))_(((f.name)))_packed_len(const sbp_(((f.encoding)))_string_t *s)
+uint8_t (((field_prefix)))_packed_len(const (((string_type))) *s)
 {
-  return sbp_(((f.encoding)))_string_packed_len(s, &(((params))));
+  return (((string_prefix)))_packed_len(s, &(((params))));
 }
 
-  uint8_t (((m.name|convert_unpacked)))_(((f.name)))_space_remaining(const sbp_(((f.encoding)))_string_t *s)
+uint8_t (((field_prefix)))_space_remaining(const (((string_type))) *s)
 {
-  return sbp_(((f.encoding)))_string_space_remaining(s, &(((params))));
-      }
+  return (((string_prefix)))_space_remaining(s, &(((params))));
+}
 
-  ((*- if f.encoding == "unterminated" or f.encoding == "null_terminated" *))
-  bool (((m.name|convert_unpacked)))_(((f.name)))_set(sbp_(((f.encoding)))_string_t *s, const char *new_str)
-  {
-  return sbp_(((f.encoding)))_string_set(s, &(((params))), new_str);
-  }
+((*- if f.encoding == "unterminated" or f.encoding == "null_terminated" *))
+ bool (((field_prefix)))_set( (((-string_type))) *s, const char *new_str)
+{
+  return (((string_prefix)))_set(s, &(((params))), new_str);
+}
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_printf(sbp_(((f.encoding)))_string_t *s, const char *fmt, ...) 
-  {
-  va_list ap;
-  va_start(ap, fmt);
-  bool ret = sbp_(((f.encoding)))_string_vprintf(s, &(((params))), fmt, ap);
-  va_end(ap);
-  return ret;
-  }
-
-  bool (((m.name|convert_unpacked)))_(((f.name)))_vprintf(sbp_(((f.encoding)))_string_t *s, const char *fmt, va_list ap)
-  {
-  return sbp_(((f.encoding)))_string_vprintf(s, &(((params))), fmt, ap);
-  }
-
-  bool (((m.name|convert_unpacked)))_(((f.name)))_append_printf(sbp_(((f.encoding)))_string_t *s, const char *fmt, ...) 
+bool (((field_prefix)))_printf( (((-string_type))) *s, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_(((f.encoding)))_string_append_vprintf(s, &(((params))), fmt, ap);
+  bool ret = (((string_prefix)))_vprintf(s, &(((params))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_append_vprintf(sbp_(((f.encoding)))_string_t *s, const char *fmt, va_list ap)
+ bool (((field_prefix)))_vprintf( (((-string_type))) *s, const char *fmt, va_list ap)
 {
-  return sbp_(((f.encoding)))_string_append_vprintf(s, &(((params))), fmt, ap);
+  return (((string_prefix)))_vprintf(s, &(((params))), fmt, ap);
 }
 
-  const char *(((m.name|convert_unpacked)))_(((f.name)))_get(const sbp_(((f.encoding)))_string_t *s)
-{
-  return sbp_(((f.encoding)))_string_get(s, &(((params))));
-}
-
-  ((*- elif f.encoding == "multipart" or f.encoding == "double_null_terminated" *))
-  uint8_t (((m.name|convert_unpacked)))_(((f.name)))_count_sections(const sbp_(((f.encoding)))_string_t *s)
-{
-  return sbp_(((f.encoding)))_string_count_sections(s, &(((params))));
-}
-
-  bool (((m.name|convert_unpacked)))_(((f.name)))_add_section(sbp_(((f.encoding)))_string_t *s, const char *new_str)
-{
-  return sbp_(((f.encoding)))_string_add_section(s, &(((params))), new_str);
-}
-
-  bool (((m.name|convert_unpacked)))_(((f.name)))_add_section_printf(sbp_(((f.encoding)))_string_t *s, const char *fmt, ...) 
+bool (((field_prefix)))_append_printf( (((-string_type))) *s, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_(((f.encoding)))_string_add_section_vprintf(s, &(((params))), fmt, ap);
+  bool ret = (((string_prefix)))_append_vprintf(s, &(((params))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_add_section_vprintf(sbp_(((f.encoding)))_string_t *s, const char *fmt, va_list ap)
+  bool (((field_prefix)))_append_vprintf( (((-string_type))) *s, const char *fmt, va_list ap)
 {
-  return sbp_(((f.encoding)))_string_add_section_vprintf(s, &(((params))), fmt, ap);
+  return (((string_prefix)))_append_vprintf(s, &(((params))), fmt, ap);
 }
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_append(sbp_(((f.encoding)))_string_t *s, const char *str)
+const char *(((field_prefix)))_get(const (((string_type))) *s)
 {
-  return sbp_(((f.encoding)))_string_append(s, &(((params))), str);
+  return (((string_prefix)))_get(s, &(((params))));
 }
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_append_printf(sbp_(((f.encoding)))_string_t *s, const char *fmt, ...) 
+((*- elif f.encoding == "multipart" or f.encoding == "double_null_terminated" *))
+uint8_t (((field_prefix)))_count_sections(const (((string_type))) *s)
+{
+  return (((string_prefix)))_count_sections(s, &(((params))));
+}
+
+bool (((field_prefix)))_add_section( (((-string_type))) *s, const char *new_str)
+{
+  return (((string_prefix)))_add_section(s, &(((params))), new_str);
+}
+
+bool (((field_prefix)))_add_section_printf( (((-string_type))) *s, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_(((f.encoding)))_string_append_vprintf(s, &(((params))), fmt, ap);
+  bool ret = (((string_prefix)))_add_section_vprintf(s, &(((params))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
-  bool (((m.name|convert_unpacked)))_(((f.name)))_append_vprintf(sbp_(((f.encoding)))_string_t *s, const char *fmt, va_list ap)
+bool (((field_prefix)))_add_section_vprintf( (((-string_type))) *s, const char *fmt, va_list ap)
 {
-  return sbp_(((f.encoding)))_string_append_vprintf(s, &(((params))), fmt, ap);
+  return (((string_prefix)))_add_section_vprintf(s, &(((params))), fmt, ap);
 }
 
-  const char *(((m.name|convert_unpacked)))_(((f.name)))_get_section(const sbp_(((f.encoding)))_string_t *s, uint8_t section)
+bool (((field_prefix)))_append( (((-string_type))) *s, const char *str)
 {
-  return sbp_(((f.encoding)))_string_get_section(s, &(((params))), section);
+  return (((string_prefix)))_append(s, &(((params))), str);
 }
 
-  uint8_t (((m.name|convert_unpacked)))_(((f.name)))_section_strlen(const sbp_(((f.encoding)))_string_t *s, uint8_t section)
+bool (((field_prefix)))_append_printf( (((-string_type))) *s, const char *fmt, ...) 
 {
-  return sbp_(((f.encoding)))_string_section_strlen(s, &(((params))), section);
+  va_list ap;
+  va_start(ap, fmt);
+  bool ret = (((string_prefix)))_append_vprintf(s, &(((params))), fmt, ap);
+  va_end(ap);
+  return ret;
 }
 
-  ((*- else *))
+bool (((field_prefix)))_append_vprintf( (((-string_type))) *s, const char *fmt, va_list ap)
+{
+  return (((string_prefix)))_append_vprintf(s, &(((params))), fmt, ap);
+}
+
+const char *(((field_prefix)))_get_section(const (((string_type))) *s, uint8_t section)
+{
+  return (((string_prefix)))_get_section(s, &(((params))), section);
+}
+
+uint8_t (((field_prefix)))_section_strlen(const (((string_type))) *s, uint8_t section)
+{
+  return (((string_prefix)))_section_strlen(s, &(((params))), section);
+}
+
+((*- else *))
   **** INVALID STRING ENCODING : (((f.encoding))) ****
-  ((* endif *))
+((* endif *))
 ((*- endif *))
 ((*- endfor *))
 
-size_t sbp_packed_size_(((m.name|convert_unpacked)))(const (((m.name|convert_unpacked))) *msg) {
+size_t sbp_packed_size_(((msg_type)))(const (((msg_type))) *msg) {
   ((*- if not m.fields *))
   (void)msg;
   return 0;
   ((*- else *))
   size_t packed_size = 0;
   ((*- for f in m.fields *))
+  ((*- set basetype = f.basetype|convert_unpacked *))
+  ((*- set field = "msg->" + f.name *))
   ((*- if f.packing == "packed-string" *))
-  packed_size += sbp_(((f.encoding)))_string_packed_len(&msg->(((f.name))), &(((m.name|convert_unpacked)))(((f.name)))_params);
+  packed_size += sbp_(((f.encoding)))_string_packed_len(&(((field))), &(((msg_type)))(((f.name)))_params);
   ((*- elif f.packing == "single" *))
-  packed_size += sbp_packed_size_(((f.basetype|convert_unpacked)))(&msg->(((f.name))));
+  packed_size += sbp_packed_size_(((basetype)))(&(((field))));
   ((*- elif f.packing == "fixed-array" *))
-  packed_size += ( (((f.max_items))) * sbp_packed_size_(((f.basetype|convert_unpacked)))(&msg->(((f.name)))[0]));
+  packed_size += ( (((f.max_items))) * sbp_packed_size_(((basetype)))(&(((field)))[0]));
   ((*- else *))
-  packed_size += (msg->(((f.size_fn))) * sbp_packed_size_(((f.basetype|convert_unpacked)))(&msg->(((f.name)))[0]));
+  packed_size += (msg->(((f.size_fn))) * sbp_packed_size_(((basetype)))(&(((field)))[0]));
   ((*- endif *))
   ((*- endfor *))
   return packed_size;
   ((*- endif *))
 }
 
-bool encode_(((m.name|convert_unpacked)))(sbp_encode_ctx_t *ctx, const (((m.name|convert_unpacked))) *msg)
+bool encode_(((msg_type)))(sbp_encode_ctx_t *ctx, const (((msg_type))) *msg)
 {
   ((*- if not m.fields *))
   (void)ctx;
@@ -192,14 +185,21 @@ bool encode_(((m.name|convert_unpacked)))(sbp_encode_ctx_t *ctx, const (((m.name
   return true;
   ((*- else *))
   ((*- for f in m.fields *))
+  ((*- set basetype = f.basetype|convert_unpacked *))
+  ((*- set field = "msg->" + f.name *))
   ((*- if f.packing == "packed-string" *))
-  if (!sbp_(((f.encoding)))_string_pack(&msg->(((f.name))), &(((m.name|convert_unpacked)))(((f.name)))_params, ctx)) { return false; }
+  if (!sbp_(((f.encoding)))_string_pack(&(((field))), &(((msg_type)))(((f.name)))_params, ctx)) { return false; }
   ((*- elif f.packing == "single" *))
-  if (!encode_(((f.basetype|convert_unpacked)))(ctx, &msg->(((f.name))))) { return false; }
+  if (!encode_(((basetype)))(ctx, &(((field))))) { return false; }
   ((*- else *))
-  for (uint8_t i = 0; i < ((* if f.packing == "fixed-array" *))(((f.max_items)))((* else *))msg->(((f.size_fn)))((*- endif *)); i++)
+  ((*- if f.packing == "fixed-array" *))
+  ((*- set max_loop = f.max_items *))
+  ((*- else *))
+  ((*- set max_loop = "msg->" + f.size_fn *))
+  ((*- endif *))
+  for (uint8_t i = 0; ret == 0 && i < (((max_loop))); i++)
   {
-    if (!encode_(((f.basetype|convert_unpacked)))(ctx, &msg->(((f.name)))[i])) { return false; }
+    if (!encode_(((basetype)))(ctx, &(((field)))[i])) { return false; }
   }
   ((*- endif *))
   ((*- endfor *))
@@ -207,12 +207,12 @@ bool encode_(((m.name|convert_unpacked)))(sbp_encode_ctx_t *ctx, const (((m.name
   ((*- endif *))
 }
 
-s8 sbp_encode_(((m.name|convert_unpacked)))(uint8_t *buf, uint8_t len, uint8_t *n_written, const (((m.name|convert_unpacked))) *msg) {
+s8 sbp_encode_(((msg_type)))(uint8_t *buf, uint8_t len, uint8_t *n_written, const (((msg_type))) *msg) {
   sbp_encode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
   ctx.offset = 0;
-  if (!encode_(((m.name|convert_unpacked)))(&ctx, msg)) {
+  if (!encode_(((msg_type)))(&ctx, msg)) {
     return SBP_ENCODE_ERROR;
   }
   if (n_written != NULL) {
@@ -221,7 +221,7 @@ s8 sbp_encode_(((m.name|convert_unpacked)))(uint8_t *buf, uint8_t len, uint8_t *
   return SBP_OK;
 }
 
-bool decode_(((m.name|convert_unpacked)))(sbp_decode_ctx_t *ctx, (((m.name|convert_unpacked))) *msg)
+bool decode_(((msg_type)))(sbp_decode_ctx_t *ctx, (((msg_type))) *msg)
 {
   ((*- if not m.fields *))
     (void)ctx;
@@ -229,19 +229,20 @@ bool decode_(((m.name|convert_unpacked)))(sbp_decode_ctx_t *ctx, (((m.name|conve
   return true;
   ((*- else *))
   ((*- for f in m.fields *))
-
+  ((*- set basetype = f.basetype|convert_unpacked *))
+  ((*- set field = "msg->" + f.name *))
   ((*- if f.packing == "packed-string" *))
-  if (!sbp_(((f.encoding)))_string_unpack(&msg->(((f.name))), &(((m.name|convert_unpacked)))(((f.name)))_params, ctx)) { return false; }
+  if (!sbp_(((f.encoding)))_string_unpack(&(((field))), &(((msg_type)))(((f.name)))_params, ctx)) { return false; }
   ((*- elif f.packing == "single" *))
-  if (!decode_(((f.basetype|convert_unpacked)))(ctx, &msg->(((f.name))))) { return false; }
+  if (!decode_(((basetype)))(ctx, &(((field))))) { return false; }
   ((*- elif f.packing == "fixed-array" *))
   for (uint8_t i = 0; i < (((f.max_items))); i++) {
-    if (!decode_(((f.basetype|convert_unpacked)))(ctx, &msg->(((f.name)))[i])) { return false; }
+    if (!decode_(((basetype)))(ctx, &(((field)))[i])) { return false; }
   }
   ((*- elif f.packing == "variable-array" *))
-    msg->(((f.size_fn))) = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_(((f.basetype|convert_unpacked)))(&msg->(((f.name)))[0]));
+    msg->(((f.size_fn))) = (uint8_t)((ctx->buf_len - ctx->offset) / sbp_packed_size_(((basetype)))(&(((field)))[0]));
   for (uint8_t i = 0; i < msg->(((f.size_fn))); i++) {
-    if (!decode_(((f.basetype|convert_unpacked)))(ctx, &msg->(((f.name)))[i])) { return false; }
+    if (!decode_(((basetype)))(ctx, &(((field)))[i])) { return false; }
   }
   ((*- endif *))
   ((*- endfor *))
@@ -249,12 +250,12 @@ bool decode_(((m.name|convert_unpacked)))(sbp_decode_ctx_t *ctx, (((m.name|conve
   ((*- endif *))
 }
 
-s8 sbp_decode_(((m.name|convert_unpacked)))(const uint8_t *buf, uint8_t len, uint8_t *n_read, (((m.name|convert_unpacked))) *msg) {
+s8 sbp_decode_(((msg_type)))(const uint8_t *buf, uint8_t len, uint8_t *n_read, (((msg_type))) *msg) {
   sbp_decode_ctx_t ctx;
   ctx.buf = buf;
   ctx.buf_len = len;
   ctx.offset = 0;
-  if (!decode_(((m.name|convert_unpacked)))(&ctx, msg)) {
+  if (!decode_(((msg_type)))(&ctx, msg)) {
     return SBP_DECODE_ERROR;
   }
   if (n_read != NULL) {
@@ -263,35 +264,41 @@ s8 sbp_decode_(((m.name|convert_unpacked)))(const uint8_t *buf, uint8_t len, uin
   return SBP_OK;
 }
 
-((*- if m.is_real_message *))
-s8 sbp_send_(((m.name|convert_unpacked)))(struct sbp_state *s, u16 sender_id, const (((m.name|convert_unpacked))) *msg, sbp_write_fn_t write)
+((* if m.is_real_message *))
+s8 sbp_send_(((msg_type)))(struct sbp_state *s, u16 sender_id, const (((msg_type))) *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
-  s8 ret = sbp_encode_(((m.name|convert_unpacked)))(payload, sizeof(payload), &payload_len, msg);
+  s8 ret = sbp_encode_(((msg_type)))(payload, sizeof(payload), &payload_len, msg);
   if (ret != SBP_OK) { return ret; }
   return sbp_payload_send(s, SBP_(((m.name))), sender_id, payload_len, payload, write);
 }
 ((*- endif *))
 
-int sbp_cmp_(((m.name|convert_unpacked)))(const (((m.name|convert_unpacked))) *a, const (((m.name|convert_unpacked))) *b) {
+int sbp_cmp_(((msg_type)))(const (((msg_type))) *a, const (((msg_type))) *b) {
   ((*- if not m.fields *))
   (void)a;
   (void)b;
   ((*- endif *))
   int ret = 0;
   ((*- for f in m.fields *))
+  ((*- set basetype = f.basetype|convert_unpacked *))
   ((* if f.packing == "packed-string" *))
-  ret = sbp_(((f.encoding)))_string_strcmp(&a->(((f.name))), &b->(((f.name))), &(((m.name|convert_unpacked)))(((f.name)))_params);
+  ret = (((msg_type)))_(((f.name)))_strcmp(&a->(((f.name))), &b->(((f.name))));
   ((*- elif f.packing == "single" *))
-  ret = sbp_cmp_(((f.basetype|convert_unpacked)))(&a->(((f.name))), &b->(((f.name))));
+  ret = sbp_cmp_(((basetype)))(&a->(((f.name))), &b->(((f.name))));
   ((*- else *))
   ((*- if f.packing == "variable-array" *))
   ret = sbp_cmp_u8(&a->(((f.size_fn))), &b->(((f.size_fn))));
   ((*- endif *))
-  for (uint8_t i = 0; i < ((* if f.packing == "fixed-array" *))(((f.max_items)))((* else *))a->(((f.size_fn)))((* endif *)) && ret == 0; i++)
+  ((*- if f.packing == "fixed-array" *))
+  ((*- set max_loop = f.max_items *))
+  ((*- else *))
+  ((*- set max_loop = "a->" + f.size_fn *))
+  ((*- endif *))
+  for (uint8_t i = 0; ret == 0 && i < (((max_loop))); i++)
   {
-    ret = sbp_cmp_(((f.basetype|convert_unpacked)))(&a->(((f.name)))[i], &b->(((f.name)))[i]);
+    ret = sbp_cmp_(((basetype)))(&a->(((f.name)))[i], &b->(((f.name)))[i]);
   }
   ((*- endif *))
   if (ret != 0) { return ret; }


### PR DESCRIPTION
Not a huge amount going on here in the generated files, just formatting and comments. Templates tidied up a little bit but it would benefit more from some attention in `c.py`, that will have to wait until the end.