### PR TITLE
[ESD-2119] Correct naming of strlen helper functions

### DIFF
--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
@@ -202,11 +202,10 @@ const char *sbp_msg_bootloader_handshake_dep_a_handshake_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_bootloader_handshake_dep_a_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_bootloader_handshake_dep_a_handshake_strlen(
-    const sbp_msg_bootloader_handshake_dep_a_t *msg, size_t section);
+    const sbp_msg_bootloader_handshake_dep_a_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_bootloader_handshake_dep_a_t

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
@@ -205,7 +205,7 @@ const char *sbp_msg_bootloader_handshake_dep_a_handshake_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_bootloader_handshake_dep_a_handshake_section_strlen(
+size_t sbp_msg_bootloader_handshake_dep_a_handshake_strlen(
     const sbp_msg_bootloader_handshake_dep_a_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
@@ -208,11 +208,10 @@ const char *sbp_msg_bootloader_handshake_resp_version_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_bootloader_handshake_resp_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_bootloader_handshake_resp_version_strlen(
-    const sbp_msg_bootloader_handshake_resp_t *msg, size_t section);
+    const sbp_msg_bootloader_handshake_resp_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_bootloader_handshake_resp_t

--- a/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
@@ -211,7 +211,7 @@ const char *sbp_msg_bootloader_handshake_resp_version_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_bootloader_handshake_resp_version_section_strlen(
+size_t sbp_msg_bootloader_handshake_resp_version_strlen(
     const sbp_msg_bootloader_handshake_resp_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
@@ -213,11 +213,10 @@ const char *sbp_msg_fileio_read_dir_req_dirname_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_read_dir_req_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_fileio_read_dir_req_dirname_strlen(
-    const sbp_msg_fileio_read_dir_req_t *msg, size_t section);
+    const sbp_msg_fileio_read_dir_req_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_fileio_read_dir_req_t

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_DIR_REQ.h
@@ -216,7 +216,7 @@ const char *sbp_msg_fileio_read_dir_req_dirname_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_fileio_read_dir_req_dirname_section_strlen(
+size_t sbp_msg_fileio_read_dir_req_dirname_strlen(
     const sbp_msg_fileio_read_dir_req_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
@@ -214,11 +214,10 @@ const char *sbp_msg_fileio_read_req_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_read_req_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_fileio_read_req_filename_strlen(
-    const sbp_msg_fileio_read_req_t *msg, size_t section);
+    const sbp_msg_fileio_read_req_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_fileio_read_req_t

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_REQ.h
@@ -217,7 +217,7 @@ const char *sbp_msg_fileio_read_req_filename_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_fileio_read_req_filename_section_strlen(
+size_t sbp_msg_fileio_read_req_filename_strlen(
     const sbp_msg_fileio_read_req_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
@@ -196,11 +196,10 @@ const char *sbp_msg_fileio_remove_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_remove_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
-size_t sbp_msg_fileio_remove_filename_strlen(const sbp_msg_fileio_remove_t *msg,
-                                             size_t section);
+size_t sbp_msg_fileio_remove_filename_strlen(
+    const sbp_msg_fileio_remove_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_fileio_remove_t

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_REMOVE.h
@@ -199,8 +199,8 @@ const char *sbp_msg_fileio_remove_filename_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_fileio_remove_filename_section_strlen(
-    const sbp_msg_fileio_remove_t *msg, size_t section);
+size_t sbp_msg_fileio_remove_filename_strlen(const sbp_msg_fileio_remove_t *msg,
+                                             size_t section);
 
 /**
  * Get encoded size of an instance of sbp_msg_fileio_remove_t

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -225,11 +225,10 @@ const char *sbp_msg_fileio_write_req_filename_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_fileio_write_req_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_fileio_write_req_filename_strlen(
-    const sbp_msg_fileio_write_req_t *msg, size_t section);
+    const sbp_msg_fileio_write_req_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_fileio_write_req_t

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -228,7 +228,7 @@ const char *sbp_msg_fileio_write_req_filename_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_fileio_write_req_filename_section_strlen(
+size_t sbp_msg_fileio_write_req_filename_strlen(
     const sbp_msg_fileio_write_req_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
@@ -224,11 +224,10 @@ const char *sbp_msg_linux_cpu_state_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_cpu_state_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_cpu_state_cmdline_strlen(
-    const sbp_msg_linux_cpu_state_t *msg, size_t section);
+    const sbp_msg_linux_cpu_state_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_cpu_state_t

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
@@ -227,7 +227,7 @@ const char *sbp_msg_linux_cpu_state_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_cpu_state_cmdline_section_strlen(
+size_t sbp_msg_linux_cpu_state_cmdline_strlen(
     const sbp_msg_linux_cpu_state_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -221,7 +221,7 @@ const char *sbp_msg_linux_cpu_state_dep_a_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_cpu_state_dep_a_cmdline_section_strlen(
+size_t sbp_msg_linux_cpu_state_dep_a_cmdline_strlen(
     const sbp_msg_linux_cpu_state_dep_a_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -218,11 +218,10 @@ const char *sbp_msg_linux_cpu_state_dep_a_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_cpu_state_dep_a_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_cpu_state_dep_a_cmdline_strlen(
-    const sbp_msg_linux_cpu_state_dep_a_t *msg, size_t section);
+    const sbp_msg_linux_cpu_state_dep_a_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_cpu_state_dep_a_t

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
@@ -227,7 +227,7 @@ const char *sbp_msg_linux_mem_state_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_mem_state_cmdline_section_strlen(
+size_t sbp_msg_linux_mem_state_cmdline_strlen(
     const sbp_msg_linux_mem_state_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
@@ -224,11 +224,10 @@ const char *sbp_msg_linux_mem_state_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_mem_state_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_mem_state_cmdline_strlen(
-    const sbp_msg_linux_mem_state_t *msg, size_t section);
+    const sbp_msg_linux_mem_state_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_mem_state_t

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -218,11 +218,10 @@ const char *sbp_msg_linux_mem_state_dep_a_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_mem_state_dep_a_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_mem_state_dep_a_cmdline_strlen(
-    const sbp_msg_linux_mem_state_dep_a_t *msg, size_t section);
+    const sbp_msg_linux_mem_state_dep_a_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_mem_state_dep_a_t

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -221,7 +221,7 @@ const char *sbp_msg_linux_mem_state_dep_a_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_mem_state_dep_a_cmdline_section_strlen(
+size_t sbp_msg_linux_mem_state_dep_a_cmdline_strlen(
     const sbp_msg_linux_mem_state_dep_a_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
@@ -215,7 +215,7 @@ const char *sbp_msg_linux_process_fd_count_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_process_fd_count_cmdline_section_strlen(
+size_t sbp_msg_linux_process_fd_count_cmdline_strlen(
     const sbp_msg_linux_process_fd_count_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_FD_COUNT.h
@@ -212,11 +212,10 @@ const char *sbp_msg_linux_process_fd_count_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_fd_count_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_process_fd_count_cmdline_strlen(
-    const sbp_msg_linux_process_fd_count_t *msg, size_t section);
+    const sbp_msg_linux_process_fd_count_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_process_fd_count_t

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
@@ -231,11 +231,10 @@ const char *sbp_msg_linux_process_socket_counts_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_socket_counts_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_process_socket_counts_cmdline_strlen(
-    const sbp_msg_linux_process_socket_counts_t *msg, size_t section);
+    const sbp_msg_linux_process_socket_counts_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_process_socket_counts_t

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
@@ -234,7 +234,7 @@ const char *sbp_msg_linux_process_socket_counts_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_process_socket_counts_cmdline_section_strlen(
+size_t sbp_msg_linux_process_socket_counts_cmdline_strlen(
     const sbp_msg_linux_process_socket_counts_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -245,7 +245,7 @@ const char *sbp_msg_linux_process_socket_queues_cmdline_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_linux_process_socket_queues_cmdline_section_strlen(
+size_t sbp_msg_linux_process_socket_queues_cmdline_strlen(
     const sbp_msg_linux_process_socket_queues_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -242,11 +242,10 @@ const char *sbp_msg_linux_process_socket_queues_cmdline_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_linux_process_socket_queues_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_linux_process_socket_queues_cmdline_strlen(
-    const sbp_msg_linux_process_socket_queues_t *msg, size_t section);
+    const sbp_msg_linux_process_socket_queues_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_linux_process_socket_queues_t

--- a/c/include/libsbp/v4/logging/MSG_LOG.h
+++ b/c/include/libsbp/v4/logging/MSG_LOG.h
@@ -191,10 +191,9 @@ const char *sbp_msg_log_text_get(const sbp_msg_log_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_log_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
-size_t sbp_msg_log_text_strlen(const sbp_msg_log_t *msg, size_t section);
+size_t sbp_msg_log_text_strlen(const sbp_msg_log_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_log_t

--- a/c/include/libsbp/v4/logging/MSG_LOG.h
+++ b/c/include/libsbp/v4/logging/MSG_LOG.h
@@ -194,8 +194,7 @@ const char *sbp_msg_log_text_get(const sbp_msg_log_t *msg);
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_log_text_section_strlen(const sbp_msg_log_t *msg,
-                                       size_t section);
+size_t sbp_msg_log_text_strlen(const sbp_msg_log_t *msg, size_t section);
 
 /**
  * Get encoded size of an instance of sbp_msg_log_t

--- a/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
+++ b/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
@@ -191,8 +191,8 @@ const char *sbp_msg_print_dep_text_get(const sbp_msg_print_dep_t *msg);
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_print_dep_text_section_strlen(const sbp_msg_print_dep_t *msg,
-                                             size_t section);
+size_t sbp_msg_print_dep_text_strlen(const sbp_msg_print_dep_t *msg,
+                                     size_t section);
 
 /**
  * Get encoded size of an instance of sbp_msg_print_dep_t

--- a/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
+++ b/c/include/libsbp/v4/logging/MSG_PRINT_DEP.h
@@ -188,11 +188,9 @@ const char *sbp_msg_print_dep_text_get(const sbp_msg_print_dep_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_print_dep_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
-size_t sbp_msg_print_dep_text_strlen(const sbp_msg_print_dep_t *msg,
-                                     size_t section);
+size_t sbp_msg_print_dep_text_strlen(const sbp_msg_print_dep_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_print_dep_t

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
@@ -204,8 +204,8 @@ const char *sbp_msg_command_output_line_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_command_output_line_section_strlen(
-    const sbp_msg_command_output_t *msg, size_t section);
+size_t sbp_msg_command_output_line_strlen(const sbp_msg_command_output_t *msg,
+                                          size_t section);
 
 /**
  * Get encoded size of an instance of sbp_msg_command_output_t

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_OUTPUT.h
@@ -201,11 +201,9 @@ const char *sbp_msg_command_output_line_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_command_output_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
-size_t sbp_msg_command_output_line_strlen(const sbp_msg_command_output_t *msg,
-                                          size_t section);
+size_t sbp_msg_command_output_line_strlen(const sbp_msg_command_output_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_command_output_t

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
@@ -199,11 +199,9 @@ const char *sbp_msg_command_req_command_get(const sbp_msg_command_req_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_command_req_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
-size_t sbp_msg_command_req_command_strlen(const sbp_msg_command_req_t *msg,
-                                          size_t section);
+size_t sbp_msg_command_req_command_strlen(const sbp_msg_command_req_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_command_req_t

--- a/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
+++ b/c/include/libsbp/v4/piksi/MSG_COMMAND_REQ.h
@@ -202,8 +202,8 @@ const char *sbp_msg_command_req_command_get(const sbp_msg_command_req_t *msg);
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_command_req_command_section_strlen(
-    const sbp_msg_command_req_t *msg, size_t section);
+size_t sbp_msg_command_req_command_strlen(const sbp_msg_command_req_t *msg,
+                                          size_t section);
 
 /**
  * Get encoded size of an instance of sbp_msg_command_req_t

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
@@ -204,7 +204,7 @@ const char *sbp_msg_csac_telemetry_telemetry_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_csac_telemetry_telemetry_section_strlen(
+size_t sbp_msg_csac_telemetry_telemetry_strlen(
     const sbp_msg_csac_telemetry_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY.h
@@ -201,11 +201,10 @@ const char *sbp_msg_csac_telemetry_telemetry_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_csac_telemetry_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_csac_telemetry_telemetry_strlen(
-    const sbp_msg_csac_telemetry_t *msg, size_t section);
+    const sbp_msg_csac_telemetry_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_csac_telemetry_t

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
@@ -211,11 +211,10 @@ const char *sbp_msg_csac_telemetry_labels_telemetry_labels_get(
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_csac_telemetry_labels_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
 size_t sbp_msg_csac_telemetry_labels_telemetry_labels_strlen(
-    const sbp_msg_csac_telemetry_labels_t *msg, size_t section);
+    const sbp_msg_csac_telemetry_labels_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_csac_telemetry_labels_t

--- a/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
+++ b/c/include/libsbp/v4/system/MSG_CSAC_TELEMETRY_LABELS.h
@@ -214,7 +214,7 @@ const char *sbp_msg_csac_telemetry_labels_telemetry_labels_get(
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_csac_telemetry_labels_telemetry_labels_section_strlen(
+size_t sbp_msg_csac_telemetry_labels_telemetry_labels_strlen(
     const sbp_msg_csac_telemetry_labels_t *msg, size_t section);
 
 /**

--- a/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
+++ b/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
@@ -209,11 +209,9 @@ const char *sbp_msg_dgnss_status_source_get(const sbp_msg_dgnss_status_t *msg);
  * The returned value does not include the NULL terminator.
  *
  * @param msg sbp_msg_dgnss_status_t instance
- * @param section Section number
- * @return Length of section
+ * @return Length of string
  */
-size_t sbp_msg_dgnss_status_source_strlen(const sbp_msg_dgnss_status_t *msg,
-                                          size_t section);
+size_t sbp_msg_dgnss_status_source_strlen(const sbp_msg_dgnss_status_t *msg);
 
 /**
  * Get encoded size of an instance of sbp_msg_dgnss_status_t

--- a/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
+++ b/c/include/libsbp/v4/system/MSG_DGNSS_STATUS.h
@@ -212,8 +212,8 @@ const char *sbp_msg_dgnss_status_source_get(const sbp_msg_dgnss_status_t *msg);
  * @param section Section number
  * @return Length of section
  */
-size_t sbp_msg_dgnss_status_source_section_strlen(
-    const sbp_msg_dgnss_status_t *msg, size_t section);
+size_t sbp_msg_dgnss_status_source_strlen(const sbp_msg_dgnss_status_t *msg,
+                                          size_t section);
 
 /**
  * Get encoded size of an instance of sbp_msg_dgnss_status_t

--- a/c/include/libsbp/version.h
+++ b/c/include/libsbp/version.h
@@ -25,10 +25,10 @@
 /** Protocol minor version. */
 #define SBP_MINOR_VERSION 4
 /** Protocol patch version. */
-#define SBP_PATCH_VERSION 8
+#define SBP_PATCH_VERSION 7
 
 /** Full SBP version string. */
-#define SBP_VERSION "3.4.9-alpha"
+#define SBP_VERSION "3.4.8-alpha"
 
 /** \} */
 

--- a/c/src/v4/bootload.c
+++ b/c/src/v4/bootload.c
@@ -155,6 +155,11 @@ const char *sbp_msg_bootloader_handshake_resp_version_get(
   return sbp_unterminated_string_get(&msg->version, 251);
 }
 
+size_t sbp_msg_bootloader_handshake_resp_version_strlen(
+    const sbp_msg_bootloader_handshake_resp_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->version, 251);
+}
+
 size_t sbp_msg_bootloader_handshake_resp_encoded_len(
     const sbp_msg_bootloader_handshake_resp_t *msg) {
   size_t encoded_len = 0;
@@ -551,6 +556,11 @@ bool sbp_msg_bootloader_handshake_dep_a_handshake_append_vprintf(
 const char *sbp_msg_bootloader_handshake_dep_a_handshake_get(
     const sbp_msg_bootloader_handshake_dep_a_t *msg) {
   return sbp_unterminated_string_get(&msg->handshake, 255);
+}
+
+size_t sbp_msg_bootloader_handshake_dep_a_handshake_strlen(
+    const sbp_msg_bootloader_handshake_dep_a_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->handshake, 255);
 }
 
 size_t sbp_msg_bootloader_handshake_dep_a_encoded_len(

--- a/c/src/v4/file_io.c
+++ b/c/src/v4/file_io.c
@@ -79,6 +79,11 @@ const char *sbp_msg_fileio_read_req_filename_get(
   return sbp_null_terminated_string_get(&msg->filename, 246);
 }
 
+size_t sbp_msg_fileio_read_req_filename_strlen(
+    const sbp_msg_fileio_read_req_t *msg) {
+  return sbp_null_terminated_string_strlen(&msg->filename, 246);
+}
+
 size_t sbp_msg_fileio_read_req_encoded_len(
     const sbp_msg_fileio_read_req_t *msg) {
   size_t encoded_len = 0;
@@ -357,6 +362,11 @@ bool sbp_msg_fileio_read_dir_req_dirname_append_vprintf(
 const char *sbp_msg_fileio_read_dir_req_dirname_get(
     const sbp_msg_fileio_read_dir_req_t *msg) {
   return sbp_null_terminated_string_get(&msg->dirname, 247);
+}
+
+size_t sbp_msg_fileio_read_dir_req_dirname_strlen(
+    const sbp_msg_fileio_read_dir_req_t *msg) {
+  return sbp_null_terminated_string_strlen(&msg->dirname, 247);
 }
 
 size_t sbp_msg_fileio_read_dir_req_encoded_len(
@@ -697,6 +707,11 @@ const char *sbp_msg_fileio_remove_filename_get(
   return sbp_null_terminated_string_get(&msg->filename, 255);
 }
 
+size_t sbp_msg_fileio_remove_filename_strlen(
+    const sbp_msg_fileio_remove_t *msg) {
+  return sbp_null_terminated_string_strlen(&msg->filename, 255);
+}
+
 size_t sbp_msg_fileio_remove_encoded_len(const sbp_msg_fileio_remove_t *msg) {
   size_t encoded_len = 0;
   encoded_len += sbp_null_terminated_string_encoded_len(&msg->filename, 255);
@@ -835,6 +850,11 @@ bool sbp_msg_fileio_write_req_filename_append_vprintf(
 const char *sbp_msg_fileio_write_req_filename_get(
     const sbp_msg_fileio_write_req_t *msg) {
   return sbp_null_terminated_string_get(&msg->filename, 247);
+}
+
+size_t sbp_msg_fileio_write_req_filename_strlen(
+    const sbp_msg_fileio_write_req_t *msg) {
+  return sbp_null_terminated_string_strlen(&msg->filename, 247);
 }
 
 size_t sbp_msg_fileio_write_req_encoded_len(

--- a/c/src/v4/linux.c
+++ b/c/src/v4/linux.c
@@ -80,6 +80,11 @@ const char *sbp_msg_linux_cpu_state_dep_a_cmdline_get(
   return sbp_unterminated_string_get(&msg->cmdline, 236);
 }
 
+size_t sbp_msg_linux_cpu_state_dep_a_cmdline_strlen(
+    const sbp_msg_linux_cpu_state_dep_a_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 236);
+}
+
 size_t sbp_msg_linux_cpu_state_dep_a_encoded_len(
     const sbp_msg_linux_cpu_state_dep_a_t *msg) {
   size_t encoded_len = 0;
@@ -277,6 +282,11 @@ bool sbp_msg_linux_mem_state_dep_a_cmdline_append_vprintf(
 const char *sbp_msg_linux_mem_state_dep_a_cmdline_get(
     const sbp_msg_linux_mem_state_dep_a_t *msg) {
   return sbp_unterminated_string_get(&msg->cmdline, 236);
+}
+
+size_t sbp_msg_linux_mem_state_dep_a_cmdline_strlen(
+    const sbp_msg_linux_mem_state_dep_a_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 236);
 }
 
 size_t sbp_msg_linux_mem_state_dep_a_encoded_len(
@@ -619,6 +629,11 @@ const char *sbp_msg_linux_process_socket_counts_cmdline_get(
   return sbp_unterminated_string_get(&msg->cmdline, 246);
 }
 
+size_t sbp_msg_linux_process_socket_counts_cmdline_strlen(
+    const sbp_msg_linux_process_socket_counts_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 246);
+}
+
 size_t sbp_msg_linux_process_socket_counts_encoded_len(
     const sbp_msg_linux_process_socket_counts_t *msg) {
   size_t encoded_len = 0;
@@ -822,6 +837,11 @@ bool sbp_msg_linux_process_socket_queues_cmdline_append_vprintf(
 const char *sbp_msg_linux_process_socket_queues_cmdline_get(
     const sbp_msg_linux_process_socket_queues_t *msg) {
   return sbp_unterminated_string_get(&msg->cmdline, 180);
+}
+
+size_t sbp_msg_linux_process_socket_queues_cmdline_strlen(
+    const sbp_msg_linux_process_socket_queues_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 180);
 }
 
 size_t sbp_msg_linux_process_socket_queues_encoded_len(
@@ -1187,6 +1207,11 @@ const char *sbp_msg_linux_process_fd_count_cmdline_get(
   return sbp_unterminated_string_get(&msg->cmdline, 250);
 }
 
+size_t sbp_msg_linux_process_fd_count_cmdline_strlen(
+    const sbp_msg_linux_process_fd_count_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 250);
+}
+
 size_t sbp_msg_linux_process_fd_count_encoded_len(
     const sbp_msg_linux_process_fd_count_t *msg) {
   size_t encoded_len = 0;
@@ -1548,6 +1573,11 @@ const char *sbp_msg_linux_cpu_state_cmdline_get(
   return sbp_unterminated_string_get(&msg->cmdline, 231);
 }
 
+size_t sbp_msg_linux_cpu_state_cmdline_strlen(
+    const sbp_msg_linux_cpu_state_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 231);
+}
+
 size_t sbp_msg_linux_cpu_state_encoded_len(
     const sbp_msg_linux_cpu_state_t *msg) {
   size_t encoded_len = 0;
@@ -1765,6 +1795,11 @@ bool sbp_msg_linux_mem_state_cmdline_append_vprintf(
 const char *sbp_msg_linux_mem_state_cmdline_get(
     const sbp_msg_linux_mem_state_t *msg) {
   return sbp_unterminated_string_get(&msg->cmdline, 231);
+}
+
+size_t sbp_msg_linux_mem_state_cmdline_strlen(
+    const sbp_msg_linux_mem_state_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->cmdline, 231);
 }
 
 size_t sbp_msg_linux_mem_state_encoded_len(

--- a/c/src/v4/logging.c
+++ b/c/src/v4/logging.c
@@ -68,6 +68,10 @@ const char *sbp_msg_log_text_get(const sbp_msg_log_t *msg) {
   return sbp_unterminated_string_get(&msg->text, 254);
 }
 
+size_t sbp_msg_log_text_strlen(const sbp_msg_log_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->text, 254);
+}
+
 size_t sbp_msg_log_encoded_len(const sbp_msg_log_t *msg) {
   size_t encoded_len = 0;
   encoded_len += sbp_u8_encoded_len(&msg->level);
@@ -314,6 +318,10 @@ bool sbp_msg_print_dep_text_append_vprintf(sbp_msg_print_dep_t *msg,
 
 const char *sbp_msg_print_dep_text_get(const sbp_msg_print_dep_t *msg) {
   return sbp_unterminated_string_get(&msg->text, 255);
+}
+
+size_t sbp_msg_print_dep_text_strlen(const sbp_msg_print_dep_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->text, 255);
 }
 
 size_t sbp_msg_print_dep_encoded_len(const sbp_msg_print_dep_t *msg) {

--- a/c/src/v4/piksi.c
+++ b/c/src/v4/piksi.c
@@ -1696,6 +1696,10 @@ const char *sbp_msg_command_req_command_get(const sbp_msg_command_req_t *msg) {
   return sbp_null_terminated_string_get(&msg->command, 251);
 }
 
+size_t sbp_msg_command_req_command_strlen(const sbp_msg_command_req_t *msg) {
+  return sbp_null_terminated_string_strlen(&msg->command, 251);
+}
+
 size_t sbp_msg_command_req_encoded_len(const sbp_msg_command_req_t *msg) {
   size_t encoded_len = 0;
   encoded_len += sbp_u32_encoded_len(&msg->sequence);
@@ -1932,6 +1936,10 @@ bool sbp_msg_command_output_line_append_vprintf(sbp_msg_command_output_t *msg,
 const char *sbp_msg_command_output_line_get(
     const sbp_msg_command_output_t *msg) {
   return sbp_unterminated_string_get(&msg->line, 251);
+}
+
+size_t sbp_msg_command_output_line_strlen(const sbp_msg_command_output_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->line, 251);
 }
 
 size_t sbp_msg_command_output_encoded_len(const sbp_msg_command_output_t *msg) {

--- a/c/src/v4/system.c
+++ b/c/src/v4/system.c
@@ -174,6 +174,10 @@ const char *sbp_msg_dgnss_status_source_get(const sbp_msg_dgnss_status_t *msg) {
   return sbp_unterminated_string_get(&msg->source, 251);
 }
 
+size_t sbp_msg_dgnss_status_source_strlen(const sbp_msg_dgnss_status_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->source, 251);
+}
+
 size_t sbp_msg_dgnss_status_encoded_len(const sbp_msg_dgnss_status_t *msg) {
   size_t encoded_len = 0;
   encoded_len += sbp_u8_encoded_len(&msg->flags);
@@ -725,6 +729,11 @@ const char *sbp_msg_csac_telemetry_telemetry_get(
   return sbp_unterminated_string_get(&msg->telemetry, 254);
 }
 
+size_t sbp_msg_csac_telemetry_telemetry_strlen(
+    const sbp_msg_csac_telemetry_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->telemetry, 254);
+}
+
 size_t sbp_msg_csac_telemetry_encoded_len(const sbp_msg_csac_telemetry_t *msg) {
   size_t encoded_len = 0;
   encoded_len += sbp_u8_encoded_len(&msg->id);
@@ -880,6 +889,11 @@ bool sbp_msg_csac_telemetry_labels_telemetry_labels_append_vprintf(
 const char *sbp_msg_csac_telemetry_labels_telemetry_labels_get(
     const sbp_msg_csac_telemetry_labels_t *msg) {
   return sbp_unterminated_string_get(&msg->telemetry_labels, 254);
+}
+
+size_t sbp_msg_csac_telemetry_labels_telemetry_labels_strlen(
+    const sbp_msg_csac_telemetry_labels_t *msg) {
+  return sbp_unterminated_string_strlen(&msg->telemetry_labels, 254);
 }
 
 size_t sbp_msg_csac_telemetry_labels_encoded_len(

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -87,6 +87,11 @@ const char *(((field_prefix)))_get(const (((m.type_name))) *msg)
   return (((string_prefix)))_get(&msg->(((f.name))), (((f.max_items))));
 }
 
+size_t (((field_prefix)))_strlen(const (((m.type_name))) *msg)
+{
+  return (((string_prefix)))_strlen(&msg->(((f.name))), (((f.max_items))));
+}
+
 ((*- elif f.encoding == "multipart" or f.encoding == "double_null_terminated" *))
 size_t (((field_prefix)))_count_sections(const (((m.type_name))) *msg)
 {

--- a/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
@@ -216,7 +216,7 @@ typedef struct {
    * @param section Section number
    * @return Length of section
    */
-  size_t (((prefix)))_section_strlen(const (((m.type_name))) *msg, size_t section);
+  size_t (((prefix)))_strlen(const (((m.type_name))) *msg, size_t section);
   ((*- elif f.encoding == "multipart" or f.encoding == "double_null_terminated" *))
   /**
    * Return the number of sections in (((comment_name)))

--- a/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
@@ -213,10 +213,9 @@ typedef struct {
    * The returned value does not include the NULL terminator.
    *
    * @param msg (((m.type_name))) instance
-   * @param section Section number
-   * @return Length of section
+   * @return Length of string
    */
-  size_t (((prefix)))_strlen(const (((m.type_name))) *msg, size_t section);
+  size_t (((prefix)))_strlen(const (((m.type_name))) *msg);
   ((*- elif f.encoding == "multipart" or f.encoding == "double_null_terminated" *))
   /**
    * Return the number of sections in (((comment_name)))

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "sbp"
-version = "3.4.9-alpha"
+version = "3.4.8-alpha"
 description = "Rust native implementation of SBP (Swift Binary Protocol) for communicating with devices made by Swift Navigation"
 authors = ["Swift Navigation <dev@swiftnav.com>"]
 repository = "https://github.com/swift-nav/libsbp"

--- a/rust/sbp2json/Cargo.toml
+++ b/rust/sbp2json/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "sbp2json"
-version = "3.4.9-alpha"
+version = "3.4.8-alpha"
 authors = ["Swift Navigation <dev@swiftnav.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Fields of type unterminated or null-terminated string have a helper function which is equivalent to `strlen`. It's badly named currently in the form `<field-prefix>_section_strlen` when it should be `<field-prefix>_strlen` (Anything to do with `section` is only relevant to multipart or double null terminated string).

Also, the function isn't actually implemented in source.