### PR TITLE
[ESD-2059] Add a typedef for write callback

### DIFF
--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -50,6 +50,21 @@ typedef uint64_t u64;
 
 #endif
 
+/**
+ * Write callback
+ *
+ * The user of libsbp must provide a write callback to function which send 
+ * messages (eg, #sbp_message_send) which conforms to this type. The write 
+ * function will be called several times during the course of sending a single 
+ * message. The context parameter can be set by calling #sbp_set_io_context.
+ *
+ * @param buff Data to write
+ * @param n Length of \p buff
+ * @param context User provided context
+ * @return Number of bytes written, or <0 to indicate error
+ */
+typedef s32 (*sbp_write_fn_t)(u8 *buff, u32 n, void *context);
+
 /* Set packing based upon toolchain */
 #if defined(__GNUC__) || defined(__clang__)
 

--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -53,8 +53,8 @@ typedef uint64_t u64;
 /**
  * Write callback
  *
- * The user of libsbp must provide a write callback to function which send 
- * messages (eg, #sbp_message_send) which conforms to this type. The write 
+ * The user of libsbp must provide a write callback conforming to this type
+ * to functions which send messages (eg, #sbp_message_send). The write 
  * function will be called several times during the course of sending a single 
  * message. The context parameter can be set by calling #sbp_set_io_context.
  *
@@ -105,4 +105,3 @@ typedef s32 (*sbp_write_fn_t)(u8 *buff, u32 n, void *context);
 /** \} */
 
 #endif /* LIBSBP_COMMON_H */
-

--- a/c/include/libsbp/cpp/message_traits.h
+++ b/c/include/libsbp/cpp/message_traits.h
@@ -62,8 +62,7 @@ struct MessageTraits<sbp_msg_print_dep_t> {
   }
   static sbp_msg_print_dep_t &get(sbp_msg_t &msg) { return msg.print_dep; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_print_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_print_dep_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_print_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -80,7 +79,7 @@ struct MessageTraits<sbp_msg_tracking_state_detailed_dep_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_tracking_state_detailed_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_state_detailed_dep_t(state, sender_id,
                                                           &msg, write);
   }
@@ -97,7 +96,7 @@ struct MessageTraits<sbp_msg_tracking_state_dep_b_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_tracking_state_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_state_dep_b_t(state, sender_id, &msg,
                                                    write);
   }
@@ -113,8 +112,7 @@ struct MessageTraits<sbp_msg_acq_result_dep_b_t> {
     return msg.acq_result_dep_b;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_acq_result_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_acq_result_dep_b_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_acq_result_dep_b_t(state, sender_id, &msg, write);
   }
 };
@@ -129,8 +127,7 @@ struct MessageTraits<sbp_msg_acq_result_dep_a_t> {
     return msg.acq_result_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_acq_result_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_acq_result_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_acq_result_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -146,7 +143,7 @@ struct MessageTraits<sbp_msg_tracking_state_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_tracking_state_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_state_dep_a_t(state, sender_id, &msg,
                                                    write);
   }
@@ -162,8 +159,7 @@ struct MessageTraits<sbp_msg_thread_state_t> {
     return msg.thread_state;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_thread_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_thread_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_thread_state_t(state, sender_id, &msg, write);
   }
 };
@@ -178,8 +174,7 @@ struct MessageTraits<sbp_msg_uart_state_depa_t> {
     return msg.uart_state_depa;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_uart_state_depa_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_uart_state_depa_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_uart_state_depa_t(state, sender_id, &msg, write);
   }
 };
@@ -192,8 +187,7 @@ struct MessageTraits<sbp_msg_iar_state_t> {
   }
   static sbp_msg_iar_state_t &get(sbp_msg_t &msg) { return msg.iar_state; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_iar_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_iar_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_iar_state_t(state, sender_id, &msg, write);
   }
 };
@@ -208,8 +202,7 @@ struct MessageTraits<sbp_msg_ephemeris_dep_a_t> {
     return msg.ephemeris_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -225,7 +218,7 @@ struct MessageTraits<sbp_msg_mask_satellite_dep_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_mask_satellite_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_mask_satellite_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -240,8 +233,7 @@ struct MessageTraits<sbp_msg_tracking_iq_dep_a_t> {
     return msg.tracking_iq_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_tracking_iq_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_tracking_iq_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_iq_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -254,8 +246,7 @@ struct MessageTraits<sbp_msg_uart_state_t> {
   }
   static sbp_msg_uart_state_t &get(sbp_msg_t &msg) { return msg.uart_state; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_uart_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_uart_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_uart_state_t(state, sender_id, &msg, write);
   }
 };
@@ -271,7 +262,7 @@ struct MessageTraits<sbp_msg_acq_sv_profile_dep_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_acq_sv_profile_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_acq_sv_profile_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -286,8 +277,7 @@ struct MessageTraits<sbp_msg_acq_result_dep_c_t> {
     return msg.acq_result_dep_c;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_acq_result_dep_c_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_acq_result_dep_c_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_acq_result_dep_c_t(state, sender_id, &msg, write);
   }
 };
@@ -304,7 +294,7 @@ struct MessageTraits<sbp_msg_tracking_state_detailed_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_tracking_state_detailed_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(state, sender_id,
                                                             &msg, write);
   }
@@ -320,8 +310,7 @@ struct MessageTraits<sbp_msg_reset_filters_t> {
     return msg.reset_filters;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_reset_filters_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_reset_filters_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_reset_filters_t(state, sender_id, &msg, write);
   }
 };
@@ -336,8 +325,7 @@ struct MessageTraits<sbp_msg_init_base_dep_t> {
     return msg.init_base_dep;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_init_base_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_init_base_dep_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_init_base_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -352,8 +340,7 @@ struct MessageTraits<sbp_msg_mask_satellite_t> {
     return msg.mask_satellite;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_mask_satellite_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_mask_satellite_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_mask_satellite_t(state, sender_id, &msg, write);
   }
 };
@@ -368,8 +355,7 @@ struct MessageTraits<sbp_msg_tracking_iq_dep_b_t> {
     return msg.tracking_iq_dep_b;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_tracking_iq_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_tracking_iq_dep_b_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_iq_dep_b_t(state, sender_id, &msg, write);
   }
 };
@@ -382,8 +368,7 @@ struct MessageTraits<sbp_msg_tracking_iq_t> {
   }
   static sbp_msg_tracking_iq_t &get(sbp_msg_t &msg) { return msg.tracking_iq; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_tracking_iq_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_tracking_iq_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_iq_t(state, sender_id, &msg, write);
   }
 };
@@ -398,8 +383,7 @@ struct MessageTraits<sbp_msg_acq_sv_profile_t> {
     return msg.acq_sv_profile;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_acq_sv_profile_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_acq_sv_profile_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_acq_sv_profile_t(state, sender_id, &msg, write);
   }
 };
@@ -412,8 +396,7 @@ struct MessageTraits<sbp_msg_acq_result_t> {
   }
   static sbp_msg_acq_result_t &get(sbp_msg_t &msg) { return msg.acq_result; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_acq_result_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_acq_result_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_acq_result_t(state, sender_id, &msg, write);
   }
 };
@@ -428,8 +411,7 @@ struct MessageTraits<sbp_msg_tracking_state_t> {
     return msg.tracking_state;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_tracking_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_tracking_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_tracking_state_t(state, sender_id, &msg, write);
   }
 };
@@ -442,8 +424,7 @@ struct MessageTraits<sbp_msg_obs_dep_b_t> {
   }
   static sbp_msg_obs_dep_b_t &get(sbp_msg_t &msg) { return msg.obs_dep_b; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_obs_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_obs_dep_b_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_obs_dep_b_t(state, sender_id, &msg, write);
   }
 };
@@ -458,8 +439,7 @@ struct MessageTraits<sbp_msg_base_pos_llh_t> {
     return msg.base_pos_llh;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_base_pos_llh_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_base_pos_llh_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_base_pos_llh_t(state, sender_id, &msg, write);
   }
 };
@@ -472,8 +452,7 @@ struct MessageTraits<sbp_msg_obs_dep_a_t> {
   }
   static sbp_msg_obs_dep_a_t &get(sbp_msg_t &msg) { return msg.obs_dep_a; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_obs_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_obs_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_obs_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -488,8 +467,7 @@ struct MessageTraits<sbp_msg_ephemeris_dep_b_t> {
     return msg.ephemeris_dep_b;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_dep_b_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_dep_b_t(state, sender_id, &msg, write);
   }
 };
@@ -504,8 +482,7 @@ struct MessageTraits<sbp_msg_ephemeris_dep_c_t> {
     return msg.ephemeris_dep_c;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_dep_c_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_dep_c_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_dep_c_t(state, sender_id, &msg, write);
   }
 };
@@ -520,8 +497,7 @@ struct MessageTraits<sbp_msg_base_pos_ecef_t> {
     return msg.base_pos_ecef;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_base_pos_ecef_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_base_pos_ecef_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_base_pos_ecef_t(state, sender_id, &msg, write);
   }
 };
@@ -534,8 +510,7 @@ struct MessageTraits<sbp_msg_obs_dep_c_t> {
   }
   static sbp_msg_obs_dep_c_t &get(sbp_msg_t &msg) { return msg.obs_dep_c; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_obs_dep_c_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_obs_dep_c_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_obs_dep_c_t(state, sender_id, &msg, write);
   }
 };
@@ -546,7 +521,7 @@ struct MessageTraits<sbp_msg_obs_t> {
   static const sbp_msg_obs_t &get(const sbp_msg_t &msg) { return msg.obs; }
   static sbp_msg_obs_t &get(sbp_msg_t &msg) { return msg.obs; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_obs_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_obs_t(state, sender_id, &msg, write);
   }
 };
@@ -559,8 +534,7 @@ struct MessageTraits<sbp_msg_specan_dep_t> {
   }
   static sbp_msg_specan_dep_t &get(sbp_msg_t &msg) { return msg.specan_dep; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_specan_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_specan_dep_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_specan_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -573,7 +547,7 @@ struct MessageTraits<sbp_msg_specan_t> {
   }
   static sbp_msg_specan_t &get(sbp_msg_t &msg) { return msg.specan; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_specan_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_specan_t(state, sender_id, &msg, write);
   }
 };
@@ -588,8 +562,7 @@ struct MessageTraits<sbp_msg_measurement_state_t> {
     return msg.measurement_state;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_measurement_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_measurement_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_measurement_state_t(state, sender_id, &msg, write);
   }
 };
@@ -602,8 +575,7 @@ struct MessageTraits<sbp_msg_set_time_t> {
   }
   static sbp_msg_set_time_t &get(sbp_msg_t &msg) { return msg.set_time; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_set_time_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_set_time_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_set_time_t(state, sender_id, &msg, write);
   }
 };
@@ -616,8 +588,7 @@ struct MessageTraits<sbp_msg_almanac_t> {
   }
   static sbp_msg_almanac_t &get(sbp_msg_t &msg) { return msg.almanac; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_almanac_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_almanac_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_almanac_t(state, sender_id, &msg, write);
   }
 };
@@ -632,8 +603,7 @@ struct MessageTraits<sbp_msg_almanac_gps_dep_t> {
     return msg.almanac_gps_dep;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_almanac_gps_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_almanac_gps_dep_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_almanac_gps_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -648,8 +618,7 @@ struct MessageTraits<sbp_msg_almanac_glo_dep_t> {
     return msg.almanac_glo_dep;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_almanac_glo_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_almanac_glo_dep_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_almanac_glo_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -662,8 +631,7 @@ struct MessageTraits<sbp_msg_almanac_gps_t> {
   }
   static sbp_msg_almanac_gps_t &get(sbp_msg_t &msg) { return msg.almanac_gps; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_almanac_gps_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_almanac_gps_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_almanac_gps_t(state, sender_id, &msg, write);
   }
 };
@@ -676,8 +644,7 @@ struct MessageTraits<sbp_msg_almanac_glo_t> {
   }
   static sbp_msg_almanac_glo_t &get(sbp_msg_t &msg) { return msg.almanac_glo; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_almanac_glo_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_almanac_glo_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_almanac_glo_t(state, sender_id, &msg, write);
   }
 };
@@ -690,8 +657,7 @@ struct MessageTraits<sbp_msg_glo_biases_t> {
   }
   static sbp_msg_glo_biases_t &get(sbp_msg_t &msg) { return msg.glo_biases; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_glo_biases_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_glo_biases_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_glo_biases_t(state, sender_id, &msg, write);
   }
 };
@@ -706,8 +672,7 @@ struct MessageTraits<sbp_msg_ephemeris_dep_d_t> {
     return msg.ephemeris_dep_d;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_dep_d_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_dep_d_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_dep_d_t(state, sender_id, &msg, write);
   }
 };
@@ -723,7 +688,7 @@ struct MessageTraits<sbp_msg_ephemeris_gps_dep_e_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_gps_dep_e_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_gps_dep_e_t(state, sender_id, &msg,
                                                   write);
   }
@@ -740,7 +705,7 @@ struct MessageTraits<sbp_msg_ephemeris_sbas_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_sbas_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(state, sender_id, &msg,
                                                    write);
   }
@@ -757,7 +722,7 @@ struct MessageTraits<sbp_msg_ephemeris_glo_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_glo_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_glo_dep_a_t(state, sender_id, &msg,
                                                   write);
   }
@@ -774,7 +739,7 @@ struct MessageTraits<sbp_msg_ephemeris_sbas_dep_b_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_sbas_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(state, sender_id, &msg,
                                                    write);
   }
@@ -791,7 +756,7 @@ struct MessageTraits<sbp_msg_ephemeris_glo_dep_b_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_glo_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_glo_dep_b_t(state, sender_id, &msg,
                                                   write);
   }
@@ -808,7 +773,7 @@ struct MessageTraits<sbp_msg_ephemeris_gps_dep_f_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_gps_dep_f_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_gps_dep_f_t(state, sender_id, &msg,
                                                   write);
   }
@@ -825,7 +790,7 @@ struct MessageTraits<sbp_msg_ephemeris_glo_dep_c_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_glo_dep_c_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_glo_dep_c_t(state, sender_id, &msg,
                                                   write);
   }
@@ -842,7 +807,7 @@ struct MessageTraits<sbp_msg_ephemeris_glo_dep_d_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_glo_dep_d_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_glo_dep_d_t(state, sender_id, &msg,
                                                   write);
   }
@@ -858,8 +823,7 @@ struct MessageTraits<sbp_msg_ephemeris_bds_t> {
     return msg.ephemeris_bds;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_bds_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_bds_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_bds_t(state, sender_id, &msg, write);
   }
 };
@@ -874,8 +838,7 @@ struct MessageTraits<sbp_msg_ephemeris_gps_t> {
     return msg.ephemeris_gps;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_gps_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_gps_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_gps_t(state, sender_id, &msg, write);
   }
 };
@@ -890,8 +853,7 @@ struct MessageTraits<sbp_msg_ephemeris_glo_t> {
     return msg.ephemeris_glo;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_glo_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_glo_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_glo_t(state, sender_id, &msg, write);
   }
 };
@@ -906,8 +868,7 @@ struct MessageTraits<sbp_msg_ephemeris_sbas_t> {
     return msg.ephemeris_sbas;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_sbas_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_sbas_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_sbas_t(state, sender_id, &msg, write);
   }
 };
@@ -922,8 +883,7 @@ struct MessageTraits<sbp_msg_ephemeris_gal_t> {
     return msg.ephemeris_gal;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_gal_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_gal_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_gal_t(state, sender_id, &msg, write);
   }
 };
@@ -938,8 +898,7 @@ struct MessageTraits<sbp_msg_ephemeris_qzss_t> {
     return msg.ephemeris_qzss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ephemeris_qzss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ephemeris_qzss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_qzss_t(state, sender_id, &msg, write);
   }
 };
@@ -950,7 +909,7 @@ struct MessageTraits<sbp_msg_iono_t> {
   static const sbp_msg_iono_t &get(const sbp_msg_t &msg) { return msg.iono; }
   static sbp_msg_iono_t &get(sbp_msg_t &msg) { return msg.iono; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_iono_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_iono_t(state, sender_id, &msg, write);
   }
 };
@@ -966,7 +925,7 @@ struct MessageTraits<sbp_msg_sv_configuration_gps_dep_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_sv_configuration_gps_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_sv_configuration_gps_dep_t(state, sender_id, &msg,
                                                        write);
   }
@@ -982,8 +941,7 @@ struct MessageTraits<sbp_msg_group_delay_dep_a_t> {
     return msg.group_delay_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_group_delay_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_group_delay_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_group_delay_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -998,8 +956,7 @@ struct MessageTraits<sbp_msg_group_delay_dep_b_t> {
     return msg.group_delay_dep_b;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_group_delay_dep_b_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_group_delay_dep_b_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_group_delay_dep_b_t(state, sender_id, &msg, write);
   }
 };
@@ -1012,8 +969,7 @@ struct MessageTraits<sbp_msg_group_delay_t> {
   }
   static sbp_msg_group_delay_t &get(sbp_msg_t &msg) { return msg.group_delay; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_group_delay_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_group_delay_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_group_delay_t(state, sender_id, &msg, write);
   }
 };
@@ -1029,7 +985,7 @@ struct MessageTraits<sbp_msg_ephemeris_gal_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ephemeris_gal_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ephemeris_gal_dep_a_t(state, sender_id, &msg,
                                                   write);
   }
@@ -1043,8 +999,7 @@ struct MessageTraits<sbp_msg_gnss_capb_t> {
   }
   static sbp_msg_gnss_capb_t &get(sbp_msg_t &msg) { return msg.gnss_capb; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_gnss_capb_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_gnss_capb_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_gnss_capb_t(state, sender_id, &msg, write);
   }
 };
@@ -1057,8 +1012,7 @@ struct MessageTraits<sbp_msg_sv_az_el_t> {
   }
   static sbp_msg_sv_az_el_t &get(sbp_msg_t &msg) { return msg.sv_az_el; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_sv_az_el_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_sv_az_el_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_sv_az_el_t(state, sender_id, &msg, write);
   }
 };
@@ -1073,8 +1027,7 @@ struct MessageTraits<sbp_msg_settings_write_t> {
     return msg.settings_write;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_settings_write_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_settings_write_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_write_t(state, sender_id, &msg, write);
   }
 };
@@ -1089,8 +1042,7 @@ struct MessageTraits<sbp_msg_settings_save_t> {
     return msg.settings_save;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_settings_save_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_settings_save_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_save_t(state, sender_id, &msg, write);
   }
 };
@@ -1106,7 +1058,7 @@ struct MessageTraits<sbp_msg_settings_read_by_index_req_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_settings_read_by_index_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_read_by_index_req_t(state, sender_id, &msg,
                                                          write);
   }
@@ -1122,8 +1074,7 @@ struct MessageTraits<sbp_msg_fileio_read_resp_t> {
     return msg.fileio_read_resp;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_fileio_read_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_fileio_read_resp_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_read_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1138,8 +1089,7 @@ struct MessageTraits<sbp_msg_settings_read_req_t> {
     return msg.settings_read_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_settings_read_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_settings_read_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_read_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1155,7 +1105,7 @@ struct MessageTraits<sbp_msg_settings_read_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_settings_read_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_read_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1172,7 +1122,7 @@ struct MessageTraits<sbp_msg_settings_read_by_index_done_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_settings_read_by_index_done_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_read_by_index_done_t(state, sender_id,
                                                           &msg, write);
   }
@@ -1190,7 +1140,7 @@ struct MessageTraits<sbp_msg_settings_read_by_index_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_settings_read_by_index_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_read_by_index_resp_t(state, sender_id,
                                                           &msg, write);
   }
@@ -1206,8 +1156,7 @@ struct MessageTraits<sbp_msg_fileio_read_req_t> {
     return msg.fileio_read_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_fileio_read_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_fileio_read_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_read_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1223,7 +1172,7 @@ struct MessageTraits<sbp_msg_fileio_read_dir_req_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_fileio_read_dir_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_read_dir_req_t(state, sender_id, &msg,
                                                   write);
   }
@@ -1240,7 +1189,7 @@ struct MessageTraits<sbp_msg_fileio_read_dir_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_fileio_read_dir_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_read_dir_resp_t(state, sender_id, &msg,
                                                    write);
   }
@@ -1256,8 +1205,7 @@ struct MessageTraits<sbp_msg_fileio_write_resp_t> {
     return msg.fileio_write_resp;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_fileio_write_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_fileio_write_resp_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_write_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1272,8 +1220,7 @@ struct MessageTraits<sbp_msg_fileio_remove_t> {
     return msg.fileio_remove;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_fileio_remove_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_fileio_remove_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_remove_t(state, sender_id, &msg, write);
   }
 };
@@ -1288,8 +1235,7 @@ struct MessageTraits<sbp_msg_fileio_write_req_t> {
     return msg.fileio_write_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_fileio_write_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_fileio_write_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_write_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1304,8 +1250,7 @@ struct MessageTraits<sbp_msg_settings_register_t> {
     return msg.settings_register;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_settings_register_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_settings_register_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_register_t(state, sender_id, &msg, write);
   }
 };
@@ -1321,7 +1266,7 @@ struct MessageTraits<sbp_msg_settings_write_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_settings_write_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_write_resp_t(state, sender_id, &msg,
                                                   write);
   }
@@ -1338,7 +1283,7 @@ struct MessageTraits<sbp_msg_bootloader_handshake_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_bootloader_handshake_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_bootloader_handshake_dep_a_t(state, sender_id, &msg,
                                                          write);
   }
@@ -1355,7 +1300,7 @@ struct MessageTraits<sbp_msg_bootloader_jump_to_app_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_bootloader_jump_to_app_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_bootloader_jump_to_app_t(state, sender_id, &msg,
                                                      write);
   }
@@ -1369,8 +1314,7 @@ struct MessageTraits<sbp_msg_reset_dep_t> {
   }
   static sbp_msg_reset_dep_t &get(sbp_msg_t &msg) { return msg.reset_dep; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_reset_dep_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_reset_dep_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_reset_dep_t(state, sender_id, &msg, write);
   }
 };
@@ -1386,7 +1330,7 @@ struct MessageTraits<sbp_msg_bootloader_handshake_req_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_bootloader_handshake_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_bootloader_handshake_req_t(state, sender_id, &msg,
                                                        write);
   }
@@ -1403,7 +1347,7 @@ struct MessageTraits<sbp_msg_bootloader_handshake_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_bootloader_handshake_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_bootloader_handshake_resp_t(state, sender_id, &msg,
                                                         write);
   }
@@ -1419,8 +1363,7 @@ struct MessageTraits<sbp_msg_device_monitor_t> {
     return msg.device_monitor;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_device_monitor_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_device_monitor_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_device_monitor_t(state, sender_id, &msg, write);
   }
 };
@@ -1431,7 +1374,7 @@ struct MessageTraits<sbp_msg_reset_t> {
   static const sbp_msg_reset_t &get(const sbp_msg_t &msg) { return msg.reset; }
   static sbp_msg_reset_t &get(sbp_msg_t &msg) { return msg.reset; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_reset_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_reset_t(state, sender_id, &msg, write);
   }
 };
@@ -1444,8 +1387,7 @@ struct MessageTraits<sbp_msg_command_req_t> {
   }
   static sbp_msg_command_req_t &get(sbp_msg_t &msg) { return msg.command_req; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_command_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_command_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_command_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1460,8 +1402,7 @@ struct MessageTraits<sbp_msg_command_resp_t> {
     return msg.command_resp;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_command_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_command_resp_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_command_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1476,8 +1417,7 @@ struct MessageTraits<sbp_msg_network_state_req_t> {
     return msg.network_state_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_network_state_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_network_state_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_network_state_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1493,7 +1433,7 @@ struct MessageTraits<sbp_msg_network_state_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_network_state_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_network_state_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1508,8 +1448,7 @@ struct MessageTraits<sbp_msg_command_output_t> {
     return msg.command_output;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_command_output_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_command_output_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_command_output_t(state, sender_id, &msg, write);
   }
 };
@@ -1525,7 +1464,7 @@ struct MessageTraits<sbp_msg_network_bandwidth_usage_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_network_bandwidth_usage_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_network_bandwidth_usage_t(state, sender_id, &msg,
                                                       write);
   }
@@ -1541,8 +1480,7 @@ struct MessageTraits<sbp_msg_cell_modem_status_t> {
     return msg.cell_modem_status;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_cell_modem_status_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_cell_modem_status_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_cell_modem_status_t(state, sender_id, &msg, write);
   }
 };
@@ -1557,8 +1495,7 @@ struct MessageTraits<sbp_msg_front_end_gain_t> {
     return msg.front_end_gain;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_front_end_gain_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_front_end_gain_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_front_end_gain_t(state, sender_id, &msg, write);
   }
 };
@@ -1571,8 +1508,7 @@ struct MessageTraits<sbp_msg_cw_results_t> {
   }
   static sbp_msg_cw_results_t &get(sbp_msg_t &msg) { return msg.cw_results; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_cw_results_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_cw_results_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_cw_results_t(state, sender_id, &msg, write);
   }
 };
@@ -1585,8 +1521,7 @@ struct MessageTraits<sbp_msg_cw_start_t> {
   }
   static sbp_msg_cw_start_t &get(sbp_msg_t &msg) { return msg.cw_start; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_cw_start_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_cw_start_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_cw_start_t(state, sender_id, &msg, write);
   }
 };
@@ -1602,7 +1537,7 @@ struct MessageTraits<sbp_msg_nap_device_dna_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_nap_device_dna_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_nap_device_dna_resp_t(state, sender_id, &msg,
                                                   write);
   }
@@ -1619,7 +1554,7 @@ struct MessageTraits<sbp_msg_nap_device_dna_req_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_nap_device_dna_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_nap_device_dna_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1632,8 +1567,7 @@ struct MessageTraits<sbp_msg_flash_done_t> {
   }
   static sbp_msg_flash_done_t &get(sbp_msg_t &msg) { return msg.flash_done; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_flash_done_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_flash_done_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_flash_done_t(state, sender_id, &msg, write);
   }
 };
@@ -1648,8 +1582,7 @@ struct MessageTraits<sbp_msg_flash_read_resp_t> {
     return msg.flash_read_resp;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_flash_read_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_flash_read_resp_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_flash_read_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1662,8 +1595,7 @@ struct MessageTraits<sbp_msg_flash_erase_t> {
   }
   static sbp_msg_flash_erase_t &get(sbp_msg_t &msg) { return msg.flash_erase; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_flash_erase_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_flash_erase_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_flash_erase_t(state, sender_id, &msg, write);
   }
 };
@@ -1679,7 +1611,7 @@ struct MessageTraits<sbp_msg_stm_flash_lock_sector_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_stm_flash_lock_sector_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_stm_flash_lock_sector_t(state, sender_id, &msg,
                                                     write);
   }
@@ -1696,7 +1628,7 @@ struct MessageTraits<sbp_msg_stm_flash_unlock_sector_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_stm_flash_unlock_sector_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_stm_flash_unlock_sector_t(state, sender_id, &msg,
                                                       write);
   }
@@ -1713,7 +1645,7 @@ struct MessageTraits<sbp_msg_stm_unique_id_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_stm_unique_id_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_stm_unique_id_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -1728,8 +1660,7 @@ struct MessageTraits<sbp_msg_flash_program_t> {
     return msg.flash_program;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_flash_program_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_flash_program_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_flash_program_t(state, sender_id, &msg, write);
   }
 };
@@ -1744,8 +1675,7 @@ struct MessageTraits<sbp_msg_flash_read_req_t> {
     return msg.flash_read_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_flash_read_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_flash_read_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_flash_read_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1760,8 +1690,7 @@ struct MessageTraits<sbp_msg_stm_unique_id_req_t> {
     return msg.stm_unique_id_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_stm_unique_id_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_stm_unique_id_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_stm_unique_id_req_t(state, sender_id, &msg, write);
   }
 };
@@ -1777,7 +1706,7 @@ struct MessageTraits<sbp_msg_m25_flash_write_status_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_m25_flash_write_status_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_m25_flash_write_status_t(state, sender_id, &msg,
                                                      write);
   }
@@ -1793,8 +1722,7 @@ struct MessageTraits<sbp_msg_gps_time_dep_a_t> {
     return msg.gps_time_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_gps_time_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_gps_time_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_gps_time_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -1807,8 +1735,7 @@ struct MessageTraits<sbp_msg_ext_event_t> {
   }
   static sbp_msg_ext_event_t &get(sbp_msg_t &msg) { return msg.ext_event; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ext_event_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ext_event_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ext_event_t(state, sender_id, &msg, write);
   }
 };
@@ -1821,8 +1748,7 @@ struct MessageTraits<sbp_msg_gps_time_t> {
   }
   static sbp_msg_gps_time_t &get(sbp_msg_t &msg) { return msg.gps_time; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_gps_time_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_gps_time_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_gps_time_t(state, sender_id, &msg, write);
   }
 };
@@ -1835,8 +1761,7 @@ struct MessageTraits<sbp_msg_utc_time_t> {
   }
   static sbp_msg_utc_time_t &get(sbp_msg_t &msg) { return msg.utc_time; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_utc_time_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_utc_time_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_utc_time_t(state, sender_id, &msg, write);
   }
 };
@@ -1851,8 +1776,7 @@ struct MessageTraits<sbp_msg_gps_time_gnss_t> {
     return msg.gps_time_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_gps_time_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_gps_time_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_gps_time_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -1867,8 +1791,7 @@ struct MessageTraits<sbp_msg_utc_time_gnss_t> {
     return msg.utc_time_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_utc_time_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_utc_time_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_utc_time_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -1884,7 +1807,7 @@ struct MessageTraits<sbp_msg_settings_register_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_settings_register_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_settings_register_resp_t(state, sender_id, &msg,
                                                      write);
   }
@@ -1900,8 +1823,7 @@ struct MessageTraits<sbp_msg_pos_ecef_dep_a_t> {
     return msg.pos_ecef_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_ecef_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_ecef_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_ecef_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -1916,8 +1838,7 @@ struct MessageTraits<sbp_msg_pos_llh_dep_a_t> {
     return msg.pos_llh_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_llh_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_llh_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_llh_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -1933,7 +1854,7 @@ struct MessageTraits<sbp_msg_baseline_ecef_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_baseline_ecef_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_baseline_ecef_dep_a_t(state, sender_id, &msg,
                                                   write);
   }
@@ -1950,7 +1871,7 @@ struct MessageTraits<sbp_msg_baseline_ned_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_baseline_ned_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_baseline_ned_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -1965,8 +1886,7 @@ struct MessageTraits<sbp_msg_vel_ecef_dep_a_t> {
     return msg.vel_ecef_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ecef_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ecef_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ecef_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -1981,8 +1901,7 @@ struct MessageTraits<sbp_msg_vel_ned_dep_a_t> {
     return msg.vel_ned_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ned_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ned_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ned_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -1995,8 +1914,7 @@ struct MessageTraits<sbp_msg_dops_dep_a_t> {
   }
   static sbp_msg_dops_dep_a_t &get(sbp_msg_t &msg) { return msg.dops_dep_a; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_dops_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_dops_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_dops_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -2012,7 +1930,7 @@ struct MessageTraits<sbp_msg_baseline_heading_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_baseline_heading_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_baseline_heading_dep_a_t(state, sender_id, &msg,
                                                      write);
   }
@@ -2024,7 +1942,7 @@ struct MessageTraits<sbp_msg_dops_t> {
   static const sbp_msg_dops_t &get(const sbp_msg_t &msg) { return msg.dops; }
   static sbp_msg_dops_t &get(sbp_msg_t &msg) { return msg.dops; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_dops_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_dops_t(state, sender_id, &msg, write);
   }
 };
@@ -2037,8 +1955,7 @@ struct MessageTraits<sbp_msg_pos_ecef_t> {
   }
   static sbp_msg_pos_ecef_t &get(sbp_msg_t &msg) { return msg.pos_ecef; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_ecef_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_ecef_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_ecef_t(state, sender_id, &msg, write);
   }
 };
@@ -2051,8 +1968,7 @@ struct MessageTraits<sbp_msg_pos_llh_t> {
   }
   static sbp_msg_pos_llh_t &get(sbp_msg_t &msg) { return msg.pos_llh; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_llh_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_llh_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_llh_t(state, sender_id, &msg, write);
   }
 };
@@ -2067,8 +1983,7 @@ struct MessageTraits<sbp_msg_baseline_ecef_t> {
     return msg.baseline_ecef;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_baseline_ecef_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_baseline_ecef_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_baseline_ecef_t(state, sender_id, &msg, write);
   }
 };
@@ -2083,8 +1998,7 @@ struct MessageTraits<sbp_msg_baseline_ned_t> {
     return msg.baseline_ned;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_baseline_ned_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_baseline_ned_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_baseline_ned_t(state, sender_id, &msg, write);
   }
 };
@@ -2097,8 +2011,7 @@ struct MessageTraits<sbp_msg_vel_ecef_t> {
   }
   static sbp_msg_vel_ecef_t &get(sbp_msg_t &msg) { return msg.vel_ecef; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ecef_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ecef_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ecef_t(state, sender_id, &msg, write);
   }
 };
@@ -2111,8 +2024,7 @@ struct MessageTraits<sbp_msg_vel_ned_t> {
   }
   static sbp_msg_vel_ned_t &get(sbp_msg_t &msg) { return msg.vel_ned; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ned_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ned_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ned_t(state, sender_id, &msg, write);
   }
 };
@@ -2127,8 +2039,7 @@ struct MessageTraits<sbp_msg_baseline_heading_t> {
     return msg.baseline_heading;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_baseline_heading_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_baseline_heading_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_baseline_heading_t(state, sender_id, &msg, write);
   }
 };
@@ -2143,8 +2054,7 @@ struct MessageTraits<sbp_msg_age_corrections_t> {
     return msg.age_corrections;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_age_corrections_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_age_corrections_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_age_corrections_t(state, sender_id, &msg, write);
   }
 };
@@ -2157,8 +2067,7 @@ struct MessageTraits<sbp_msg_pos_llh_cov_t> {
   }
   static sbp_msg_pos_llh_cov_t &get(sbp_msg_t &msg) { return msg.pos_llh_cov; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_llh_cov_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_llh_cov_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_llh_cov_t(state, sender_id, &msg, write);
   }
 };
@@ -2171,8 +2080,7 @@ struct MessageTraits<sbp_msg_vel_ned_cov_t> {
   }
   static sbp_msg_vel_ned_cov_t &get(sbp_msg_t &msg) { return msg.vel_ned_cov; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ned_cov_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ned_cov_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ned_cov_t(state, sender_id, &msg, write);
   }
 };
@@ -2185,8 +2093,7 @@ struct MessageTraits<sbp_msg_vel_body_t> {
   }
   static sbp_msg_vel_body_t &get(sbp_msg_t &msg) { return msg.vel_body; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_body_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_body_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_body_t(state, sender_id, &msg, write);
   }
 };
@@ -2201,8 +2108,7 @@ struct MessageTraits<sbp_msg_pos_ecef_cov_t> {
     return msg.pos_ecef_cov;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_ecef_cov_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_ecef_cov_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_ecef_cov_t(state, sender_id, &msg, write);
   }
 };
@@ -2217,8 +2123,7 @@ struct MessageTraits<sbp_msg_vel_ecef_cov_t> {
     return msg.vel_ecef_cov;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ecef_cov_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ecef_cov_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ecef_cov_t(state, sender_id, &msg, write);
   }
 };
@@ -2234,7 +2139,7 @@ struct MessageTraits<sbp_msg_protection_level_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_protection_level_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_protection_level_dep_a_t(state, sender_id, &msg,
                                                      write);
   }
@@ -2250,8 +2155,7 @@ struct MessageTraits<sbp_msg_protection_level_t> {
     return msg.protection_level;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_protection_level_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_protection_level_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_protection_level_t(state, sender_id, &msg, write);
   }
 };
@@ -2264,8 +2168,7 @@ struct MessageTraits<sbp_msg_orient_quat_t> {
   }
   static sbp_msg_orient_quat_t &get(sbp_msg_t &msg) { return msg.orient_quat; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_orient_quat_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_orient_quat_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_orient_quat_t(state, sender_id, &msg, write);
   }
 };
@@ -2280,8 +2183,7 @@ struct MessageTraits<sbp_msg_orient_euler_t> {
     return msg.orient_euler;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_orient_euler_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_orient_euler_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_orient_euler_t(state, sender_id, &msg, write);
   }
 };
@@ -2296,8 +2198,7 @@ struct MessageTraits<sbp_msg_angular_rate_t> {
     return msg.angular_rate;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_angular_rate_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_angular_rate_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_angular_rate_t(state, sender_id, &msg, write);
   }
 };
@@ -2312,8 +2213,7 @@ struct MessageTraits<sbp_msg_pos_ecef_gnss_t> {
     return msg.pos_ecef_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_ecef_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_ecef_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_ecef_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2328,8 +2228,7 @@ struct MessageTraits<sbp_msg_pos_llh_gnss_t> {
     return msg.pos_llh_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_llh_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_llh_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_llh_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2344,8 +2243,7 @@ struct MessageTraits<sbp_msg_vel_ecef_gnss_t> {
     return msg.vel_ecef_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ecef_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ecef_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ecef_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2360,8 +2258,7 @@ struct MessageTraits<sbp_msg_vel_ned_gnss_t> {
     return msg.vel_ned_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ned_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ned_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ned_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2376,8 +2273,7 @@ struct MessageTraits<sbp_msg_pos_llh_cov_gnss_t> {
     return msg.pos_llh_cov_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_llh_cov_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_llh_cov_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_llh_cov_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2392,8 +2288,7 @@ struct MessageTraits<sbp_msg_vel_ned_cov_gnss_t> {
     return msg.vel_ned_cov_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ned_cov_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ned_cov_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ned_cov_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2408,8 +2303,7 @@ struct MessageTraits<sbp_msg_pos_ecef_cov_gnss_t> {
     return msg.pos_ecef_cov_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pos_ecef_cov_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pos_ecef_cov_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pos_ecef_cov_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2424,8 +2318,7 @@ struct MessageTraits<sbp_msg_vel_ecef_cov_gnss_t> {
     return msg.vel_ecef_cov_gnss;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_vel_ecef_cov_gnss_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_vel_ecef_cov_gnss_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_vel_ecef_cov_gnss_t(state, sender_id, &msg, write);
   }
 };
@@ -2438,8 +2331,7 @@ struct MessageTraits<sbp_msg_ndb_event_t> {
   }
   static sbp_msg_ndb_event_t &get(sbp_msg_t &msg) { return msg.ndb_event; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ndb_event_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ndb_event_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ndb_event_t(state, sender_id, &msg, write);
   }
 };
@@ -2450,7 +2342,7 @@ struct MessageTraits<sbp_msg_log_t> {
   static const sbp_msg_log_t &get(const sbp_msg_t &msg) { return msg.log; }
   static sbp_msg_log_t &get(sbp_msg_t &msg) { return msg.log; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_log_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_log_t(state, sender_id, &msg, write);
   }
 };
@@ -2461,7 +2353,7 @@ struct MessageTraits<sbp_msg_fwd_t> {
   static const sbp_msg_fwd_t &get(const sbp_msg_t &msg) { return msg.fwd; }
   static sbp_msg_fwd_t &get(sbp_msg_t &msg) { return msg.fwd; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_fwd_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fwd_t(state, sender_id, &msg, write);
   }
 };
@@ -2477,7 +2369,7 @@ struct MessageTraits<sbp_msg_ssr_orbit_clock_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_orbit_clock_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(state, sender_id, &msg,
                                                     write);
   }
@@ -2493,8 +2385,7 @@ struct MessageTraits<sbp_msg_ssr_orbit_clock_t> {
     return msg.ssr_orbit_clock;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ssr_orbit_clock_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ssr_orbit_clock_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_orbit_clock_t(state, sender_id, &msg, write);
   }
 };
@@ -2509,8 +2400,7 @@ struct MessageTraits<sbp_msg_ssr_code_biases_t> {
     return msg.ssr_code_biases;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ssr_code_biases_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ssr_code_biases_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_code_biases_t(state, sender_id, &msg, write);
   }
 };
@@ -2525,8 +2415,7 @@ struct MessageTraits<sbp_msg_ssr_phase_biases_t> {
     return msg.ssr_phase_biases;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ssr_phase_biases_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ssr_phase_biases_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_phase_biases_t(state, sender_id, &msg, write);
   }
 };
@@ -2542,7 +2431,7 @@ struct MessageTraits<sbp_msg_ssr_stec_correction_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_stec_correction_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(state, sender_id, &msg,
                                                         write);
   }
@@ -2560,7 +2449,7 @@ struct MessageTraits<sbp_msg_ssr_gridded_correction_no_std_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_gridded_correction_no_std_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
         state, sender_id, &msg, write);
   }
@@ -2577,7 +2466,7 @@ struct MessageTraits<sbp_msg_ssr_grid_definition_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_grid_definition_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(state, sender_id, &msg,
                                                         write);
   }
@@ -2594,7 +2483,7 @@ struct MessageTraits<sbp_msg_ssr_tile_definition_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_tile_definition_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_tile_definition_t(state, sender_id, &msg,
                                                   write);
   }
@@ -2612,7 +2501,7 @@ struct MessageTraits<sbp_msg_ssr_gridded_correction_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_gridded_correction_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(state, sender_id,
                                                            &msg, write);
   }
@@ -2629,7 +2518,7 @@ struct MessageTraits<sbp_msg_ssr_stec_correction_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_stec_correction_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_stec_correction_t(state, sender_id, &msg,
                                                   write);
   }
@@ -2646,7 +2535,7 @@ struct MessageTraits<sbp_msg_ssr_gridded_correction_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_ssr_gridded_correction_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_gridded_correction_t(state, sender_id, &msg,
                                                      write);
   }
@@ -2662,8 +2551,7 @@ struct MessageTraits<sbp_msg_ssr_satellite_apc_t> {
     return msg.ssr_satellite_apc;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ssr_satellite_apc_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ssr_satellite_apc_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ssr_satellite_apc_t(state, sender_id, &msg, write);
   }
 };
@@ -2674,7 +2562,7 @@ struct MessageTraits<sbp_msg_osr_t> {
   static const sbp_msg_osr_t &get(const sbp_msg_t &msg) { return msg.osr; }
   static sbp_msg_osr_t &get(sbp_msg_t &msg) { return msg.osr; }
   static s8 send(sbp_state_t *state, u16 sender_id, const sbp_msg_osr_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_osr_t(state, sender_id, &msg, write);
   }
 };
@@ -2687,8 +2575,7 @@ struct MessageTraits<sbp_msg_user_data_t> {
   }
   static sbp_msg_user_data_t &get(sbp_msg_t &msg) { return msg.user_data; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_user_data_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_user_data_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_user_data_t(state, sender_id, &msg, write);
   }
 };
@@ -2701,8 +2588,7 @@ struct MessageTraits<sbp_msg_imu_raw_t> {
   }
   static sbp_msg_imu_raw_t &get(sbp_msg_t &msg) { return msg.imu_raw; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_imu_raw_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_imu_raw_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_imu_raw_t(state, sender_id, &msg, write);
   }
 };
@@ -2715,8 +2601,7 @@ struct MessageTraits<sbp_msg_imu_aux_t> {
   }
   static sbp_msg_imu_aux_t &get(sbp_msg_t &msg) { return msg.imu_aux; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_imu_aux_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_imu_aux_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_imu_aux_t(state, sender_id, &msg, write);
   }
 };
@@ -2729,8 +2614,7 @@ struct MessageTraits<sbp_msg_mag_raw_t> {
   }
   static sbp_msg_mag_raw_t &get(sbp_msg_t &msg) { return msg.mag_raw; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_mag_raw_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_mag_raw_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_mag_raw_t(state, sender_id, &msg, write);
   }
 };
@@ -2743,8 +2627,7 @@ struct MessageTraits<sbp_msg_odometry_t> {
   }
   static sbp_msg_odometry_t &get(sbp_msg_t &msg) { return msg.odometry; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_odometry_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_odometry_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_odometry_t(state, sender_id, &msg, write);
   }
 };
@@ -2757,8 +2640,7 @@ struct MessageTraits<sbp_msg_wheeltick_t> {
   }
   static sbp_msg_wheeltick_t &get(sbp_msg_t &msg) { return msg.wheeltick; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_wheeltick_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_wheeltick_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_wheeltick_t(state, sender_id, &msg, write);
   }
 };
@@ -2773,8 +2655,7 @@ struct MessageTraits<sbp_msg_fileio_config_req_t> {
     return msg.fileio_config_req;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_fileio_config_req_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_fileio_config_req_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_config_req_t(state, sender_id, &msg, write);
   }
 };
@@ -2790,7 +2671,7 @@ struct MessageTraits<sbp_msg_fileio_config_resp_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_fileio_config_resp_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_fileio_config_resp_t(state, sender_id, &msg, write);
   }
 };
@@ -2803,8 +2684,7 @@ struct MessageTraits<sbp_msg_sbas_raw_t> {
   }
   static sbp_msg_sbas_raw_t &get(sbp_msg_t &msg) { return msg.sbas_raw; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_sbas_raw_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_sbas_raw_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_sbas_raw_t(state, sender_id, &msg, write);
   }
 };
@@ -2820,7 +2700,7 @@ struct MessageTraits<sbp_msg_linux_cpu_state_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_cpu_state_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_cpu_state_dep_a_t(state, sender_id, &msg,
                                                     write);
   }
@@ -2837,7 +2717,7 @@ struct MessageTraits<sbp_msg_linux_mem_state_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_mem_state_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_mem_state_dep_a_t(state, sender_id, &msg,
                                                     write);
   }
@@ -2854,7 +2734,7 @@ struct MessageTraits<sbp_msg_linux_sys_state_dep_a_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_sys_state_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_sys_state_dep_a_t(state, sender_id, &msg,
                                                     write);
   }
@@ -2872,7 +2752,7 @@ struct MessageTraits<sbp_msg_linux_process_socket_counts_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_process_socket_counts_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_process_socket_counts_t(state, sender_id,
                                                           &msg, write);
   }
@@ -2890,7 +2770,7 @@ struct MessageTraits<sbp_msg_linux_process_socket_queues_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_process_socket_queues_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_process_socket_queues_t(state, sender_id,
                                                           &msg, write);
   }
@@ -2907,7 +2787,7 @@ struct MessageTraits<sbp_msg_linux_socket_usage_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_socket_usage_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_socket_usage_t(state, sender_id, &msg, write);
   }
 };
@@ -2923,7 +2803,7 @@ struct MessageTraits<sbp_msg_linux_process_fd_count_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_process_fd_count_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_process_fd_count_t(state, sender_id, &msg,
                                                      write);
   }
@@ -2940,7 +2820,7 @@ struct MessageTraits<sbp_msg_linux_process_fd_summary_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_linux_process_fd_summary_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_process_fd_summary_t(state, sender_id, &msg,
                                                        write);
   }
@@ -2956,8 +2836,7 @@ struct MessageTraits<sbp_msg_linux_cpu_state_t> {
     return msg.linux_cpu_state;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_linux_cpu_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_linux_cpu_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_cpu_state_t(state, sender_id, &msg, write);
   }
 };
@@ -2972,8 +2851,7 @@ struct MessageTraits<sbp_msg_linux_mem_state_t> {
     return msg.linux_mem_state;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_linux_mem_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_linux_mem_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_mem_state_t(state, sender_id, &msg, write);
   }
 };
@@ -2988,8 +2866,7 @@ struct MessageTraits<sbp_msg_linux_sys_state_t> {
     return msg.linux_sys_state;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_linux_sys_state_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_linux_sys_state_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_linux_sys_state_t(state, sender_id, &msg, write);
   }
 };
@@ -3002,8 +2879,7 @@ struct MessageTraits<sbp_msg_startup_t> {
   }
   static sbp_msg_startup_t &get(sbp_msg_t &msg) { return msg.startup; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_startup_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_startup_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_startup_t(state, sender_id, &msg, write);
   }
 };
@@ -3018,8 +2894,7 @@ struct MessageTraits<sbp_msg_dgnss_status_t> {
     return msg.dgnss_status;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_dgnss_status_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_dgnss_status_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_dgnss_status_t(state, sender_id, &msg, write);
   }
 };
@@ -3032,8 +2907,7 @@ struct MessageTraits<sbp_msg_ins_status_t> {
   }
   static sbp_msg_ins_status_t &get(sbp_msg_t &msg) { return msg.ins_status; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ins_status_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ins_status_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ins_status_t(state, sender_id, &msg, write);
   }
 };
@@ -3048,8 +2922,7 @@ struct MessageTraits<sbp_msg_csac_telemetry_t> {
     return msg.csac_telemetry;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_csac_telemetry_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_csac_telemetry_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_csac_telemetry_t(state, sender_id, &msg, write);
   }
 };
@@ -3065,7 +2938,7 @@ struct MessageTraits<sbp_msg_csac_telemetry_labels_t> {
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
                  const sbp_msg_csac_telemetry_labels_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 sbp_write_fn_t write) {
     return sbp_send_sbp_msg_csac_telemetry_labels_t(state, sender_id, &msg,
                                                     write);
   }
@@ -3079,8 +2952,7 @@ struct MessageTraits<sbp_msg_ins_updates_t> {
   }
   static sbp_msg_ins_updates_t &get(sbp_msg_t &msg) { return msg.ins_updates; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_ins_updates_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_ins_updates_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_ins_updates_t(state, sender_id, &msg, write);
   }
 };
@@ -3095,8 +2967,7 @@ struct MessageTraits<sbp_msg_gnss_time_offset_t> {
     return msg.gnss_time_offset;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_gnss_time_offset_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_gnss_time_offset_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_gnss_time_offset_t(state, sender_id, &msg, write);
   }
 };
@@ -3109,8 +2980,7 @@ struct MessageTraits<sbp_msg_pps_time_t> {
   }
   static sbp_msg_pps_time_t &get(sbp_msg_t &msg) { return msg.pps_time; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_pps_time_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_pps_time_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_pps_time_t(state, sender_id, &msg, write);
   }
 };
@@ -3123,8 +2993,7 @@ struct MessageTraits<sbp_msg_group_meta_t> {
   }
   static sbp_msg_group_meta_t &get(sbp_msg_t &msg) { return msg.group_meta; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_group_meta_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_group_meta_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_group_meta_t(state, sender_id, &msg, write);
   }
 };
@@ -3137,8 +3006,7 @@ struct MessageTraits<sbp_msg_soln_meta_t> {
   }
   static sbp_msg_soln_meta_t &get(sbp_msg_t &msg) { return msg.soln_meta; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_soln_meta_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_soln_meta_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_soln_meta_t(state, sender_id, &msg, write);
   }
 };
@@ -3153,8 +3021,7 @@ struct MessageTraits<sbp_msg_soln_meta_dep_a_t> {
     return msg.soln_meta_dep_a;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_soln_meta_dep_a_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_soln_meta_dep_a_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_soln_meta_dep_a_t(state, sender_id, &msg, write);
   }
 };
@@ -3169,8 +3036,7 @@ struct MessageTraits<sbp_msg_status_report_t> {
     return msg.status_report;
   }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_status_report_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_status_report_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_status_report_t(state, sender_id, &msg, write);
   }
 };
@@ -3183,8 +3049,7 @@ struct MessageTraits<sbp_msg_heartbeat_t> {
   }
   static sbp_msg_heartbeat_t &get(sbp_msg_t &msg) { return msg.heartbeat; }
   static s8 send(sbp_state_t *state, u16 sender_id,
-                 const sbp_msg_heartbeat_t &msg,
-                 s32 (*write)(u8 *, u32, void *)) {
+                 const sbp_msg_heartbeat_t &msg, sbp_write_fn_t write) {
     return sbp_send_sbp_msg_heartbeat_t(state, sender_id, &msg, write);
   }
 };

--- a/c/include/libsbp/legacy/api.h
+++ b/c/include/libsbp/legacy/api.h
@@ -41,7 +41,7 @@ s8 sbp_all_payload_callback_register(sbp_state_t *s, sbp_frame_callback_t cb,
 s8 sbp_payload_process(sbp_state_t *s, u16 sender_id, u16 msg_type, u8 msg_len,
     u8 payload[]);
 s8 sbp_payload_send(sbp_state_t *s, u16 msg_type, u16 sender_id, u8 len, u8 *payload,
-                    s32 (*write)(u8 *buff, u32 n, void* context));
+                    sbp_write_fn_t write);
 
 #ifdef __cplusplus
 }

--- a/c/include/libsbp/legacy/compat.h
+++ b/c/include/libsbp/legacy/compat.h
@@ -46,7 +46,7 @@ static inline s8 sbp_process_payload(sbp_state_t *s, u16 sender_id, u16 msg_type
 }
 
 SBP_DEPRECATED
-static inline s8 sbp_send_message(sbp_state_t *s, u16 msg_type, u16 sender_id, u8 len, u8 payload[], s32 (*write)(u8 *buff, u32 n, void* context))
+static inline s8 sbp_send_message(sbp_state_t *s, u16 msg_type, u16 sender_id, u8 len, u8 payload[], sbp_write_fn_t write)
 {
   return sbp_payload_send(s, msg_type, sender_id, len, payload, write);
 }

--- a/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT.h
+++ b/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT.h
@@ -139,7 +139,7 @@ s8 sbp_decode_sbp_msg_acq_result_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_acq_result_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_acq_result_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_acq_result_t

--- a/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT_DEP_A.h
+++ b/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT_DEP_A.h
@@ -139,8 +139,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_acq_result_dep_a_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_acq_result_dep_a_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_acq_result_dep_a_t

--- a/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT_DEP_B.h
+++ b/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT_DEP_B.h
@@ -139,8 +139,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_b_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_acq_result_dep_b_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_acq_result_dep_b_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_acq_result_dep_b_t

--- a/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT_DEP_C.h
+++ b/c/include/libsbp/new/acquisition/MSG_ACQ_RESULT_DEP_C.h
@@ -138,8 +138,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_c_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_acq_result_dep_c_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_acq_result_dep_c_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_acq_result_dep_c_t

--- a/c/include/libsbp/new/acquisition/MSG_ACQ_SV_PROFILE.h
+++ b/c/include/libsbp/new/acquisition/MSG_ACQ_SV_PROFILE.h
@@ -135,8 +135,7 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_acq_sv_profile_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_acq_sv_profile_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_acq_sv_profile_t

--- a/c/include/libsbp/new/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
+++ b/c/include/libsbp/new/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
@@ -135,7 +135,7 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_acq_sv_profile_dep_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_dep_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_acq_sv_profile_dep_t

--- a/c/include/libsbp/new/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
+++ b/c/include/libsbp/new/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
@@ -281,8 +281,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(
  */
 s8 sbp_send_sbp_msg_bootloader_handshake_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_bootloader_handshake_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_bootloader_handshake_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_bootloader_handshake_dep_a_t

--- a/c/include/libsbp/new/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
+++ b/c/include/libsbp/new/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
@@ -128,8 +128,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_req_t(
  */
 s8 sbp_send_sbp_msg_bootloader_handshake_req_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_bootloader_handshake_req_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_bootloader_handshake_req_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_bootloader_handshake_req_t

--- a/c/include/libsbp/new/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
+++ b/c/include/libsbp/new/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
@@ -286,8 +286,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_resp_t(
  */
 s8 sbp_send_sbp_msg_bootloader_handshake_resp_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_bootloader_handshake_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_bootloader_handshake_resp_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_bootloader_handshake_resp_t

--- a/c/include/libsbp/new/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
+++ b/c/include/libsbp/new/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
@@ -124,8 +124,7 @@ s8 sbp_decode_sbp_msg_bootloader_jump_to_app_t(
  */
 s8 sbp_send_sbp_msg_bootloader_jump_to_app_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_bootloader_jump_to_app_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_bootloader_jump_to_app_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_bootloader_jump_to_app_t

--- a/c/include/libsbp/new/bootload/MSG_NAP_DEVICE_DNA_REQ.h
+++ b/c/include/libsbp/new/bootload/MSG_NAP_DEVICE_DNA_REQ.h
@@ -127,7 +127,7 @@ s8 sbp_decode_sbp_msg_nap_device_dna_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_nap_device_dna_req_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_req_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_nap_device_dna_req_t

--- a/c/include/libsbp/new/bootload/MSG_NAP_DEVICE_DNA_RESP.h
+++ b/c/include/libsbp/new/bootload/MSG_NAP_DEVICE_DNA_RESP.h
@@ -127,8 +127,7 @@ s8 sbp_decode_sbp_msg_nap_device_dna_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_nap_device_dna_resp_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_nap_device_dna_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_nap_device_dna_resp_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_nap_device_dna_resp_t

--- a/c/include/libsbp/new/ext_events/MSG_EXT_EVENT.h
+++ b/c/include/libsbp/new/ext_events/MSG_EXT_EVENT.h
@@ -140,7 +140,7 @@ s8 sbp_decode_sbp_msg_ext_event_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ext_event_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_ext_event_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ext_event_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_CONFIG_REQ.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_CONFIG_REQ.h
@@ -123,8 +123,7 @@ s8 sbp_decode_sbp_msg_fileio_config_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_config_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_fileio_config_req_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_config_req_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_CONFIG_RESP.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_CONFIG_RESP.h
@@ -140,7 +140,7 @@ s8 sbp_decode_sbp_msg_fileio_config_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_config_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_config_resp_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_READ_DIR_REQ.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_READ_DIR_REQ.h
@@ -291,8 +291,7 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_read_dir_req_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_fileio_read_dir_req_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_fileio_read_dir_req_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_read_dir_req_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_READ_DIR_RESP.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_READ_DIR_RESP.h
@@ -329,8 +329,7 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_resp_t(
  */
 s8 sbp_send_sbp_msg_fileio_read_dir_resp_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_fileio_read_dir_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_fileio_read_dir_resp_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_read_dir_resp_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_READ_REQ.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_READ_REQ.h
@@ -293,8 +293,7 @@ s8 sbp_decode_sbp_msg_fileio_read_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_read_req_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_fileio_read_req_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_read_req_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_READ_RESP.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_READ_RESP.h
@@ -140,8 +140,7 @@ s8 sbp_decode_sbp_msg_fileio_read_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_read_resp_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_fileio_read_resp_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_read_resp_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_REMOVE.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_REMOVE.h
@@ -275,8 +275,7 @@ s8 sbp_decode_sbp_msg_fileio_remove_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_remove_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_fileio_remove_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_remove_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -303,8 +303,7 @@ s8 sbp_decode_sbp_msg_fileio_write_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_write_req_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_fileio_write_req_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_write_req_t

--- a/c/include/libsbp/new/file_io/MSG_FILEIO_WRITE_RESP.h
+++ b/c/include/libsbp/new/file_io/MSG_FILEIO_WRITE_RESP.h
@@ -124,8 +124,7 @@ s8 sbp_decode_sbp_msg_fileio_write_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_fileio_write_resp_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_fileio_write_resp_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fileio_write_resp_t

--- a/c/include/libsbp/new/flash/MSG_FLASH_DONE.h
+++ b/c/include/libsbp/new/flash/MSG_FLASH_DONE.h
@@ -121,7 +121,7 @@ s8 sbp_decode_sbp_msg_flash_done_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_flash_done_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_flash_done_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_flash_done_t

--- a/c/include/libsbp/new/flash/MSG_FLASH_ERASE.h
+++ b/c/include/libsbp/new/flash/MSG_FLASH_ERASE.h
@@ -128,7 +128,7 @@ s8 sbp_decode_sbp_msg_flash_erase_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_flash_erase_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_flash_erase_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_flash_erase_t

--- a/c/include/libsbp/new/flash/MSG_FLASH_PROGRAM.h
+++ b/c/include/libsbp/new/flash/MSG_FLASH_PROGRAM.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_flash_program_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_flash_program_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_flash_program_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_flash_program_t

--- a/c/include/libsbp/new/flash/MSG_FLASH_READ_REQ.h
+++ b/c/include/libsbp/new/flash/MSG_FLASH_READ_REQ.h
@@ -137,8 +137,7 @@ s8 sbp_decode_sbp_msg_flash_read_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_flash_read_req_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_flash_read_req_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_flash_read_req_t

--- a/c/include/libsbp/new/flash/MSG_FLASH_READ_RESP.h
+++ b/c/include/libsbp/new/flash/MSG_FLASH_READ_RESP.h
@@ -137,8 +137,7 @@ s8 sbp_decode_sbp_msg_flash_read_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_flash_read_resp_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_flash_read_resp_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_flash_read_resp_t

--- a/c/include/libsbp/new/flash/MSG_M25_FLASH_WRITE_STATUS.h
+++ b/c/include/libsbp/new/flash/MSG_M25_FLASH_WRITE_STATUS.h
@@ -125,8 +125,7 @@ s8 sbp_decode_sbp_msg_m25_flash_write_status_t(
  */
 s8 sbp_send_sbp_msg_m25_flash_write_status_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_m25_flash_write_status_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_m25_flash_write_status_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_m25_flash_write_status_t

--- a/c/include/libsbp/new/flash/MSG_STM_FLASH_LOCK_SECTOR.h
+++ b/c/include/libsbp/new/flash/MSG_STM_FLASH_LOCK_SECTOR.h
@@ -125,8 +125,7 @@ s8 sbp_decode_sbp_msg_stm_flash_lock_sector_t(
  */
 s8 sbp_send_sbp_msg_stm_flash_lock_sector_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_stm_flash_lock_sector_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_stm_flash_lock_sector_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_stm_flash_lock_sector_t

--- a/c/include/libsbp/new/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
+++ b/c/include/libsbp/new/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
@@ -126,8 +126,7 @@ s8 sbp_decode_sbp_msg_stm_flash_unlock_sector_t(
  */
 s8 sbp_send_sbp_msg_stm_flash_unlock_sector_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_stm_flash_unlock_sector_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_stm_flash_unlock_sector_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_stm_flash_unlock_sector_t

--- a/c/include/libsbp/new/flash/MSG_STM_UNIQUE_ID_REQ.h
+++ b/c/include/libsbp/new/flash/MSG_STM_UNIQUE_ID_REQ.h
@@ -125,8 +125,7 @@ s8 sbp_decode_sbp_msg_stm_unique_id_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_stm_unique_id_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_stm_unique_id_req_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_stm_unique_id_req_t

--- a/c/include/libsbp/new/flash/MSG_STM_UNIQUE_ID_RESP.h
+++ b/c/include/libsbp/new/flash/MSG_STM_UNIQUE_ID_RESP.h
@@ -125,7 +125,7 @@ s8 sbp_decode_sbp_msg_stm_unique_id_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_stm_unique_id_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_stm_unique_id_resp_t

--- a/c/include/libsbp/new/imu/MSG_IMU_AUX.h
+++ b/c/include/libsbp/new/imu/MSG_IMU_AUX.h
@@ -130,7 +130,7 @@ s8 sbp_decode_sbp_msg_imu_aux_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_imu_aux_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_imu_aux_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_imu_aux_t

--- a/c/include/libsbp/new/imu/MSG_IMU_RAW.h
+++ b/c/include/libsbp/new/imu/MSG_IMU_RAW.h
@@ -161,7 +161,7 @@ s8 sbp_decode_sbp_msg_imu_raw_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_imu_raw_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_imu_raw_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_imu_raw_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_CPU_STATE.h
@@ -301,8 +301,7 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_linux_cpu_state_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_linux_cpu_state_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_cpu_state_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -294,8 +294,7 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(
  */
 s8 sbp_send_sbp_msg_linux_cpu_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_cpu_state_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_cpu_state_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_cpu_state_dep_a_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_MEM_STATE.h
@@ -301,8 +301,7 @@ s8 sbp_decode_sbp_msg_linux_mem_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_linux_mem_state_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_linux_mem_state_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_mem_state_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -294,8 +294,7 @@ s8 sbp_decode_sbp_msg_linux_mem_state_dep_a_t(
  */
 s8 sbp_send_sbp_msg_linux_mem_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_mem_state_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_mem_state_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_mem_state_dep_a_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_FD_COUNT.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_FD_COUNT.h
@@ -289,8 +289,7 @@ s8 sbp_decode_sbp_msg_linux_process_fd_count_t(
  */
 s8 sbp_send_sbp_msg_linux_process_fd_count_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_process_fd_count_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_process_fd_count_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_process_fd_count_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
@@ -340,8 +340,7 @@ s8 sbp_decode_sbp_msg_linux_process_fd_summary_t(
  */
 s8 sbp_send_sbp_msg_linux_process_fd_summary_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_process_fd_summary_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_process_fd_summary_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_process_fd_summary_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
@@ -310,8 +310,7 @@ s8 sbp_decode_sbp_msg_linux_process_socket_counts_t(
  */
 s8 sbp_send_sbp_msg_linux_process_socket_counts_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_process_socket_counts_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_process_socket_counts_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_process_socket_counts_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -321,8 +321,7 @@ s8 sbp_decode_sbp_msg_linux_process_socket_queues_t(
  */
 s8 sbp_send_sbp_msg_linux_process_socket_queues_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_process_socket_queues_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_process_socket_queues_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_process_socket_queues_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_SOCKET_USAGE.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_SOCKET_USAGE.h
@@ -139,7 +139,7 @@ s8 sbp_decode_sbp_msg_linux_socket_usage_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_linux_socket_usage_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_linux_socket_usage_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_socket_usage_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_SYS_STATE.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_SYS_STATE.h
@@ -156,8 +156,7 @@ s8 sbp_decode_sbp_msg_linux_sys_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_linux_sys_state_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_linux_sys_state_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_sys_state_t

--- a/c/include/libsbp/new/linux/MSG_LINUX_SYS_STATE_DEP_A.h
+++ b/c/include/libsbp/new/linux/MSG_LINUX_SYS_STATE_DEP_A.h
@@ -149,8 +149,7 @@ s8 sbp_decode_sbp_msg_linux_sys_state_dep_a_t(
  */
 s8 sbp_send_sbp_msg_linux_sys_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_linux_sys_state_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_linux_sys_state_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_linux_sys_state_dep_a_t

--- a/c/include/libsbp/new/logging/MSG_FWD.h
+++ b/c/include/libsbp/new/logging/MSG_FWD.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_fwd_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_fwd_t(struct sbp_state *s, u16 sender_id,
-                          const sbp_msg_fwd_t *msg,
-                          s32 (*write)(u8 *buff, u32 n, void *context));
+                          const sbp_msg_fwd_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_fwd_t

--- a/c/include/libsbp/new/logging/MSG_LOG.h
+++ b/c/include/libsbp/new/logging/MSG_LOG.h
@@ -267,8 +267,7 @@ s8 sbp_decode_sbp_msg_log_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_log_t(struct sbp_state *s, u16 sender_id,
-                          const sbp_msg_log_t *msg,
-                          s32 (*write)(u8 *buff, u32 n, void *context));
+                          const sbp_msg_log_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_log_t

--- a/c/include/libsbp/new/logging/MSG_PRINT_DEP.h
+++ b/c/include/libsbp/new/logging/MSG_PRINT_DEP.h
@@ -265,7 +265,7 @@ s8 sbp_decode_sbp_msg_print_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_print_dep_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_print_dep_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_print_dep_t

--- a/c/include/libsbp/new/mag/MSG_MAG_RAW.h
+++ b/c/include/libsbp/new/mag/MSG_MAG_RAW.h
@@ -139,7 +139,7 @@ s8 sbp_decode_sbp_msg_mag_raw_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_mag_raw_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_mag_raw_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_mag_raw_t

--- a/c/include/libsbp/new/navigation/MSG_AGE_CORRECTIONS.h
+++ b/c/include/libsbp/new/navigation/MSG_AGE_CORRECTIONS.h
@@ -127,8 +127,7 @@ s8 sbp_decode_sbp_msg_age_corrections_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_age_corrections_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_age_corrections_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_age_corrections_t

--- a/c/include/libsbp/new/navigation/MSG_BASELINE_ECEF.h
+++ b/c/include/libsbp/new/navigation/MSG_BASELINE_ECEF.h
@@ -154,8 +154,7 @@ s8 sbp_decode_sbp_msg_baseline_ecef_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_baseline_ecef_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_baseline_ecef_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_baseline_ecef_t

--- a/c/include/libsbp/new/navigation/MSG_BASELINE_ECEF_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_BASELINE_ECEF_DEP_A.h
@@ -155,8 +155,7 @@ s8 sbp_decode_sbp_msg_baseline_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_baseline_ecef_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_baseline_ecef_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_baseline_ecef_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_baseline_ecef_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_BASELINE_HEADING_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_BASELINE_HEADING_DEP_A.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_baseline_heading_dep_a_t(
  */
 s8 sbp_send_sbp_msg_baseline_heading_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_baseline_heading_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_baseline_heading_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_baseline_heading_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_BASELINE_NED.h
+++ b/c/include/libsbp/new/navigation/MSG_BASELINE_NED.h
@@ -161,8 +161,7 @@ s8 sbp_decode_sbp_msg_baseline_ned_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_baseline_ned_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_baseline_ned_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_baseline_ned_t

--- a/c/include/libsbp/new/navigation/MSG_BASELINE_NED_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_BASELINE_NED_DEP_A.h
@@ -163,7 +163,7 @@ s8 sbp_decode_sbp_msg_baseline_ned_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_baseline_ned_dep_a_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_baseline_ned_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_DOPS.h
+++ b/c/include/libsbp/new/navigation/MSG_DOPS.h
@@ -150,8 +150,7 @@ s8 sbp_decode_sbp_msg_dops_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_dops_t(struct sbp_state *s, u16 sender_id,
-                           const sbp_msg_dops_t *msg,
-                           s32 (*write)(u8 *buff, u32 n, void *context));
+                           const sbp_msg_dops_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_dops_t

--- a/c/include/libsbp/new/navigation/MSG_DOPS_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_DOPS_DEP_A.h
@@ -145,7 +145,7 @@ s8 sbp_decode_sbp_msg_dops_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_dops_dep_a_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_dops_dep_a_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_dops_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_GPS_TIME.h
+++ b/c/include/libsbp/new/navigation/MSG_GPS_TIME.h
@@ -138,7 +138,7 @@ s8 sbp_decode_sbp_msg_gps_time_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_gps_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_gps_time_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_gps_time_t

--- a/c/include/libsbp/new/navigation/MSG_GPS_TIME_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_GPS_TIME_DEP_A.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_gps_time_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_gps_time_dep_a_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_gps_time_dep_a_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_gps_time_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_GPS_TIME_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_GPS_TIME_GNSS.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_gps_time_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_gps_time_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_gps_time_gnss_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_gps_time_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_POS_ECEF.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_ECEF.h
@@ -154,7 +154,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_ecef_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_pos_ecef_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_ecef_t

--- a/c/include/libsbp/new/navigation/MSG_POS_ECEF_COV.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_ECEF_COV.h
@@ -183,8 +183,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_ecef_cov_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_pos_ecef_cov_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_ecef_cov_t

--- a/c/include/libsbp/new/navigation/MSG_POS_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_ECEF_COV_GNSS.h
@@ -183,8 +183,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_pos_ecef_cov_gnss_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_ecef_cov_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_POS_ECEF_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_ECEF_DEP_A.h
@@ -157,8 +157,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_ecef_dep_a_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_pos_ecef_dep_a_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_ecef_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_POS_ECEF_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_ECEF_GNSS.h
@@ -157,8 +157,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_ecef_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_pos_ecef_gnss_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_ecef_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_POS_LLH.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_LLH.h
@@ -158,7 +158,7 @@ s8 sbp_decode_sbp_msg_pos_llh_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_llh_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_pos_llh_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_llh_t

--- a/c/include/libsbp/new/navigation/MSG_POS_LLH_COV.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_LLH_COV.h
@@ -182,7 +182,7 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_llh_cov_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_pos_llh_cov_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_llh_cov_t

--- a/c/include/libsbp/new/navigation/MSG_POS_LLH_COV_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_LLH_COV_GNSS.h
@@ -183,8 +183,7 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_llh_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_pos_llh_cov_gnss_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_llh_cov_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_POS_LLH_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_LLH_DEP_A.h
@@ -162,8 +162,7 @@ s8 sbp_decode_sbp_msg_pos_llh_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_llh_dep_a_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_pos_llh_dep_a_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_llh_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_POS_LLH_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_POS_LLH_GNSS.h
@@ -161,8 +161,7 @@ s8 sbp_decode_sbp_msg_pos_llh_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pos_llh_gnss_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_pos_llh_gnss_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pos_llh_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_PROTECTION_LEVEL.h
+++ b/c/include/libsbp/new/navigation/MSG_PROTECTION_LEVEL.h
@@ -225,8 +225,7 @@ s8 sbp_decode_sbp_msg_protection_level_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_protection_level_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_protection_level_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_protection_level_t

--- a/c/include/libsbp/new/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
@@ -156,8 +156,7 @@ s8 sbp_decode_sbp_msg_protection_level_dep_a_t(
  */
 s8 sbp_send_sbp_msg_protection_level_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_protection_level_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_protection_level_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_protection_level_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_UTC_TIME.h
+++ b/c/include/libsbp/new/navigation/MSG_UTC_TIME.h
@@ -159,7 +159,7 @@ s8 sbp_decode_sbp_msg_utc_time_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_utc_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_utc_time_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_utc_time_t

--- a/c/include/libsbp/new/navigation/MSG_UTC_TIME_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_UTC_TIME_GNSS.h
@@ -162,8 +162,7 @@ s8 sbp_decode_sbp_msg_utc_time_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_utc_time_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_utc_time_gnss_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_utc_time_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_BODY.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_BODY.h
@@ -181,7 +181,7 @@ s8 sbp_decode_sbp_msg_vel_body_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_body_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_vel_body_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_body_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_ECEF.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_ECEF.h
@@ -150,7 +150,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ecef_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_vel_ecef_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ecef_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_ECEF_COV.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_ECEF_COV.h
@@ -178,8 +178,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ecef_cov_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_vel_ecef_cov_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ecef_cov_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_ECEF_COV_GNSS.h
@@ -178,8 +178,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_vel_ecef_cov_gnss_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ecef_cov_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_ECEF_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_ECEF_DEP_A.h
@@ -153,8 +153,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ecef_dep_a_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_vel_ecef_dep_a_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ecef_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_ECEF_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_ECEF_GNSS.h
@@ -153,8 +153,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ecef_gnss_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_vel_ecef_gnss_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ecef_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_NED.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_NED.h
@@ -156,7 +156,7 @@ s8 sbp_decode_sbp_msg_vel_ned_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ned_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_vel_ned_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ned_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_NED_COV.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_NED_COV.h
@@ -180,7 +180,7 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ned_cov_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_vel_ned_cov_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ned_cov_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_NED_COV_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_NED_COV_GNSS.h
@@ -181,8 +181,7 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ned_cov_gnss_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_vel_ned_cov_gnss_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ned_cov_gnss_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_NED_DEP_A.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_NED_DEP_A.h
@@ -161,8 +161,7 @@ s8 sbp_decode_sbp_msg_vel_ned_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ned_dep_a_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_vel_ned_dep_a_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ned_dep_a_t

--- a/c/include/libsbp/new/navigation/MSG_VEL_NED_GNSS.h
+++ b/c/include/libsbp/new/navigation/MSG_VEL_NED_GNSS.h
@@ -159,8 +159,7 @@ s8 sbp_decode_sbp_msg_vel_ned_gnss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_vel_ned_gnss_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_vel_ned_gnss_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_vel_ned_gnss_t

--- a/c/include/libsbp/new/ndb/MSG_NDB_EVENT.h
+++ b/c/include/libsbp/new/ndb/MSG_NDB_EVENT.h
@@ -161,7 +161,7 @@ s8 sbp_decode_sbp_msg_ndb_event_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ndb_event_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_ndb_event_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ndb_event_t

--- a/c/include/libsbp/new/observation/MSG_ALMANAC_GLO.h
+++ b/c/include/libsbp/new/observation/MSG_ALMANAC_GLO.h
@@ -161,7 +161,7 @@ s8 sbp_decode_sbp_msg_almanac_glo_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_almanac_glo_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_almanac_glo_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_almanac_glo_t

--- a/c/include/libsbp/new/observation/MSG_ALMANAC_GLO_DEP.h
+++ b/c/include/libsbp/new/observation/MSG_ALMANAC_GLO_DEP.h
@@ -162,8 +162,7 @@ s8 sbp_decode_sbp_msg_almanac_glo_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_almanac_glo_dep_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_almanac_glo_dep_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_almanac_glo_dep_t

--- a/c/include/libsbp/new/observation/MSG_ALMANAC_GPS.h
+++ b/c/include/libsbp/new/observation/MSG_ALMANAC_GPS.h
@@ -170,7 +170,7 @@ s8 sbp_decode_sbp_msg_almanac_gps_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_almanac_gps_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_almanac_gps_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_almanac_gps_t

--- a/c/include/libsbp/new/observation/MSG_ALMANAC_GPS_DEP.h
+++ b/c/include/libsbp/new/observation/MSG_ALMANAC_GPS_DEP.h
@@ -171,8 +171,7 @@ s8 sbp_decode_sbp_msg_almanac_gps_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_almanac_gps_dep_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_almanac_gps_dep_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_almanac_gps_dep_t

--- a/c/include/libsbp/new/observation/MSG_BASE_POS_ECEF.h
+++ b/c/include/libsbp/new/observation/MSG_BASE_POS_ECEF.h
@@ -136,8 +136,7 @@ s8 sbp_decode_sbp_msg_base_pos_ecef_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_base_pos_ecef_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_base_pos_ecef_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_base_pos_ecef_t

--- a/c/include/libsbp/new/observation/MSG_BASE_POS_LLH.h
+++ b/c/include/libsbp/new/observation/MSG_BASE_POS_LLH.h
@@ -135,8 +135,7 @@ s8 sbp_decode_sbp_msg_base_pos_llh_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_base_pos_llh_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_base_pos_llh_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_base_pos_llh_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_BDS.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_BDS.h
@@ -250,8 +250,7 @@ s8 sbp_decode_sbp_msg_ephemeris_bds_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_bds_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_bds_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_bds_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_A.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_A.h
@@ -251,8 +251,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_dep_a_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_a_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_dep_a_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_B.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_B.h
@@ -256,8 +256,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_b_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_dep_b_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_b_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_dep_b_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_C.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_C.h
@@ -270,8 +270,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_c_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_dep_c_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_c_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_dep_c_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_D.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_DEP_D.h
@@ -270,8 +270,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_d_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_dep_d_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ephemeris_dep_d_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_dep_d_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GAL.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GAL.h
@@ -251,8 +251,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_gal_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gal_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_gal_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GAL_DEP_A.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GAL_DEP_A.h
@@ -245,8 +245,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_gal_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_gal_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_gal_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_gal_dep_a_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO.h
@@ -166,8 +166,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_glo_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_glo_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_glo_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_A.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_A.h
@@ -152,8 +152,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_glo_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_glo_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_glo_dep_a_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_B.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_B.h
@@ -152,8 +152,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_b_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_b_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_glo_dep_b_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_glo_dep_b_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_glo_dep_b_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_C.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_C.h
@@ -162,8 +162,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_c_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_c_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_glo_dep_c_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_glo_dep_c_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_glo_dep_c_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_D.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GLO_DEP_D.h
@@ -165,8 +165,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_d_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_glo_dep_d_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_glo_dep_d_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_glo_dep_d_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_glo_dep_d_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GPS.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GPS.h
@@ -241,8 +241,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_gps_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_ephemeris_gps_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_gps_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GPS_DEP_E.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GPS_DEP_E.h
@@ -242,8 +242,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_e_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_gps_dep_e_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_gps_dep_e_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_gps_dep_e_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_gps_dep_e_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_GPS_DEP_F.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_GPS_DEP_F.h
@@ -240,8 +240,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_f_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_gps_dep_f_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_gps_dep_f_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_gps_dep_f_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_gps_dep_f_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_QZSS.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_QZSS.h
@@ -239,8 +239,7 @@ s8 sbp_decode_sbp_msg_ephemeris_qzss_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_qzss_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_ephemeris_qzss_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_qzss_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_SBAS.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_SBAS.h
@@ -144,8 +144,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ephemeris_sbas_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_ephemeris_sbas_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_sbas_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
@@ -145,8 +145,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_a_t(
  */
 s8 sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_sbas_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_sbas_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_sbas_dep_a_t

--- a/c/include/libsbp/new/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
+++ b/c/include/libsbp/new/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
@@ -150,8 +150,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_b_t(
  */
 s8 sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ephemeris_sbas_dep_b_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ephemeris_sbas_dep_b_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ephemeris_sbas_dep_b_t

--- a/c/include/libsbp/new/observation/MSG_GLO_BIASES.h
+++ b/c/include/libsbp/new/observation/MSG_GLO_BIASES.h
@@ -142,7 +142,7 @@ s8 sbp_decode_sbp_msg_glo_biases_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_glo_biases_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_glo_biases_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_glo_biases_t

--- a/c/include/libsbp/new/observation/MSG_GNSS_CAPB.h
+++ b/c/include/libsbp/new/observation/MSG_GNSS_CAPB.h
@@ -122,7 +122,7 @@ s8 sbp_decode_sbp_msg_gnss_capb_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_gnss_capb_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_gnss_capb_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_gnss_capb_t

--- a/c/include/libsbp/new/observation/MSG_GROUP_DELAY.h
+++ b/c/include/libsbp/new/observation/MSG_GROUP_DELAY.h
@@ -140,7 +140,7 @@ s8 sbp_decode_sbp_msg_group_delay_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_group_delay_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_group_delay_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_group_delay_t

--- a/c/include/libsbp/new/observation/MSG_GROUP_DELAY_DEP_A.h
+++ b/c/include/libsbp/new/observation/MSG_GROUP_DELAY_DEP_A.h
@@ -140,8 +140,7 @@ s8 sbp_decode_sbp_msg_group_delay_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_group_delay_dep_a_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_group_delay_dep_a_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_group_delay_dep_a_t

--- a/c/include/libsbp/new/observation/MSG_GROUP_DELAY_DEP_B.h
+++ b/c/include/libsbp/new/observation/MSG_GROUP_DELAY_DEP_B.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_group_delay_dep_b_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_group_delay_dep_b_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_group_delay_dep_b_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_group_delay_dep_b_t

--- a/c/include/libsbp/new/observation/MSG_IONO.h
+++ b/c/include/libsbp/new/observation/MSG_IONO.h
@@ -137,8 +137,7 @@ s8 sbp_decode_sbp_msg_iono_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_iono_t(struct sbp_state *s, u16 sender_id,
-                           const sbp_msg_iono_t *msg,
-                           s32 (*write)(u8 *buff, u32 n, void *context));
+                           const sbp_msg_iono_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_iono_t

--- a/c/include/libsbp/new/observation/MSG_OBS.h
+++ b/c/include/libsbp/new/observation/MSG_OBS.h
@@ -141,8 +141,7 @@ s8 sbp_decode_sbp_msg_obs_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_obs_t(struct sbp_state *s, u16 sender_id,
-                          const sbp_msg_obs_t *msg,
-                          s32 (*write)(u8 *buff, u32 n, void *context));
+                          const sbp_msg_obs_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_obs_t

--- a/c/include/libsbp/new/observation/MSG_OBS_DEP_A.h
+++ b/c/include/libsbp/new/observation/MSG_OBS_DEP_A.h
@@ -137,7 +137,7 @@ s8 sbp_decode_sbp_msg_obs_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_obs_dep_a_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_obs_dep_a_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_obs_dep_a_t

--- a/c/include/libsbp/new/observation/MSG_OBS_DEP_B.h
+++ b/c/include/libsbp/new/observation/MSG_OBS_DEP_B.h
@@ -140,7 +140,7 @@ s8 sbp_decode_sbp_msg_obs_dep_b_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_obs_dep_b_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_obs_dep_b_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_obs_dep_b_t

--- a/c/include/libsbp/new/observation/MSG_OBS_DEP_C.h
+++ b/c/include/libsbp/new/observation/MSG_OBS_DEP_C.h
@@ -142,7 +142,7 @@ s8 sbp_decode_sbp_msg_obs_dep_c_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_obs_dep_c_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_obs_dep_c_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_obs_dep_c_t

--- a/c/include/libsbp/new/observation/MSG_OSR.h
+++ b/c/include/libsbp/new/observation/MSG_OSR.h
@@ -136,8 +136,7 @@ s8 sbp_decode_sbp_msg_osr_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_osr_t(struct sbp_state *s, u16 sender_id,
-                          const sbp_msg_osr_t *msg,
-                          s32 (*write)(u8 *buff, u32 n, void *context));
+                          const sbp_msg_osr_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_osr_t

--- a/c/include/libsbp/new/observation/MSG_SV_AZ_EL.h
+++ b/c/include/libsbp/new/observation/MSG_SV_AZ_EL.h
@@ -132,7 +132,7 @@ s8 sbp_decode_sbp_msg_sv_az_el_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_sv_az_el_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_sv_az_el_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_sv_az_el_t

--- a/c/include/libsbp/new/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
+++ b/c/include/libsbp/new/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
@@ -132,8 +132,7 @@ s8 sbp_decode_sbp_msg_sv_configuration_gps_dep_t(
  */
 s8 sbp_send_sbp_msg_sv_configuration_gps_dep_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_sv_configuration_gps_dep_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_sv_configuration_gps_dep_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_sv_configuration_gps_dep_t

--- a/c/include/libsbp/new/orientation/MSG_ANGULAR_RATE.h
+++ b/c/include/libsbp/new/orientation/MSG_ANGULAR_RATE.h
@@ -149,8 +149,7 @@ s8 sbp_decode_sbp_msg_angular_rate_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_angular_rate_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_angular_rate_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_angular_rate_t

--- a/c/include/libsbp/new/orientation/MSG_BASELINE_HEADING.h
+++ b/c/include/libsbp/new/orientation/MSG_BASELINE_HEADING.h
@@ -139,8 +139,7 @@ s8 sbp_decode_sbp_msg_baseline_heading_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_baseline_heading_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_baseline_heading_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_baseline_heading_t

--- a/c/include/libsbp/new/orientation/MSG_ORIENT_EULER.h
+++ b/c/include/libsbp/new/orientation/MSG_ORIENT_EULER.h
@@ -161,8 +161,7 @@ s8 sbp_decode_sbp_msg_orient_euler_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_orient_euler_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_orient_euler_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_orient_euler_t

--- a/c/include/libsbp/new/orientation/MSG_ORIENT_QUAT.h
+++ b/c/include/libsbp/new/orientation/MSG_ORIENT_QUAT.h
@@ -169,7 +169,7 @@ s8 sbp_decode_sbp_msg_orient_quat_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_orient_quat_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_orient_quat_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_orient_quat_t

--- a/c/include/libsbp/new/piksi/MSG_ALMANAC.h
+++ b/c/include/libsbp/new/piksi/MSG_ALMANAC.h
@@ -121,7 +121,7 @@ s8 sbp_decode_sbp_msg_almanac_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_almanac_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_almanac_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_almanac_t

--- a/c/include/libsbp/new/piksi/MSG_CELL_MODEM_STATUS.h
+++ b/c/include/libsbp/new/piksi/MSG_CELL_MODEM_STATUS.h
@@ -145,8 +145,7 @@ s8 sbp_decode_sbp_msg_cell_modem_status_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_cell_modem_status_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_cell_modem_status_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_cell_modem_status_t

--- a/c/include/libsbp/new/piksi/MSG_COMMAND_OUTPUT.h
+++ b/c/include/libsbp/new/piksi/MSG_COMMAND_OUTPUT.h
@@ -278,8 +278,7 @@ s8 sbp_decode_sbp_msg_command_output_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_command_output_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_command_output_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_command_output_t

--- a/c/include/libsbp/new/piksi/MSG_COMMAND_REQ.h
+++ b/c/include/libsbp/new/piksi/MSG_COMMAND_REQ.h
@@ -276,7 +276,7 @@ s8 sbp_decode_sbp_msg_command_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_command_req_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_command_req_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_command_req_t

--- a/c/include/libsbp/new/piksi/MSG_COMMAND_RESP.h
+++ b/c/include/libsbp/new/piksi/MSG_COMMAND_RESP.h
@@ -128,8 +128,7 @@ s8 sbp_decode_sbp_msg_command_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_command_resp_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_command_resp_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_command_resp_t

--- a/c/include/libsbp/new/piksi/MSG_CW_RESULTS.h
+++ b/c/include/libsbp/new/piksi/MSG_CW_RESULTS.h
@@ -123,7 +123,7 @@ s8 sbp_decode_sbp_msg_cw_results_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_cw_results_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_cw_results_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_cw_results_t

--- a/c/include/libsbp/new/piksi/MSG_CW_START.h
+++ b/c/include/libsbp/new/piksi/MSG_CW_START.h
@@ -122,7 +122,7 @@ s8 sbp_decode_sbp_msg_cw_start_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_cw_start_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_cw_start_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_cw_start_t

--- a/c/include/libsbp/new/piksi/MSG_DEVICE_MONITOR.h
+++ b/c/include/libsbp/new/piksi/MSG_DEVICE_MONITOR.h
@@ -144,8 +144,7 @@ s8 sbp_decode_sbp_msg_device_monitor_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_device_monitor_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_device_monitor_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_device_monitor_t

--- a/c/include/libsbp/new/piksi/MSG_FRONT_END_GAIN.h
+++ b/c/include/libsbp/new/piksi/MSG_FRONT_END_GAIN.h
@@ -133,8 +133,7 @@ s8 sbp_decode_sbp_msg_front_end_gain_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_front_end_gain_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_front_end_gain_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_front_end_gain_t

--- a/c/include/libsbp/new/piksi/MSG_IAR_STATE.h
+++ b/c/include/libsbp/new/piksi/MSG_IAR_STATE.h
@@ -121,7 +121,7 @@ s8 sbp_decode_sbp_msg_iar_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_iar_state_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_iar_state_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_iar_state_t

--- a/c/include/libsbp/new/piksi/MSG_INIT_BASE_DEP.h
+++ b/c/include/libsbp/new/piksi/MSG_INIT_BASE_DEP.h
@@ -123,8 +123,7 @@ s8 sbp_decode_sbp_msg_init_base_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_init_base_dep_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_init_base_dep_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_init_base_dep_t

--- a/c/include/libsbp/new/piksi/MSG_MASK_SATELLITE.h
+++ b/c/include/libsbp/new/piksi/MSG_MASK_SATELLITE.h
@@ -129,8 +129,7 @@ s8 sbp_decode_sbp_msg_mask_satellite_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_mask_satellite_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_mask_satellite_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_mask_satellite_t

--- a/c/include/libsbp/new/piksi/MSG_MASK_SATELLITE_DEP.h
+++ b/c/include/libsbp/new/piksi/MSG_MASK_SATELLITE_DEP.h
@@ -129,7 +129,7 @@ s8 sbp_decode_sbp_msg_mask_satellite_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_mask_satellite_dep_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_dep_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_mask_satellite_dep_t

--- a/c/include/libsbp/new/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
+++ b/c/include/libsbp/new/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
@@ -138,8 +138,7 @@ s8 sbp_decode_sbp_msg_network_bandwidth_usage_t(
  */
 s8 sbp_send_sbp_msg_network_bandwidth_usage_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_network_bandwidth_usage_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_network_bandwidth_usage_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_network_bandwidth_usage_t

--- a/c/include/libsbp/new/piksi/MSG_NETWORK_STATE_REQ.h
+++ b/c/include/libsbp/new/piksi/MSG_NETWORK_STATE_REQ.h
@@ -124,8 +124,7 @@ s8 sbp_decode_sbp_msg_network_state_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_network_state_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_network_state_req_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_network_state_req_t

--- a/c/include/libsbp/new/piksi/MSG_NETWORK_STATE_RESP.h
+++ b/c/include/libsbp/new/piksi/MSG_NETWORK_STATE_RESP.h
@@ -159,7 +159,7 @@ s8 sbp_decode_sbp_msg_network_state_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_network_state_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_network_state_resp_t

--- a/c/include/libsbp/new/piksi/MSG_RESET.h
+++ b/c/include/libsbp/new/piksi/MSG_RESET.h
@@ -118,8 +118,7 @@ s8 sbp_decode_sbp_msg_reset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_reset_t(struct sbp_state *s, u16 sender_id,
-                            const sbp_msg_reset_t *msg,
-                            s32 (*write)(u8 *buff, u32 n, void *context));
+                            const sbp_msg_reset_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_reset_t

--- a/c/include/libsbp/new/piksi/MSG_RESET_DEP.h
+++ b/c/include/libsbp/new/piksi/MSG_RESET_DEP.h
@@ -120,7 +120,7 @@ s8 sbp_decode_sbp_msg_reset_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_reset_dep_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_reset_dep_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_reset_dep_t

--- a/c/include/libsbp/new/piksi/MSG_RESET_FILTERS.h
+++ b/c/include/libsbp/new/piksi/MSG_RESET_FILTERS.h
@@ -123,8 +123,7 @@ s8 sbp_decode_sbp_msg_reset_filters_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_reset_filters_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_reset_filters_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_reset_filters_t

--- a/c/include/libsbp/new/piksi/MSG_SET_TIME.h
+++ b/c/include/libsbp/new/piksi/MSG_SET_TIME.h
@@ -121,7 +121,7 @@ s8 sbp_decode_sbp_msg_set_time_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_set_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_set_time_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_set_time_t

--- a/c/include/libsbp/new/piksi/MSG_SPECAN.h
+++ b/c/include/libsbp/new/piksi/MSG_SPECAN.h
@@ -160,8 +160,7 @@ s8 sbp_decode_sbp_msg_specan_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
  * @param SBP_OK on success, or other libsbp error code
  */
 s8 sbp_send_sbp_msg_specan_t(struct sbp_state *s, u16 sender_id,
-                             const sbp_msg_specan_t *msg,
-                             s32 (*write)(u8 *buff, u32 n, void *context));
+                             const sbp_msg_specan_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_specan_t

--- a/c/include/libsbp/new/piksi/MSG_SPECAN_DEP.h
+++ b/c/include/libsbp/new/piksi/MSG_SPECAN_DEP.h
@@ -162,7 +162,7 @@ s8 sbp_decode_sbp_msg_specan_dep_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_specan_dep_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_specan_dep_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_specan_dep_t

--- a/c/include/libsbp/new/piksi/MSG_THREAD_STATE.h
+++ b/c/include/libsbp/new/piksi/MSG_THREAD_STATE.h
@@ -135,8 +135,7 @@ s8 sbp_decode_sbp_msg_thread_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_thread_state_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_thread_state_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_thread_state_t

--- a/c/include/libsbp/new/piksi/MSG_UART_STATE.h
+++ b/c/include/libsbp/new/piksi/MSG_UART_STATE.h
@@ -150,7 +150,7 @@ s8 sbp_decode_sbp_msg_uart_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_uart_state_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_uart_state_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_uart_state_t

--- a/c/include/libsbp/new/piksi/MSG_UART_STATE_DEPA.h
+++ b/c/include/libsbp/new/piksi/MSG_UART_STATE_DEPA.h
@@ -139,8 +139,7 @@ s8 sbp_decode_sbp_msg_uart_state_depa_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_uart_state_depa_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_uart_state_depa_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_uart_state_depa_t

--- a/c/include/libsbp/new/sbas/MSG_SBAS_RAW.h
+++ b/c/include/libsbp/new/sbas/MSG_SBAS_RAW.h
@@ -136,7 +136,7 @@ s8 sbp_decode_sbp_msg_sbas_raw_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_sbas_raw_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_sbas_raw_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_sbas_raw_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
@@ -127,8 +127,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_done_t(
  */
 s8 sbp_send_sbp_msg_settings_read_by_index_done_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_settings_read_by_index_done_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_settings_read_by_index_done_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_read_by_index_done_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
@@ -128,8 +128,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_req_t(
  */
 s8 sbp_send_sbp_msg_settings_read_by_index_req_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_settings_read_by_index_req_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_settings_read_by_index_req_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_read_by_index_req_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
@@ -337,8 +337,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_resp_t(
  */
 s8 sbp_send_sbp_msg_settings_read_by_index_resp_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_settings_read_by_index_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_settings_read_by_index_resp_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_read_by_index_resp_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_READ_REQ.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_READ_REQ.h
@@ -323,8 +323,7 @@ s8 sbp_decode_sbp_msg_settings_read_req_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_settings_read_req_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_settings_read_req_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_read_req_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_READ_RESP.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_READ_RESP.h
@@ -324,7 +324,7 @@ s8 sbp_decode_sbp_msg_settings_read_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_settings_read_resp_t(
     struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_read_resp_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_REGISTER.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_REGISTER.h
@@ -319,8 +319,7 @@ s8 sbp_decode_sbp_msg_settings_register_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_settings_register_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_settings_register_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_register_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_REGISTER_RESP.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_REGISTER_RESP.h
@@ -332,8 +332,7 @@ s8 sbp_decode_sbp_msg_settings_register_resp_t(
  */
 s8 sbp_send_sbp_msg_settings_register_resp_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_settings_register_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_settings_register_resp_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_register_resp_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_SAVE.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_SAVE.h
@@ -123,8 +123,7 @@ s8 sbp_decode_sbp_msg_settings_save_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_settings_save_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_settings_save_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_save_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_WRITE.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_WRITE.h
@@ -324,8 +324,7 @@ s8 sbp_decode_sbp_msg_settings_write_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_settings_write_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_settings_write_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_write_t

--- a/c/include/libsbp/new/settings/MSG_SETTINGS_WRITE_RESP.h
+++ b/c/include/libsbp/new/settings/MSG_SETTINGS_WRITE_RESP.h
@@ -329,8 +329,7 @@ s8 sbp_decode_sbp_msg_settings_write_resp_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_settings_write_resp_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_settings_write_resp_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_settings_write_resp_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_settings_write_resp_t

--- a/c/include/libsbp/new/solution_meta/MSG_SOLN_META.h
+++ b/c/include/libsbp/new/solution_meta/MSG_SOLN_META.h
@@ -175,7 +175,7 @@ s8 sbp_decode_sbp_msg_soln_meta_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_soln_meta_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_soln_meta_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_soln_meta_t

--- a/c/include/libsbp/new/solution_meta/MSG_SOLN_META_DEP_A.h
+++ b/c/include/libsbp/new/solution_meta/MSG_SOLN_META_DEP_A.h
@@ -181,8 +181,7 @@ s8 sbp_decode_sbp_msg_soln_meta_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_soln_meta_dep_a_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_soln_meta_dep_a_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_soln_meta_dep_a_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_CODE_BIASES.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_CODE_BIASES.h
@@ -160,8 +160,7 @@ s8 sbp_decode_sbp_msg_ssr_code_biases_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ssr_code_biases_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ssr_code_biases_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_code_biases_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_GRIDDED_CORRECTION.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_GRIDDED_CORRECTION.h
@@ -155,8 +155,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_t(
  */
 s8 sbp_send_sbp_msg_ssr_gridded_correction_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_gridded_correction_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_gridded_correction_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_gridded_correction_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
@@ -152,8 +152,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(
  */
 s8 sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_gridded_correction_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_gridded_correction_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_gridded_correction_dep_a_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
@@ -155,7 +155,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
 s8 sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(
     struct sbp_state *s, u16 sender_id,
     const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_gridded_correction_no_std_dep_a_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
@@ -142,8 +142,7 @@ s8 sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(
  */
 s8 sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_grid_definition_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_grid_definition_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_grid_definition_dep_a_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_ORBIT_CLOCK.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_ORBIT_CLOCK.h
@@ -196,8 +196,7 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ssr_orbit_clock_t(struct sbp_state *s, u16 sender_id,
                                       const sbp_msg_ssr_orbit_clock_t *msg,
-                                      s32 (*write)(u8 *buff, u32 n,
-                                                   void *context));
+                                      sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_orbit_clock_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
@@ -193,8 +193,7 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(
  */
 s8 sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_orbit_clock_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_orbit_clock_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_orbit_clock_dep_a_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_PHASE_BIASES.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_PHASE_BIASES.h
@@ -182,8 +182,7 @@ s8 sbp_decode_sbp_msg_ssr_phase_biases_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ssr_phase_biases_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_ssr_phase_biases_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_phase_biases_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_SATELLITE_APC.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_SATELLITE_APC.h
@@ -130,8 +130,7 @@ s8 sbp_decode_sbp_msg_ssr_satellite_apc_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ssr_satellite_apc_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_ssr_satellite_apc_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_satellite_apc_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_STEC_CORRECTION.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_STEC_CORRECTION.h
@@ -145,8 +145,7 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ssr_stec_correction_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_stec_correction_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_stec_correction_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_stec_correction_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
@@ -140,8 +140,7 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(
  */
 s8 sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_stec_correction_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_stec_correction_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_stec_correction_dep_a_t

--- a/c/include/libsbp/new/ssr/MSG_SSR_TILE_DEFINITION.h
+++ b/c/include/libsbp/new/ssr/MSG_SSR_TILE_DEFINITION.h
@@ -205,8 +205,7 @@ s8 sbp_decode_sbp_msg_ssr_tile_definition_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ssr_tile_definition_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_ssr_tile_definition_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_ssr_tile_definition_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ssr_tile_definition_t

--- a/c/include/libsbp/new/system/MSG_CSAC_TELEMETRY.h
+++ b/c/include/libsbp/new/system/MSG_CSAC_TELEMETRY.h
@@ -278,8 +278,7 @@ s8 sbp_decode_sbp_msg_csac_telemetry_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_csac_telemetry_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_csac_telemetry_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_csac_telemetry_t

--- a/c/include/libsbp/new/system/MSG_CSAC_TELEMETRY_LABELS.h
+++ b/c/include/libsbp/new/system/MSG_CSAC_TELEMETRY_LABELS.h
@@ -288,8 +288,7 @@ s8 sbp_decode_sbp_msg_csac_telemetry_labels_t(
  */
 s8 sbp_send_sbp_msg_csac_telemetry_labels_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_csac_telemetry_labels_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_csac_telemetry_labels_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_csac_telemetry_labels_t

--- a/c/include/libsbp/new/system/MSG_DGNSS_STATUS.h
+++ b/c/include/libsbp/new/system/MSG_DGNSS_STATUS.h
@@ -287,8 +287,7 @@ s8 sbp_decode_sbp_msg_dgnss_status_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_dgnss_status_t(struct sbp_state *s, u16 sender_id,
                                    const sbp_msg_dgnss_status_t *msg,
-                                   s32 (*write)(u8 *buff, u32 n,
-                                                void *context));
+                                   sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_dgnss_status_t

--- a/c/include/libsbp/new/system/MSG_GNSS_TIME_OFFSET.h
+++ b/c/include/libsbp/new/system/MSG_GNSS_TIME_OFFSET.h
@@ -138,8 +138,7 @@ s8 sbp_decode_sbp_msg_gnss_time_offset_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_gnss_time_offset_t(struct sbp_state *s, u16 sender_id,
                                        const sbp_msg_gnss_time_offset_t *msg,
-                                       s32 (*write)(u8 *buff, u32 n,
-                                                    void *context));
+                                       sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_gnss_time_offset_t

--- a/c/include/libsbp/new/system/MSG_GROUP_META.h
+++ b/c/include/libsbp/new/system/MSG_GROUP_META.h
@@ -137,7 +137,7 @@ s8 sbp_decode_sbp_msg_group_meta_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_group_meta_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_group_meta_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_group_meta_t

--- a/c/include/libsbp/new/system/MSG_HEARTBEAT.h
+++ b/c/include/libsbp/new/system/MSG_HEARTBEAT.h
@@ -123,7 +123,7 @@ s8 sbp_decode_sbp_msg_heartbeat_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_heartbeat_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_heartbeat_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_heartbeat_t

--- a/c/include/libsbp/new/system/MSG_INS_STATUS.h
+++ b/c/include/libsbp/new/system/MSG_INS_STATUS.h
@@ -120,7 +120,7 @@ s8 sbp_decode_sbp_msg_ins_status_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ins_status_t(struct sbp_state *s, u16 sender_id,
                                  const sbp_msg_ins_status_t *msg,
-                                 s32 (*write)(u8 *buff, u32 n, void *context));
+                                 sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ins_status_t

--- a/c/include/libsbp/new/system/MSG_INS_UPDATES.h
+++ b/c/include/libsbp/new/system/MSG_INS_UPDATES.h
@@ -152,7 +152,7 @@ s8 sbp_decode_sbp_msg_ins_updates_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_ins_updates_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_ins_updates_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_ins_updates_t

--- a/c/include/libsbp/new/system/MSG_PPS_TIME.h
+++ b/c/include/libsbp/new/system/MSG_PPS_TIME.h
@@ -127,7 +127,7 @@ s8 sbp_decode_sbp_msg_pps_time_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_pps_time_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_pps_time_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_pps_time_t

--- a/c/include/libsbp/new/system/MSG_STARTUP.h
+++ b/c/include/libsbp/new/system/MSG_STARTUP.h
@@ -130,7 +130,7 @@ s8 sbp_decode_sbp_msg_startup_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_startup_t(struct sbp_state *s, u16 sender_id,
                               const sbp_msg_startup_t *msg,
-                              s32 (*write)(u8 *buff, u32 n, void *context));
+                              sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_startup_t

--- a/c/include/libsbp/new/system/MSG_STATUS_REPORT.h
+++ b/c/include/libsbp/new/system/MSG_STATUS_REPORT.h
@@ -157,8 +157,7 @@ s8 sbp_decode_sbp_msg_status_report_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_status_report_t(struct sbp_state *s, u16 sender_id,
                                     const sbp_msg_status_report_t *msg,
-                                    s32 (*write)(u8 *buff, u32 n,
-                                                 void *context));
+                                    sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_status_report_t

--- a/c/include/libsbp/new/tracking/MSG_MEASUREMENT_STATE.h
+++ b/c/include/libsbp/new/tracking/MSG_MEASUREMENT_STATE.h
@@ -136,8 +136,7 @@ s8 sbp_decode_sbp_msg_measurement_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_measurement_state_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_measurement_state_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_measurement_state_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_IQ.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_IQ.h
@@ -134,7 +134,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_tracking_iq_t(struct sbp_state *s, u16 sender_id,
                                   const sbp_msg_tracking_iq_t *msg,
-                                  s32 (*write)(u8 *buff, u32 n, void *context));
+                                  sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_iq_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_IQ_DEP_A.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_IQ_DEP_A.h
@@ -134,8 +134,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_a_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_tracking_iq_dep_a_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_tracking_iq_dep_a_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_iq_dep_a_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_IQ_DEP_B.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_IQ_DEP_B.h
@@ -135,8 +135,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_b_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_tracking_iq_dep_b_t(struct sbp_state *s, u16 sender_id,
                                         const sbp_msg_tracking_iq_dep_b_t *msg,
-                                        s32 (*write)(u8 *buff, u32 n,
-                                                     void *context));
+                                        sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_iq_dep_b_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_STATE.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_STATE.h
@@ -136,8 +136,7 @@ s8 sbp_decode_sbp_msg_tracking_state_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_tracking_state_t(struct sbp_state *s, u16 sender_id,
                                      const sbp_msg_tracking_state_t *msg,
-                                     s32 (*write)(u8 *buff, u32 n,
-                                                  void *context));
+                                     sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_state_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DEP_A.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DEP_A.h
@@ -135,8 +135,7 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_a_t(
  */
 s8 sbp_send_sbp_msg_tracking_state_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_tracking_state_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_tracking_state_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_state_dep_a_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DEP_B.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DEP_B.h
@@ -135,8 +135,7 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_b_t(
  */
 s8 sbp_send_sbp_msg_tracking_state_dep_b_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_tracking_state_dep_b_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_tracking_state_dep_b_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_state_dep_b_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
@@ -239,8 +239,7 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_t(
  */
 s8 sbp_send_sbp_msg_tracking_state_detailed_dep_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_tracking_state_detailed_dep_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_tracking_state_detailed_dep_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_state_detailed_dep_t

--- a/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
+++ b/c/include/libsbp/new/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
@@ -240,8 +240,7 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(
  */
 s8 sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(
     struct sbp_state *s, u16 sender_id,
-    const sbp_msg_tracking_state_detailed_dep_a_t *msg,
-    s32 (*write)(u8 *buff, u32 n, void *context));
+    const sbp_msg_tracking_state_detailed_dep_a_t *msg, sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_tracking_state_detailed_dep_a_t

--- a/c/include/libsbp/new/user/MSG_USER_DATA.h
+++ b/c/include/libsbp/new/user/MSG_USER_DATA.h
@@ -130,7 +130,7 @@ s8 sbp_decode_sbp_msg_user_data_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_user_data_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_user_data_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_user_data_t

--- a/c/include/libsbp/new/vehicle/MSG_ODOMETRY.h
+++ b/c/include/libsbp/new/vehicle/MSG_ODOMETRY.h
@@ -138,7 +138,7 @@ s8 sbp_decode_sbp_msg_odometry_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_odometry_t(struct sbp_state *s, u16 sender_id,
                                const sbp_msg_odometry_t *msg,
-                               s32 (*write)(u8 *buff, u32 n, void *context));
+                               sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_odometry_t

--- a/c/include/libsbp/new/vehicle/MSG_WHEELTICK.h
+++ b/c/include/libsbp/new/vehicle/MSG_WHEELTICK.h
@@ -149,7 +149,7 @@ s8 sbp_decode_sbp_msg_wheeltick_t(const uint8_t *buf, uint8_t len,
  */
 s8 sbp_send_sbp_msg_wheeltick_t(struct sbp_state *s, u16 sender_id,
                                 const sbp_msg_wheeltick_t *msg,
-                                s32 (*write)(u8 *buff, u32 n, void *context));
+                                sbp_write_fn_t write);
 
 /**
  * Compare two instances of sbp_msg_wheeltick_t

--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -153,7 +153,7 @@ s8 sbp_process_message(sbp_state_t *s, u16 sender_id, u16 msg_type, const sbp_ms
 s8 sbp_process_frame(sbp_state_t *s, u16 sender_id, u16 msg_type,
                      u8 payload_len, u8 payload[], u16 frame_len, u8 frame[], u8 cb_mask);
 s8 sbp_message_send(sbp_state_t *s, u16 msg_type, u16 sender_id, const sbp_msg_t *msg,
-                    s32 (*write)(u8 *buff, u32 n, void* context));
+                    sbp_write_fn_t write);
 
 #ifdef __cplusplus
 }

--- a/c/src/new/acquisition.c
+++ b/c/src/new/acquisition.c
@@ -65,7 +65,7 @@ s8 sbp_decode_sbp_msg_acq_result_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_acq_result_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -145,7 +145,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_c_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_c_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_acq_result_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_c_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -225,7 +225,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_b_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_acq_result_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -305,7 +305,7 @@ s8 sbp_decode_sbp_msg_acq_result_dep_a_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_result_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_acq_result_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_result_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -622,7 +622,7 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_sv_profile_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_acq_sv_profile_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -694,7 +694,7 @@ s8 sbp_decode_sbp_msg_acq_sv_profile_dep_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_acq_sv_profile_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_acq_sv_profile_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_acq_sv_profile_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/bootload.c
+++ b/c/src/new/bootload.c
@@ -57,7 +57,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_req_t(const uint8_t *buf, uint8_t len
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_handshake_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_bootloader_handshake_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -187,7 +187,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_resp_t(const uint8_t *buf, uint8_t le
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_handshake_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_bootloader_handshake_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -252,7 +252,7 @@ s8 sbp_decode_sbp_msg_bootloader_jump_to_app_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_jump_to_app_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_jump_to_app_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_bootloader_jump_to_app_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_jump_to_app_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -315,7 +315,7 @@ s8 sbp_decode_sbp_msg_nap_device_dna_req_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_nap_device_dna_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_nap_device_dna_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -381,7 +381,7 @@ s8 sbp_decode_sbp_msg_nap_device_dna_resp_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_nap_device_dna_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_nap_device_dna_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_nap_device_dna_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -512,7 +512,7 @@ s8 sbp_decode_sbp_msg_bootloader_handshake_dep_a_t(const uint8_t *buf, uint8_t l
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_bootloader_handshake_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_bootloader_handshake_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_bootloader_handshake_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/ext_events.c
+++ b/c/src/new/ext_events.c
@@ -68,7 +68,7 @@ s8 sbp_decode_sbp_msg_ext_event_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ext_event_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ext_event_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ext_event_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ext_event_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/file_io.c
+++ b/c/src/new/file_io.c
@@ -131,7 +131,7 @@ s8 sbp_decode_sbp_msg_fileio_read_req_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -211,7 +211,7 @@ s8 sbp_decode_sbp_msg_fileio_read_resp_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -352,7 +352,7 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_req_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_dir_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_dir_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_read_dir_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_dir_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -504,7 +504,7 @@ s8 sbp_decode_sbp_msg_fileio_read_dir_resp_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_read_dir_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_dir_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_read_dir_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_read_dir_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -635,7 +635,7 @@ s8 sbp_decode_sbp_msg_fileio_remove_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_remove_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_remove_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_remove_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_remove_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -778,7 +778,7 @@ s8 sbp_decode_sbp_msg_fileio_write_req_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_write_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_write_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_write_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_write_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -853,7 +853,7 @@ s8 sbp_decode_sbp_msg_fileio_write_resp_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_write_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_write_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_write_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_write_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -915,7 +915,7 @@ s8 sbp_decode_sbp_msg_fileio_config_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_config_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_config_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -986,7 +986,7 @@ s8 sbp_decode_sbp_msg_fileio_config_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fileio_config_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fileio_config_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fileio_config_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/flash.c
+++ b/c/src/new/flash.c
@@ -76,7 +76,7 @@ s8 sbp_decode_sbp_msg_flash_program_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_program_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_program_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_flash_program_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_program_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -154,7 +154,7 @@ s8 sbp_decode_sbp_msg_flash_done_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_done_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_done_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_flash_done_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_done_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -227,7 +227,7 @@ s8 sbp_decode_sbp_msg_flash_read_req_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_read_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_flash_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_read_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -309,7 +309,7 @@ s8 sbp_decode_sbp_msg_flash_read_resp_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_read_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_flash_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_read_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -383,7 +383,7 @@ s8 sbp_decode_sbp_msg_flash_erase_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_flash_erase_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_erase_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_flash_erase_t(struct sbp_state *s, u16 sender_id, const sbp_msg_flash_erase_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -448,7 +448,7 @@ s8 sbp_decode_sbp_msg_stm_flash_lock_sector_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_flash_lock_sector_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_flash_lock_sector_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_stm_flash_lock_sector_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_flash_lock_sector_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -510,7 +510,7 @@ s8 sbp_decode_sbp_msg_stm_flash_unlock_sector_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_flash_unlock_sector_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_flash_unlock_sector_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_stm_flash_unlock_sector_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_flash_unlock_sector_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -573,7 +573,7 @@ s8 sbp_decode_sbp_msg_stm_unique_id_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_unique_id_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_stm_unique_id_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -639,7 +639,7 @@ s8 sbp_decode_sbp_msg_stm_unique_id_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_stm_unique_id_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_stm_unique_id_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_stm_unique_id_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -709,7 +709,7 @@ s8 sbp_decode_sbp_msg_m25_flash_write_status_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_m25_flash_write_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_m25_flash_write_status_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_m25_flash_write_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_m25_flash_write_status_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/imu.c
+++ b/c/src/new/imu.c
@@ -77,7 +77,7 @@ s8 sbp_decode_sbp_msg_imu_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_imu_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_imu_raw_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_imu_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_imu_raw_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -166,7 +166,7 @@ s8 sbp_decode_sbp_msg_imu_aux_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_imu_aux_t(struct sbp_state *s, u16 sender_id, const sbp_msg_imu_aux_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_imu_aux_t(struct sbp_state *s, u16 sender_id, const sbp_msg_imu_aux_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/linux.c
+++ b/c/src/new/linux.c
@@ -139,7 +139,7 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_cpu_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_cpu_state_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_cpu_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_cpu_state_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -299,7 +299,7 @@ s8 sbp_decode_sbp_msg_linux_mem_state_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_mem_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_mem_state_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_mem_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_mem_state_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -391,7 +391,7 @@ s8 sbp_decode_sbp_msg_linux_sys_state_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_sys_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_sys_state_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_sys_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_sys_state_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -549,7 +549,7 @@ s8 sbp_decode_sbp_msg_linux_process_socket_counts_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_socket_counts_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_socket_counts_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_process_socket_counts_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_socket_counts_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -718,7 +718,7 @@ s8 sbp_decode_sbp_msg_linux_process_socket_queues_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_socket_queues_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_socket_queues_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_process_socket_queues_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_socket_queues_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -823,7 +823,7 @@ s8 sbp_decode_sbp_msg_linux_socket_usage_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_socket_usage_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_socket_usage_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_socket_usage_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_socket_usage_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -975,7 +975,7 @@ s8 sbp_decode_sbp_msg_linux_process_fd_count_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_fd_count_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_fd_count_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_process_fd_count_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_fd_count_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1130,7 +1130,7 @@ s8 sbp_decode_sbp_msg_linux_process_fd_summary_t(const uint8_t *buf, uint8_t len
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_process_fd_summary_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_fd_summary_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_process_fd_summary_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_process_fd_summary_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1284,7 +1284,7 @@ s8 sbp_decode_sbp_msg_linux_cpu_state_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_cpu_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_cpu_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_cpu_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_cpu_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1456,7 +1456,7 @@ s8 sbp_decode_sbp_msg_linux_mem_state_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_mem_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_mem_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_mem_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_mem_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1560,7 +1560,7 @@ s8 sbp_decode_sbp_msg_linux_sys_state_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_linux_sys_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_sys_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_linux_sys_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_linux_sys_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/logging.c
+++ b/c/src/new/logging.c
@@ -125,7 +125,7 @@ s8 sbp_decode_sbp_msg_log_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_log_t(struct sbp_state *s, u16 sender_id, const sbp_msg_log_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_log_t(struct sbp_state *s, u16 sender_id, const sbp_msg_log_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -202,7 +202,7 @@ s8 sbp_decode_sbp_msg_fwd_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_fwd_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fwd_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_fwd_t(struct sbp_state *s, u16 sender_id, const sbp_msg_fwd_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -340,7 +340,7 @@ s8 sbp_decode_sbp_msg_print_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_print_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_print_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_print_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_print_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/mag.c
+++ b/c/src/new/mag.c
@@ -68,7 +68,7 @@ s8 sbp_decode_sbp_msg_mag_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_mag_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mag_raw_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_mag_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mag_raw_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/navigation.c
+++ b/c/src/new/navigation.c
@@ -65,7 +65,7 @@ s8 sbp_decode_sbp_msg_gps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gps_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_gps_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -145,7 +145,7 @@ s8 sbp_decode_sbp_msg_gps_time_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gps_time_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_gps_time_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -240,7 +240,7 @@ s8 sbp_decode_sbp_msg_utc_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_utc_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_utc_time_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_utc_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_utc_time_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -350,7 +350,7 @@ s8 sbp_decode_sbp_msg_utc_time_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_utc_time_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_utc_time_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_utc_time_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_utc_time_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -454,7 +454,7 @@ s8 sbp_decode_sbp_msg_dops_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, s
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_dops_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dops_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_dops_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dops_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -552,7 +552,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -665,7 +665,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_cov_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_ecef_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_cov_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -781,7 +781,7 @@ s8 sbp_decode_sbp_msg_pos_llh_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_llh_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -897,7 +897,7 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_cov_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_llh_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_cov_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1010,7 +1010,7 @@ s8 sbp_decode_sbp_msg_baseline_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ecef_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_baseline_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ecef_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1111,7 +1111,7 @@ s8 sbp_decode_sbp_msg_baseline_ned_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ned_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_baseline_ned_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1212,7 +1212,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1325,7 +1325,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_cov_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ecef_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_cov_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1441,7 +1441,7 @@ s8 sbp_decode_sbp_msg_vel_ned_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ned_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1557,7 +1557,7 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_cov_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ned_cov_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_cov_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1670,7 +1670,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_ecef_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1783,7 +1783,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_cov_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_cov_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1899,7 +1899,7 @@ s8 sbp_decode_sbp_msg_pos_llh_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_llh_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2015,7 +2015,7 @@ s8 sbp_decode_sbp_msg_pos_llh_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_cov_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_llh_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_cov_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2128,7 +2128,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ecef_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2241,7 +2241,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_cov_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ecef_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_cov_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2357,7 +2357,7 @@ s8 sbp_decode_sbp_msg_vel_ned_gnss_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ned_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2473,7 +2473,7 @@ s8 sbp_decode_sbp_msg_vel_ned_cov_gnss_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_cov_gnss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ned_cov_gnss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_cov_gnss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2601,7 +2601,7 @@ s8 sbp_decode_sbp_msg_vel_body_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_body_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_body_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_body_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_body_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2699,7 +2699,7 @@ s8 sbp_decode_sbp_msg_age_corrections_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_age_corrections_t(struct sbp_state *s, u16 sender_id, const sbp_msg_age_corrections_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_age_corrections_t(struct sbp_state *s, u16 sender_id, const sbp_msg_age_corrections_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2773,7 +2773,7 @@ s8 sbp_decode_sbp_msg_gps_time_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gps_time_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_gps_time_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gps_time_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2859,7 +2859,7 @@ s8 sbp_decode_sbp_msg_dops_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_dops_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dops_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_dops_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dops_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2954,7 +2954,7 @@ s8 sbp_decode_sbp_msg_pos_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_ecef_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3055,7 +3055,7 @@ s8 sbp_decode_sbp_msg_pos_llh_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pos_llh_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pos_llh_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pos_llh_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3156,7 +3156,7 @@ s8 sbp_decode_sbp_msg_baseline_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ecef_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_baseline_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ecef_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3257,7 +3257,7 @@ s8 sbp_decode_sbp_msg_baseline_ned_dep_a_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_ned_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_baseline_ned_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_ned_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3358,7 +3358,7 @@ s8 sbp_decode_sbp_msg_vel_ecef_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ecef_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ecef_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3459,7 +3459,7 @@ s8 sbp_decode_sbp_msg_vel_ned_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_vel_ned_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_vel_ned_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_vel_ned_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3551,7 +3551,7 @@ s8 sbp_decode_sbp_msg_baseline_heading_dep_a_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_heading_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_heading_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_baseline_heading_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_heading_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3640,7 +3640,7 @@ s8 sbp_decode_sbp_msg_protection_level_dep_a_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_protection_level_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_protection_level_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_protection_level_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_protection_level_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3780,7 +3780,7 @@ s8 sbp_decode_sbp_msg_protection_level_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_protection_level_t(struct sbp_state *s, u16 sender_id, const sbp_msg_protection_level_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_protection_level_t(struct sbp_state *s, u16 sender_id, const sbp_msg_protection_level_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/ndb.c
+++ b/c/src/new/ndb.c
@@ -77,7 +77,7 @@ s8 sbp_decode_sbp_msg_ndb_event_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ndb_event_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ndb_event_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ndb_event_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ndb_event_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/observation.c
+++ b/c/src/new/observation.c
@@ -371,7 +371,7 @@ s8 sbp_decode_sbp_msg_obs_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_obs_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -446,7 +446,7 @@ s8 sbp_decode_sbp_msg_base_pos_llh_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_base_pos_llh_t(struct sbp_state *s, u16 sender_id, const sbp_msg_base_pos_llh_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_base_pos_llh_t(struct sbp_state *s, u16 sender_id, const sbp_msg_base_pos_llh_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -520,7 +520,7 @@ s8 sbp_decode_sbp_msg_base_pos_ecef_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_base_pos_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_base_pos_ecef_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_base_pos_ecef_t(struct sbp_state *s, u16 sender_id, const sbp_msg_base_pos_ecef_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -906,7 +906,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_e_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gps_dep_e_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_dep_e_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_gps_dep_e_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_dep_e_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1100,7 +1100,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_dep_f_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gps_dep_f_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_dep_f_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_gps_dep_f_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_dep_f_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1294,7 +1294,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gps_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gps_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_gps_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gps_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1488,7 +1488,7 @@ s8 sbp_decode_sbp_msg_ephemeris_qzss_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_qzss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_qzss_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_qzss_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_qzss_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1685,7 +1685,7 @@ s8 sbp_decode_sbp_msg_ephemeris_bds_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_bds_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_bds_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_bds_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_bds_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1885,7 +1885,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_dep_a_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gal_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gal_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_gal_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gal_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2088,7 +2088,7 @@ s8 sbp_decode_sbp_msg_ephemeris_gal_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_gal_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gal_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_gal_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_gal_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2252,7 +2252,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_a_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_sbas_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2368,7 +2368,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_a_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2484,7 +2484,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_dep_b_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_sbas_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2600,7 +2600,7 @@ s8 sbp_decode_sbp_msg_ephemeris_sbas_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_sbas_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_sbas_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_sbas_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2716,7 +2716,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_b_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2838,7 +2838,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_c_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_c_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_c_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2969,7 +2969,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_dep_d_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_dep_d_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_d_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_glo_dep_d_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_dep_d_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3103,7 +3103,7 @@ s8 sbp_decode_sbp_msg_ephemeris_glo_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_glo_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_glo_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_glo_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3282,7 +3282,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_d_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_d_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_d_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_dep_d_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_d_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3503,7 +3503,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3718,7 +3718,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -3942,7 +3942,7 @@ s8 sbp_decode_sbp_msg_ephemeris_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ephemeris_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_c_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ephemeris_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ephemeris_dep_c_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -4451,7 +4451,7 @@ s8 sbp_decode_sbp_msg_obs_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_obs_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -4529,7 +4529,7 @@ s8 sbp_decode_sbp_msg_obs_dep_b_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_obs_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -4607,7 +4607,7 @@ s8 sbp_decode_sbp_msg_obs_dep_c_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_obs_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_c_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_obs_dep_c_t(struct sbp_state *s, u16 sender_id, const sbp_msg_obs_dep_c_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -4700,7 +4700,7 @@ s8 sbp_decode_sbp_msg_iono_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, s
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_iono_t(struct sbp_state *s, u16 sender_id, const sbp_msg_iono_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_iono_t(struct sbp_state *s, u16 sender_id, const sbp_msg_iono_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -4789,7 +4789,7 @@ s8 sbp_decode_sbp_msg_sv_configuration_gps_dep_t(const uint8_t *buf, uint8_t len
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_sv_configuration_gps_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sv_configuration_gps_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_sv_configuration_gps_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sv_configuration_gps_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -4995,7 +4995,7 @@ s8 sbp_decode_sbp_msg_gnss_capb_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gnss_capb_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gnss_capb_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_gnss_capb_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gnss_capb_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5075,7 +5075,7 @@ s8 sbp_decode_sbp_msg_group_delay_dep_a_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_delay_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_group_delay_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5167,7 +5167,7 @@ s8 sbp_decode_sbp_msg_group_delay_dep_b_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_delay_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_group_delay_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5259,7 +5259,7 @@ s8 sbp_decode_sbp_msg_group_delay_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_delay_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_group_delay_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_delay_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5531,7 +5531,7 @@ s8 sbp_decode_sbp_msg_almanac_gps_dep_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_gps_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_gps_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_almanac_gps_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_gps_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5647,7 +5647,7 @@ s8 sbp_decode_sbp_msg_almanac_gps_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_gps_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_gps_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_almanac_gps_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_gps_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5757,7 +5757,7 @@ s8 sbp_decode_sbp_msg_almanac_glo_dep_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_glo_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_glo_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_almanac_glo_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_glo_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5861,7 +5861,7 @@ s8 sbp_decode_sbp_msg_almanac_glo_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_glo_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_glo_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_almanac_glo_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_glo_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -5956,7 +5956,7 @@ s8 sbp_decode_sbp_msg_glo_biases_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_glo_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_glo_biases_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_glo_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_glo_biases_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -6102,7 +6102,7 @@ s8 sbp_decode_sbp_msg_sv_az_el_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_sv_az_el_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sv_az_el_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_sv_az_el_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sv_az_el_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -6177,7 +6177,7 @@ s8 sbp_decode_sbp_msg_osr_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, sb
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_osr_t(struct sbp_state *s, u16 sender_id, const sbp_msg_osr_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_osr_t(struct sbp_state *s, u16 sender_id, const sbp_msg_osr_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/orientation.c
+++ b/c/src/new/orientation.c
@@ -65,7 +65,7 @@ s8 sbp_decode_sbp_msg_baseline_heading_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_baseline_heading_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_heading_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_baseline_heading_t(struct sbp_state *s, u16 sender_id, const sbp_msg_baseline_heading_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -163,7 +163,7 @@ s8 sbp_decode_sbp_msg_orient_quat_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_orient_quat_t(struct sbp_state *s, u16 sender_id, const sbp_msg_orient_quat_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_orient_quat_t(struct sbp_state *s, u16 sender_id, const sbp_msg_orient_quat_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -273,7 +273,7 @@ s8 sbp_decode_sbp_msg_orient_euler_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_orient_euler_t(struct sbp_state *s, u16 sender_id, const sbp_msg_orient_euler_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_orient_euler_t(struct sbp_state *s, u16 sender_id, const sbp_msg_orient_euler_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -368,7 +368,7 @@ s8 sbp_decode_sbp_msg_angular_rate_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_angular_rate_t(struct sbp_state *s, u16 sender_id, const sbp_msg_angular_rate_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_angular_rate_t(struct sbp_state *s, u16 sender_id, const sbp_msg_angular_rate_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/piksi.c
+++ b/c/src/new/piksi.c
@@ -57,7 +57,7 @@ s8 sbp_decode_sbp_msg_almanac_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_almanac_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_almanac_t(struct sbp_state *s, u16 sender_id, const sbp_msg_almanac_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -119,7 +119,7 @@ s8 sbp_decode_sbp_msg_set_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_set_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_set_time_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_set_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_set_time_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -180,7 +180,7 @@ s8 sbp_decode_sbp_msg_reset_t(const uint8_t *buf, uint8_t len, uint8_t *n_read, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_reset_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_reset_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -243,7 +243,7 @@ s8 sbp_decode_sbp_msg_reset_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_reset_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_reset_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -305,7 +305,7 @@ s8 sbp_decode_sbp_msg_cw_results_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_cw_results_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cw_results_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_cw_results_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cw_results_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -367,7 +367,7 @@ s8 sbp_decode_sbp_msg_cw_start_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_cw_start_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cw_start_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_cw_start_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cw_start_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -428,7 +428,7 @@ s8 sbp_decode_sbp_msg_reset_filters_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_reset_filters_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_filters_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_reset_filters_t(struct sbp_state *s, u16 sender_id, const sbp_msg_reset_filters_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -491,7 +491,7 @@ s8 sbp_decode_sbp_msg_init_base_dep_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_init_base_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_init_base_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_init_base_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_init_base_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -563,7 +563,7 @@ s8 sbp_decode_sbp_msg_thread_state_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_thread_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_thread_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_thread_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_thread_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -874,7 +874,7 @@ s8 sbp_decode_sbp_msg_uart_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_uart_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_uart_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_uart_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_uart_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -957,7 +957,7 @@ s8 sbp_decode_sbp_msg_uart_state_depa_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_uart_state_depa_t(struct sbp_state *s, u16 sender_id, const sbp_msg_uart_state_depa_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_uart_state_depa_t(struct sbp_state *s, u16 sender_id, const sbp_msg_uart_state_depa_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1028,7 +1028,7 @@ s8 sbp_decode_sbp_msg_iar_state_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_iar_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_iar_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_iar_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_iar_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1093,7 +1093,7 @@ s8 sbp_decode_sbp_msg_mask_satellite_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_mask_satellite_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_mask_satellite_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1161,7 +1161,7 @@ s8 sbp_decode_sbp_msg_mask_satellite_dep_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_mask_satellite_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_mask_satellite_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_mask_satellite_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1238,7 +1238,7 @@ s8 sbp_decode_sbp_msg_device_monitor_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_device_monitor_t(struct sbp_state *s, u16 sender_id, const sbp_msg_device_monitor_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_device_monitor_t(struct sbp_state *s, u16 sender_id, const sbp_msg_device_monitor_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1381,7 +1381,7 @@ s8 sbp_decode_sbp_msg_command_req_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_command_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_command_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1449,7 +1449,7 @@ s8 sbp_decode_sbp_msg_command_resp_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_command_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_command_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1583,7 +1583,7 @@ s8 sbp_decode_sbp_msg_command_output_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_command_output_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_output_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_command_output_t(struct sbp_state *s, u16 sender_id, const sbp_msg_command_output_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1649,7 +1649,7 @@ s8 sbp_decode_sbp_msg_network_state_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_network_state_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_network_state_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1746,7 +1746,7 @@ s8 sbp_decode_sbp_msg_network_state_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_network_state_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_network_state_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_state_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1930,7 +1930,7 @@ s8 sbp_decode_sbp_msg_network_bandwidth_usage_t(const uint8_t *buf, uint8_t len,
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_network_bandwidth_usage_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_bandwidth_usage_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_network_bandwidth_usage_t(struct sbp_state *s, u16 sender_id, const sbp_msg_network_bandwidth_usage_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2008,7 +2008,7 @@ s8 sbp_decode_sbp_msg_cell_modem_status_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_cell_modem_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cell_modem_status_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_cell_modem_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_cell_modem_status_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2104,7 +2104,7 @@ s8 sbp_decode_sbp_msg_specan_dep_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_specan_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_specan_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_specan_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_specan_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2212,7 +2212,7 @@ s8 sbp_decode_sbp_msg_specan_t(const uint8_t *buf, uint8_t len, uint8_t *n_read,
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_specan_t(struct sbp_state *s, u16 sender_id, const sbp_msg_specan_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_specan_t(struct sbp_state *s, u16 sender_id, const sbp_msg_specan_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2309,7 +2309,7 @@ s8 sbp_decode_sbp_msg_front_end_gain_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_front_end_gain_t(struct sbp_state *s, u16 sender_id, const sbp_msg_front_end_gain_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_front_end_gain_t(struct sbp_state *s, u16 sender_id, const sbp_msg_front_end_gain_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/sbas.c
+++ b/c/src/new/sbas.c
@@ -70,7 +70,7 @@ s8 sbp_decode_sbp_msg_sbas_raw_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_sbas_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sbas_raw_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_sbas_raw_t(struct sbp_state *s, u16 sender_id, const sbp_msg_sbas_raw_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/settings.c
+++ b/c/src/new/settings.c
@@ -57,7 +57,7 @@ s8 sbp_decode_sbp_msg_settings_save_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_save_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_save_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_save_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_save_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -199,7 +199,7 @@ s8 sbp_decode_sbp_msg_settings_write_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_write_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_write_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_write_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_write_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -345,7 +345,7 @@ s8 sbp_decode_sbp_msg_settings_write_resp_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_write_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_write_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_write_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_write_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -491,7 +491,7 @@ s8 sbp_decode_sbp_msg_settings_read_req_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_read_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -634,7 +634,7 @@ s8 sbp_decode_sbp_msg_settings_read_resp_t(const uint8_t *buf, uint8_t len, uint
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_read_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -696,7 +696,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_req_t(const uint8_t *buf, uint8_t l
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_by_index_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_req_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_read_by_index_req_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_req_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -842,7 +842,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_resp_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_by_index_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_read_by_index_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -908,7 +908,7 @@ s8 sbp_decode_sbp_msg_settings_read_by_index_done_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_read_by_index_done_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_done_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_read_by_index_done_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_read_by_index_done_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1050,7 +1050,7 @@ s8 sbp_decode_sbp_msg_settings_register_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_register_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_register_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_register_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_register_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1196,7 +1196,7 @@ s8 sbp_decode_sbp_msg_settings_register_resp_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_settings_register_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_register_resp_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_settings_register_resp_t(struct sbp_state *s, u16 sender_id, const sbp_msg_settings_register_resp_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/solution_meta.c
+++ b/c/src/new/solution_meta.c
@@ -146,7 +146,7 @@ s8 sbp_decode_sbp_msg_soln_meta_dep_a_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_soln_meta_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_soln_meta_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_soln_meta_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_soln_meta_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -260,7 +260,7 @@ s8 sbp_decode_sbp_msg_soln_meta_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_soln_meta_t(struct sbp_state *s, u16 sender_id, const sbp_msg_soln_meta_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_soln_meta_t(struct sbp_state *s, u16 sender_id, const sbp_msg_soln_meta_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/ssr.c
+++ b/c/src/new/ssr.c
@@ -745,7 +745,7 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_orbit_clock_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_orbit_clock_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -864,7 +864,7 @@ s8 sbp_decode_sbp_msg_ssr_code_biases_t(const uint8_t *buf, uint8_t len, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_code_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_code_biases_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_code_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_code_biases_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -972,7 +972,7 @@ s8 sbp_decode_sbp_msg_ssr_phase_biases_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_phase_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_phase_biases_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_phase_biases_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_phase_biases_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1071,7 +1071,7 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_stec_correction_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_stec_correction_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_stec_correction_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_stec_correction_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1155,7 +1155,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_t(const uint8_t *buf, uint8_t len, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_gridded_correction_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_gridded_correction_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1254,7 +1254,7 @@ s8 sbp_decode_sbp_msg_ssr_tile_definition_t(const uint8_t *buf, uint8_t len, uin
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_tile_definition_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_tile_definition_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_tile_definition_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_tile_definition_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1440,7 +1440,7 @@ s8 sbp_decode_sbp_msg_ssr_satellite_apc_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_satellite_apc_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_satellite_apc_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_satellite_apc_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_satellite_apc_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1545,7 +1545,7 @@ s8 sbp_decode_sbp_msg_ssr_orbit_clock_dep_a_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_orbit_clock_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_orbit_clock_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1901,7 +1901,7 @@ s8 sbp_decode_sbp_msg_ssr_stec_correction_dep_a_t(const uint8_t *buf, uint8_t le
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_stec_correction_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_stec_correction_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_stec_correction_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1985,7 +1985,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(const uint8_t *buf, 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_gridded_correction_no_std_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_no_std_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2075,7 +2075,7 @@ s8 sbp_decode_sbp_msg_ssr_gridded_correction_dep_a_t(const uint8_t *buf, uint8_t
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_gridded_correction_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -2159,7 +2159,7 @@ s8 sbp_decode_sbp_msg_ssr_grid_definition_dep_a_t(const uint8_t *buf, uint8_t le
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_grid_definition_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ssr_grid_definition_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ssr_grid_definition_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/system.c
+++ b/c/src/new/system.c
@@ -62,7 +62,7 @@ s8 sbp_decode_sbp_msg_startup_t(const uint8_t *buf, uint8_t len, uint8_t *n_read
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_startup_t(struct sbp_state *s, u16 sender_id, const sbp_msg_startup_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_startup_t(struct sbp_state *s, u16 sender_id, const sbp_msg_startup_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -205,7 +205,7 @@ s8 sbp_decode_sbp_msg_dgnss_status_t(const uint8_t *buf, uint8_t len, uint8_t *n
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_dgnss_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dgnss_status_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_dgnss_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_dgnss_status_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -276,7 +276,7 @@ s8 sbp_decode_sbp_msg_heartbeat_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_heartbeat_t(struct sbp_state *s, u16 sender_id, const sbp_msg_heartbeat_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_heartbeat_t(struct sbp_state *s, u16 sender_id, const sbp_msg_heartbeat_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -422,7 +422,7 @@ s8 sbp_decode_sbp_msg_status_report_t(const uint8_t *buf, uint8_t len, uint8_t *
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_status_report_t(struct sbp_state *s, u16 sender_id, const sbp_msg_status_report_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_status_report_t(struct sbp_state *s, u16 sender_id, const sbp_msg_status_report_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -500,7 +500,7 @@ s8 sbp_decode_sbp_msg_ins_status_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ins_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ins_status_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ins_status_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ins_status_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -631,7 +631,7 @@ s8 sbp_decode_sbp_msg_csac_telemetry_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_csac_telemetry_t(struct sbp_state *s, u16 sender_id, const sbp_msg_csac_telemetry_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_csac_telemetry_t(struct sbp_state *s, u16 sender_id, const sbp_msg_csac_telemetry_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -765,7 +765,7 @@ s8 sbp_decode_sbp_msg_csac_telemetry_labels_t(const uint8_t *buf, uint8_t len, u
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_csac_telemetry_labels_t(struct sbp_state *s, u16 sender_id, const sbp_msg_csac_telemetry_labels_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_csac_telemetry_labels_t(struct sbp_state *s, u16 sender_id, const sbp_msg_csac_telemetry_labels_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -848,7 +848,7 @@ s8 sbp_decode_sbp_msg_ins_updates_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_ins_updates_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ins_updates_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_ins_updates_t(struct sbp_state *s, u16 sender_id, const sbp_msg_ins_updates_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -937,7 +937,7 @@ s8 sbp_decode_sbp_msg_gnss_time_offset_t(const uint8_t *buf, uint8_t len, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_gnss_time_offset_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gnss_time_offset_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_gnss_time_offset_t(struct sbp_state *s, u16 sender_id, const sbp_msg_gnss_time_offset_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1011,7 +1011,7 @@ s8 sbp_decode_sbp_msg_pps_time_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_pps_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pps_time_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_pps_time_t(struct sbp_state *s, u16 sender_id, const sbp_msg_pps_time_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1091,7 +1091,7 @@ s8 sbp_decode_sbp_msg_group_meta_t(const uint8_t *buf, uint8_t len, uint8_t *n_r
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_group_meta_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_meta_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_group_meta_t(struct sbp_state *s, u16 sender_id, const sbp_msg_group_meta_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/tracking.c
+++ b/c/src/new/tracking.c
@@ -116,7 +116,7 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_a_t(const uint8_t *buf, uint8_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_detailed_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_state_detailed_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_detailed_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -298,7 +298,7 @@ s8 sbp_decode_sbp_msg_tracking_state_detailed_dep_t(const uint8_t *buf, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_detailed_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_detailed_dep_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_state_detailed_dep_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_detailed_dep_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -492,7 +492,7 @@ s8 sbp_decode_sbp_msg_tracking_state_t(const uint8_t *buf, uint8_t len, uint8_t 
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -624,7 +624,7 @@ s8 sbp_decode_sbp_msg_measurement_state_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_measurement_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_measurement_state_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_measurement_state_t(struct sbp_state *s, u16 sender_id, const sbp_msg_measurement_state_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -761,7 +761,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_t(const uint8_t *buf, uint8_t len, uint8_t *n_
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_iq_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_iq_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -903,7 +903,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_b_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_iq_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_iq_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -985,7 +985,7 @@ s8 sbp_decode_sbp_msg_tracking_iq_dep_a_t(const uint8_t *buf, uint8_t len, uint8
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_iq_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_iq_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_iq_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1128,7 +1128,7 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_a_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_dep_a_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_state_dep_a_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_dep_a_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -1266,7 +1266,7 @@ s8 sbp_decode_sbp_msg_tracking_state_dep_b_t(const uint8_t *buf, uint8_t len, ui
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_tracking_state_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_dep_b_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_tracking_state_dep_b_t(struct sbp_state *s, u16 sender_id, const sbp_msg_tracking_state_dep_b_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/user.c
+++ b/c/src/new/user.c
@@ -62,7 +62,7 @@ s8 sbp_decode_sbp_msg_user_data_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_user_data_t(struct sbp_state *s, u16 sender_id, const sbp_msg_user_data_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_user_data_t(struct sbp_state *s, u16 sender_id, const sbp_msg_user_data_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/new/vehicle.c
+++ b/c/src/new/vehicle.c
@@ -62,7 +62,7 @@ s8 sbp_decode_sbp_msg_odometry_t(const uint8_t *buf, uint8_t len, uint8_t *n_rea
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_odometry_t(struct sbp_state *s, u16 sender_id, const sbp_msg_odometry_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_odometry_t(struct sbp_state *s, u16 sender_id, const sbp_msg_odometry_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
@@ -139,7 +139,7 @@ s8 sbp_decode_sbp_msg_wheeltick_t(const uint8_t *buf, uint8_t len, uint8_t *n_re
   }
   return SBP_OK;
 }
-s8 sbp_send_sbp_msg_wheeltick_t(struct sbp_state *s, u16 sender_id, const sbp_msg_wheeltick_t *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_sbp_msg_wheeltick_t(struct sbp_state *s, u16 sender_id, const sbp_msg_wheeltick_t *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -748,7 +748,7 @@ s8 sbp_process_frame(sbp_state_t *s, u16 sender_id, u16 msg_type,
  *         not be sent or was only partially sent.
  */
 s8 sbp_payload_send(sbp_state_t *s, u16 msg_type, u16 sender_id, u8 len, u8 *payload,
-                    s32 (*write)(u8 *buff, u32 n, void *context))
+                    sbp_write_fn_t write)
 {
   /* Check our payload data pointer isn't NULL unless len = 0. */
   if (len != 0 && payload == 0) {
@@ -822,7 +822,7 @@ s8 sbp_payload_send(sbp_state_t *s, u16 msg_type, u16 sender_id, u8 len, u8 *pay
   return SBP_OK;
 }
 
-s8 sbp_message_send(sbp_state_t *s, u16 msg_type, u16 sender_id, const sbp_msg_t *msg, s32 (*write)(u8 *buff, u32 n, void *context)) {
+s8 sbp_message_send(sbp_state_t *s, u16 msg_type, u16 sender_id, const sbp_msg_t *msg, sbp_write_fn_t write) {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;
   s8 ret = sbp_encode_msg(payload, sizeof(payload), &payload_len, msg_type, msg);

--- a/generator/sbpg/targets/resources/c/cpp/message_traits_template.h
+++ b/generator/sbpg/targets/resources/c/cpp/message_traits_template.h
@@ -47,7 +47,7 @@ struct MessageTraits<(((msg_type)))> {
   static (((msg_type)))& get(sbp_msg_t &msg) {
     return msg.(((member_name)));
   }
-  static s8 send(sbp_state_t *state, u16 sender_id, const (((msg_type))) &msg, s32 (*write)(u8 *, u32, void *)) {
+  static s8 send(sbp_state_t *state, u16 sender_id, const (((msg_type))) &msg, sbp_write_fn_t write) {
     return sbp_send_(((msg_type)))(state, sender_id, &msg, write);
   }
 };

--- a/generator/sbpg/targets/resources/c/new/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/new/sbp_messages_template.h
@@ -392,7 +392,7 @@ s8 sbp_decode_(((msg_type)))(const uint8_t *buf, uint8_t len, uint8_t *n_read, (
  * @param write Write function
  * @param SBP_OK on success, or other libsbp error code
  */
-s8 sbp_send_(((msg_type)))(struct sbp_state  *s, u16 sender_id, const (((msg_type))) *msg, s32 (*write)(u8 *buff, u32 n, void *context));
+s8 sbp_send_(((msg_type)))(struct sbp_state  *s, u16 sender_id, const (((msg_type))) *msg, sbp_write_fn_t write);
 ((*- endif *))
 
 /**

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -246,7 +246,7 @@ s8 sbp_decode_(((m.name|convert_unpacked)))(const uint8_t *buf, uint8_t len, uin
 }
 
 ((*- if m.is_real_message *))
-s8 sbp_send_(((m.name|convert_unpacked)))(struct sbp_state *s, u16 sender_id, const (((m.name|convert_unpacked))) *msg, s32 (*write)(u8 *buff, u32 n, void *context))
+s8 sbp_send_(((m.name|convert_unpacked)))(struct sbp_state *s, u16 sender_id, const (((m.name|convert_unpacked))) *msg, sbp_write_fn_t write)
 {
   uint8_t payload[SBP_MAX_PAYLOAD_LEN];
   uint8_t payload_len;


### PR DESCRIPTION
The signature for the write callback is now defined in parameter lists all over libsbp. Better to turn it in to a typedef to avoid repetition. 