### PR TITLE
Doxygen errors

### DIFF
--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -56,7 +56,7 @@ typedef uint64_t u64;
  * The user of libsbp must provide a write callback conforming to this type
  * to functions which send messages (eg, #sbp_message_send). The write 
  * function will be called several times during the course of sending a single 
- * message. The context parameter can be set by calling #sbp_set_io_context.
+ * message. The context parameter can be set by calling #sbp_state_set_io_context.
  *
  * @param buff Data to write
  * @param n Length of \p buff

--- a/c/include/libsbp/cpp/message_handler.h
+++ b/c/include/libsbp/cpp/message_handler.h
@@ -40,8 +40,8 @@ using CallbackMsgFn = void (ClassT::*)(uint16_t, const ArgT &);
  * @tparam func Pointer to the member function to call
  *
  * @param sender_id The decoded sender ID, is forwarded on to `func`
- * @param len The length of the message, is forwarded on to `func`
- * @param msg The raw message payload
+ * @param msg_type SBP message type
+ * @param msg The decoded message
  * @param context Pointer to an instance of `ClassT` to call `func` on
  */
 template<typename MsgT, typename ClassT, CallbackMsgFn<ClassT, MsgT> func>

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT.h
@@ -119,7 +119,7 @@ s8 sbp_msg_acq_result_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_acq_result_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_acq_result_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT.h
@@ -130,7 +130,7 @@ s8 sbp_msg_acq_result_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_acq_result_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_acq_result_t *msg,

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_A.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_A.h
@@ -131,7 +131,7 @@ s8 sbp_msg_acq_result_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_acq_result_dep_a_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_acq_result_dep_a_t *msg,

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_A.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_A.h
@@ -120,7 +120,7 @@ s8 sbp_msg_acq_result_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_acq_result_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_acq_result_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_B.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_B.h
@@ -131,7 +131,7 @@ s8 sbp_msg_acq_result_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_acq_result_dep_b_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_acq_result_dep_b_t *msg,

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_B.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_B.h
@@ -120,7 +120,7 @@ s8 sbp_msg_acq_result_dep_b_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_acq_result_dep_b_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_acq_result_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_C.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_C.h
@@ -130,7 +130,7 @@ s8 sbp_msg_acq_result_dep_c_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_acq_result_dep_c_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_acq_result_dep_c_t *msg,

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_C.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_RESULT_DEP_C.h
@@ -119,7 +119,7 @@ s8 sbp_msg_acq_result_dep_c_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_acq_result_dep_c_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_acq_result_dep_c_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE.h
@@ -114,7 +114,7 @@ s8 sbp_msg_acq_sv_profile_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_acq_sv_profile_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_acq_sv_profile_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE.h
@@ -125,7 +125,7 @@ s8 sbp_msg_acq_sv_profile_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_acq_sv_profile_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_acq_sv_profile_t *msg,

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
@@ -116,7 +116,7 @@ s8 sbp_msg_acq_sv_profile_dep_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_acq_sv_profile_dep_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_acq_sv_profile_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
@@ -127,7 +127,7 @@ s8 sbp_msg_acq_sv_profile_dep_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_acq_sv_profile_dep_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_acq_sv_profile_dep_t *msg,

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
@@ -71,7 +71,7 @@ bool sbp_msg_bootloader_handshake_dep_a_handshake_valid(
  * Tests 2 instances of sbp_msg_bootloader_handshake_dep_a_t::handshake for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_bootloader_handshake_dep_a_t instance
@@ -202,6 +202,8 @@ const char *sbp_msg_bootloader_handshake_dep_a_handshake_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_bootloader_handshake_dep_a_t instance
+ * @param msg sbp_msg_bootloader_handshake_dep_a_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_bootloader_handshake_dep_a_handshake_section_strlen(
@@ -276,7 +278,7 @@ s8 sbp_msg_bootloader_handshake_dep_a_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_bootloader_handshake_dep_a_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
@@ -202,7 +202,6 @@ const char *sbp_msg_bootloader_handshake_dep_a_handshake_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_bootloader_handshake_dep_a_t instance
- * @param msg sbp_msg_bootloader_handshake_dep_a_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -267,7 +266,7 @@ s8 sbp_msg_bootloader_handshake_dep_a_decode(
  * Send an instance of sbp_msg_bootloader_handshake_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_bootloader_handshake_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
@@ -109,7 +109,7 @@ s8 sbp_msg_bootloader_handshake_req_decode(
  * Send an instance of sbp_msg_bootloader_handshake_req_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_bootloader_handshake_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
@@ -120,7 +120,7 @@ s8 sbp_msg_bootloader_handshake_req_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_bootloader_handshake_req_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
@@ -208,7 +208,6 @@ const char *sbp_msg_bootloader_handshake_resp_version_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_bootloader_handshake_resp_t instance
- * @param msg sbp_msg_bootloader_handshake_resp_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -272,7 +271,7 @@ s8 sbp_msg_bootloader_handshake_resp_decode(
  * Send an instance of sbp_msg_bootloader_handshake_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_bootloader_handshake_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
@@ -79,7 +79,7 @@ bool sbp_msg_bootloader_handshake_resp_version_valid(
  * Tests 2 instances of sbp_msg_bootloader_handshake_resp_t::version for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_bootloader_handshake_resp_t instance
@@ -208,6 +208,8 @@ const char *sbp_msg_bootloader_handshake_resp_version_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_bootloader_handshake_resp_t instance
+ * @param msg sbp_msg_bootloader_handshake_resp_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_bootloader_handshake_resp_version_section_strlen(
@@ -281,7 +283,7 @@ s8 sbp_msg_bootloader_handshake_resp_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_bootloader_handshake_resp_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
@@ -105,7 +105,7 @@ s8 sbp_msg_bootloader_jump_to_app_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_bootloader_jump_to_app_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_bootloader_jump_to_app_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
@@ -116,7 +116,7 @@ s8 sbp_msg_bootloader_jump_to_app_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_bootloader_jump_to_app_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_bootloader_jump_to_app_t *msg,

--- a/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_REQ.h
+++ b/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_REQ.h
@@ -108,7 +108,7 @@ s8 sbp_msg_nap_device_dna_req_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_nap_device_dna_req_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_nap_device_dna_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_REQ.h
+++ b/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_REQ.h
@@ -119,7 +119,7 @@ s8 sbp_msg_nap_device_dna_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_nap_device_dna_req_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_nap_device_dna_req_t *msg,

--- a/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_RESP.h
@@ -108,7 +108,7 @@ s8 sbp_msg_nap_device_dna_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_nap_device_dna_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_nap_device_dna_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_RESP.h
@@ -119,7 +119,7 @@ s8 sbp_msg_nap_device_dna_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_nap_device_dna_resp_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_nap_device_dna_resp_t *msg,

--- a/c/include/libsbp/v4/ext_events/MSG_EXT_EVENT.h
+++ b/c/include/libsbp/v4/ext_events/MSG_EXT_EVENT.h
@@ -132,7 +132,7 @@ s8 sbp_msg_ext_event_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ext_event_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_ext_event_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/ext_events/MSG_EXT_EVENT.h
+++ b/c/include/libsbp/v4/ext_events/MSG_EXT_EVENT.h
@@ -121,7 +121,7 @@ s8 sbp_msg_ext_event_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_ext_event_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ext_event_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_REQ.h
@@ -104,7 +104,7 @@ s8 sbp_msg_fileio_config_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_fileio_config_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_config_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_REQ.h
@@ -115,7 +115,7 @@ s8 sbp_msg_fileio_config_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_config_req_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_fileio_config_req_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_RESP.h
@@ -121,7 +121,7 @@ s8 sbp_msg_fileio_config_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_fileio_config_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_config_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_CONFIG_RESP.h
@@ -132,7 +132,7 @@ s8 sbp_msg_fileio_config_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_config_resp_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_fileio_config_resp_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
@@ -87,7 +87,7 @@ bool sbp_msg_fileio_read_dir_req_dirname_valid(
 /**
  * Tests 2 instances of sbp_msg_fileio_read_dir_req_t::dirname for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_fileio_read_dir_req_t instance
@@ -213,6 +213,8 @@ const char *sbp_msg_fileio_read_dir_req_dirname_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_read_dir_req_t instance
+ * @param msg sbp_msg_fileio_read_dir_req_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_fileio_read_dir_req_dirname_section_strlen(
@@ -283,7 +285,7 @@ s8 sbp_msg_fileio_read_dir_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_read_dir_req_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_fileio_read_dir_req_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
@@ -213,7 +213,6 @@ const char *sbp_msg_fileio_read_dir_req_dirname_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_read_dir_req_t instance
- * @param msg sbp_msg_fileio_read_dir_req_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -274,7 +273,7 @@ s8 sbp_msg_fileio_read_dir_req_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_fileio_read_dir_req_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_read_dir_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_RESP.h
@@ -314,7 +314,7 @@ s8 sbp_msg_fileio_read_dir_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_fileio_read_dir_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_read_dir_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_RESP.h
@@ -79,7 +79,7 @@ bool sbp_msg_fileio_read_dir_resp_contents_valid(
 /**
  * Tests 2 instances of sbp_msg_fileio_read_dir_resp_t::contents for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_fileio_read_dir_resp_t instance
@@ -325,7 +325,7 @@ s8 sbp_msg_fileio_read_dir_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_read_dir_resp_send(sbp_state_t *s, u16 sender_id,
                                      const sbp_msg_fileio_read_dir_resp_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
@@ -90,7 +90,7 @@ bool sbp_msg_fileio_read_req_filename_valid(
 /**
  * Tests 2 instances of sbp_msg_fileio_read_req_t::filename for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_fileio_read_req_t instance
@@ -214,6 +214,8 @@ const char *sbp_msg_fileio_read_req_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_read_req_t instance
+ * @param msg sbp_msg_fileio_read_req_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_fileio_read_req_filename_section_strlen(
@@ -282,7 +284,7 @@ s8 sbp_msg_fileio_read_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_read_req_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_fileio_read_req_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
@@ -214,7 +214,6 @@ const char *sbp_msg_fileio_read_req_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_read_req_t instance
- * @param msg sbp_msg_fileio_read_req_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -273,7 +272,7 @@ s8 sbp_msg_fileio_read_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_fileio_read_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_read_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_RESP.h
@@ -132,7 +132,7 @@ s8 sbp_msg_fileio_read_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_read_resp_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_fileio_read_resp_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_RESP.h
@@ -121,7 +121,7 @@ s8 sbp_msg_fileio_read_resp_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_fileio_read_resp_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_read_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
@@ -196,7 +196,6 @@ const char *sbp_msg_fileio_remove_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_remove_t instance
- * @param msg sbp_msg_fileio_remove_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -253,7 +252,7 @@ s8 sbp_msg_fileio_remove_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_fileio_remove_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_remove_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
@@ -71,7 +71,7 @@ bool sbp_msg_fileio_remove_filename_valid(const sbp_msg_fileio_remove_t *msg);
 /**
  * Tests 2 instances of sbp_msg_fileio_remove_t::filename for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_fileio_remove_t instance
@@ -196,6 +196,8 @@ const char *sbp_msg_fileio_remove_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_remove_t instance
+ * @param msg sbp_msg_fileio_remove_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_fileio_remove_filename_section_strlen(
@@ -262,7 +264,7 @@ s8 sbp_msg_fileio_remove_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_remove_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_fileio_remove_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -100,7 +100,7 @@ bool sbp_msg_fileio_write_req_filename_valid(
 /**
  * Tests 2 instances of sbp_msg_fileio_write_req_t::filename for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_fileio_write_req_t instance
@@ -225,6 +225,8 @@ const char *sbp_msg_fileio_write_req_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_write_req_t instance
+ * @param msg sbp_msg_fileio_write_req_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_fileio_write_req_filename_section_strlen(
@@ -294,7 +296,7 @@ s8 sbp_msg_fileio_write_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_write_req_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_fileio_write_req_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -225,7 +225,6 @@ const char *sbp_msg_fileio_write_req_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_write_req_t instance
- * @param msg sbp_msg_fileio_write_req_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -285,7 +284,7 @@ s8 sbp_msg_fileio_write_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_fileio_write_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_write_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_RESP.h
@@ -116,7 +116,7 @@ s8 sbp_msg_fileio_write_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fileio_write_resp_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_fileio_write_resp_t *msg,

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_RESP.h
@@ -105,7 +105,7 @@ s8 sbp_msg_fileio_write_resp_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_fileio_write_resp_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fileio_write_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_FLASH_DONE.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_DONE.h
@@ -112,7 +112,7 @@ s8 sbp_msg_flash_done_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_flash_done_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_flash_done_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_FLASH_DONE.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_DONE.h
@@ -101,7 +101,7 @@ s8 sbp_msg_flash_done_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_flash_done_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_flash_done_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_FLASH_ERASE.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_ERASE.h
@@ -107,7 +107,7 @@ s8 sbp_msg_flash_erase_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_flash_erase_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_flash_erase_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_FLASH_ERASE.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_ERASE.h
@@ -118,7 +118,7 @@ s8 sbp_msg_flash_erase_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_flash_erase_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_flash_erase_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_FLASH_PROGRAM.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_PROGRAM.h
@@ -119,7 +119,7 @@ s8 sbp_msg_flash_program_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_flash_program_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_flash_program_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_FLASH_PROGRAM.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_PROGRAM.h
@@ -130,7 +130,7 @@ s8 sbp_msg_flash_program_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_flash_program_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_flash_program_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_FLASH_READ_REQ.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_READ_REQ.h
@@ -116,7 +116,7 @@ s8 sbp_msg_flash_read_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_flash_read_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_flash_read_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_FLASH_READ_REQ.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_READ_REQ.h
@@ -127,7 +127,7 @@ s8 sbp_msg_flash_read_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_flash_read_req_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_flash_read_req_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_FLASH_READ_RESP.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_READ_RESP.h
@@ -117,7 +117,7 @@ s8 sbp_msg_flash_read_resp_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_flash_read_resp_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_flash_read_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_FLASH_READ_RESP.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_READ_RESP.h
@@ -128,7 +128,7 @@ s8 sbp_msg_flash_read_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_flash_read_resp_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_flash_read_resp_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_M25_FLASH_WRITE_STATUS.h
+++ b/c/include/libsbp/v4/flash/MSG_M25_FLASH_WRITE_STATUS.h
@@ -117,7 +117,7 @@ s8 sbp_msg_m25_flash_write_status_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_m25_flash_write_status_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_m25_flash_write_status_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_M25_FLASH_WRITE_STATUS.h
+++ b/c/include/libsbp/v4/flash/MSG_M25_FLASH_WRITE_STATUS.h
@@ -106,7 +106,7 @@ s8 sbp_msg_m25_flash_write_status_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_m25_flash_write_status_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_m25_flash_write_status_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_STM_FLASH_LOCK_SECTOR.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_FLASH_LOCK_SECTOR.h
@@ -117,7 +117,7 @@ s8 sbp_msg_stm_flash_lock_sector_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_stm_flash_lock_sector_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_stm_flash_lock_sector_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_STM_FLASH_LOCK_SECTOR.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_FLASH_LOCK_SECTOR.h
@@ -106,7 +106,7 @@ s8 sbp_msg_stm_flash_lock_sector_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_stm_flash_lock_sector_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_stm_flash_lock_sector_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
@@ -118,7 +118,7 @@ s8 sbp_msg_stm_flash_unlock_sector_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_stm_flash_unlock_sector_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_stm_flash_unlock_sector_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
@@ -107,7 +107,7 @@ s8 sbp_msg_stm_flash_unlock_sector_decode(
  * Send an instance of sbp_msg_stm_flash_unlock_sector_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_stm_flash_unlock_sector_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_REQ.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_REQ.h
@@ -117,7 +117,7 @@ s8 sbp_msg_stm_unique_id_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_stm_unique_id_req_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_stm_unique_id_req_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_REQ.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_REQ.h
@@ -106,7 +106,7 @@ s8 sbp_msg_stm_unique_id_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_stm_unique_id_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_stm_unique_id_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_RESP.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_RESP.h
@@ -117,7 +117,7 @@ s8 sbp_msg_stm_unique_id_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_stm_unique_id_resp_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_stm_unique_id_resp_t *msg,

--- a/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_RESP.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_RESP.h
@@ -106,7 +106,7 @@ s8 sbp_msg_stm_unique_id_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_stm_unique_id_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_stm_unique_id_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/imu/MSG_IMU_AUX.h
+++ b/c/include/libsbp/v4/imu/MSG_IMU_AUX.h
@@ -122,7 +122,7 @@ s8 sbp_msg_imu_aux_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_imu_aux_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_imu_aux_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/imu/MSG_IMU_AUX.h
+++ b/c/include/libsbp/v4/imu/MSG_IMU_AUX.h
@@ -111,7 +111,7 @@ s8 sbp_msg_imu_aux_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_imu_aux_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_imu_aux_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/imu/MSG_IMU_RAW.h
+++ b/c/include/libsbp/v4/imu/MSG_IMU_RAW.h
@@ -153,7 +153,7 @@ s8 sbp_msg_imu_raw_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_imu_raw_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_imu_raw_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/imu/MSG_IMU_RAW.h
+++ b/c/include/libsbp/v4/imu/MSG_IMU_RAW.h
@@ -142,7 +142,7 @@ s8 sbp_msg_imu_raw_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_imu_raw_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_imu_raw_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
@@ -100,7 +100,7 @@ bool sbp_msg_linux_cpu_state_cmdline_valid(
 /**
  * Tests 2 instances of sbp_msg_linux_cpu_state_t::cmdline for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_cpu_state_t instance
@@ -224,6 +224,8 @@ const char *sbp_msg_linux_cpu_state_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_cpu_state_t instance
+ * @param msg sbp_msg_linux_cpu_state_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_cpu_state_cmdline_section_strlen(
@@ -292,7 +294,7 @@ s8 sbp_msg_linux_cpu_state_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_cpu_state_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_linux_cpu_state_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
@@ -224,7 +224,6 @@ const char *sbp_msg_linux_cpu_state_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_cpu_state_t instance
- * @param msg sbp_msg_linux_cpu_state_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -283,7 +282,7 @@ s8 sbp_msg_linux_cpu_state_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_linux_cpu_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_cpu_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -218,7 +218,6 @@ const char *sbp_msg_linux_cpu_state_dep_a_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_cpu_state_dep_a_t instance
- * @param msg sbp_msg_linux_cpu_state_dep_a_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -281,7 +280,7 @@ s8 sbp_msg_linux_cpu_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_linux_cpu_state_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_cpu_state_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -91,7 +91,7 @@ bool sbp_msg_linux_cpu_state_dep_a_cmdline_valid(
 /**
  * Tests 2 instances of sbp_msg_linux_cpu_state_dep_a_t::cmdline for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_cpu_state_dep_a_t instance
@@ -218,6 +218,8 @@ const char *sbp_msg_linux_cpu_state_dep_a_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_cpu_state_dep_a_t instance
+ * @param msg sbp_msg_linux_cpu_state_dep_a_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_cpu_state_dep_a_cmdline_section_strlen(
@@ -290,7 +292,7 @@ s8 sbp_msg_linux_cpu_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_cpu_state_dep_a_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_linux_cpu_state_dep_a_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
@@ -100,7 +100,7 @@ bool sbp_msg_linux_mem_state_cmdline_valid(
 /**
  * Tests 2 instances of sbp_msg_linux_mem_state_t::cmdline for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_mem_state_t instance
@@ -224,6 +224,8 @@ const char *sbp_msg_linux_mem_state_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_mem_state_t instance
+ * @param msg sbp_msg_linux_mem_state_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_mem_state_cmdline_section_strlen(
@@ -292,7 +294,7 @@ s8 sbp_msg_linux_mem_state_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_mem_state_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_linux_mem_state_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
@@ -224,7 +224,6 @@ const char *sbp_msg_linux_mem_state_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_mem_state_t instance
- * @param msg sbp_msg_linux_mem_state_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -283,7 +282,7 @@ s8 sbp_msg_linux_mem_state_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_linux_mem_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_mem_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -218,7 +218,6 @@ const char *sbp_msg_linux_mem_state_dep_a_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_mem_state_dep_a_t instance
- * @param msg sbp_msg_linux_mem_state_dep_a_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -281,7 +280,7 @@ s8 sbp_msg_linux_mem_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_linux_mem_state_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_mem_state_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -91,7 +91,7 @@ bool sbp_msg_linux_mem_state_dep_a_cmdline_valid(
 /**
  * Tests 2 instances of sbp_msg_linux_mem_state_dep_a_t::cmdline for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_mem_state_dep_a_t instance
@@ -218,6 +218,8 @@ const char *sbp_msg_linux_mem_state_dep_a_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_mem_state_dep_a_t instance
+ * @param msg sbp_msg_linux_mem_state_dep_a_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_mem_state_dep_a_cmdline_section_strlen(
@@ -290,7 +292,7 @@ s8 sbp_msg_linux_mem_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_mem_state_dep_a_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_linux_mem_state_dep_a_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
@@ -212,7 +212,6 @@ const char *sbp_msg_linux_process_fd_count_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_fd_count_t instance
- * @param msg sbp_msg_linux_process_fd_count_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -275,7 +274,7 @@ s8 sbp_msg_linux_process_fd_count_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_linux_process_fd_count_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_process_fd_count_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
@@ -85,7 +85,7 @@ bool sbp_msg_linux_process_fd_count_cmdline_valid(
 /**
  * Tests 2 instances of sbp_msg_linux_process_fd_count_t::cmdline for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_process_fd_count_t instance
@@ -212,6 +212,8 @@ const char *sbp_msg_linux_process_fd_count_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_fd_count_t instance
+ * @param msg sbp_msg_linux_process_fd_count_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_process_fd_count_cmdline_section_strlen(
@@ -284,7 +286,7 @@ s8 sbp_msg_linux_process_fd_count_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_process_fd_count_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_linux_process_fd_count_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
@@ -80,7 +80,7 @@ bool sbp_msg_linux_process_fd_summary_most_opened_valid(
  * Tests 2 instances of sbp_msg_linux_process_fd_summary_t::most_opened for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_process_fd_summary_t instance
@@ -331,7 +331,7 @@ s8 sbp_msg_linux_process_fd_summary_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_process_fd_summary_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
@@ -320,7 +320,7 @@ s8 sbp_msg_linux_process_fd_summary_decode(
  * Send an instance of sbp_msg_linux_process_fd_summary_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_process_fd_summary_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
@@ -231,7 +231,6 @@ const char *sbp_msg_linux_process_socket_counts_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_socket_counts_t instance
- * @param msg sbp_msg_linux_process_socket_counts_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -296,7 +295,7 @@ s8 sbp_msg_linux_process_socket_counts_decode(
  * Send an instance of sbp_msg_linux_process_socket_counts_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_process_socket_counts_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
@@ -100,7 +100,7 @@ bool sbp_msg_linux_process_socket_counts_cmdline_valid(
  * Tests 2 instances of sbp_msg_linux_process_socket_counts_t::cmdline for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_process_socket_counts_t instance
@@ -231,6 +231,8 @@ const char *sbp_msg_linux_process_socket_counts_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_socket_counts_t instance
+ * @param msg sbp_msg_linux_process_socket_counts_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_process_socket_counts_cmdline_section_strlen(
@@ -305,7 +307,7 @@ s8 sbp_msg_linux_process_socket_counts_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_process_socket_counts_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -111,7 +111,7 @@ bool sbp_msg_linux_process_socket_queues_cmdline_valid(
  * Tests 2 instances of sbp_msg_linux_process_socket_queues_t::cmdline for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_linux_process_socket_queues_t instance
@@ -242,6 +242,8 @@ const char *sbp_msg_linux_process_socket_queues_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_socket_queues_t instance
+ * @param msg sbp_msg_linux_process_socket_queues_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_linux_process_socket_queues_cmdline_section_strlen(
@@ -316,7 +318,7 @@ s8 sbp_msg_linux_process_socket_queues_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_process_socket_queues_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -242,7 +242,6 @@ const char *sbp_msg_linux_process_socket_queues_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_socket_queues_t instance
- * @param msg sbp_msg_linux_process_socket_queues_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -307,7 +306,7 @@ s8 sbp_msg_linux_process_socket_queues_decode(
  * Send an instance of sbp_msg_linux_process_socket_queues_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_process_socket_queues_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SOCKET_USAGE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SOCKET_USAGE.h
@@ -120,7 +120,7 @@ s8 sbp_msg_linux_socket_usage_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_linux_socket_usage_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_socket_usage_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SOCKET_USAGE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SOCKET_USAGE.h
@@ -131,7 +131,7 @@ s8 sbp_msg_linux_socket_usage_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_socket_usage_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_linux_socket_usage_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE.h
@@ -136,7 +136,7 @@ s8 sbp_msg_linux_sys_state_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_linux_sys_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_sys_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE.h
@@ -147,7 +147,7 @@ s8 sbp_msg_linux_sys_state_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_sys_state_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_linux_sys_state_t *msg,

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE_DEP_A.h
@@ -130,7 +130,7 @@ s8 sbp_msg_linux_sys_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_linux_sys_state_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_linux_sys_state_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SYS_STATE_DEP_A.h
@@ -141,7 +141,7 @@ s8 sbp_msg_linux_sys_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_linux_sys_state_dep_a_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_linux_sys_state_dep_a_t *msg,

--- a/c/include/libsbp/v4/logging/MSG_FWD.h
+++ b/c/include/libsbp/v4/logging/MSG_FWD.h
@@ -123,7 +123,7 @@ s8 sbp_msg_fwd_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_fwd_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_fwd_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/logging/MSG_FWD.h
+++ b/c/include/libsbp/v4/logging/MSG_FWD.h
@@ -134,7 +134,7 @@ s8 sbp_msg_fwd_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_fwd_send(sbp_state_t *s, u16 sender_id, const sbp_msg_fwd_t *msg,
                     sbp_write_fn_t write);

--- a/c/include/libsbp/v4/logging/MSG_LOG.h
+++ b/c/include/libsbp/v4/logging/MSG_LOG.h
@@ -191,7 +191,6 @@ const char *sbp_msg_log_text_get(const sbp_msg_log_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_log_t instance
- * @param msg sbp_msg_log_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -248,7 +247,7 @@ s8 sbp_msg_log_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_log_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_log_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/logging/MSG_LOG.h
+++ b/c/include/libsbp/v4/logging/MSG_LOG.h
@@ -75,7 +75,7 @@ bool sbp_msg_log_text_valid(const sbp_msg_log_t *msg);
 /**
  * Tests 2 instances of sbp_msg_log_t::text for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_log_t instance
@@ -191,6 +191,8 @@ const char *sbp_msg_log_text_get(const sbp_msg_log_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_log_t instance
+ * @param msg sbp_msg_log_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_log_text_section_strlen(const sbp_msg_log_t *msg,
@@ -257,7 +259,7 @@ s8 sbp_msg_log_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_log_send(sbp_state_t *s, u16 sender_id, const sbp_msg_log_t *msg,
                     sbp_write_fn_t write);

--- a/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
+++ b/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
@@ -68,7 +68,7 @@ bool sbp_msg_print_dep_text_valid(const sbp_msg_print_dep_t *msg);
 /**
  * Tests 2 instances of sbp_msg_print_dep_t::text for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_print_dep_t instance
@@ -188,6 +188,8 @@ const char *sbp_msg_print_dep_text_get(const sbp_msg_print_dep_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_print_dep_t instance
+ * @param msg sbp_msg_print_dep_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_print_dep_text_section_strlen(const sbp_msg_print_dep_t *msg,
@@ -254,7 +256,7 @@ s8 sbp_msg_print_dep_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_print_dep_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_print_dep_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
+++ b/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
@@ -188,7 +188,6 @@ const char *sbp_msg_print_dep_text_get(const sbp_msg_print_dep_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_print_dep_t instance
- * @param msg sbp_msg_print_dep_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -245,7 +244,7 @@ s8 sbp_msg_print_dep_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_print_dep_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_print_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/mag/MSG_MAG_RAW.h
+++ b/c/include/libsbp/v4/mag/MSG_MAG_RAW.h
@@ -120,7 +120,7 @@ s8 sbp_msg_mag_raw_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_mag_raw_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_mag_raw_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/mag/MSG_MAG_RAW.h
+++ b/c/include/libsbp/v4/mag/MSG_MAG_RAW.h
@@ -131,7 +131,7 @@ s8 sbp_msg_mag_raw_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_mag_raw_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_mag_raw_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_AGE_CORRECTIONS.h
+++ b/c/include/libsbp/v4/navigation/MSG_AGE_CORRECTIONS.h
@@ -118,7 +118,7 @@ s8 sbp_msg_age_corrections_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_age_corrections_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_age_corrections_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_AGE_CORRECTIONS.h
+++ b/c/include/libsbp/v4/navigation/MSG_AGE_CORRECTIONS.h
@@ -107,7 +107,7 @@ s8 sbp_msg_age_corrections_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_age_corrections_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_age_corrections_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF.h
@@ -143,7 +143,7 @@ s8 sbp_msg_baseline_ecef_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_baseline_ecef_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_baseline_ecef_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF.h
@@ -132,7 +132,7 @@ s8 sbp_msg_baseline_ecef_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_baseline_ecef_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_baseline_ecef_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF_DEP_A.h
@@ -136,7 +136,7 @@ s8 sbp_msg_baseline_ecef_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_baseline_ecef_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_baseline_ecef_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_ECEF_DEP_A.h
@@ -147,7 +147,7 @@ s8 sbp_msg_baseline_ecef_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_baseline_ecef_dep_a_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_baseline_ecef_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_HEADING_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_HEADING_DEP_A.h
@@ -133,7 +133,7 @@ s8 sbp_msg_baseline_heading_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_baseline_heading_dep_a_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_baseline_heading_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_HEADING_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_HEADING_DEP_A.h
@@ -122,7 +122,7 @@ s8 sbp_msg_baseline_heading_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_baseline_heading_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_baseline_heading_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_NED.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_NED.h
@@ -139,7 +139,7 @@ s8 sbp_msg_baseline_ned_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_baseline_ned_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_baseline_ned_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_NED.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_NED.h
@@ -150,7 +150,7 @@ s8 sbp_msg_baseline_ned_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_baseline_ned_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_baseline_ned_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_NED_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_NED_DEP_A.h
@@ -144,7 +144,7 @@ s8 sbp_msg_baseline_ned_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_baseline_ned_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_baseline_ned_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_BASELINE_NED_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_BASELINE_NED_DEP_A.h
@@ -155,7 +155,7 @@ s8 sbp_msg_baseline_ned_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_baseline_ned_dep_a_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_baseline_ned_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_DOPS.h
+++ b/c/include/libsbp/v4/navigation/MSG_DOPS.h
@@ -143,7 +143,7 @@ s8 sbp_msg_dops_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_dops_send(sbp_state_t *s, u16 sender_id, const sbp_msg_dops_t *msg,
                      sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_DOPS.h
+++ b/c/include/libsbp/v4/navigation/MSG_DOPS.h
@@ -132,7 +132,7 @@ s8 sbp_msg_dops_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_dops_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_dops_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_DOPS_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_DOPS_DEP_A.h
@@ -125,7 +125,7 @@ s8 sbp_msg_dops_dep_a_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_dops_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_dops_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_DOPS_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_DOPS_DEP_A.h
@@ -136,7 +136,7 @@ s8 sbp_msg_dops_dep_a_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_dops_dep_a_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_dops_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_GPS_TIME.h
+++ b/c/include/libsbp/v4/navigation/MSG_GPS_TIME.h
@@ -130,7 +130,7 @@ s8 sbp_msg_gps_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_gps_time_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_gps_time_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_GPS_TIME.h
+++ b/c/include/libsbp/v4/navigation/MSG_GPS_TIME.h
@@ -119,7 +119,7 @@ s8 sbp_msg_gps_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_gps_time_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_gps_time_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_GPS_TIME_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_GPS_TIME_DEP_A.h
@@ -131,7 +131,7 @@ s8 sbp_msg_gps_time_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_gps_time_dep_a_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_gps_time_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_GPS_TIME_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_GPS_TIME_DEP_A.h
@@ -120,7 +120,7 @@ s8 sbp_msg_gps_time_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_gps_time_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_gps_time_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_GPS_TIME_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_GPS_TIME_GNSS.h
@@ -119,7 +119,7 @@ s8 sbp_msg_gps_time_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_gps_time_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_gps_time_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_GPS_TIME_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_GPS_TIME_GNSS.h
@@ -130,7 +130,7 @@ s8 sbp_msg_gps_time_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_gps_time_gnss_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_gps_time_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF.h
@@ -146,7 +146,7 @@ s8 sbp_msg_pos_ecef_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_ecef_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_pos_ecef_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF.h
@@ -135,7 +135,7 @@ s8 sbp_msg_pos_ecef_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_pos_ecef_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_ecef_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV.h
@@ -161,7 +161,7 @@ s8 sbp_msg_pos_ecef_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_pos_ecef_cov_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_ecef_cov_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV.h
@@ -172,7 +172,7 @@ s8 sbp_msg_pos_ecef_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_ecef_cov_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_pos_ecef_cov_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV_GNSS.h
@@ -175,7 +175,7 @@ s8 sbp_msg_pos_ecef_cov_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_ecef_cov_gnss_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_pos_ecef_cov_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_COV_GNSS.h
@@ -164,7 +164,7 @@ s8 sbp_msg_pos_ecef_cov_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_pos_ecef_cov_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_ecef_cov_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_DEP_A.h
@@ -136,7 +136,7 @@ s8 sbp_msg_pos_ecef_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_pos_ecef_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_ecef_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_DEP_A.h
@@ -147,7 +147,7 @@ s8 sbp_msg_pos_ecef_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_ecef_dep_a_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_pos_ecef_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_GNSS.h
@@ -135,7 +135,7 @@ s8 sbp_msg_pos_ecef_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_pos_ecef_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_ecef_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_ECEF_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_ECEF_GNSS.h
@@ -146,7 +146,7 @@ s8 sbp_msg_pos_ecef_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_ecef_gnss_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_pos_ecef_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH.h
@@ -150,7 +150,7 @@ s8 sbp_msg_pos_llh_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_llh_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_pos_llh_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH.h
@@ -139,7 +139,7 @@ s8 sbp_msg_pos_llh_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_pos_llh_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_llh_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV.h
@@ -172,7 +172,7 @@ s8 sbp_msg_pos_llh_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_llh_cov_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_pos_llh_cov_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV.h
@@ -161,7 +161,7 @@ s8 sbp_msg_pos_llh_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_pos_llh_cov_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_llh_cov_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV_GNSS.h
@@ -175,7 +175,7 @@ s8 sbp_msg_pos_llh_cov_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_llh_cov_gnss_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_pos_llh_cov_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_COV_GNSS.h
@@ -164,7 +164,7 @@ s8 sbp_msg_pos_llh_cov_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_pos_llh_cov_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_llh_cov_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_DEP_A.h
@@ -151,7 +151,7 @@ s8 sbp_msg_pos_llh_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_llh_dep_a_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_pos_llh_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_DEP_A.h
@@ -140,7 +140,7 @@ s8 sbp_msg_pos_llh_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_pos_llh_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_llh_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_GNSS.h
@@ -139,7 +139,7 @@ s8 sbp_msg_pos_llh_gnss_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_pos_llh_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pos_llh_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_POS_LLH_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_POS_LLH_GNSS.h
@@ -150,7 +150,7 @@ s8 sbp_msg_pos_llh_gnss_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pos_llh_gnss_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_pos_llh_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL.h
+++ b/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL.h
@@ -206,7 +206,7 @@ s8 sbp_msg_protection_level_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_protection_level_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_protection_level_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL.h
+++ b/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL.h
@@ -217,7 +217,7 @@ s8 sbp_msg_protection_level_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_protection_level_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_protection_level_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
@@ -137,7 +137,7 @@ s8 sbp_msg_protection_level_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_protection_level_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_protection_level_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
@@ -148,7 +148,7 @@ s8 sbp_msg_protection_level_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_protection_level_dep_a_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_protection_level_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_UTC_TIME.h
+++ b/c/include/libsbp/v4/navigation/MSG_UTC_TIME.h
@@ -140,7 +140,7 @@ s8 sbp_msg_utc_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_utc_time_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_utc_time_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_UTC_TIME.h
+++ b/c/include/libsbp/v4/navigation/MSG_UTC_TIME.h
@@ -151,7 +151,7 @@ s8 sbp_msg_utc_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_utc_time_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_utc_time_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_UTC_TIME_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_UTC_TIME_GNSS.h
@@ -140,7 +140,7 @@ s8 sbp_msg_utc_time_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_utc_time_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_utc_time_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_UTC_TIME_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_UTC_TIME_GNSS.h
@@ -151,7 +151,7 @@ s8 sbp_msg_utc_time_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_utc_time_gnss_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_utc_time_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_BODY.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_BODY.h
@@ -173,7 +173,7 @@ s8 sbp_msg_vel_body_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_body_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_vel_body_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_VEL_BODY.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_BODY.h
@@ -162,7 +162,7 @@ s8 sbp_msg_vel_body_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_vel_body_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_body_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF.h
@@ -131,7 +131,7 @@ s8 sbp_msg_vel_ecef_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_vel_ecef_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ecef_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF.h
@@ -142,7 +142,7 @@ s8 sbp_msg_vel_ecef_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ecef_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_vel_ecef_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV.h
@@ -167,7 +167,7 @@ s8 sbp_msg_vel_ecef_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ecef_cov_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_vel_ecef_cov_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV.h
@@ -156,7 +156,7 @@ s8 sbp_msg_vel_ecef_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_vel_ecef_cov_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ecef_cov_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV_GNSS.h
@@ -170,7 +170,7 @@ s8 sbp_msg_vel_ecef_cov_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ecef_cov_gnss_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_vel_ecef_cov_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_COV_GNSS.h
@@ -159,7 +159,7 @@ s8 sbp_msg_vel_ecef_cov_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_vel_ecef_cov_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ecef_cov_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_DEP_A.h
@@ -132,7 +132,7 @@ s8 sbp_msg_vel_ecef_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_vel_ecef_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ecef_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_DEP_A.h
@@ -143,7 +143,7 @@ s8 sbp_msg_vel_ecef_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ecef_dep_a_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_vel_ecef_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_GNSS.h
@@ -142,7 +142,7 @@ s8 sbp_msg_vel_ecef_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ecef_gnss_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_vel_ecef_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_ECEF_GNSS.h
@@ -131,7 +131,7 @@ s8 sbp_msg_vel_ecef_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_vel_ecef_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ecef_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED.h
@@ -137,7 +137,7 @@ s8 sbp_msg_vel_ned_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_vel_ned_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ned_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED.h
@@ -148,7 +148,7 @@ s8 sbp_msg_vel_ned_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ned_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_vel_ned_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV.h
@@ -170,7 +170,7 @@ s8 sbp_msg_vel_ned_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ned_cov_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_vel_ned_cov_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV.h
@@ -159,7 +159,7 @@ s8 sbp_msg_vel_ned_cov_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_vel_ned_cov_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ned_cov_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV_GNSS.h
@@ -162,7 +162,7 @@ s8 sbp_msg_vel_ned_cov_gnss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_vel_ned_cov_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ned_cov_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_COV_GNSS.h
@@ -173,7 +173,7 @@ s8 sbp_msg_vel_ned_cov_gnss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ned_cov_gnss_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_vel_ned_cov_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_DEP_A.h
@@ -150,7 +150,7 @@ s8 sbp_msg_vel_ned_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ned_dep_a_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_vel_ned_dep_a_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_DEP_A.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_DEP_A.h
@@ -139,7 +139,7 @@ s8 sbp_msg_vel_ned_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_vel_ned_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ned_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_GNSS.h
@@ -148,7 +148,7 @@ s8 sbp_msg_vel_ned_gnss_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_vel_ned_gnss_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_vel_ned_gnss_t *msg,

--- a/c/include/libsbp/v4/navigation/MSG_VEL_NED_GNSS.h
+++ b/c/include/libsbp/v4/navigation/MSG_VEL_NED_GNSS.h
@@ -137,7 +137,7 @@ s8 sbp_msg_vel_ned_gnss_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_vel_ned_gnss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_vel_ned_gnss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ndb/MSG_NDB_EVENT.h
+++ b/c/include/libsbp/v4/ndb/MSG_NDB_EVENT.h
@@ -153,7 +153,7 @@ s8 sbp_msg_ndb_event_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ndb_event_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_ndb_event_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/ndb/MSG_NDB_EVENT.h
+++ b/c/include/libsbp/v4/ndb/MSG_NDB_EVENT.h
@@ -142,7 +142,7 @@ s8 sbp_msg_ndb_event_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_ndb_event_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ndb_event_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO.h
@@ -140,7 +140,7 @@ s8 sbp_msg_almanac_glo_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_almanac_glo_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_almanac_glo_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO.h
@@ -151,7 +151,7 @@ s8 sbp_msg_almanac_glo_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_almanac_glo_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_almanac_glo_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO_DEP.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO_DEP.h
@@ -153,7 +153,7 @@ s8 sbp_msg_almanac_glo_dep_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_almanac_glo_dep_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_almanac_glo_dep_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO_DEP.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GLO_DEP.h
@@ -142,7 +142,7 @@ s8 sbp_msg_almanac_glo_dep_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_almanac_glo_dep_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_almanac_glo_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS.h
@@ -149,7 +149,7 @@ s8 sbp_msg_almanac_gps_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_almanac_gps_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_almanac_gps_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS.h
@@ -160,7 +160,7 @@ s8 sbp_msg_almanac_gps_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_almanac_gps_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_almanac_gps_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS_DEP.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS_DEP.h
@@ -151,7 +151,7 @@ s8 sbp_msg_almanac_gps_dep_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_almanac_gps_dep_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_almanac_gps_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS_DEP.h
+++ b/c/include/libsbp/v4/observation/MSG_ALMANAC_GPS_DEP.h
@@ -162,7 +162,7 @@ s8 sbp_msg_almanac_gps_dep_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_almanac_gps_dep_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_almanac_gps_dep_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_BASE_POS_ECEF.h
+++ b/c/include/libsbp/v4/observation/MSG_BASE_POS_ECEF.h
@@ -114,7 +114,7 @@ s8 sbp_msg_base_pos_ecef_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_base_pos_ecef_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_base_pos_ecef_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_BASE_POS_ECEF.h
+++ b/c/include/libsbp/v4/observation/MSG_BASE_POS_ECEF.h
@@ -125,7 +125,7 @@ s8 sbp_msg_base_pos_ecef_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_base_pos_ecef_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_base_pos_ecef_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_BASE_POS_LLH.h
+++ b/c/include/libsbp/v4/observation/MSG_BASE_POS_LLH.h
@@ -124,7 +124,7 @@ s8 sbp_msg_base_pos_llh_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_base_pos_llh_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_base_pos_llh_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_BASE_POS_LLH.h
+++ b/c/include/libsbp/v4/observation/MSG_BASE_POS_LLH.h
@@ -113,7 +113,7 @@ s8 sbp_msg_base_pos_llh_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_base_pos_llh_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_base_pos_llh_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_BDS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_BDS.h
@@ -239,7 +239,7 @@ s8 sbp_msg_ephemeris_bds_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_bds_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_ephemeris_bds_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_BDS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_BDS.h
@@ -228,7 +228,7 @@ s8 sbp_msg_ephemeris_bds_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_bds_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_bds_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_A.h
@@ -242,7 +242,7 @@ s8 sbp_msg_ephemeris_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_dep_a_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_ephemeris_dep_a_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_A.h
@@ -231,7 +231,7 @@ s8 sbp_msg_ephemeris_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_B.h
@@ -236,7 +236,7 @@ s8 sbp_msg_ephemeris_dep_b_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_dep_b_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_B.h
@@ -247,7 +247,7 @@ s8 sbp_msg_ephemeris_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_dep_b_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_ephemeris_dep_b_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_C.h
@@ -261,7 +261,7 @@ s8 sbp_msg_ephemeris_dep_c_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_dep_c_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_ephemeris_dep_c_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_C.h
@@ -250,7 +250,7 @@ s8 sbp_msg_ephemeris_dep_c_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_dep_c_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_dep_c_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_D.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_D.h
@@ -250,7 +250,7 @@ s8 sbp_msg_ephemeris_dep_d_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_dep_d_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_dep_d_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_D.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_DEP_D.h
@@ -261,7 +261,7 @@ s8 sbp_msg_ephemeris_dep_d_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_dep_d_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_ephemeris_dep_d_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL.h
@@ -240,7 +240,7 @@ s8 sbp_msg_ephemeris_gal_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_gal_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_ephemeris_gal_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL.h
@@ -229,7 +229,7 @@ s8 sbp_msg_ephemeris_gal_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_gal_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_gal_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL_DEP_A.h
@@ -226,7 +226,7 @@ s8 sbp_msg_ephemeris_gal_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_gal_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_gal_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GAL_DEP_A.h
@@ -237,7 +237,7 @@ s8 sbp_msg_ephemeris_gal_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_gal_dep_a_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gal_dep_a_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO.h
@@ -144,7 +144,7 @@ s8 sbp_msg_ephemeris_glo_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_glo_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_glo_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO.h
@@ -155,7 +155,7 @@ s8 sbp_msg_ephemeris_glo_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_glo_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_ephemeris_glo_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_A.h
@@ -133,7 +133,7 @@ s8 sbp_msg_ephemeris_glo_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_glo_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_glo_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_A.h
@@ -144,7 +144,7 @@ s8 sbp_msg_ephemeris_glo_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_glo_dep_a_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_glo_dep_a_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_B.h
@@ -144,7 +144,7 @@ s8 sbp_msg_ephemeris_glo_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_glo_dep_b_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_glo_dep_b_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_B.h
@@ -133,7 +133,7 @@ s8 sbp_msg_ephemeris_glo_dep_b_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_glo_dep_b_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_glo_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_C.h
@@ -154,7 +154,7 @@ s8 sbp_msg_ephemeris_glo_dep_c_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_glo_dep_c_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_glo_dep_c_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_C.h
@@ -143,7 +143,7 @@ s8 sbp_msg_ephemeris_glo_dep_c_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_glo_dep_c_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_glo_dep_c_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_D.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_D.h
@@ -146,7 +146,7 @@ s8 sbp_msg_ephemeris_glo_dep_d_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_glo_dep_d_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_glo_dep_d_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_D.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_D.h
@@ -157,7 +157,7 @@ s8 sbp_msg_ephemeris_glo_dep_d_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_glo_dep_d_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_glo_dep_d_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS.h
@@ -230,7 +230,7 @@ s8 sbp_msg_ephemeris_gps_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_gps_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_ephemeris_gps_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS.h
@@ -219,7 +219,7 @@ s8 sbp_msg_ephemeris_gps_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_gps_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_gps_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_E.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_E.h
@@ -234,7 +234,7 @@ s8 sbp_msg_ephemeris_gps_dep_e_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_gps_dep_e_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gps_dep_e_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_E.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_E.h
@@ -223,7 +223,7 @@ s8 sbp_msg_ephemeris_gps_dep_e_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_gps_dep_e_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_gps_dep_e_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_F.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_F.h
@@ -221,7 +221,7 @@ s8 sbp_msg_ephemeris_gps_dep_f_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_gps_dep_f_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_gps_dep_f_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_F.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GPS_DEP_F.h
@@ -232,7 +232,7 @@ s8 sbp_msg_ephemeris_gps_dep_f_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_gps_dep_f_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gps_dep_f_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_QZSS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_QZSS.h
@@ -218,7 +218,7 @@ s8 sbp_msg_ephemeris_qzss_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_qzss_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_qzss_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_QZSS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_QZSS.h
@@ -229,7 +229,7 @@ s8 sbp_msg_ephemeris_qzss_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_qzss_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_ephemeris_qzss_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS.h
@@ -134,7 +134,7 @@ s8 sbp_msg_ephemeris_sbas_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_sbas_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_ephemeris_sbas_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS.h
@@ -123,7 +123,7 @@ s8 sbp_msg_ephemeris_sbas_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ephemeris_sbas_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_sbas_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
@@ -126,7 +126,7 @@ s8 sbp_msg_ephemeris_sbas_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_sbas_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_sbas_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
@@ -137,7 +137,7 @@ s8 sbp_msg_ephemeris_sbas_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_sbas_dep_a_send(sbp_state_t *s, u16 sender_id,
                                      const sbp_msg_ephemeris_sbas_dep_a_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
@@ -131,7 +131,7 @@ s8 sbp_msg_ephemeris_sbas_dep_b_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ephemeris_sbas_dep_b_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ephemeris_sbas_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
@@ -142,7 +142,7 @@ s8 sbp_msg_ephemeris_sbas_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ephemeris_sbas_dep_b_send(sbp_state_t *s, u16 sender_id,
                                      const sbp_msg_ephemeris_sbas_dep_b_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_GLO_BIASES.h
+++ b/c/include/libsbp/v4/observation/MSG_GLO_BIASES.h
@@ -133,7 +133,7 @@ s8 sbp_msg_glo_biases_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_glo_biases_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_glo_biases_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_GLO_BIASES.h
+++ b/c/include/libsbp/v4/observation/MSG_GLO_BIASES.h
@@ -122,7 +122,7 @@ s8 sbp_msg_glo_biases_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_glo_biases_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_glo_biases_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_GNSS_CAPB.h
+++ b/c/include/libsbp/v4/observation/MSG_GNSS_CAPB.h
@@ -114,7 +114,7 @@ s8 sbp_msg_gnss_capb_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_gnss_capb_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_gnss_capb_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_GNSS_CAPB.h
+++ b/c/include/libsbp/v4/observation/MSG_GNSS_CAPB.h
@@ -103,7 +103,7 @@ s8 sbp_msg_gnss_capb_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_gnss_capb_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_gnss_capb_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_GROUP_DELAY.h
+++ b/c/include/libsbp/v4/observation/MSG_GROUP_DELAY.h
@@ -119,7 +119,7 @@ s8 sbp_msg_group_delay_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_group_delay_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_group_delay_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_GROUP_DELAY.h
+++ b/c/include/libsbp/v4/observation/MSG_GROUP_DELAY.h
@@ -130,7 +130,7 @@ s8 sbp_msg_group_delay_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_group_delay_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_group_delay_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_A.h
@@ -132,7 +132,7 @@ s8 sbp_msg_group_delay_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_group_delay_dep_a_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_group_delay_dep_a_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_A.h
@@ -121,7 +121,7 @@ s8 sbp_msg_group_delay_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_group_delay_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_group_delay_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_B.h
@@ -133,7 +133,7 @@ s8 sbp_msg_group_delay_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_group_delay_dep_b_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_group_delay_dep_b_t *msg,

--- a/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_GROUP_DELAY_DEP_B.h
@@ -122,7 +122,7 @@ s8 sbp_msg_group_delay_dep_b_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_group_delay_dep_b_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_group_delay_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_IONO.h
+++ b/c/include/libsbp/v4/observation/MSG_IONO.h
@@ -119,7 +119,7 @@ s8 sbp_msg_iono_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_iono_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_iono_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_IONO.h
+++ b/c/include/libsbp/v4/observation/MSG_IONO.h
@@ -130,7 +130,7 @@ s8 sbp_msg_iono_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_iono_send(sbp_state_t *s, u16 sender_id, const sbp_msg_iono_t *msg,
                      sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_OBS.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS.h
@@ -123,7 +123,7 @@ s8 sbp_msg_obs_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_obs_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_obs_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_OBS.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS.h
@@ -134,7 +134,7 @@ s8 sbp_msg_obs_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_obs_send(sbp_state_t *s, u16 sender_id, const sbp_msg_obs_t *msg,
                     sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_A.h
@@ -118,7 +118,7 @@ s8 sbp_msg_obs_dep_a_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_obs_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_obs_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_A.h
@@ -129,7 +129,7 @@ s8 sbp_msg_obs_dep_a_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_obs_dep_a_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_obs_dep_a_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_B.h
@@ -121,7 +121,7 @@ s8 sbp_msg_obs_dep_b_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_obs_dep_b_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_obs_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_B.h
@@ -132,7 +132,7 @@ s8 sbp_msg_obs_dep_b_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_obs_dep_b_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_obs_dep_b_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_C.h
@@ -134,7 +134,7 @@ s8 sbp_msg_obs_dep_c_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_obs_dep_c_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_obs_dep_c_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_C.h
@@ -123,7 +123,7 @@ s8 sbp_msg_obs_dep_c_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_obs_dep_c_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_obs_dep_c_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_OSR.h
+++ b/c/include/libsbp/v4/observation/MSG_OSR.h
@@ -118,7 +118,7 @@ s8 sbp_msg_osr_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_osr_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_osr_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_OSR.h
+++ b/c/include/libsbp/v4/observation/MSG_OSR.h
@@ -129,7 +129,7 @@ s8 sbp_msg_osr_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_osr_send(sbp_state_t *s, u16 sender_id, const sbp_msg_osr_t *msg,
                     sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_SV_AZ_EL.h
+++ b/c/include/libsbp/v4/observation/MSG_SV_AZ_EL.h
@@ -113,7 +113,7 @@ s8 sbp_msg_sv_az_el_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_sv_az_el_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_sv_az_el_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_SV_AZ_EL.h
+++ b/c/include/libsbp/v4/observation/MSG_SV_AZ_EL.h
@@ -124,7 +124,7 @@ s8 sbp_msg_sv_az_el_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_sv_az_el_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_sv_az_el_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
+++ b/c/include/libsbp/v4/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
@@ -113,7 +113,7 @@ s8 sbp_msg_sv_configuration_gps_dep_decode(
  * Send an instance of sbp_msg_sv_configuration_gps_dep_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_sv_configuration_gps_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
+++ b/c/include/libsbp/v4/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
@@ -124,7 +124,7 @@ s8 sbp_msg_sv_configuration_gps_dep_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_sv_configuration_gps_dep_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/orientation/MSG_ANGULAR_RATE.h
+++ b/c/include/libsbp/v4/orientation/MSG_ANGULAR_RATE.h
@@ -138,7 +138,7 @@ s8 sbp_msg_angular_rate_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_angular_rate_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_angular_rate_t *msg,

--- a/c/include/libsbp/v4/orientation/MSG_ANGULAR_RATE.h
+++ b/c/include/libsbp/v4/orientation/MSG_ANGULAR_RATE.h
@@ -127,7 +127,7 @@ s8 sbp_msg_angular_rate_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_angular_rate_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_angular_rate_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/orientation/MSG_BASELINE_HEADING.h
+++ b/c/include/libsbp/v4/orientation/MSG_BASELINE_HEADING.h
@@ -120,7 +120,7 @@ s8 sbp_msg_baseline_heading_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_baseline_heading_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_baseline_heading_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/orientation/MSG_BASELINE_HEADING.h
+++ b/c/include/libsbp/v4/orientation/MSG_BASELINE_HEADING.h
@@ -131,7 +131,7 @@ s8 sbp_msg_baseline_heading_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_baseline_heading_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_baseline_heading_t *msg,

--- a/c/include/libsbp/v4/orientation/MSG_ORIENT_EULER.h
+++ b/c/include/libsbp/v4/orientation/MSG_ORIENT_EULER.h
@@ -150,7 +150,7 @@ s8 sbp_msg_orient_euler_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_orient_euler_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_orient_euler_t *msg,

--- a/c/include/libsbp/v4/orientation/MSG_ORIENT_EULER.h
+++ b/c/include/libsbp/v4/orientation/MSG_ORIENT_EULER.h
@@ -139,7 +139,7 @@ s8 sbp_msg_orient_euler_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_orient_euler_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_orient_euler_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/orientation/MSG_ORIENT_QUAT.h
+++ b/c/include/libsbp/v4/orientation/MSG_ORIENT_QUAT.h
@@ -159,7 +159,7 @@ s8 sbp_msg_orient_quat_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_orient_quat_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_orient_quat_t *msg,

--- a/c/include/libsbp/v4/orientation/MSG_ORIENT_QUAT.h
+++ b/c/include/libsbp/v4/orientation/MSG_ORIENT_QUAT.h
@@ -148,7 +148,7 @@ s8 sbp_msg_orient_quat_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_orient_quat_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_orient_quat_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_ALMANAC.h
+++ b/c/include/libsbp/v4/piksi/MSG_ALMANAC.h
@@ -102,7 +102,7 @@ s8 sbp_msg_almanac_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_almanac_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_almanac_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_ALMANAC.h
+++ b/c/include/libsbp/v4/piksi/MSG_ALMANAC.h
@@ -113,7 +113,7 @@ s8 sbp_msg_almanac_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_almanac_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_almanac_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_CELL_MODEM_STATUS.h
+++ b/c/include/libsbp/v4/piksi/MSG_CELL_MODEM_STATUS.h
@@ -126,7 +126,7 @@ s8 sbp_msg_cell_modem_status_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_cell_modem_status_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_cell_modem_status_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_CELL_MODEM_STATUS.h
+++ b/c/include/libsbp/v4/piksi/MSG_CELL_MODEM_STATUS.h
@@ -137,7 +137,7 @@ s8 sbp_msg_cell_modem_status_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_cell_modem_status_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_cell_modem_status_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
@@ -201,7 +201,6 @@ const char *sbp_msg_command_output_line_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_command_output_t instance
- * @param msg sbp_msg_command_output_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -259,7 +258,7 @@ s8 sbp_msg_command_output_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_command_output_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_command_output_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
@@ -76,7 +76,7 @@ bool sbp_msg_command_output_line_valid(const sbp_msg_command_output_t *msg);
 /**
  * Tests 2 instances of sbp_msg_command_output_t::line for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_command_output_t instance
@@ -201,6 +201,8 @@ const char *sbp_msg_command_output_line_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_command_output_t instance
+ * @param msg sbp_msg_command_output_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_command_output_line_section_strlen(
@@ -268,7 +270,7 @@ s8 sbp_msg_command_output_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_command_output_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_command_output_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
@@ -75,7 +75,7 @@ bool sbp_msg_command_req_command_valid(const sbp_msg_command_req_t *msg);
 /**
  * Tests 2 instances of sbp_msg_command_req_t::command for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_command_req_t instance
@@ -199,6 +199,8 @@ const char *sbp_msg_command_req_command_get(const sbp_msg_command_req_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_command_req_t instance
+ * @param msg sbp_msg_command_req_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_command_req_command_section_strlen(
@@ -265,7 +267,7 @@ s8 sbp_msg_command_req_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_command_req_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_command_req_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
@@ -199,7 +199,6 @@ const char *sbp_msg_command_req_command_get(const sbp_msg_command_req_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_command_req_t instance
- * @param msg sbp_msg_command_req_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -256,7 +255,7 @@ s8 sbp_msg_command_req_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_command_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_command_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_RESP.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_RESP.h
@@ -117,7 +117,7 @@ s8 sbp_msg_command_resp_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_command_resp_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_command_resp_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_RESP.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_RESP.h
@@ -106,7 +106,7 @@ s8 sbp_msg_command_resp_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_command_resp_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_command_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_CW_RESULTS.h
+++ b/c/include/libsbp/v4/piksi/MSG_CW_RESULTS.h
@@ -114,7 +114,7 @@ s8 sbp_msg_cw_results_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_cw_results_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_cw_results_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_CW_RESULTS.h
+++ b/c/include/libsbp/v4/piksi/MSG_CW_RESULTS.h
@@ -103,7 +103,7 @@ s8 sbp_msg_cw_results_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_cw_results_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_cw_results_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_CW_START.h
+++ b/c/include/libsbp/v4/piksi/MSG_CW_START.h
@@ -103,7 +103,7 @@ s8 sbp_msg_cw_start_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_cw_start_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_cw_start_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_CW_START.h
+++ b/c/include/libsbp/v4/piksi/MSG_CW_START.h
@@ -114,7 +114,7 @@ s8 sbp_msg_cw_start_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_cw_start_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_cw_start_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_DEVICE_MONITOR.h
+++ b/c/include/libsbp/v4/piksi/MSG_DEVICE_MONITOR.h
@@ -134,7 +134,7 @@ s8 sbp_msg_device_monitor_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_device_monitor_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_device_monitor_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_DEVICE_MONITOR.h
+++ b/c/include/libsbp/v4/piksi/MSG_DEVICE_MONITOR.h
@@ -123,7 +123,7 @@ s8 sbp_msg_device_monitor_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_device_monitor_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_device_monitor_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_FRONT_END_GAIN.h
+++ b/c/include/libsbp/v4/piksi/MSG_FRONT_END_GAIN.h
@@ -112,7 +112,7 @@ s8 sbp_msg_front_end_gain_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_front_end_gain_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_front_end_gain_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_FRONT_END_GAIN.h
+++ b/c/include/libsbp/v4/piksi/MSG_FRONT_END_GAIN.h
@@ -123,7 +123,7 @@ s8 sbp_msg_front_end_gain_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_front_end_gain_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_front_end_gain_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_IAR_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_IAR_STATE.h
@@ -102,7 +102,7 @@ s8 sbp_msg_iar_state_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_iar_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_iar_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_IAR_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_IAR_STATE.h
@@ -113,7 +113,7 @@ s8 sbp_msg_iar_state_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_iar_state_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_iar_state_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_INIT_BASE_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_INIT_BASE_DEP.h
@@ -101,7 +101,7 @@ s8 sbp_msg_init_base_dep_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_init_base_dep_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_init_base_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_INIT_BASE_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_INIT_BASE_DEP.h
@@ -112,7 +112,7 @@ s8 sbp_msg_init_base_dep_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_init_base_dep_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_init_base_dep_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE.h
+++ b/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE.h
@@ -119,7 +119,7 @@ s8 sbp_msg_mask_satellite_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_mask_satellite_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_mask_satellite_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE.h
+++ b/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE.h
@@ -108,7 +108,7 @@ s8 sbp_msg_mask_satellite_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_mask_satellite_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_mask_satellite_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE_DEP.h
@@ -121,7 +121,7 @@ s8 sbp_msg_mask_satellite_dep_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_mask_satellite_dep_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_mask_satellite_dep_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_MASK_SATELLITE_DEP.h
@@ -110,7 +110,7 @@ s8 sbp_msg_mask_satellite_dep_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_mask_satellite_dep_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_mask_satellite_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
@@ -130,7 +130,7 @@ s8 sbp_msg_network_bandwidth_usage_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_network_bandwidth_usage_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_network_bandwidth_usage_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
@@ -119,7 +119,7 @@ s8 sbp_msg_network_bandwidth_usage_decode(
  * Send an instance of sbp_msg_network_bandwidth_usage_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_network_bandwidth_usage_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_REQ.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_REQ.h
@@ -105,7 +105,7 @@ s8 sbp_msg_network_state_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_network_state_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_network_state_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_REQ.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_REQ.h
@@ -116,7 +116,7 @@ s8 sbp_msg_network_state_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_network_state_req_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_network_state_req_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_RESP.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_RESP.h
@@ -140,7 +140,7 @@ s8 sbp_msg_network_state_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_network_state_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_network_state_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_RESP.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_RESP.h
@@ -151,7 +151,7 @@ s8 sbp_msg_network_state_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_network_state_resp_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_network_state_resp_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_RESET.h
+++ b/c/include/libsbp/v4/piksi/MSG_RESET.h
@@ -111,7 +111,7 @@ s8 sbp_msg_reset_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_reset_send(sbp_state_t *s, u16 sender_id, const sbp_msg_reset_t *msg,
                       sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_RESET.h
+++ b/c/include/libsbp/v4/piksi/MSG_RESET.h
@@ -100,7 +100,7 @@ s8 sbp_msg_reset_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_reset_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_reset_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_RESET_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_RESET_DEP.h
@@ -101,7 +101,7 @@ s8 sbp_msg_reset_dep_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_reset_dep_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_reset_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_RESET_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_RESET_DEP.h
@@ -112,7 +112,7 @@ s8 sbp_msg_reset_dep_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_reset_dep_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_reset_dep_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_RESET_FILTERS.h
+++ b/c/include/libsbp/v4/piksi/MSG_RESET_FILTERS.h
@@ -112,7 +112,7 @@ s8 sbp_msg_reset_filters_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_reset_filters_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_reset_filters_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_RESET_FILTERS.h
+++ b/c/include/libsbp/v4/piksi/MSG_RESET_FILTERS.h
@@ -101,7 +101,7 @@ s8 sbp_msg_reset_filters_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_reset_filters_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_reset_filters_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_SET_TIME.h
+++ b/c/include/libsbp/v4/piksi/MSG_SET_TIME.h
@@ -102,7 +102,7 @@ s8 sbp_msg_set_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_set_time_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_set_time_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_SET_TIME.h
+++ b/c/include/libsbp/v4/piksi/MSG_SET_TIME.h
@@ -113,7 +113,7 @@ s8 sbp_msg_set_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_set_time_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_set_time_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_SPECAN.h
+++ b/c/include/libsbp/v4/piksi/MSG_SPECAN.h
@@ -142,7 +142,7 @@ s8 sbp_msg_specan_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_specan_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_specan_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_SPECAN.h
+++ b/c/include/libsbp/v4/piksi/MSG_SPECAN.h
@@ -153,7 +153,7 @@ s8 sbp_msg_specan_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_specan_send(sbp_state_t *s, u16 sender_id,
                        const sbp_msg_specan_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/piksi/MSG_SPECAN_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_SPECAN_DEP.h
@@ -142,7 +142,7 @@ s8 sbp_msg_specan_dep_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_specan_dep_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_specan_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_SPECAN_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_SPECAN_DEP.h
@@ -153,7 +153,7 @@ s8 sbp_msg_specan_dep_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_specan_dep_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_specan_dep_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_THREAD_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_THREAD_STATE.h
@@ -113,7 +113,7 @@ s8 sbp_msg_thread_state_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_thread_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_thread_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_THREAD_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_THREAD_STATE.h
@@ -124,7 +124,7 @@ s8 sbp_msg_thread_state_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_thread_state_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_thread_state_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_UART_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_UART_STATE.h
@@ -130,7 +130,7 @@ s8 sbp_msg_uart_state_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_uart_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_uart_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/piksi/MSG_UART_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_UART_STATE.h
@@ -141,7 +141,7 @@ s8 sbp_msg_uart_state_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_uart_state_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_uart_state_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_UART_STATE_DEPA.h
+++ b/c/include/libsbp/v4/piksi/MSG_UART_STATE_DEPA.h
@@ -130,7 +130,7 @@ s8 sbp_msg_uart_state_depa_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_uart_state_depa_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_uart_state_depa_t *msg,

--- a/c/include/libsbp/v4/piksi/MSG_UART_STATE_DEPA.h
+++ b/c/include/libsbp/v4/piksi/MSG_UART_STATE_DEPA.h
@@ -119,7 +119,7 @@ s8 sbp_msg_uart_state_depa_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_uart_state_depa_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_uart_state_depa_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/sbas/MSG_SBAS_RAW.h
+++ b/c/include/libsbp/v4/sbas/MSG_SBAS_RAW.h
@@ -128,7 +128,7 @@ s8 sbp_msg_sbas_raw_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_sbas_raw_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_sbas_raw_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/sbas/MSG_SBAS_RAW.h
+++ b/c/include/libsbp/v4/sbas/MSG_SBAS_RAW.h
@@ -117,7 +117,7 @@ s8 sbp_msg_sbas_raw_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_sbas_raw_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_sbas_raw_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
@@ -108,7 +108,7 @@ s8 sbp_msg_settings_read_by_index_done_decode(
  * Send an instance of sbp_msg_settings_read_by_index_done_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_read_by_index_done_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
@@ -119,7 +119,7 @@ s8 sbp_msg_settings_read_by_index_done_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_read_by_index_done_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
@@ -120,7 +120,7 @@ s8 sbp_msg_settings_read_by_index_req_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_read_by_index_req_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
@@ -109,7 +109,7 @@ s8 sbp_msg_settings_read_by_index_req_decode(
  * Send an instance of sbp_msg_settings_read_by_index_req_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_read_by_index_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
@@ -79,7 +79,7 @@ bool sbp_msg_settings_read_by_index_resp_setting_valid(
  * Tests 2 instances of sbp_msg_settings_read_by_index_resp_t::setting for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_read_by_index_resp_t instance
@@ -331,7 +331,7 @@ s8 sbp_msg_settings_read_by_index_resp_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_read_by_index_resp_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
@@ -320,7 +320,7 @@ s8 sbp_msg_settings_read_by_index_resp_decode(
  * Send an instance of sbp_msg_settings_read_by_index_resp_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_read_by_index_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_REQ.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_REQ.h
@@ -307,7 +307,7 @@ s8 sbp_msg_settings_read_req_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_settings_read_req_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_read_req_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_REQ.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_REQ.h
@@ -76,7 +76,7 @@ bool sbp_msg_settings_read_req_setting_valid(
 /**
  * Tests 2 instances of sbp_msg_settings_read_req_t::setting for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_read_req_t instance
@@ -318,7 +318,7 @@ s8 sbp_msg_settings_read_req_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_read_req_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_settings_read_req_t *msg,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_RESP.h
@@ -75,7 +75,7 @@ bool sbp_msg_settings_read_resp_setting_valid(
 /**
  * Tests 2 instances of sbp_msg_settings_read_resp_t::setting for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_read_resp_t instance
@@ -319,7 +319,7 @@ s8 sbp_msg_settings_read_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_read_resp_send(sbp_state_t *s, u16 sender_id,
                                    const sbp_msg_settings_read_resp_t *msg,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_READ_RESP.h
@@ -308,7 +308,7 @@ s8 sbp_msg_settings_read_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_settings_read_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_read_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER.h
@@ -303,7 +303,7 @@ s8 sbp_msg_settings_register_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_settings_register_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_register_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER.h
@@ -72,7 +72,7 @@ bool sbp_msg_settings_register_setting_valid(
 /**
  * Tests 2 instances of sbp_msg_settings_register_t::setting for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_register_t instance
@@ -314,7 +314,7 @@ s8 sbp_msg_settings_register_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_register_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_settings_register_t *msg,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER_RESP.h
@@ -80,7 +80,7 @@ bool sbp_msg_settings_register_resp_setting_valid(
 /**
  * Tests 2 instances of sbp_msg_settings_register_resp_t::setting for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_register_resp_t instance
@@ -328,7 +328,7 @@ s8 sbp_msg_settings_register_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_register_resp_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_settings_register_resp_t *msg,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_REGISTER_RESP.h
@@ -317,7 +317,7 @@ s8 sbp_msg_settings_register_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_settings_register_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_register_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_SAVE.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_SAVE.h
@@ -112,7 +112,7 @@ s8 sbp_msg_settings_save_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_save_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_settings_save_t *msg,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_SAVE.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_SAVE.h
@@ -101,7 +101,7 @@ s8 sbp_msg_settings_save_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_settings_save_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_save_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE.h
@@ -74,7 +74,7 @@ bool sbp_msg_settings_write_setting_valid(const sbp_msg_settings_write_t *msg);
 /**
  * Tests 2 instances of sbp_msg_settings_write_t::setting for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_write_t instance
@@ -313,7 +313,7 @@ s8 sbp_msg_settings_write_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_write_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_settings_write_t *msg,

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE.h
@@ -302,7 +302,7 @@ s8 sbp_msg_settings_write_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_settings_write_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_write_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE_RESP.h
@@ -314,7 +314,7 @@ s8 sbp_msg_settings_write_resp_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_settings_write_resp_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_settings_write_resp_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE_RESP.h
+++ b/c/include/libsbp/v4/settings/MSG_SETTINGS_WRITE_RESP.h
@@ -81,7 +81,7 @@ bool sbp_msg_settings_write_resp_setting_valid(
 /**
  * Tests 2 instances of sbp_msg_settings_write_resp_t::setting for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_settings_write_resp_t instance
@@ -325,7 +325,7 @@ s8 sbp_msg_settings_write_resp_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_settings_write_resp_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_settings_write_resp_t *msg,

--- a/c/include/libsbp/v4/solution_meta/MSG_SOLN_META.h
+++ b/c/include/libsbp/v4/solution_meta/MSG_SOLN_META.h
@@ -167,7 +167,7 @@ s8 sbp_msg_soln_meta_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_soln_meta_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_soln_meta_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/solution_meta/MSG_SOLN_META.h
+++ b/c/include/libsbp/v4/solution_meta/MSG_SOLN_META.h
@@ -156,7 +156,7 @@ s8 sbp_msg_soln_meta_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_soln_meta_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_soln_meta_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/solution_meta/MSG_SOLN_META_DEP_A.h
+++ b/c/include/libsbp/v4/solution_meta/MSG_SOLN_META_DEP_A.h
@@ -161,7 +161,7 @@ s8 sbp_msg_soln_meta_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_soln_meta_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_soln_meta_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/solution_meta/MSG_SOLN_META_DEP_A.h
+++ b/c/include/libsbp/v4/solution_meta/MSG_SOLN_META_DEP_A.h
@@ -172,7 +172,7 @@ s8 sbp_msg_soln_meta_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_soln_meta_dep_a_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_soln_meta_dep_a_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_CODE_BIASES.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_CODE_BIASES.h
@@ -151,7 +151,7 @@ s8 sbp_msg_ssr_code_biases_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_code_biases_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_ssr_code_biases_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_CODE_BIASES.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_CODE_BIASES.h
@@ -140,7 +140,7 @@ s8 sbp_msg_ssr_code_biases_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ssr_code_biases_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_code_biases_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h
@@ -136,7 +136,7 @@ s8 sbp_msg_ssr_gridded_correction_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ssr_gridded_correction_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_gridded_correction_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h
@@ -147,7 +147,7 @@ s8 sbp_msg_ssr_gridded_correction_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_gridded_correction_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
@@ -133,7 +133,7 @@ s8 sbp_msg_ssr_gridded_correction_dep_a_decode(
  * Send an instance of sbp_msg_ssr_gridded_correction_dep_a_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_gridded_correction_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
@@ -144,7 +144,7 @@ s8 sbp_msg_ssr_gridded_correction_dep_a_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_gridded_correction_dep_a_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
@@ -135,7 +135,7 @@ s8 sbp_msg_ssr_gridded_correction_no_std_dep_a_decode(
  * Send an instance of sbp_msg_ssr_gridded_correction_no_std_dep_a_t with the
  * given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_gridded_correction_no_std_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
@@ -146,7 +146,7 @@ s8 sbp_msg_ssr_gridded_correction_no_std_dep_a_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_gridded_correction_no_std_dep_a_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
@@ -123,7 +123,7 @@ s8 sbp_msg_ssr_grid_definition_dep_a_decode(
  * Send an instance of sbp_msg_ssr_grid_definition_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_grid_definition_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
@@ -134,7 +134,7 @@ s8 sbp_msg_ssr_grid_definition_dep_a_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_grid_definition_dep_a_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK.h
@@ -176,7 +176,7 @@ s8 sbp_msg_ssr_orbit_clock_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ssr_orbit_clock_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_orbit_clock_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK.h
@@ -187,7 +187,7 @@ s8 sbp_msg_ssr_orbit_clock_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_orbit_clock_send(sbp_state_t *s, u16 sender_id,
                                 const sbp_msg_ssr_orbit_clock_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
@@ -174,7 +174,7 @@ s8 sbp_msg_ssr_orbit_clock_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ssr_orbit_clock_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_orbit_clock_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
@@ -185,7 +185,7 @@ s8 sbp_msg_ssr_orbit_clock_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_orbit_clock_dep_a_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_dep_a_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_PHASE_BIASES.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_PHASE_BIASES.h
@@ -174,7 +174,7 @@ s8 sbp_msg_ssr_phase_biases_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_phase_biases_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_ssr_phase_biases_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_PHASE_BIASES.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_PHASE_BIASES.h
@@ -163,7 +163,7 @@ s8 sbp_msg_ssr_phase_biases_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ssr_phase_biases_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_phase_biases_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_SATELLITE_APC.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_SATELLITE_APC.h
@@ -122,7 +122,7 @@ s8 sbp_msg_ssr_satellite_apc_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_satellite_apc_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_ssr_satellite_apc_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_SATELLITE_APC.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_SATELLITE_APC.h
@@ -111,7 +111,7 @@ s8 sbp_msg_ssr_satellite_apc_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_ssr_satellite_apc_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_satellite_apc_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION.h
@@ -126,7 +126,7 @@ s8 sbp_msg_ssr_stec_correction_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ssr_stec_correction_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_stec_correction_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION.h
@@ -137,7 +137,7 @@ s8 sbp_msg_ssr_stec_correction_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_stec_correction_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ssr_stec_correction_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
@@ -121,7 +121,7 @@ s8 sbp_msg_ssr_stec_correction_dep_a_decode(
  * Send an instance of sbp_msg_ssr_stec_correction_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_stec_correction_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
@@ -132,7 +132,7 @@ s8 sbp_msg_ssr_stec_correction_dep_a_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_stec_correction_dep_a_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_TILE_DEFINITION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_TILE_DEFINITION.h
@@ -197,7 +197,7 @@ s8 sbp_msg_ssr_tile_definition_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ssr_tile_definition_send(sbp_state_t *s, u16 sender_id,
                                     const sbp_msg_ssr_tile_definition_t *msg,

--- a/c/include/libsbp/v4/ssr/MSG_SSR_TILE_DEFINITION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_TILE_DEFINITION.h
@@ -186,7 +186,7 @@ s8 sbp_msg_ssr_tile_definition_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_ssr_tile_definition_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ssr_tile_definition_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
@@ -77,7 +77,7 @@ bool sbp_msg_csac_telemetry_telemetry_valid(
 /**
  * Tests 2 instances of sbp_msg_csac_telemetry_t::telemetry for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_csac_telemetry_t instance
@@ -201,6 +201,8 @@ const char *sbp_msg_csac_telemetry_telemetry_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_csac_telemetry_t instance
+ * @param msg sbp_msg_csac_telemetry_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_csac_telemetry_telemetry_section_strlen(
@@ -268,7 +270,7 @@ s8 sbp_msg_csac_telemetry_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_csac_telemetry_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_csac_telemetry_t *msg,

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
@@ -201,7 +201,6 @@ const char *sbp_msg_csac_telemetry_telemetry_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_csac_telemetry_t instance
- * @param msg sbp_msg_csac_telemetry_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -259,7 +258,7 @@ s8 sbp_msg_csac_telemetry_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_csac_telemetry_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_csac_telemetry_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
@@ -79,7 +79,7 @@ bool sbp_msg_csac_telemetry_labels_telemetry_labels_valid(
  * Tests 2 instances of sbp_msg_csac_telemetry_labels_t::telemetry_labels for
  * equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_csac_telemetry_labels_t instance
@@ -211,6 +211,8 @@ const char *sbp_msg_csac_telemetry_labels_telemetry_labels_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_csac_telemetry_labels_t instance
+ * @param msg sbp_msg_csac_telemetry_labels_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_csac_telemetry_labels_telemetry_labels_section_strlen(
@@ -283,7 +285,7 @@ s8 sbp_msg_csac_telemetry_labels_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_csac_telemetry_labels_send(
     sbp_state_t *s, u16 sender_id, const sbp_msg_csac_telemetry_labels_t *msg,

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
@@ -211,7 +211,6 @@ const char *sbp_msg_csac_telemetry_labels_telemetry_labels_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_csac_telemetry_labels_t instance
- * @param msg sbp_msg_csac_telemetry_labels_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -274,7 +273,7 @@ s8 sbp_msg_csac_telemetry_labels_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_csac_telemetry_labels_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_csac_telemetry_labels_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
+++ b/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
@@ -85,7 +85,7 @@ bool sbp_msg_dgnss_status_source_valid(const sbp_msg_dgnss_status_t *msg);
 /**
  * Tests 2 instances of sbp_msg_dgnss_status_t::source for equality
  *
- * Returns a value with the same definitions as #strcmp from the C standard
+ * Returns a value with the same definitions as strcmp from the C standard
  * library
  *
  * @param a sbp_msg_dgnss_status_t instance
@@ -209,6 +209,8 @@ const char *sbp_msg_dgnss_status_source_get(const sbp_msg_dgnss_status_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_dgnss_status_t instance
+ * @param msg sbp_msg_dgnss_status_t instance
+ * @param section Section number
  * @return Length of section
  */
 size_t sbp_msg_dgnss_status_source_section_strlen(
@@ -275,7 +277,7 @@ s8 sbp_msg_dgnss_status_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_dgnss_status_send(sbp_state_t *s, u16 sender_id,
                              const sbp_msg_dgnss_status_t *msg,

--- a/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
+++ b/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
@@ -209,7 +209,6 @@ const char *sbp_msg_dgnss_status_source_get(const sbp_msg_dgnss_status_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_dgnss_status_t instance
- * @param msg sbp_msg_dgnss_status_t instance
  * @param section Section number
  * @return Length of section
  */
@@ -266,7 +265,7 @@ s8 sbp_msg_dgnss_status_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_dgnss_status_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_dgnss_status_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_GNSS_TIME_OFFSET.h
+++ b/c/include/libsbp/v4/system/MSG_GNSS_TIME_OFFSET.h
@@ -130,7 +130,7 @@ s8 sbp_msg_gnss_time_offset_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_gnss_time_offset_send(sbp_state_t *s, u16 sender_id,
                                  const sbp_msg_gnss_time_offset_t *msg,

--- a/c/include/libsbp/v4/system/MSG_GNSS_TIME_OFFSET.h
+++ b/c/include/libsbp/v4/system/MSG_GNSS_TIME_OFFSET.h
@@ -119,7 +119,7 @@ s8 sbp_msg_gnss_time_offset_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_gnss_time_offset_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_gnss_time_offset_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_GROUP_META.h
+++ b/c/include/libsbp/v4/system/MSG_GROUP_META.h
@@ -128,7 +128,7 @@ s8 sbp_msg_group_meta_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_group_meta_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_group_meta_t *msg,

--- a/c/include/libsbp/v4/system/MSG_GROUP_META.h
+++ b/c/include/libsbp/v4/system/MSG_GROUP_META.h
@@ -117,7 +117,7 @@ s8 sbp_msg_group_meta_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_group_meta_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_group_meta_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_HEARTBEAT.h
+++ b/c/include/libsbp/v4/system/MSG_HEARTBEAT.h
@@ -104,7 +104,7 @@ s8 sbp_msg_heartbeat_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_heartbeat_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_heartbeat_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_HEARTBEAT.h
+++ b/c/include/libsbp/v4/system/MSG_HEARTBEAT.h
@@ -115,7 +115,7 @@ s8 sbp_msg_heartbeat_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_heartbeat_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_heartbeat_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/system/MSG_INS_STATUS.h
+++ b/c/include/libsbp/v4/system/MSG_INS_STATUS.h
@@ -100,7 +100,7 @@ s8 sbp_msg_ins_status_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_ins_status_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ins_status_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_INS_STATUS.h
+++ b/c/include/libsbp/v4/system/MSG_INS_STATUS.h
@@ -111,7 +111,7 @@ s8 sbp_msg_ins_status_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ins_status_send(sbp_state_t *s, u16 sender_id,
                            const sbp_msg_ins_status_t *msg,

--- a/c/include/libsbp/v4/system/MSG_INS_UPDATES.h
+++ b/c/include/libsbp/v4/system/MSG_INS_UPDATES.h
@@ -142,7 +142,7 @@ s8 sbp_msg_ins_updates_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_ins_updates_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_ins_updates_t *msg,

--- a/c/include/libsbp/v4/system/MSG_INS_UPDATES.h
+++ b/c/include/libsbp/v4/system/MSG_INS_UPDATES.h
@@ -131,7 +131,7 @@ s8 sbp_msg_ins_updates_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_ins_updates_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_ins_updates_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_PPS_TIME.h
+++ b/c/include/libsbp/v4/system/MSG_PPS_TIME.h
@@ -108,7 +108,7 @@ s8 sbp_msg_pps_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_pps_time_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_pps_time_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_PPS_TIME.h
+++ b/c/include/libsbp/v4/system/MSG_PPS_TIME.h
@@ -119,7 +119,7 @@ s8 sbp_msg_pps_time_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_pps_time_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_pps_time_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/system/MSG_STARTUP.h
+++ b/c/include/libsbp/v4/system/MSG_STARTUP.h
@@ -122,7 +122,7 @@ s8 sbp_msg_startup_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_startup_send(sbp_state_t *s, u16 sender_id,
                         const sbp_msg_startup_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/system/MSG_STARTUP.h
+++ b/c/include/libsbp/v4/system/MSG_STARTUP.h
@@ -111,7 +111,7 @@ s8 sbp_msg_startup_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_startup_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_startup_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_STATUS_REPORT.h
+++ b/c/include/libsbp/v4/system/MSG_STATUS_REPORT.h
@@ -135,7 +135,7 @@ s8 sbp_msg_status_report_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_status_report_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_status_report_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/system/MSG_STATUS_REPORT.h
+++ b/c/include/libsbp/v4/system/MSG_STATUS_REPORT.h
@@ -146,7 +146,7 @@ s8 sbp_msg_status_report_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_status_report_send(sbp_state_t *s, u16 sender_id,
                               const sbp_msg_status_report_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_MEASUREMENT_STATE.h
+++ b/c/include/libsbp/v4/tracking/MSG_MEASUREMENT_STATE.h
@@ -128,7 +128,7 @@ s8 sbp_msg_measurement_state_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_measurement_state_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_measurement_state_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_MEASUREMENT_STATE.h
+++ b/c/include/libsbp/v4/tracking/MSG_MEASUREMENT_STATE.h
@@ -117,7 +117,7 @@ s8 sbp_msg_measurement_state_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_measurement_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_measurement_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ.h
@@ -124,7 +124,7 @@ s8 sbp_msg_tracking_iq_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_iq_send(sbp_state_t *s, u16 sender_id,
                             const sbp_msg_tracking_iq_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ.h
@@ -113,7 +113,7 @@ s8 sbp_msg_tracking_iq_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_tracking_iq_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_iq_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_A.h
@@ -115,7 +115,7 @@ s8 sbp_msg_tracking_iq_dep_a_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_tracking_iq_dep_a_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_iq_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_A.h
@@ -126,7 +126,7 @@ s8 sbp_msg_tracking_iq_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_iq_dep_a_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_tracking_iq_dep_a_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_B.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_B.h
@@ -127,7 +127,7 @@ s8 sbp_msg_tracking_iq_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_iq_dep_b_send(sbp_state_t *s, u16 sender_id,
                                   const sbp_msg_tracking_iq_dep_b_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_B.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_B.h
@@ -116,7 +116,7 @@ s8 sbp_msg_tracking_iq_dep_b_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_tracking_iq_dep_b_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_iq_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE.h
@@ -126,7 +126,7 @@ s8 sbp_msg_tracking_state_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_state_send(sbp_state_t *s, u16 sender_id,
                                const sbp_msg_tracking_state_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE.h
@@ -115,7 +115,7 @@ s8 sbp_msg_tracking_state_decode(const uint8_t *buf, uint8_t len,
 /**
  * Send an instance of sbp_msg_tracking_state_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_state_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_A.h
@@ -116,7 +116,7 @@ s8 sbp_msg_tracking_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_tracking_state_dep_a_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_state_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_A.h
@@ -127,7 +127,7 @@ s8 sbp_msg_tracking_state_dep_a_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_state_dep_a_send(sbp_state_t *s, u16 sender_id,
                                      const sbp_msg_tracking_state_dep_a_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_B.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_B.h
@@ -127,7 +127,7 @@ s8 sbp_msg_tracking_state_dep_b_decode(const uint8_t *buf, uint8_t len,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_state_dep_b_send(sbp_state_t *s, u16 sender_id,
                                      const sbp_msg_tracking_state_dep_b_t *msg,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_B.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_B.h
@@ -116,7 +116,7 @@ s8 sbp_msg_tracking_state_dep_b_decode(const uint8_t *buf, uint8_t len,
  * Send an instance of sbp_msg_tracking_state_dep_b_t with the given write
  * function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_state_dep_b_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
@@ -231,7 +231,7 @@ s8 sbp_msg_tracking_state_detailed_dep_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_state_detailed_dep_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
@@ -220,7 +220,7 @@ s8 sbp_msg_tracking_state_detailed_dep_decode(
  * Send an instance of sbp_msg_tracking_state_detailed_dep_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_state_detailed_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
@@ -232,7 +232,7 @@ s8 sbp_msg_tracking_state_detailed_dep_a_decode(
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_tracking_state_detailed_dep_a_send(
     sbp_state_t *s, u16 sender_id,

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
@@ -221,7 +221,7 @@ s8 sbp_msg_tracking_state_detailed_dep_a_decode(
  * Send an instance of sbp_msg_tracking_state_detailed_dep_a_t with the given
  * write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_tracking_state_detailed_dep_a_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/user/MSG_USER_DATA.h
+++ b/c/include/libsbp/v4/user/MSG_USER_DATA.h
@@ -122,7 +122,7 @@ s8 sbp_msg_user_data_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_user_data_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_user_data_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/user/MSG_USER_DATA.h
+++ b/c/include/libsbp/v4/user/MSG_USER_DATA.h
@@ -111,7 +111,7 @@ s8 sbp_msg_user_data_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_user_data_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_user_data_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/vehicle/MSG_ODOMETRY.h
+++ b/c/include/libsbp/v4/vehicle/MSG_ODOMETRY.h
@@ -130,7 +130,7 @@ s8 sbp_msg_odometry_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_odometry_send(sbp_state_t *s, u16 sender_id,
                          const sbp_msg_odometry_t *msg, sbp_write_fn_t write);

--- a/c/include/libsbp/v4/vehicle/MSG_ODOMETRY.h
+++ b/c/include/libsbp/v4/vehicle/MSG_ODOMETRY.h
@@ -119,7 +119,7 @@ s8 sbp_msg_odometry_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_odometry_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_odometry_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/vehicle/MSG_WHEELTICK.h
+++ b/c/include/libsbp/v4/vehicle/MSG_WHEELTICK.h
@@ -130,7 +130,7 @@ s8 sbp_msg_wheeltick_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
 /**
  * Send an instance of sbp_msg_wheeltick_t with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on
+ * An equivalent of #sbp_message_send which operates specifically on
  * sbp_msg_wheeltick_t
  *
  * The given message will be encoded to wire representation and passed in to the

--- a/c/include/libsbp/v4/vehicle/MSG_WHEELTICK.h
+++ b/c/include/libsbp/v4/vehicle/MSG_WHEELTICK.h
@@ -141,7 +141,7 @@ s8 sbp_msg_wheeltick_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 sbp_msg_wheeltick_send(sbp_state_t *s, u16 sender_id,
                           const sbp_msg_wheeltick_t *msg, sbp_write_fn_t write);

--- a/c/src/include/libsbp/internal/v4/string/double_null_terminated.h
+++ b/c/src/include/libsbp/internal/v4/string/double_null_terminated.h
@@ -108,7 +108,7 @@ size_t sbp_double_null_terminated_string_count_sections(const sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param new_str New section string
+ * @param str New section string
  * @return true on success, false otherwise
  */
 bool sbp_double_null_terminated_string_add_section(sbp_string_t *s,
@@ -153,7 +153,7 @@ bool sbp_double_null_terminated_string_add_section_vprintf(
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param String to append
+ * @param new_str String to append
  * @return true on success, false otherwise
  */
 bool sbp_double_null_terminated_string_append(sbp_string_t *s,

--- a/c/src/include/libsbp/internal/v4/string/null_terminated.h
+++ b/c/src/include/libsbp/internal/v4/string/null_terminated.h
@@ -37,8 +37,7 @@ void sbp_null_terminated_string_init(sbp_string_t *s);
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- *
- * @return
+ * @return true if valid, false otherwise
  */
 bool sbp_null_terminated_string_valid(const sbp_string_t *s,
                                       size_t max_encoded_len);
@@ -51,11 +50,10 @@ bool sbp_null_terminated_string_valid(const sbp_string_t *s,
  *
  * An invalid string will be considered as less than a valid string.
  *
- * @param a
- * @param b
+ * @param a string
+ * @param b string
  * @param max_encoded_len Maximum encoded length
- *
- * @return
+ * @return Comparison result
  */
 int sbp_null_terminated_string_strcmp(const sbp_string_t *a,
                                       const sbp_string_t *b,
@@ -68,8 +66,7 @@ int sbp_null_terminated_string_strcmp(const sbp_string_t *a,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- *
- * @return
+ * @return Encoded length
  */
 size_t sbp_null_terminated_string_encoded_len(const sbp_string_t *s,
                                               size_t max_encoded_len);
@@ -82,8 +79,7 @@ size_t sbp_null_terminated_string_encoded_len(const sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- *
- * @return
+ * @return Available space
  */
 size_t sbp_null_terminated_string_space_remaining(const sbp_string_t *s,
                                                   size_t max_encoded_len);
@@ -93,8 +89,7 @@ size_t sbp_null_terminated_string_space_remaining(const sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- *
- * @return
+ * @return Length of string
  */
 size_t sbp_null_terminated_string_strlen(const sbp_string_t *s,
                                          size_t max_encoded_len);
@@ -107,9 +102,8 @@ size_t sbp_null_terminated_string_strlen(const sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param new_str
- *
- * @return
+ * @param new_str New string contents
+ * @return true on success, false otherwise
  */
 bool sbp_null_terminated_string_set(sbp_string_t *s, size_t max_encoded_len,
                                     const char *new_str);
@@ -122,13 +116,12 @@ bool sbp_null_terminated_string_set(sbp_string_t *s, size_t max_encoded_len,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param fmt
- * @param va_list
- *
- * @return
+ * @param fmt print style format specification
+ * @param ap Argument list
+ * @return true on success, false otherwise
  */
 bool sbp_null_terminated_string_vprintf(sbp_string_t *s, size_t max_encoded_len,
-                                        const char *fmt, va_list /*ap*/);
+                                        const char *fmt, va_list ap);
 
 /**
  * Append to a null terminated string.
@@ -143,9 +136,8 @@ bool sbp_null_terminated_string_vprintf(sbp_string_t *s, size_t max_encoded_len,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param new_str
- *
- * @return
+ * @param new_str String to append
+ * @return true on success, false otherwise
  */
 bool sbp_null_terminated_string_append(sbp_string_t *s, size_t max_encoded_len,
                                        const char *new_str);
@@ -162,14 +154,13 @@ bool sbp_null_terminated_string_append(sbp_string_t *s, size_t max_encoded_len,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param fmt
- * @param va_list
- *
- * @return
+ * @param fmt printf style format specification
+ * @param ap Argument list
+ * @return true on success, false otherwise
  */
 bool sbp_null_terminated_string_append_vprintf(sbp_string_t *s,
                                                size_t max_encoded_len,
-                                               const char *fmt, va_list /*ap*/);
+                                               const char *fmt, va_list ap);
 
 /**
  * Get contents
@@ -178,8 +169,7 @@ bool sbp_null_terminated_string_append_vprintf(sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- *
- * @return
+ * @return String contents, or NULL
  */
 const char *sbp_null_terminated_string_get(const sbp_string_t *s,
                                            size_t max_encoded_len);
@@ -192,9 +182,8 @@ const char *sbp_null_terminated_string_get(const sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param ctx
- *
- * @return
+ * @param ctx Encode context
+ * @return true on success, false otherwise
  */
 bool sbp_null_terminated_string_encode(const sbp_string_t *s,
                                        size_t max_encoded_len,
@@ -213,9 +202,8 @@ bool sbp_null_terminated_string_encode(const sbp_string_t *s,
  *
  * @param s string
  * @param max_encoded_len Maximum encoded length
- * @param ctx
- *
- * @return
+ * @param ctx Decode context
+ * @return true on success, false otherwise
  */
 bool sbp_null_terminated_string_decode(sbp_string_t *s, size_t max_encoded_len,
                                        sbp_decode_ctx_t *ctx);

--- a/c/src/include/libsbp/internal/v4/string/sbp_string.h
+++ b/c/src/include/libsbp/internal/v4/string/sbp_string.h
@@ -71,7 +71,7 @@ typedef struct {
  *
  * @param a string
  * @param b string
- * @param max_encoded_len
+ * @param max_encoded_len Maximum encoded length
  * @param params string params
  */
 int sbp_string_cmp(const sbp_string_t *a, const sbp_string_t *b,
@@ -142,7 +142,7 @@ bool sbp_string_encode(const sbp_string_t *s, size_t max_encoded_len,
  * @param s destination string
  * @param max_encoded_len Maximum encoded length
  * @param ctx Decode context
- * @param param string params
+ * @param params string params
  * @return true on success, false otherwise
  */
 bool sbp_string_decode(sbp_string_t *s, size_t max_encoded_len,

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -29,7 +29,7 @@
  * ---------
  *
  * First setup a callback for the message you will be receiving. Our callback
- * function must have type #sbp_msg_callback_t or #sbp_msg_frame_callback_t,
+ * function must have type #sbp_msg_callback_t or #sbp_frame_callback_t,
  * i.e. it must be of the form:
  *
  * ~~~

--- a/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
@@ -110,7 +110,7 @@ typedef struct {
   /**
    * Tests 2 instances of (((comment_name))) for equality
    *
-   * Returns a value with the same definitions as #strcmp from the C standard library
+   * Returns a value with the same definitions as strcmp from the C standard library
    *
    * @param a (((m.type_name))) instance
    * @param b (((m.type_name))) instance
@@ -213,6 +213,8 @@ typedef struct {
    * The returned value does not include the NULL terminator.
    *
    * @param msg (((m.type_name))) instance
+   * @param msg (((m.type_name))) instance
+   * @param section Section number
    * @return Length of section
    */
   size_t (((prefix)))_section_strlen(const (((m.type_name))) *msg, size_t section);
@@ -382,7 +384,7 @@ s8 (((m.prefix)))_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read, (((m.
  * @param sender_id SBP sender id
  * @param msg Message to send
  * @param write Write function
- * @param SBP_OK on success, or other libsbp error code
+ * @return SBP_OK on success, or other libsbp error code
  */
 s8 (((m.prefix)))_send(sbp_state_t  *s, u16 sender_id, const (((m.type_name))) *msg, sbp_write_fn_t write);
 ((*- endif *))

--- a/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
@@ -213,7 +213,6 @@ typedef struct {
    * The returned value does not include the NULL terminator.
    *
    * @param msg (((m.type_name))) instance
-   * @param msg (((m.type_name))) instance
    * @param section Section number
    * @return Length of section
    */
@@ -376,7 +375,7 @@ s8 (((m.prefix)))_decode(const uint8_t *buf, uint8_t len, uint8_t *n_read, (((m.
 /**
  * Send an instance of (((m.type_name))) with the given write function
  *
- * An equivalent of #sbp_send_message which operates specifically on (((m.type_name)))
+ * An equivalent of #sbp_message_send which operates specifically on (((m.type_name)))
  *
  * The given message will be encoded to wire representation and passed in to the given write function callback. The write callback will be called several times for each invocation of this function.
  *


### PR DESCRIPTION
Address mistakes in comment blocks which are causing doxygen error.

The most current error remaining on this PR is to do with an undocumented argument `s` and documentation for an extra argument `msg`. This will be resolved when the items on [this document](https://swift-nav.atlassian.net/wiki/spaces/~61688916/pages/1837891645/Name+location+changes+needed) are actioned after everything else has been completed