### PR TITLE
build.gradle: Fix gradle 4 compatibility

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -11,6 +11,7 @@ on:
       - "generator/**"
       - "spec/**"
       - "c/test/**"
+      - "java/build.gradle"
       - "java/test/**"
       - "rust/sbp/tests/**"
 jobs:

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -49,7 +49,8 @@ archivesBaseName = 'sbp'
 
 jacocoTestReport {
     reports {
-        xml.required = true
+        // Using deprecated 'enabled' for gradle 4 compatibility
+        xml.enabled = true
     }
 }
 


### PR DESCRIPTION
xml.required is not supported on gradle 4.