### PR TITLE
[ESD-2117] Add #define for max items in arrays

### DIFF
--- a/c/include/libsbp/acquisition_macros.h
+++ b/c/include/libsbp/acquisition_macros.h
@@ -60,6 +60,14 @@
 
 #define SBP_MSG_ACQ_SV_PROFILE 0x002E
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_acq_sv_profile_t::acq_sv_profile (V4 API) or
+ * msg_acq_sv_profile_t::acq_sv_profile (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_ACQ_SV_PROFILE_ACQ_SV_PROFILE_MAX 7u
+
+/**
  * Encoded length of sbp_msg_acq_sv_profile_t (V4 API) and
  * msg_acq_sv_profile_t (legacy API)
  *
@@ -75,6 +83,14 @@
 #define SBP_MSG_ACQ_SV_PROFILE_ENCODED_OVERHEAD 0u
 
 #define SBP_MSG_ACQ_SV_PROFILE_DEP 0x001E
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_acq_sv_profile_dep_t::acq_sv_profile (V4 API) or
+ * msg_acq_sv_profile_dep_t::acq_sv_profile (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_ACQ_SV_PROFILE_DEP_ACQ_SV_PROFILE_MAX 7u
+
 /**
  * Encoded length of sbp_msg_acq_sv_profile_dep_t (V4 API) and
  * msg_acq_sv_profile_dep_t (legacy API)

--- a/c/include/libsbp/bootload_macros.h
+++ b/c/include/libsbp/bootload_macros.h
@@ -63,6 +63,14 @@
   } while (0)
 
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_bootloader_handshake_resp_t::version (V4 API) or
+ * msg_bootloader_handshake_resp_t::version (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX 251u
+
+/**
  * Encoded length of sbp_msg_bootloader_handshake_resp_t (V4 API) and
  * msg_bootloader_handshake_resp_t (legacy API)
  *
@@ -93,12 +101,27 @@
 
 #define SBP_MSG_NAP_DEVICE_DNA_RESP 0x00DD
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_nap_device_dna_resp_t::dna (V4 API) or msg_nap_device_dna_resp_t::dna
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_NAP_DEVICE_DNA_RESP_DNA_MAX 8u
+
+/**
  * Encoded length of sbp_msg_nap_device_dna_resp_t (V4 API) and
  * msg_nap_device_dna_resp_t (legacy API)
  */
 #define SBP_MSG_NAP_DEVICE_DNA_RESP_ENCODED_LEN 8u
 
 #define SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A 0x00B0
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_bootloader_handshake_dep_a_t::handshake (V4 API) or
+ * msg_bootloader_handshake_dep_a_t::handshake (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX 255u
+
 /**
  * Encoded length of sbp_msg_bootloader_handshake_dep_a_t (V4 API) and
  * msg_bootloader_handshake_dep_a_t (legacy API)

--- a/c/include/libsbp/file_io_macros.h
+++ b/c/include/libsbp/file_io_macros.h
@@ -20,6 +20,14 @@
 
 #define SBP_MSG_FILEIO_READ_REQ 0x00A8
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_read_req_t::filename (V4 API) or
+ * msg_fileio_read_req_t::filename (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX 246u
+
+/**
  * Encoded length of sbp_msg_fileio_read_req_t (V4 API) and
  * msg_fileio_read_req_t (legacy API)
  *
@@ -35,6 +43,14 @@
 #define SBP_MSG_FILEIO_READ_REQ_ENCODED_OVERHEAD 9u
 
 #define SBP_MSG_FILEIO_READ_RESP 0x00A3
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_read_resp_t::contents (V4 API) or
+ * msg_fileio_read_resp_t::contents (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_FILEIO_READ_RESP_CONTENTS_MAX 251u
+
 /**
  * Encoded length of sbp_msg_fileio_read_resp_t (V4 API) and
  * msg_fileio_read_resp_t (legacy API)
@@ -52,6 +68,14 @@
 
 #define SBP_MSG_FILEIO_READ_DIR_REQ 0x00A9
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_read_dir_req_t::dirname (V4 API) or
+ * msg_fileio_read_dir_req_t::dirname (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX 247u
+
+/**
  * Encoded length of sbp_msg_fileio_read_dir_req_t (V4 API) and
  * msg_fileio_read_dir_req_t (legacy API)
  *
@@ -67,6 +91,14 @@
 #define SBP_MSG_FILEIO_READ_DIR_REQ_ENCODED_OVERHEAD 8u
 
 #define SBP_MSG_FILEIO_READ_DIR_RESP 0x00AA
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_read_dir_resp_t::contents (V4 API) or
+ * msg_fileio_read_dir_resp_t::contents (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX 251u
+
 /**
  * Encoded length of sbp_msg_fileio_read_dir_resp_t (V4 API) and
  * msg_fileio_read_dir_resp_t (legacy API)
@@ -84,6 +116,13 @@
 
 #define SBP_MSG_FILEIO_REMOVE 0x00AC
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_remove_t::filename (V4 API) or msg_fileio_remove_t::filename
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_FILEIO_REMOVE_FILENAME_MAX 255u
+
+/**
  * Encoded length of sbp_msg_fileio_remove_t (V4 API) and
  * msg_fileio_remove_t (legacy API)
  *
@@ -99,6 +138,21 @@
 #define SBP_MSG_FILEIO_REMOVE_ENCODED_OVERHEAD 0u
 
 #define SBP_MSG_FILEIO_WRITE_REQ 0x00AD
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_write_req_t::filename (V4 API) or
+ * msg_fileio_write_req_t::filename (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX 247u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_fileio_write_req_t::data (V4 API) or msg_fileio_write_req_t::data
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_FILEIO_WRITE_REQ_DATA_MAX 247u
+
 /**
  * Encoded length of sbp_msg_fileio_write_req_t (V4 API) and
  * msg_fileio_write_req_t (legacy API)

--- a/c/include/libsbp/flash_macros.h
+++ b/c/include/libsbp/flash_macros.h
@@ -33,6 +33,21 @@
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_FLASH_STM (0)
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_FLASH_M25 (1)
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_flash_program_t::addr_start (V4 API) or
+ * msg_flash_program_t::addr_start (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_FLASH_PROGRAM_ADDR_START_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_flash_program_t::data (V4 API) or msg_flash_program_t::data (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_FLASH_PROGRAM_DATA_MAX 250u
+
+/**
  * Encoded length of sbp_msg_flash_program_t (V4 API) and
  * msg_flash_program_t (legacy API)
  *
@@ -86,6 +101,14 @@
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_FLASH_STM (0)
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_FLASH_M25 (1)
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_flash_read_req_t::addr_start (V4 API) or
+ * msg_flash_read_req_t::addr_start (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_FLASH_READ_REQ_ADDR_START_MAX 3u
+
+/**
  * Encoded length of sbp_msg_flash_read_req_t (V4 API) and
  * msg_flash_read_req_t (legacy API)
  */
@@ -105,6 +128,14 @@
 
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_FLASH_STM (0)
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_FLASH_M25 (1)
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_flash_read_resp_t::addr_start (V4 API) or
+ * msg_flash_read_resp_t::addr_start (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_FLASH_READ_RESP_ADDR_START_MAX 3u
+
 /**
  * Encoded length of sbp_msg_flash_read_resp_t (V4 API) and
  * msg_flash_read_resp_t (legacy API)
@@ -154,12 +185,28 @@
 
 #define SBP_MSG_STM_UNIQUE_ID_RESP 0x00E5
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_stm_unique_id_resp_t::stm_id (V4 API) or
+ * msg_stm_unique_id_resp_t::stm_id (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_STM_UNIQUE_ID_RESP_STM_ID_MAX 12u
+
+/**
  * Encoded length of sbp_msg_stm_unique_id_resp_t (V4 API) and
  * msg_stm_unique_id_resp_t (legacy API)
  */
 #define SBP_MSG_STM_UNIQUE_ID_RESP_ENCODED_LEN 12u
 
 #define SBP_MSG_M25_FLASH_WRITE_STATUS 0x00F3
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_m25_flash_write_status_t::status (V4 API) or
+ * msg_m25_flash_write_status_t::status (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_M25_FLASH_WRITE_STATUS_STATUS_MAX 1u
+
 /**
  * Encoded length of sbp_msg_m25_flash_write_status_t (V4 API) and
  * msg_m25_flash_write_status_t (legacy API)

--- a/c/include/libsbp/linux_macros.h
+++ b/c/include/libsbp/linux_macros.h
@@ -20,6 +20,22 @@
 
 #define SBP_MSG_LINUX_CPU_STATE_DEP_A 0x7F00
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_cpu_state_dep_a_t::tname (V4 API) or
+ * msg_linux_cpu_state_dep_a_t::tname (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_LINUX_CPU_STATE_DEP_A_TNAME_MAX 15u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_cpu_state_dep_a_t::cmdline (V4 API) or
+ * msg_linux_cpu_state_dep_a_t::cmdline (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX 236u
+
+/**
  * Encoded length of sbp_msg_linux_cpu_state_dep_a_t (V4 API) and
  * msg_linux_cpu_state_dep_a_t (legacy API)
  *
@@ -35,6 +51,22 @@
 #define SBP_MSG_LINUX_CPU_STATE_DEP_A_ENCODED_OVERHEAD 19u
 
 #define SBP_MSG_LINUX_MEM_STATE_DEP_A 0x7F01
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_mem_state_dep_a_t::tname (V4 API) or
+ * msg_linux_mem_state_dep_a_t::tname (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_LINUX_MEM_STATE_DEP_A_TNAME_MAX 15u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_mem_state_dep_a_t::cmdline (V4 API) or
+ * msg_linux_mem_state_dep_a_t::cmdline (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX 236u
+
 /**
  * Encoded length of sbp_msg_linux_mem_state_dep_a_t (V4 API) and
  * msg_linux_mem_state_dep_a_t (legacy API)
@@ -59,6 +91,14 @@
 
 #define SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS 0x7F03
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_process_socket_counts_t::cmdline (V4 API) or
+ * msg_linux_process_socket_counts_t::cmdline (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX 246u
+
+/**
  * Encoded length of sbp_msg_linux_process_socket_counts_t (V4 API) and
  * msg_linux_process_socket_counts_t (legacy API)
  *
@@ -74,6 +114,22 @@
 #define SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_ENCODED_OVERHEAD 9u
 
 #define SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES 0x7F04
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_process_socket_queues_t::address_of_largest (V4 API) or
+ * msg_linux_process_socket_queues_t::address_of_largest (legacy API) before the
+ * maximum SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_ADDRESS_OF_LARGEST_MAX 64u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_process_socket_queues_t::cmdline (V4 API) or
+ * msg_linux_process_socket_queues_t::cmdline (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX 180u
+
 /**
  * Encoded length of sbp_msg_linux_process_socket_queues_t (V4 API) and
  * msg_linux_process_socket_queues_t (legacy API)
@@ -91,12 +147,36 @@
 
 #define SBP_MSG_LINUX_SOCKET_USAGE 0x7F05
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_socket_usage_t::socket_state_counts (V4 API) or
+ * msg_linux_socket_usage_t::socket_state_counts (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_STATE_COUNTS_MAX 16u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_socket_usage_t::socket_type_counts (V4 API) or
+ * msg_linux_socket_usage_t::socket_type_counts (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_TYPE_COUNTS_MAX 16u
+
+/**
  * Encoded length of sbp_msg_linux_socket_usage_t (V4 API) and
  * msg_linux_socket_usage_t (legacy API)
  */
 #define SBP_MSG_LINUX_SOCKET_USAGE_ENCODED_LEN 72u
 
 #define SBP_MSG_LINUX_PROCESS_FD_COUNT 0x7F06
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_process_fd_count_t::cmdline (V4 API) or
+ * msg_linux_process_fd_count_t::cmdline (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX 250u
+
 /**
  * Encoded length of sbp_msg_linux_process_fd_count_t (V4 API) and
  * msg_linux_process_fd_count_t (legacy API)
@@ -113,6 +193,14 @@
 #define SBP_MSG_LINUX_PROCESS_FD_COUNT_ENCODED_OVERHEAD 5u
 
 #define SBP_MSG_LINUX_PROCESS_FD_SUMMARY 0x7F07
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_process_fd_summary_t::most_opened (V4 API) or
+ * msg_linux_process_fd_summary_t::most_opened (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX 251u
+
 /**
  * Encoded length of sbp_msg_linux_process_fd_summary_t (V4 API) and
  * msg_linux_process_fd_summary_t (legacy API)
@@ -143,6 +231,20 @@
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SYSTEM_TIME_IN_SECONDS (0)
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_GPS_TOW_IN_MILLISECONDS (1)
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_cpu_state_t::tname (V4 API) or msg_linux_cpu_state_t::tname
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_CPU_STATE_TNAME_MAX 15u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_cpu_state_t::cmdline (V4 API) or msg_linux_cpu_state_t::cmdline
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX 231u
+
+/**
  * Encoded length of sbp_msg_linux_cpu_state_t (V4 API) and
  * msg_linux_cpu_state_t (legacy API)
  *
@@ -171,6 +273,20 @@
 
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SYSTEM_TIME_IN_SECONDS (0)
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_GPS_TOW_IN_MILLISECONDS (1)
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_mem_state_t::tname (V4 API) or msg_linux_mem_state_t::tname
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_MEM_STATE_TNAME_MAX 15u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_linux_mem_state_t::cmdline (V4 API) or msg_linux_mem_state_t::cmdline
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX 231u
+
 /**
  * Encoded length of sbp_msg_linux_mem_state_t (V4 API) and
  * msg_linux_mem_state_t (legacy API)

--- a/c/include/libsbp/logging_macros.h
+++ b/c/include/libsbp/logging_macros.h
@@ -38,6 +38,13 @@
 #define SBP_LOG_LOGGING_LEVEL_INFO (6)
 #define SBP_LOG_LOGGING_LEVEL_DEBUG (7)
 /**
+ * The maximum number of items that can be stored in sbp_msg_log_t::text (V4
+ * API) or msg_log_t::text (legacy API) before the maximum SBP message size is
+ * exceeded
+ */
+#define SBP_MSG_LOG_TEXT_MAX 254u
+
+/**
  * Encoded length of sbp_msg_log_t (V4 API) and
  * msg_log_t (legacy API)
  *
@@ -54,6 +61,13 @@
 
 #define SBP_MSG_FWD 0x0402
 /**
+ * The maximum number of items that can be stored in sbp_msg_fwd_t::fwd_payload
+ * (V4 API) or msg_fwd_t::fwd_payload (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_FWD_FWD_PAYLOAD_MAX 253u
+
+/**
  * Encoded length of sbp_msg_fwd_t (V4 API) and
  * msg_fwd_t (legacy API)
  *
@@ -69,6 +83,13 @@
 #define SBP_MSG_FWD_ENCODED_OVERHEAD 2u
 
 #define SBP_MSG_PRINT_DEP 0x0010
+/**
+ * The maximum number of items that can be stored in sbp_msg_print_dep_t::text
+ * (V4 API) or msg_print_dep_t::text (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_PRINT_DEP_TEXT_MAX 255u
+
 /**
  * Encoded length of sbp_msg_print_dep_t (V4 API) and
  * msg_print_dep_t (legacy API)

--- a/c/include/libsbp/observation_macros.h
+++ b/c/include/libsbp/observation_macros.h
@@ -186,6 +186,13 @@
 
 #define SBP_MSG_OBS 0x004A
 /**
+ * The maximum number of items that can be stored in sbp_msg_obs_t::obs (V4 API)
+ * or msg_obs_t::obs (legacy API) before the maximum SBP message size is
+ * exceeded
+ */
+#define SBP_MSG_OBS_OBS_MAX 14u
+
+/**
  * Encoded length of sbp_msg_obs_t (V4 API) and
  * msg_obs_t (legacy API)
  *
@@ -283,12 +290,57 @@
 
 #define SBP_MSG_EPHEMERIS_SBAS_DEP_A 0x0082
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_dep_a_t::pos (V4 API) or
+ * msg_ephemeris_sbas_dep_a_t::pos (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_DEP_A_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_dep_a_t::vel (V4 API) or
+ * msg_ephemeris_sbas_dep_a_t::vel (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_DEP_A_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_dep_a_t::acc (V4 API) or
+ * msg_ephemeris_sbas_dep_a_t::acc (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_DEP_A_ACC_MAX 3u
+
+/**
  * Encoded length of sbp_msg_ephemeris_sbas_dep_a_t (V4 API) and
  * msg_ephemeris_sbas_dep_a_t (legacy API)
  */
 #define SBP_MSG_EPHEMERIS_SBAS_DEP_A_ENCODED_LEN 112u
 
 #define SBP_MSG_EPHEMERIS_GLO_DEP_A 0x0083
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_a_t::pos (V4 API) or msg_ephemeris_glo_dep_a_t::pos
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_A_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_a_t::vel (V4 API) or msg_ephemeris_glo_dep_a_t::vel
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_A_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_a_t::acc (V4 API) or msg_ephemeris_glo_dep_a_t::acc
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_A_ACC_MAX 3u
+
 /**
  * Encoded length of sbp_msg_ephemeris_glo_dep_a_t (V4 API) and
  * msg_ephemeris_glo_dep_a_t (legacy API)
@@ -297,12 +349,57 @@
 
 #define SBP_MSG_EPHEMERIS_SBAS_DEP_B 0x0084
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_dep_b_t::pos (V4 API) or
+ * msg_ephemeris_sbas_dep_b_t::pos (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_DEP_B_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_dep_b_t::vel (V4 API) or
+ * msg_ephemeris_sbas_dep_b_t::vel (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_DEP_B_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_dep_b_t::acc (V4 API) or
+ * msg_ephemeris_sbas_dep_b_t::acc (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_DEP_B_ACC_MAX 3u
+
+/**
  * Encoded length of sbp_msg_ephemeris_sbas_dep_b_t (V4 API) and
  * msg_ephemeris_sbas_dep_b_t (legacy API)
  */
 #define SBP_MSG_EPHEMERIS_SBAS_DEP_B_ENCODED_LEN 110u
 
 #define SBP_MSG_EPHEMERIS_SBAS 0x008C
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_t::pos (V4 API) or msg_ephemeris_sbas_t::pos (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_t::vel (V4 API) or msg_ephemeris_sbas_t::vel (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_sbas_t::acc (V4 API) or msg_ephemeris_sbas_t::acc (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_SBAS_ACC_MAX 3u
+
 /**
  * Encoded length of sbp_msg_ephemeris_sbas_t (V4 API) and
  * msg_ephemeris_sbas_t (legacy API)
@@ -311,12 +408,54 @@
 
 #define SBP_MSG_EPHEMERIS_GLO_DEP_B 0x0085
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_b_t::pos (V4 API) or msg_ephemeris_glo_dep_b_t::pos
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_B_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_b_t::vel (V4 API) or msg_ephemeris_glo_dep_b_t::vel
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_B_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_b_t::acc (V4 API) or msg_ephemeris_glo_dep_b_t::acc
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_B_ACC_MAX 3u
+
+/**
  * Encoded length of sbp_msg_ephemeris_glo_dep_b_t (V4 API) and
  * msg_ephemeris_glo_dep_b_t (legacy API)
  */
 #define SBP_MSG_EPHEMERIS_GLO_DEP_B_ENCODED_LEN 110u
 
 #define SBP_MSG_EPHEMERIS_GLO_DEP_C 0x0087
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_c_t::pos (V4 API) or msg_ephemeris_glo_dep_c_t::pos
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_C_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_c_t::vel (V4 API) or msg_ephemeris_glo_dep_c_t::vel
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_C_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_c_t::acc (V4 API) or msg_ephemeris_glo_dep_c_t::acc
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_C_ACC_MAX 3u
+
 /**
  * Encoded length of sbp_msg_ephemeris_glo_dep_c_t (V4 API) and
  * msg_ephemeris_glo_dep_c_t (legacy API)
@@ -325,12 +464,54 @@
 
 #define SBP_MSG_EPHEMERIS_GLO_DEP_D 0x0088
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_d_t::pos (V4 API) or msg_ephemeris_glo_dep_d_t::pos
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_D_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_d_t::vel (V4 API) or msg_ephemeris_glo_dep_d_t::vel
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_D_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_dep_d_t::acc (V4 API) or msg_ephemeris_glo_dep_d_t::acc
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_DEP_D_ACC_MAX 3u
+
+/**
  * Encoded length of sbp_msg_ephemeris_glo_dep_d_t (V4 API) and
  * msg_ephemeris_glo_dep_d_t (legacy API)
  */
 #define SBP_MSG_EPHEMERIS_GLO_DEP_D_ENCODED_LEN 120u
 
 #define SBP_MSG_EPHEMERIS_GLO 0x008B
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_t::pos (V4 API) or msg_ephemeris_glo_t::pos (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_POS_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_t::vel (V4 API) or msg_ephemeris_glo_t::vel (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_VEL_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ephemeris_glo_t::acc (V4 API) or msg_ephemeris_glo_t::acc (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_EPHEMERIS_GLO_ACC_MAX 3u
+
 /**
  * Encoded length of sbp_msg_ephemeris_glo_t (V4 API) and
  * msg_ephemeris_glo_t (legacy API)
@@ -397,6 +578,13 @@
 
 #define SBP_MSG_OBS_DEP_A 0x0045
 /**
+ * The maximum number of items that can be stored in sbp_msg_obs_dep_a_t::obs
+ * (V4 API) or msg_obs_dep_a_t::obs (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_OBS_DEP_A_OBS_MAX 19u
+
+/**
  * Encoded length of sbp_msg_obs_dep_a_t (V4 API) and
  * msg_obs_dep_a_t (legacy API)
  *
@@ -413,6 +601,13 @@
 
 #define SBP_MSG_OBS_DEP_B 0x0043
 /**
+ * The maximum number of items that can be stored in sbp_msg_obs_dep_b_t::obs
+ * (V4 API) or msg_obs_dep_b_t::obs (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_OBS_DEP_B_OBS_MAX 15u
+
+/**
  * Encoded length of sbp_msg_obs_dep_b_t (V4 API) and
  * msg_obs_dep_b_t (legacy API)
  *
@@ -428,6 +623,13 @@
 #define SBP_MSG_OBS_DEP_B_ENCODED_OVERHEAD 7u
 
 #define SBP_MSG_OBS_DEP_C 0x0049
+/**
+ * The maximum number of items that can be stored in sbp_msg_obs_dep_c_t::obs
+ * (V4 API) or msg_obs_dep_c_t::obs (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_OBS_DEP_C_OBS_MAX 15u
+
 /**
  * Encoded length of sbp_msg_obs_dep_c_t (V4 API) and
  * msg_obs_dep_c_t (legacy API)
@@ -546,6 +748,13 @@
 
 #define SBP_MSG_SV_AZ_EL 0x0097
 /**
+ * The maximum number of items that can be stored in sbp_msg_sv_az_el_t::azel
+ * (V4 API) or msg_sv_az_el_t::azel (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_SV_AZ_EL_AZEL_MAX 63u
+
+/**
  * Encoded length of sbp_msg_sv_az_el_t (V4 API) and
  * msg_sv_az_el_t (legacy API)
  *
@@ -561,6 +770,13 @@
 #define SBP_MSG_SV_AZ_EL_ENCODED_OVERHEAD 0u
 
 #define SBP_MSG_OSR 0x0640
+/**
+ * The maximum number of items that can be stored in sbp_msg_osr_t::obs (V4 API)
+ * or msg_osr_t::obs (legacy API) before the maximum SBP message size is
+ * exceeded
+ */
+#define SBP_MSG_OSR_OBS_MAX 12u
+
 /**
  * Encoded length of sbp_msg_osr_t (V4 API) and
  * msg_osr_t (legacy API)

--- a/c/include/libsbp/piksi_macros.h
+++ b/c/include/libsbp/piksi_macros.h
@@ -103,6 +103,13 @@
 
 #define SBP_MSG_THREAD_STATE 0x0017
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_thread_state_t::name (V4 API) or msg_thread_state_t::name (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_THREAD_STATE_NAME_MAX 20u
+
+/**
  * Encoded length of sbp_msg_thread_state_t (V4 API) and
  * msg_thread_state_t (legacy API)
  */
@@ -226,6 +233,13 @@
 
 #define SBP_MSG_COMMAND_REQ 0x00B8
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_command_req_t::command (V4 API) or msg_command_req_t::command (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_COMMAND_REQ_COMMAND_MAX 251u
+
+/**
  * Encoded length of sbp_msg_command_req_t (V4 API) and
  * msg_command_req_t (legacy API)
  *
@@ -249,6 +263,13 @@
 
 #define SBP_MSG_COMMAND_OUTPUT 0x00BC
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_command_output_t::line (V4 API) or msg_command_output_t::line (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_COMMAND_OUTPUT_LINE_MAX 251u
+
+/**
  * Encoded length of sbp_msg_command_output_t (V4 API) and
  * msg_command_output_t (legacy API)
  *
@@ -271,6 +292,30 @@
 #define SBP_MSG_NETWORK_STATE_REQ_ENCODED_LEN 0u
 
 #define SBP_MSG_NETWORK_STATE_RESP 0x00BB
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_network_state_resp_t::ipv4_address (V4 API) or
+ * msg_network_state_resp_t::ipv4_address (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_NETWORK_STATE_RESP_IPV4_ADDRESS_MAX 4u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_network_state_resp_t::ipv6_address (V4 API) or
+ * msg_network_state_resp_t::ipv6_address (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_NETWORK_STATE_RESP_IPV6_ADDRESS_MAX 16u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_network_state_resp_t::interface_name (V4 API) or
+ * msg_network_state_resp_t::interface_name (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_NETWORK_STATE_RESP_INTERFACE_NAME_MAX 16u
+
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT (15u)
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_GET(flags) \
@@ -528,12 +573,28 @@
 #define SBP_MSG_NETWORK_STATE_RESP_ENCODED_LEN 50u
 
 /**
+ * The maximum number of items that can be stored in
+ * sbp_network_usage_t::interface_name (V4 API) or
+ * network_usage_t::interface_name (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_NETWORK_USAGE_INTERFACE_NAME_MAX 16u
+
+/**
  * Encoded length of sbp_network_usage_t (V4 API) and
  * network_usage_t (legacy API)
  */
 #define SBP_NETWORK_USAGE_ENCODED_LEN 40u
 
 #define SBP_MSG_NETWORK_BANDWIDTH_USAGE 0x00BD
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_network_bandwidth_usage_t::interfaces (V4 API) or
+ * msg_network_bandwidth_usage_t::interfaces (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_NETWORK_BANDWIDTH_USAGE_INTERFACES_MAX 6u
+
 /**
  * Encoded length of sbp_msg_network_bandwidth_usage_t (V4 API) and
  * msg_network_bandwidth_usage_t (legacy API)
@@ -551,6 +612,14 @@
 
 #define SBP_MSG_CELL_MODEM_STATUS 0x00BE
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_cell_modem_status_t::reserved (V4 API) or
+ * msg_cell_modem_status_t::reserved (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_CELL_MODEM_STATUS_RESERVED_MAX 250u
+
+/**
  * Encoded length of sbp_msg_cell_modem_status_t (V4 API) and
  * msg_cell_modem_status_t (legacy API)
  *
@@ -566,6 +635,14 @@
 #define SBP_MSG_CELL_MODEM_STATUS_ENCODED_OVERHEAD 5u
 
 #define SBP_MSG_SPECAN_DEP 0x0050
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_specan_dep_t::amplitude_value (V4 API) or
+ * msg_specan_dep_t::amplitude_value (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_SPECAN_DEP_AMPLITUDE_VALUE_MAX 231u
+
 /**
  * Encoded length of sbp_msg_specan_dep_t (V4 API) and
  * msg_specan_dep_t (legacy API)
@@ -583,6 +660,13 @@
 
 #define SBP_MSG_SPECAN 0x0051
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_specan_t::amplitude_value (V4 API) or msg_specan_t::amplitude_value
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SPECAN_AMPLITUDE_VALUE_MAX 227u
+
+/**
  * Encoded length of sbp_msg_specan_t (V4 API) and
  * msg_specan_t (legacy API)
  *
@@ -598,6 +682,20 @@
 #define SBP_MSG_SPECAN_ENCODED_OVERHEAD 28u
 
 #define SBP_MSG_FRONT_END_GAIN 0x00BF
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_front_end_gain_t::rf_gain (V4 API) or msg_front_end_gain_t::rf_gain
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_FRONT_END_GAIN_RF_GAIN_MAX 8u
+
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_front_end_gain_t::if_gain (V4 API) or msg_front_end_gain_t::if_gain
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_FRONT_END_GAIN_IF_GAIN_MAX 8u
+
 /**
  * Encoded length of sbp_msg_front_end_gain_t (V4 API) and
  * msg_front_end_gain_t (legacy API)

--- a/c/include/libsbp/sbas_macros.h
+++ b/c/include/libsbp/sbas_macros.h
@@ -20,6 +20,13 @@
 
 #define SBP_MSG_SBAS_RAW 0x7777
 /**
+ * The maximum number of items that can be stored in sbp_msg_sbas_raw_t::data
+ * (V4 API) or msg_sbas_raw_t::data (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_SBAS_RAW_DATA_MAX 27u
+
+/**
  * Encoded length of sbp_msg_sbas_raw_t (V4 API) and
  * msg_sbas_raw_t (legacy API)
  */

--- a/c/include/libsbp/settings_macros.h
+++ b/c/include/libsbp/settings_macros.h
@@ -27,6 +27,13 @@
 
 #define SBP_MSG_SETTINGS_WRITE 0x00A0
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_write_t::setting (V4 API) or msg_settings_write_t::setting
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SETTINGS_WRITE_SETTING_MAX 255u
+
+/**
  * Encoded length of sbp_msg_settings_write_t (V4 API) and
  * msg_settings_write_t (legacy API)
  *
@@ -65,6 +72,14 @@
   (5)
 #define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_REJECTED_UNSPECIFIED_ERROR (6)
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_write_resp_t::setting (V4 API) or
+ * msg_settings_write_resp_t::setting (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX 254u
+
+/**
  * Encoded length of sbp_msg_settings_write_resp_t (V4 API) and
  * msg_settings_write_resp_t (legacy API)
  *
@@ -81,6 +96,14 @@
 
 #define SBP_MSG_SETTINGS_READ_REQ 0x00A4
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_read_req_t::setting (V4 API) or
+ * msg_settings_read_req_t::setting (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX 255u
+
+/**
  * Encoded length of sbp_msg_settings_read_req_t (V4 API) and
  * msg_settings_read_req_t (legacy API)
  *
@@ -96,6 +119,14 @@
 #define SBP_MSG_SETTINGS_READ_REQ_ENCODED_OVERHEAD 0u
 
 #define SBP_MSG_SETTINGS_READ_RESP 0x00A5
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_read_resp_t::setting (V4 API) or
+ * msg_settings_read_resp_t::setting (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX 255u
+
 /**
  * Encoded length of sbp_msg_settings_read_resp_t (V4 API) and
  * msg_settings_read_resp_t (legacy API)
@@ -120,6 +151,14 @@
 
 #define SBP_MSG_SETTINGS_READ_BY_INDEX_RESP 0x00A7
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_read_by_index_resp_t::setting (V4 API) or
+ * msg_settings_read_by_index_resp_t::setting (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX 253u
+
+/**
  * Encoded length of sbp_msg_settings_read_by_index_resp_t (V4 API) and
  * msg_settings_read_by_index_resp_t (legacy API)
  *
@@ -142,6 +181,14 @@
 #define SBP_MSG_SETTINGS_READ_BY_INDEX_DONE_ENCODED_LEN 0u
 
 #define SBP_MSG_SETTINGS_REGISTER 0x00AE
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_register_t::setting (V4 API) or
+ * msg_settings_register_t::setting (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_SETTINGS_REGISTER_SETTING_MAX 255u
+
 /**
  * Encoded length of sbp_msg_settings_register_t (V4 API) and
  * msg_settings_register_t (legacy API)
@@ -177,6 +224,14 @@
   (2)
 #define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_REJECTED_MALFORMED_MESSAGE \
   (3)
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_settings_register_resp_t::setting (V4 API) or
+ * msg_settings_register_resp_t::setting (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX 254u
+
 /**
  * Encoded length of sbp_msg_settings_register_resp_t (V4 API) and
  * msg_settings_register_resp_t (legacy API)

--- a/c/include/libsbp/solution_meta_macros.h
+++ b/c/include/libsbp/solution_meta_macros.h
@@ -79,6 +79,13 @@
 #define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_NO_SEED_VALUES_NOR_GNSS_MEASUREMENTS \
   (4)
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_soln_meta_dep_a_t::sol_in (V4 API) or msg_soln_meta_dep_a_t::sol_in
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SOLN_META_DEP_A_SOL_IN_MAX 118u
+
+/**
  * Encoded length of sbp_msg_soln_meta_dep_a_t (V4 API) and
  * msg_soln_meta_dep_a_t (legacy API)
  *
@@ -122,6 +129,13 @@
        (SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_MASK))      \
       << (SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT))); \
   } while (0)
+
+/**
+ * The maximum number of items that can be stored in sbp_msg_soln_meta_t::sol_in
+ * (V4 API) or msg_soln_meta_t::sol_in (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_SOLN_META_SOL_IN_MAX 119u
 
 /**
  * Encoded length of sbp_msg_soln_meta_t (V4 API) and

--- a/c/include/libsbp/ssr_macros.h
+++ b/c/include/libsbp/ssr_macros.h
@@ -43,6 +43,13 @@
 #define SBP_GRIDDED_CORRECTION_HEADER_ENCODED_LEN 17u
 
 /**
+ * The maximum number of items that can be stored in
+ * sbp_stec_sat_element_t::stec_coeff (V4 API) or stec_sat_element_t::stec_coeff
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_STEC_SAT_ELEMENT_STEC_COEFF_MAX 4u
+
+/**
  * Encoded length of sbp_stec_sat_element_t (V4 API) and
  * stec_sat_element_t (legacy API)
  */
@@ -81,6 +88,13 @@
 
 #define SBP_MSG_SSR_CODE_BIASES 0x05E1
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_code_biases_t::biases (V4 API) or msg_ssr_code_biases_t::biases
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_CODE_BIASES_BIASES_MAX 81u
+
+/**
  * Encoded length of sbp_msg_ssr_code_biases_t (V4 API) and
  * msg_ssr_code_biases_t (legacy API)
  *
@@ -96,6 +110,13 @@
 #define SBP_MSG_SSR_CODE_BIASES_ENCODED_OVERHEAD 10u
 
 #define SBP_MSG_SSR_PHASE_BIASES 0x05E6
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_phase_biases_t::biases (V4 API) or msg_ssr_phase_biases_t::biases
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_PHASE_BIASES_BIASES_MAX 30u
+
 /**
  * Encoded length of sbp_msg_ssr_phase_biases_t (V4 API) and
  * msg_ssr_phase_biases_t (legacy API)
@@ -113,6 +134,14 @@
 
 #define SBP_MSG_SSR_STEC_CORRECTION 0x05FB
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_stec_correction_t::stec_sat_list (V4 API) or
+ * msg_ssr_stec_correction_t::stec_sat_list (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_SSR_STEC_CORRECTION_STEC_SAT_LIST_MAX 21u
+
+/**
  * Encoded length of sbp_msg_ssr_stec_correction_t (V4 API) and
  * msg_ssr_stec_correction_t (legacy API)
  *
@@ -128,6 +157,14 @@
 #define SBP_MSG_SSR_STEC_CORRECTION_ENCODED_OVERHEAD 14u
 
 #define SBP_MSG_SSR_GRIDDED_CORRECTION 0x05FC
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_gridded_correction_t::stec_residuals (V4 API) or
+ * msg_ssr_gridded_correction_t::stec_residuals (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_GRIDDED_CORRECTION_STEC_RESIDUALS_MAX 46u
+
 /**
  * Encoded length of sbp_msg_ssr_gridded_correction_t (V4 API) and
  * msg_ssr_gridded_correction_t (legacy API)
@@ -182,12 +219,33 @@
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_BEIDOU_3I_CAST (18)
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_QZSS (19)
 /**
+ * The maximum number of items that can be stored in sbp_satellite_apc_t::pco
+ * (V4 API) or satellite_apc_t::pco (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_SATELLITE_APC_PCO_MAX 3u
+
+/**
+ * The maximum number of items that can be stored in sbp_satellite_apc_t::pcv
+ * (V4 API) or satellite_apc_t::pcv (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_SATELLITE_APC_PCV_MAX 21u
+
+/**
  * Encoded length of sbp_satellite_apc_t (V4 API) and
  * satellite_apc_t (legacy API)
  */
 #define SBP_SATELLITE_APC_ENCODED_LEN 32u
 
 #define SBP_MSG_SSR_SATELLITE_APC 0x0604
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_satellite_apc_t::apc (V4 API) or msg_ssr_satellite_apc_t::apc
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_SATELLITE_APC_APC_MAX 7u
+
 /**
  * Encoded length of sbp_msg_ssr_satellite_apc_t (V4 API) and
  * msg_ssr_satellite_apc_t (legacy API)
@@ -230,6 +288,14 @@
 
 #define SBP_MSG_SSR_STEC_CORRECTION_DEP_A 0x05EB
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_stec_correction_dep_a_t::stec_sat_list (V4 API) or
+ * msg_ssr_stec_correction_dep_a_t::stec_sat_list (legacy API) before the
+ * maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_STEC_CORRECTION_DEP_A_STEC_SAT_LIST_MAX 22u
+
+/**
  * Encoded length of sbp_msg_ssr_stec_correction_dep_a_t (V4 API) and
  * msg_ssr_stec_correction_dep_a_t (legacy API)
  *
@@ -245,6 +311,14 @@
 #define SBP_MSG_SSR_STEC_CORRECTION_DEP_A_ENCODED_OVERHEAD 10u
 
 #define SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A 0x05F0
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_gridded_correction_no_std_dep_a_t::stec_residuals (V4 API) or
+ * msg_ssr_gridded_correction_no_std_dep_a_t::stec_residuals (legacy API) before
+ * the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A_STEC_RESIDUALS_MAX 59u
+
 /**
  * Encoded length of sbp_msg_ssr_gridded_correction_no_std_dep_a_t (V4 API) and
  * msg_ssr_gridded_correction_no_std_dep_a_t (legacy API)
@@ -263,6 +337,14 @@
 
 #define SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A 0x05FA
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_gridded_correction_dep_a_t::stec_residuals (V4 API) or
+ * msg_ssr_gridded_correction_dep_a_t::stec_residuals (legacy API) before the
+ * maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A_STEC_RESIDUALS_MAX 47u
+
+/**
  * Encoded length of sbp_msg_ssr_gridded_correction_dep_a_t (V4 API) and
  * msg_ssr_gridded_correction_dep_a_t (legacy API)
  *
@@ -278,6 +360,14 @@
 #define SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A_ENCODED_OVERHEAD 19u
 
 #define SBP_MSG_SSR_GRID_DEFINITION_DEP_A 0x05F5
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_grid_definition_dep_a_t::rle_list (V4 API) or
+ * msg_ssr_grid_definition_dep_a_t::rle_list (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_SSR_GRID_DEFINITION_DEP_A_RLE_LIST_MAX 246u
+
 /**
  * Encoded length of sbp_msg_ssr_grid_definition_dep_a_t (V4 API) and
  * msg_ssr_grid_definition_dep_a_t (legacy API)

--- a/c/include/libsbp/system_macros.h
+++ b/c/include/libsbp/system_macros.h
@@ -67,6 +67,13 @@
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_CODE_DIFFERENCE (1)
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_RTK (2)
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_dgnss_status_t::source (V4 API) or msg_dgnss_status_t::source (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_DGNSS_STATUS_SOURCE_MAX 251u
+
+/**
  * Encoded length of sbp_msg_dgnss_status_t (V4 API) and
  * msg_dgnss_status_t (legacy API)
  *
@@ -254,6 +261,13 @@
   } while (0)
 
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_status_report_t::status (V4 API) or msg_status_report_t::status
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_STATUS_REPORT_STATUS_MAX 60u
+
+/**
  * Encoded length of sbp_msg_status_report_t (V4 API) and
  * msg_status_report_t (legacy API)
  *
@@ -374,6 +388,14 @@
 
 #define SBP_MSG_CSAC_TELEMETRY 0xFF04
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_csac_telemetry_t::telemetry (V4 API) or
+ * msg_csac_telemetry_t::telemetry (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX 254u
+
+/**
  * Encoded length of sbp_msg_csac_telemetry_t (V4 API) and
  * msg_csac_telemetry_t (legacy API)
  *
@@ -389,6 +411,14 @@
 #define SBP_MSG_CSAC_TELEMETRY_ENCODED_OVERHEAD 1u
 
 #define SBP_MSG_CSAC_TELEMETRY_LABELS 0xFF05
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_csac_telemetry_labels_t::telemetry_labels (V4 API) or
+ * msg_csac_telemetry_labels_t::telemetry_labels (legacy API) before the maximum
+ * SBP message size is exceeded
+ */
+#define SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX 254u
+
 /**
  * Encoded length of sbp_msg_csac_telemetry_labels_t (V4 API) and
  * msg_csac_telemetry_labels_t (legacy API)
@@ -682,6 +712,13 @@
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_NONE (0)
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_GNSS_ONLY (1)
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_GNSSINS (2)
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_group_meta_t::group_msgs (V4 API) or msg_group_meta_t::group_msgs
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_GROUP_META_GROUP_MSGS_MAX 126u
+
 /**
  * Encoded length of sbp_msg_group_meta_t (V4 API) and
  * msg_group_meta_t (legacy API)

--- a/c/include/libsbp/tracking_macros.h
+++ b/c/include/libsbp/tracking_macros.h
@@ -584,6 +584,13 @@
 
 #define SBP_MSG_TRACKING_STATE 0x0041
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_tracking_state_t::states (V4 API) or msg_tracking_state_t::states
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_TRACKING_STATE_STATES_MAX 63u
+
+/**
  * Encoded length of sbp_msg_tracking_state_t (V4 API) and
  * msg_tracking_state_t (legacy API)
  *
@@ -605,6 +612,14 @@
 #define SBP_MEASUREMENT_STATE_ENCODED_LEN 3u
 
 #define SBP_MSG_MEASUREMENT_STATE 0x0061
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_measurement_state_t::states (V4 API) or
+ * msg_measurement_state_t::states (legacy API) before the maximum SBP message
+ * size is exceeded
+ */
+#define SBP_MSG_MEASUREMENT_STATE_STATES_MAX 85u
+
 /**
  * Encoded length of sbp_msg_measurement_state_t (V4 API) and
  * msg_measurement_state_t (legacy API)
@@ -628,6 +643,13 @@
 
 #define SBP_MSG_TRACKING_IQ 0x002D
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_tracking_iq_t::corrs (V4 API) or msg_tracking_iq_t::corrs (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_TRACKING_IQ_CORRS_MAX 3u
+
+/**
  * Encoded length of sbp_msg_tracking_iq_t (V4 API) and
  * msg_tracking_iq_t (legacy API)
  */
@@ -641,12 +663,26 @@
 
 #define SBP_MSG_TRACKING_IQ_DEP_B 0x002C
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_tracking_iq_dep_b_t::corrs (V4 API) or msg_tracking_iq_dep_b_t::corrs
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_TRACKING_IQ_DEP_B_CORRS_MAX 3u
+
+/**
  * Encoded length of sbp_msg_tracking_iq_dep_b_t (V4 API) and
  * msg_tracking_iq_dep_b_t (legacy API)
  */
 #define SBP_MSG_TRACKING_IQ_DEP_B_ENCODED_LEN 27u
 
 #define SBP_MSG_TRACKING_IQ_DEP_A 0x001C
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_tracking_iq_dep_a_t::corrs (V4 API) or msg_tracking_iq_dep_a_t::corrs
+ * (legacy API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_TRACKING_IQ_DEP_A_CORRS_MAX 3u
+
 /**
  * Encoded length of sbp_msg_tracking_iq_dep_a_t (V4 API) and
  * msg_tracking_iq_dep_a_t (legacy API)
@@ -673,6 +709,14 @@
 #define SBP_TRACKING_CHANNEL_STATE_DEP_A_ENCODED_LEN 6u
 
 #define SBP_MSG_TRACKING_STATE_DEP_A 0x0016
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_tracking_state_dep_a_t::states (V4 API) or
+ * msg_tracking_state_dep_a_t::states (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_TRACKING_STATE_DEP_A_STATES_MAX 42u
+
 /**
  * Encoded length of sbp_msg_tracking_state_dep_a_t (V4 API) and
  * msg_tracking_state_dep_a_t (legacy API)
@@ -708,6 +752,14 @@
 #define SBP_TRACKING_CHANNEL_STATE_DEP_B_ENCODED_LEN 9u
 
 #define SBP_MSG_TRACKING_STATE_DEP_B 0x0013
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_tracking_state_dep_b_t::states (V4 API) or
+ * msg_tracking_state_dep_b_t::states (legacy API) before the maximum SBP
+ * message size is exceeded
+ */
+#define SBP_MSG_TRACKING_STATE_DEP_B_STATES_MAX 28u
+
 /**
  * Encoded length of sbp_msg_tracking_state_dep_b_t (V4 API) and
  * msg_tracking_state_dep_b_t (legacy API)

--- a/c/include/libsbp/user_macros.h
+++ b/c/include/libsbp/user_macros.h
@@ -20,6 +20,13 @@
 
 #define SBP_MSG_USER_DATA 0x0800
 /**
+ * The maximum number of items that can be stored in
+ * sbp_msg_user_data_t::contents (V4 API) or msg_user_data_t::contents (legacy
+ * API) before the maximum SBP message size is exceeded
+ */
+#define SBP_MSG_USER_DATA_CONTENTS_MAX 255u
+
+/**
  * Encoded length of sbp_msg_user_data_t (V4 API) and
  * msg_user_data_t (legacy API)
  *

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE.h
@@ -48,7 +48,8 @@ typedef struct {
   /**
    * SV profiles during acquisition time
    */
-  sbp_acq_sv_profile_t acq_sv_profile[7];
+  sbp_acq_sv_profile_t
+      acq_sv_profile[SBP_MSG_ACQ_SV_PROFILE_ACQ_SV_PROFILE_MAX];
   /**
    * Number of elements in acq_sv_profile
    *

--- a/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
+++ b/c/include/libsbp/v4/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
@@ -47,7 +47,8 @@ typedef struct {
   /**
    * SV profiles during acquisition time
    */
-  sbp_acq_sv_profile_dep_t acq_sv_profile[7];
+  sbp_acq_sv_profile_dep_t
+      acq_sv_profile[SBP_MSG_ACQ_SV_PROFILE_DEP_ACQ_SV_PROFILE_MAX];
   /**
    * Number of elements in acq_sv_profile
    *

--- a/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_RESP.h
+++ b/c/include/libsbp/v4/bootload/MSG_NAP_DEVICE_DNA_RESP.h
@@ -51,7 +51,7 @@ typedef struct {
   /**
    * 57-bit SwiftNAP FPGA Device ID. Remaining bits are padded on the right.
    */
-  u8 dna[8];
+  u8 dna[SBP_MSG_NAP_DEVICE_DNA_RESP_DNA_MAX];
 } sbp_msg_nap_device_dna_resp_t;
 
 /**

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_RESP.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_READ_RESP.h
@@ -54,7 +54,7 @@ typedef struct {
   /**
    * Contents of read file
    */
-  u8 contents[251];
+  u8 contents[SBP_MSG_FILEIO_READ_RESP_CONTENTS_MAX];
   /**
    * Number of elements in contents
    *

--- a/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/v4/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -66,7 +66,7 @@ typedef struct {
   /**
    * Variable-length array of data to write
    */
-  u8 data[247];
+  u8 data[SBP_MSG_FILEIO_WRITE_REQ_DATA_MAX];
   /**
    * Number of elements in data
    *

--- a/c/include/libsbp/v4/flash/MSG_FLASH_PROGRAM.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_PROGRAM.h
@@ -55,7 +55,7 @@ typedef struct {
   /**
    * Starting address offset to program [bytes]
    */
-  u8 addr_start[3];
+  u8 addr_start[SBP_MSG_FLASH_PROGRAM_ADDR_START_MAX];
 
   /**
    * Length of set of addresses to program, counting up from starting address
@@ -66,7 +66,7 @@ typedef struct {
   /**
    * Data to program addresses with, with length N=addr_len
    */
-  u8 data[250];
+  u8 data[SBP_MSG_FLASH_PROGRAM_DATA_MAX];
 } sbp_msg_flash_program_t;
 
 /**

--- a/c/include/libsbp/v4/flash/MSG_FLASH_READ_REQ.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_READ_REQ.h
@@ -56,7 +56,7 @@ typedef struct {
   /**
    * Starting address offset to read from [bytes]
    */
-  u8 addr_start[3];
+  u8 addr_start[SBP_MSG_FLASH_READ_REQ_ADDR_START_MAX];
 
   /**
    * Length of set of addresses to read, counting up from starting address

--- a/c/include/libsbp/v4/flash/MSG_FLASH_READ_RESP.h
+++ b/c/include/libsbp/v4/flash/MSG_FLASH_READ_RESP.h
@@ -56,7 +56,7 @@ typedef struct {
   /**
    * Starting address offset to read from [bytes]
    */
-  u8 addr_start[3];
+  u8 addr_start[SBP_MSG_FLASH_READ_RESP_ADDR_START_MAX];
 
   /**
    * Length of set of addresses to read, counting up from starting address

--- a/c/include/libsbp/v4/flash/MSG_M25_FLASH_WRITE_STATUS.h
+++ b/c/include/libsbp/v4/flash/MSG_M25_FLASH_WRITE_STATUS.h
@@ -47,7 +47,7 @@ typedef struct {
   /**
    * Byte to write to the M25 flash status register
    */
-  u8 status[1];
+  u8 status[SBP_MSG_M25_FLASH_WRITE_STATUS_STATUS_MAX];
 } sbp_msg_m25_flash_write_status_t;
 
 /**

--- a/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_RESP.h
+++ b/c/include/libsbp/v4/flash/MSG_STM_UNIQUE_ID_RESP.h
@@ -49,7 +49,7 @@ typedef struct {
   /**
    * Device unique ID
    */
-  u8 stm_id[12];
+  u8 stm_id[SBP_MSG_STM_UNIQUE_ID_RESP_STM_ID_MAX];
 } sbp_msg_stm_unique_id_resp_t;
 
 /**

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE.h
@@ -72,7 +72,7 @@ typedef struct {
   /**
    * fixed length string representing the thread name
    */
-  char tname[15];
+  char tname[SBP_MSG_LINUX_CPU_STATE_TNAME_MAX];
 
   /**
    * the command line (as much as it fits in the remaining packet)

--- a/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -62,7 +62,7 @@ typedef struct {
   /**
    * fixed length string representing the thread name
    */
-  char tname[15];
+  char tname[SBP_MSG_LINUX_CPU_STATE_DEP_A_TNAME_MAX];
 
   /**
    * the command line (as much as it fits in the remaining packet)

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE.h
@@ -72,7 +72,7 @@ typedef struct {
   /**
    * fixed length string representing the thread name
    */
-  char tname[15];
+  char tname[SBP_MSG_LINUX_MEM_STATE_TNAME_MAX];
 
   /**
    * the command line (as much as it fits in the remaining packet)

--- a/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -62,7 +62,7 @@ typedef struct {
   /**
    * fixed length string representing the thread name
    */
-  char tname[15];
+  char tname[SBP_MSG_LINUX_MEM_STATE_DEP_A_TNAME_MAX];
 
   /**
    * the command line (as much as it fits in the remaining packet)

--- a/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -81,7 +81,8 @@ typedef struct {
    * Address of the largest queue, remote or local depending on the
    * directionality of the connection.
    */
-  char address_of_largest[64];
+  char address_of_largest
+      [SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_ADDRESS_OF_LARGEST_MAX];
 
   /**
    * the command line of the process in question

--- a/c/include/libsbp/v4/linux/MSG_LINUX_SOCKET_USAGE.h
+++ b/c/include/libsbp/v4/linux/MSG_LINUX_SOCKET_USAGE.h
@@ -57,13 +57,13 @@ typedef struct {
    * A count for each socket type reported in the `socket_types_reported` field,
    * the first entry corresponds to the first enabled bit in `types_reported`.
    */
-  u16 socket_state_counts[16];
+  u16 socket_state_counts[SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_STATE_COUNTS_MAX];
 
   /**
    * A count for each socket type reported in the `socket_types_reported` field,
    * the first entry corresponds to the first enabled bit in `types_reported`.
    */
-  u16 socket_type_counts[16];
+  u16 socket_type_counts[SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_TYPE_COUNTS_MAX];
 } sbp_msg_linux_socket_usage_t;
 
 /**

--- a/c/include/libsbp/v4/logging/MSG_FWD.h
+++ b/c/include/libsbp/v4/logging/MSG_FWD.h
@@ -59,7 +59,7 @@ typedef struct {
   /**
    * variable length wrapped binary message
    */
-  u8 fwd_payload[253];
+  u8 fwd_payload[SBP_MSG_FWD_FWD_PAYLOAD_MAX];
   /**
    * Number of elements in fwd_payload
    *

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO.h
@@ -70,17 +70,17 @@ typedef struct {
   /**
    * Position of the SV at tb in PZ-90.02 coordinates system [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_GLO_POS_MAX];
 
   /**
    * Velocity vector of the SV at tb in PZ-90.02 coordinates system [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_GLO_VEL_MAX];
 
   /**
    * Acceleration vector of the SV at tb in PZ-90.02 coordinates sys [m/s^2]
    */
-  float acc[3];
+  float acc[SBP_MSG_EPHEMERIS_GLO_ACC_MAX];
 
   /**
    * Frequency slot. FCN+8 (that is [1..14]). 0 or 0xFF for invalid

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_A.h
@@ -65,17 +65,17 @@ typedef struct {
   /**
    * Position of the SV at tb in PZ-90.02 coordinates system [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_GLO_DEP_A_POS_MAX];
 
   /**
    * Velocity vector of the SV at tb in PZ-90.02 coordinates system [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_GLO_DEP_A_VEL_MAX];
 
   /**
    * Acceleration vector of the SV at tb in PZ-90.02 coordinates sys [m/s^2]
    */
-  double acc[3];
+  double acc[SBP_MSG_EPHEMERIS_GLO_DEP_A_ACC_MAX];
 } sbp_msg_ephemeris_glo_dep_a_t;
 
 /**

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_B.h
@@ -65,17 +65,17 @@ typedef struct {
   /**
    * Position of the SV at tb in PZ-90.02 coordinates system [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_GLO_DEP_B_POS_MAX];
 
   /**
    * Velocity vector of the SV at tb in PZ-90.02 coordinates system [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_GLO_DEP_B_VEL_MAX];
 
   /**
    * Acceleration vector of the SV at tb in PZ-90.02 coordinates sys [m/s^2]
    */
-  double acc[3];
+  double acc[SBP_MSG_EPHEMERIS_GLO_DEP_B_ACC_MAX];
 } sbp_msg_ephemeris_glo_dep_b_t;
 
 /**

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_C.h
@@ -70,17 +70,17 @@ typedef struct {
   /**
    * Position of the SV at tb in PZ-90.02 coordinates system [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_GLO_DEP_C_POS_MAX];
 
   /**
    * Velocity vector of the SV at tb in PZ-90.02 coordinates system [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_GLO_DEP_C_VEL_MAX];
 
   /**
    * Acceleration vector of the SV at tb in PZ-90.02 coordinates sys [m/s^2]
    */
-  double acc[3];
+  double acc[SBP_MSG_EPHEMERIS_GLO_DEP_C_ACC_MAX];
 
   /**
    * Frequency slot. FCN+8 (that is [1..14]). 0 or 0xFF for invalid

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_D.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_GLO_DEP_D.h
@@ -68,17 +68,17 @@ typedef struct {
   /**
    * Position of the SV at tb in PZ-90.02 coordinates system [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_GLO_DEP_D_POS_MAX];
 
   /**
    * Velocity vector of the SV at tb in PZ-90.02 coordinates system [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_GLO_DEP_D_VEL_MAX];
 
   /**
    * Acceleration vector of the SV at tb in PZ-90.02 coordinates sys [m/s^2]
    */
-  double acc[3];
+  double acc[SBP_MSG_EPHEMERIS_GLO_DEP_D_ACC_MAX];
 
   /**
    * Frequency slot. FCN+8 (that is [1..14]). 0 or 0xFF for invalid

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS.h
@@ -48,17 +48,17 @@ typedef struct {
   /**
    * Position of the GEO at time toe [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_SBAS_POS_MAX];
 
   /**
    * Velocity of the GEO at time toe [m/s]
    */
-  float vel[3];
+  float vel[SBP_MSG_EPHEMERIS_SBAS_VEL_MAX];
 
   /**
    * Acceleration of the GEO at time toe [m/s^2]
    */
-  float acc[3];
+  float acc[SBP_MSG_EPHEMERIS_SBAS_ACC_MAX];
 
   /**
    * Time offset of the GEO clock w.r.t. SBAS Network Time [s]

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
@@ -48,17 +48,17 @@ typedef struct {
   /**
    * Position of the GEO at time toe [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_SBAS_DEP_A_POS_MAX];
 
   /**
    * Velocity of the GEO at time toe [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_SBAS_DEP_A_VEL_MAX];
 
   /**
    * Acceleration of the GEO at time toe [m/s^2]
    */
-  double acc[3];
+  double acc[SBP_MSG_EPHEMERIS_SBAS_DEP_A_ACC_MAX];
 
   /**
    * Time offset of the GEO clock w.r.t. SBAS Network Time [s]

--- a/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
@@ -53,17 +53,17 @@ typedef struct {
   /**
    * Position of the GEO at time toe [m]
    */
-  double pos[3];
+  double pos[SBP_MSG_EPHEMERIS_SBAS_DEP_B_POS_MAX];
 
   /**
    * Velocity of the GEO at time toe [m/s]
    */
-  double vel[3];
+  double vel[SBP_MSG_EPHEMERIS_SBAS_DEP_B_VEL_MAX];
 
   /**
    * Acceleration of the GEO at time toe [m/s^2]
    */
-  double acc[3];
+  double acc[SBP_MSG_EPHEMERIS_SBAS_DEP_B_ACC_MAX];
 
   /**
    * Time offset of the GEO clock w.r.t. SBAS Network Time [s]

--- a/c/include/libsbp/v4/observation/MSG_OBS.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS.h
@@ -58,7 +58,7 @@ typedef struct {
   /**
    * Pseudorange and carrier phase observation for a satellite being tracked.
    */
-  sbp_packed_obs_content_t obs[14];
+  sbp_packed_obs_content_t obs[SBP_MSG_OBS_OBS_MAX];
   /**
    * Number of elements in obs
    *

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_A.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_A.h
@@ -53,7 +53,7 @@ typedef struct {
   /**
    * Pseudorange and carrier phase observation for a satellite being tracked.
    */
-  sbp_packed_obs_content_dep_a_t obs[19];
+  sbp_packed_obs_content_dep_a_t obs[SBP_MSG_OBS_DEP_A_OBS_MAX];
   /**
    * Number of elements in obs
    *

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_B.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_B.h
@@ -56,7 +56,7 @@ typedef struct {
   /**
    * Pseudorange and carrier phase observation for a satellite being tracked.
    */
-  sbp_packed_obs_content_dep_b_t obs[15];
+  sbp_packed_obs_content_dep_b_t obs[SBP_MSG_OBS_DEP_B_OBS_MAX];
   /**
    * Number of elements in obs
    *

--- a/c/include/libsbp/v4/observation/MSG_OBS_DEP_C.h
+++ b/c/include/libsbp/v4/observation/MSG_OBS_DEP_C.h
@@ -58,7 +58,7 @@ typedef struct {
   /**
    * Pseudorange and carrier phase observation for a satellite being tracked.
    */
-  sbp_packed_obs_content_dep_c_t obs[15];
+  sbp_packed_obs_content_dep_c_t obs[SBP_MSG_OBS_DEP_C_OBS_MAX];
   /**
    * Number of elements in obs
    *

--- a/c/include/libsbp/v4/observation/MSG_OSR.h
+++ b/c/include/libsbp/v4/observation/MSG_OSR.h
@@ -53,7 +53,7 @@ typedef struct {
   /**
    * Network correction for a satellite signal.
    */
-  sbp_packed_osr_content_t obs[12];
+  sbp_packed_osr_content_t obs[SBP_MSG_OSR_OBS_MAX];
   /**
    * Number of elements in obs
    *

--- a/c/include/libsbp/v4/observation/MSG_SV_AZ_EL.h
+++ b/c/include/libsbp/v4/observation/MSG_SV_AZ_EL.h
@@ -48,7 +48,7 @@ typedef struct {
   /**
    * Azimuth and elevation per satellite
    */
-  sbp_sv_az_el_t azel[63];
+  sbp_sv_az_el_t azel[SBP_MSG_SV_AZ_EL_AZEL_MAX];
   /**
    * Number of elements in azel
    *

--- a/c/include/libsbp/v4/piksi/MSG_CELL_MODEM_STATUS.h
+++ b/c/include/libsbp/v4/piksi/MSG_CELL_MODEM_STATUS.h
@@ -58,7 +58,7 @@ typedef struct {
   /**
    * Unspecified data TBD for this schema
    */
-  u8 reserved[250];
+  u8 reserved[SBP_MSG_CELL_MODEM_STATUS_RESERVED_MAX];
   /**
    * Number of elements in reserved
    *

--- a/c/include/libsbp/v4/piksi/MSG_FRONT_END_GAIN.h
+++ b/c/include/libsbp/v4/piksi/MSG_FRONT_END_GAIN.h
@@ -52,12 +52,12 @@ typedef struct {
   /**
    * RF gain for each frontend channel [percent]
    */
-  s8 rf_gain[8];
+  s8 rf_gain[SBP_MSG_FRONT_END_GAIN_RF_GAIN_MAX];
 
   /**
    * Intermediate frequency gain for each frontend channel [percent]
    */
-  s8 if_gain[8];
+  s8 if_gain[SBP_MSG_FRONT_END_GAIN_IF_GAIN_MAX];
 } sbp_msg_front_end_gain_t;
 
 /**

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
@@ -47,7 +47,8 @@ typedef struct {
   /**
    * Usage measurement array
    */
-  sbp_network_usage_t interfaces[6];
+  sbp_network_usage_t
+      interfaces[SBP_MSG_NETWORK_BANDWIDTH_USAGE_INTERFACES_MAX];
   /**
    * Number of elements in interfaces
    *

--- a/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_RESP.h
+++ b/c/include/libsbp/v4/piksi/MSG_NETWORK_STATE_RESP.h
@@ -47,7 +47,7 @@ typedef struct {
   /**
    * IPv4 address (all zero when unavailable)
    */
-  u8 ipv4_address[4];
+  u8 ipv4_address[SBP_MSG_NETWORK_STATE_RESP_IPV4_ADDRESS_MAX];
 
   /**
    * IPv4 netmask CIDR notation
@@ -57,7 +57,7 @@ typedef struct {
   /**
    * IPv6 address (all zero when unavailable)
    */
-  u8 ipv6_address[16];
+  u8 ipv6_address[SBP_MSG_NETWORK_STATE_RESP_IPV6_ADDRESS_MAX];
 
   /**
    * IPv6 netmask CIDR notation
@@ -77,7 +77,7 @@ typedef struct {
   /**
    * Interface Name
    */
-  char interface_name[16];
+  char interface_name[SBP_MSG_NETWORK_STATE_RESP_INTERFACE_NAME_MAX];
 
   /**
    * Interface flags from SIOCGIFFLAGS

--- a/c/include/libsbp/v4/piksi/MSG_SPECAN.h
+++ b/c/include/libsbp/v4/piksi/MSG_SPECAN.h
@@ -77,7 +77,7 @@ typedef struct {
   /**
    * Amplitude values (in the above units) of points in this packet
    */
-  u8 amplitude_value[227];
+  u8 amplitude_value[SBP_MSG_SPECAN_AMPLITUDE_VALUE_MAX];
   /**
    * Number of elements in amplitude_value
    *

--- a/c/include/libsbp/v4/piksi/MSG_SPECAN_DEP.h
+++ b/c/include/libsbp/v4/piksi/MSG_SPECAN_DEP.h
@@ -77,7 +77,7 @@ typedef struct {
   /**
    * Amplitude values (in the above units) of points in this packet
    */
-  u8 amplitude_value[231];
+  u8 amplitude_value[SBP_MSG_SPECAN_DEP_AMPLITUDE_VALUE_MAX];
   /**
    * Number of elements in amplitude_value
    *

--- a/c/include/libsbp/v4/piksi/MSG_THREAD_STATE.h
+++ b/c/include/libsbp/v4/piksi/MSG_THREAD_STATE.h
@@ -48,7 +48,7 @@ typedef struct {
   /**
    * Thread name (NULL terminated)
    */
-  char name[20];
+  char name[SBP_MSG_THREAD_STATE_NAME_MAX];
 
   /**
    * Percentage cpu use for this thread. Values range from 0 - 1000 and needs to

--- a/c/include/libsbp/v4/piksi/NetworkUsage.h
+++ b/c/include/libsbp/v4/piksi/NetworkUsage.h
@@ -70,7 +70,7 @@ typedef struct {
   /**
    * Interface Name
    */
-  char interface_name[16];
+  char interface_name[SBP_NETWORK_USAGE_INTERFACE_NAME_MAX];
 } sbp_network_usage_t;
 
 /**

--- a/c/include/libsbp/v4/sbas/MSG_SBAS_RAW.h
+++ b/c/include/libsbp/v4/sbas/MSG_SBAS_RAW.h
@@ -63,7 +63,7 @@ typedef struct {
   /**
    * Raw SBAS data field of 212 bits (last byte padded with zeros).
    */
-  u8 data[27];
+  u8 data[SBP_MSG_SBAS_RAW_DATA_MAX];
 } sbp_msg_sbas_raw_t;
 
 /**

--- a/c/include/libsbp/v4/solution_meta/MSG_SOLN_META.h
+++ b/c/include/libsbp/v4/solution_meta/MSG_SOLN_META.h
@@ -92,7 +92,7 @@ typedef struct {
    * consists of flags containing (meta)data pertaining to that specific single
    * sensor. Refer to each (XX)InputType descriptor in the present doc.
    */
-  sbp_solution_input_type_t sol_in[119];
+  sbp_solution_input_type_t sol_in[SBP_MSG_SOLN_META_SOL_IN_MAX];
   /**
    * Number of elements in sol_in
    *

--- a/c/include/libsbp/v4/solution_meta/MSG_SOLN_META_DEP_A.h
+++ b/c/include/libsbp/v4/solution_meta/MSG_SOLN_META_DEP_A.h
@@ -95,7 +95,7 @@ typedef struct {
    * consists of flags containing (meta)data pertaining to that specific single
    * sensor. Refer to each (XX)InputType descriptor in the present doc.
    */
-  sbp_solution_input_type_t sol_in[118];
+  sbp_solution_input_type_t sol_in[SBP_MSG_SOLN_META_DEP_A_SOL_IN_MAX];
   /**
    * Number of elements in sol_in
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_CODE_BIASES.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_CODE_BIASES.h
@@ -73,7 +73,7 @@ typedef struct {
   /**
    * Code biases for the different satellite signals
    */
-  sbp_code_biases_content_t biases[81];
+  sbp_code_biases_content_t biases[SBP_MSG_SSR_CODE_BIASES_BIASES_MAX];
   /**
    * Number of elements in biases
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h
@@ -65,7 +65,8 @@ typedef struct {
   /**
    * STEC residuals for each satellite (mean, stddev).
    */
-  sbp_stec_residual_t stec_residuals[46];
+  sbp_stec_residual_t
+      stec_residuals[SBP_MSG_SSR_GRIDDED_CORRECTION_STEC_RESIDUALS_MAX];
   /**
    * Number of elements in stec_residuals
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
@@ -60,7 +60,8 @@ typedef struct {
   /**
    * STEC residuals for each satellite (mean, stddev)
    */
-  sbp_stec_residual_t stec_residuals[47];
+  sbp_stec_residual_t
+      stec_residuals[SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A_STEC_RESIDUALS_MAX];
   /**
    * Number of elements in stec_residuals
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
@@ -60,7 +60,8 @@ typedef struct {
   /**
    * STEC residuals for each satellite
    */
-  sbp_stec_residual_no_std_t stec_residuals[59];
+  sbp_stec_residual_no_std_t stec_residuals
+      [SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A_STEC_RESIDUALS_MAX];
   /**
    * Number of elements in stec_residuals
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
@@ -51,7 +51,7 @@ typedef struct {
    * quadrants that contain transitions between valid and invalid (and vice
    * versa) are encoded as u8 integers.
    */
-  u8 rle_list[246];
+  u8 rle_list[SBP_MSG_SSR_GRID_DEFINITION_DEP_A_RLE_LIST_MAX];
   /**
    * Number of elements in rle_list
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_PHASE_BIASES.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_PHASE_BIASES.h
@@ -95,7 +95,7 @@ typedef struct {
   /**
    * Phase biases corrections for a satellite being tracked.
    */
-  sbp_phase_biases_content_t biases[30];
+  sbp_phase_biases_content_t biases[SBP_MSG_SSR_PHASE_BIASES_BIASES_MAX];
   /**
    * Number of elements in biases
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_SATELLITE_APC.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_SATELLITE_APC.h
@@ -43,7 +43,7 @@ typedef struct {
   /**
    * Satellite antenna phase center corrections
    */
-  sbp_satellite_apc_t apc[7];
+  sbp_satellite_apc_t apc[SBP_MSG_SSR_SATELLITE_APC_APC_MAX];
   /**
    * Number of elements in apc
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION.h
@@ -57,7 +57,8 @@ typedef struct {
   /**
    * Array of STEC polynomial coeffcients for each space vehicle.
    */
-  sbp_stec_sat_element_t stec_sat_list[21];
+  sbp_stec_sat_element_t
+      stec_sat_list[SBP_MSG_SSR_STEC_CORRECTION_STEC_SAT_LIST_MAX];
   /**
    * Number of elements in stec_sat_list
    *

--- a/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
@@ -49,7 +49,8 @@ typedef struct {
   /**
    * Array of STEC information for each space vehicle
    */
-  sbp_stec_sat_element_t stec_sat_list[22];
+  sbp_stec_sat_element_t
+      stec_sat_list[SBP_MSG_SSR_STEC_CORRECTION_DEP_A_STEC_SAT_LIST_MAX];
   /**
    * Number of elements in stec_sat_list
    *

--- a/c/include/libsbp/v4/ssr/STECSatElement.h
+++ b/c/include/libsbp/v4/ssr/STECSatElement.h
@@ -59,7 +59,7 @@ typedef struct {
    * Coefficents of the STEC polynomial in the order of C00, C01, C10, C11 [C00
    * = 0.05 TECU, C01/C10 = 0.02 TECU/deg, C11 0.02 TECU/deg^2]
    */
-  s16 stec_coeff[4];
+  s16 stec_coeff[SBP_STEC_SAT_ELEMENT_STEC_COEFF_MAX];
 } sbp_stec_sat_element_t;
 
 /**

--- a/c/include/libsbp/v4/ssr/SatelliteAPC.h
+++ b/c/include/libsbp/v4/ssr/SatelliteAPC.h
@@ -64,14 +64,14 @@ typedef struct {
    * Mean phase center offset, X Y and Z axises. See IGS ANTEX file format
    * description for coordinate system definition. [1 mm]
    */
-  s16 pco[3];
+  s16 pco[SBP_SATELLITE_APC_PCO_MAX];
 
   /**
    * Elevation dependent phase center variations. First element is 0 degrees
    * separation from the Z axis, subsequent elements represent elevation
    * variations in 1 degree increments. [1 mm]
    */
-  s8 pcv[21];
+  s8 pcv[SBP_SATELLITE_APC_PCV_MAX];
 } sbp_satellite_apc_t;
 
 /**

--- a/c/include/libsbp/v4/system/MSG_GROUP_META.h
+++ b/c/include/libsbp/v4/system/MSG_GROUP_META.h
@@ -64,7 +64,7 @@ typedef struct {
    * An inorder list of message types included in the Solution Group, including
    * GROUP_META itself
    */
-  u16 group_msgs[126];
+  u16 group_msgs[SBP_MSG_GROUP_META_GROUP_MSGS_MAX];
 } sbp_msg_group_meta_t;
 
 /**

--- a/c/include/libsbp/v4/system/MSG_STATUS_REPORT.h
+++ b/c/include/libsbp/v4/system/MSG_STATUS_REPORT.h
@@ -71,7 +71,7 @@ typedef struct {
   /**
    * Reported status of individual subsystems
    */
-  sbp_sub_system_report_t status[60];
+  sbp_sub_system_report_t status[SBP_MSG_STATUS_REPORT_STATUS_MAX];
   /**
    * Number of elements in status
    *

--- a/c/include/libsbp/v4/tracking/MSG_MEASUREMENT_STATE.h
+++ b/c/include/libsbp/v4/tracking/MSG_MEASUREMENT_STATE.h
@@ -49,7 +49,7 @@ typedef struct {
   /**
    * ME signal tracking channel state
    */
-  sbp_measurement_state_t states[85];
+  sbp_measurement_state_t states[SBP_MSG_MEASUREMENT_STATE_STATES_MAX];
   /**
    * Number of elements in states
    *

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ.h
@@ -59,7 +59,7 @@ typedef struct {
   /**
    * Early, Prompt and Late correlations
    */
-  sbp_tracking_channel_correlation_t corrs[3];
+  sbp_tracking_channel_correlation_t corrs[SBP_MSG_TRACKING_IQ_CORRS_MAX];
 } sbp_msg_tracking_iq_t;
 
 /**

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_A.h
@@ -58,7 +58,8 @@ typedef struct {
   /**
    * Early, Prompt and Late correlations
    */
-  sbp_tracking_channel_correlation_dep_t corrs[3];
+  sbp_tracking_channel_correlation_dep_t
+      corrs[SBP_MSG_TRACKING_IQ_DEP_A_CORRS_MAX];
 } sbp_msg_tracking_iq_dep_a_t;
 
 /**

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_B.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_IQ_DEP_B.h
@@ -59,7 +59,8 @@ typedef struct {
   /**
    * Early, Prompt and Late correlations
    */
-  sbp_tracking_channel_correlation_dep_t corrs[3];
+  sbp_tracking_channel_correlation_dep_t
+      corrs[SBP_MSG_TRACKING_IQ_DEP_B_CORRS_MAX];
 } sbp_msg_tracking_iq_dep_b_t;
 
 /**

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE.h
@@ -49,7 +49,7 @@ typedef struct {
   /**
    * Signal tracking channel state
    */
-  sbp_tracking_channel_state_t states[63];
+  sbp_tracking_channel_state_t states[SBP_MSG_TRACKING_STATE_STATES_MAX];
   /**
    * Number of elements in states
    *

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_A.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_A.h
@@ -47,7 +47,8 @@ typedef struct {
   /**
    * Satellite tracking channel state
    */
-  sbp_tracking_channel_state_dep_a_t states[42];
+  sbp_tracking_channel_state_dep_a_t
+      states[SBP_MSG_TRACKING_STATE_DEP_A_STATES_MAX];
   /**
    * Number of elements in states
    *

--- a/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_B.h
+++ b/c/include/libsbp/v4/tracking/MSG_TRACKING_STATE_DEP_B.h
@@ -47,7 +47,8 @@ typedef struct {
   /**
    * Signal tracking channel state
    */
-  sbp_tracking_channel_state_dep_b_t states[28];
+  sbp_tracking_channel_state_dep_b_t
+      states[SBP_MSG_TRACKING_STATE_DEP_B_STATES_MAX];
   /**
    * Number of elements in states
    *

--- a/c/include/libsbp/v4/user/MSG_USER_DATA.h
+++ b/c/include/libsbp/v4/user/MSG_USER_DATA.h
@@ -47,7 +47,7 @@ typedef struct {
   /**
    * User data payload
    */
-  u8 contents[255];
+  u8 contents[SBP_MSG_USER_DATA_CONTENTS_MAX];
   /**
    * Number of elements in contents
    *

--- a/c/src/v4/bootload.c
+++ b/c/src/v4/bootload.c
@@ -92,66 +92,76 @@ void sbp_msg_bootloader_handshake_resp_version_init(
 
 bool sbp_msg_bootloader_handshake_resp_version_valid(
     const sbp_msg_bootloader_handshake_resp_t *msg) {
-  return sbp_unterminated_string_valid(&msg->version, 251);
+  return sbp_unterminated_string_valid(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX);
 }
 
 int sbp_msg_bootloader_handshake_resp_version_strcmp(
     const sbp_msg_bootloader_handshake_resp_t *a,
     const sbp_msg_bootloader_handshake_resp_t *b) {
-  return sbp_unterminated_string_strcmp(&a->version, &b->version, 251);
+  return sbp_unterminated_string_strcmp(
+      &a->version, &b->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX);
 }
 
 size_t sbp_msg_bootloader_handshake_resp_version_encoded_len(
     const sbp_msg_bootloader_handshake_resp_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->version, 251);
+  return sbp_unterminated_string_encoded_len(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX);
 }
 
 size_t sbp_msg_bootloader_handshake_resp_version_space_remaining(
     const sbp_msg_bootloader_handshake_resp_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->version, 251);
+  return sbp_unterminated_string_space_remaining(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX);
 }
 bool sbp_msg_bootloader_handshake_resp_version_set(
     sbp_msg_bootloader_handshake_resp_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->version, 251, new_str);
+  return sbp_unterminated_string_set(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, new_str);
 }
 
 bool sbp_msg_bootloader_handshake_resp_version_printf(
     sbp_msg_bootloader_handshake_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->version, 251, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_bootloader_handshake_resp_version_vprintf(
     sbp_msg_bootloader_handshake_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->version, 251, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, fmt, ap);
 }
 
 bool sbp_msg_bootloader_handshake_resp_version_append_printf(
     sbp_msg_bootloader_handshake_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->version, 251, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_bootloader_handshake_resp_version_append_vprintf(
     sbp_msg_bootloader_handshake_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->version, 251, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, fmt, ap);
 }
 
 const char *sbp_msg_bootloader_handshake_resp_version_get(
     const sbp_msg_bootloader_handshake_resp_t *msg) {
-  return sbp_unterminated_string_get(&msg->version, 251);
+  return sbp_unterminated_string_get(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX);
 }
 
 size_t sbp_msg_bootloader_handshake_resp_version_strlen(
     const sbp_msg_bootloader_handshake_resp_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->version, 251);
+  return sbp_unterminated_string_strlen(
+      &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX);
 }
 
 bool sbp_msg_bootloader_handshake_resp_encode_internal(
@@ -159,7 +169,8 @@ bool sbp_msg_bootloader_handshake_resp_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->flags)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->version, 251, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, ctx)) {
     return false;
   }
   return true;
@@ -186,7 +197,8 @@ bool sbp_msg_bootloader_handshake_resp_decode_internal(
   if (!sbp_u32_decode(ctx, &msg->flags)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->version, 251, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->version, SBP_MSG_BOOTLOADER_HANDSHAKE_RESP_VERSION_MAX, ctx)) {
     return false;
   }
   return true;
@@ -383,7 +395,7 @@ int sbp_msg_nap_device_dna_req_cmp(const sbp_msg_nap_device_dna_req_t *a,
 
 bool sbp_msg_nap_device_dna_resp_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_nap_device_dna_resp_t *msg) {
-  for (size_t i = 0; i < 8; i++) {
+  for (size_t i = 0; i < SBP_MSG_NAP_DEVICE_DNA_RESP_DNA_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->dna[i])) {
       return false;
     }
@@ -409,7 +421,7 @@ s8 sbp_msg_nap_device_dna_resp_encode(
 
 bool sbp_msg_nap_device_dna_resp_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_nap_device_dna_resp_t *msg) {
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_NAP_DEVICE_DNA_RESP_DNA_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->dna[i])) {
       return false;
     }
@@ -451,7 +463,8 @@ int sbp_msg_nap_device_dna_resp_cmp(const sbp_msg_nap_device_dna_resp_t *a,
                                     const sbp_msg_nap_device_dna_resp_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_NAP_DEVICE_DNA_RESP_DNA_MAX;
+       i++) {
     ret = sbp_u8_cmp(&a->dna[i], &b->dna[i]);
   }
   if (ret != 0) {
@@ -467,71 +480,89 @@ void sbp_msg_bootloader_handshake_dep_a_handshake_init(
 
 bool sbp_msg_bootloader_handshake_dep_a_handshake_valid(
     const sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  return sbp_unterminated_string_valid(&msg->handshake, 255);
+  return sbp_unterminated_string_valid(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX);
 }
 
 int sbp_msg_bootloader_handshake_dep_a_handshake_strcmp(
     const sbp_msg_bootloader_handshake_dep_a_t *a,
     const sbp_msg_bootloader_handshake_dep_a_t *b) {
-  return sbp_unterminated_string_strcmp(&a->handshake, &b->handshake, 255);
+  return sbp_unterminated_string_strcmp(
+      &a->handshake, &b->handshake,
+      SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX);
 }
 
 size_t sbp_msg_bootloader_handshake_dep_a_handshake_encoded_len(
     const sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->handshake, 255);
+  return sbp_unterminated_string_encoded_len(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX);
 }
 
 size_t sbp_msg_bootloader_handshake_dep_a_handshake_space_remaining(
     const sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->handshake, 255);
+  return sbp_unterminated_string_space_remaining(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX);
 }
 bool sbp_msg_bootloader_handshake_dep_a_handshake_set(
     sbp_msg_bootloader_handshake_dep_a_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->handshake, 255, new_str);
+  return sbp_unterminated_string_set(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX,
+      new_str);
 }
 
 bool sbp_msg_bootloader_handshake_dep_a_handshake_printf(
     sbp_msg_bootloader_handshake_dep_a_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->handshake, 255, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX, fmt,
+      ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_bootloader_handshake_dep_a_handshake_vprintf(
     sbp_msg_bootloader_handshake_dep_a_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->handshake, 255, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX, fmt,
+      ap);
 }
 
 bool sbp_msg_bootloader_handshake_dep_a_handshake_append_printf(
     sbp_msg_bootloader_handshake_dep_a_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->handshake, 255, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX, fmt,
+      ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_bootloader_handshake_dep_a_handshake_append_vprintf(
     sbp_msg_bootloader_handshake_dep_a_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->handshake, 255, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX, fmt,
+      ap);
 }
 
 const char *sbp_msg_bootloader_handshake_dep_a_handshake_get(
     const sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  return sbp_unterminated_string_get(&msg->handshake, 255);
+  return sbp_unterminated_string_get(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX);
 }
 
 size_t sbp_msg_bootloader_handshake_dep_a_handshake_strlen(
     const sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->handshake, 255);
+  return sbp_unterminated_string_strlen(
+      &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX);
 }
 
 bool sbp_msg_bootloader_handshake_dep_a_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  if (!sbp_unterminated_string_encode(&msg->handshake, 255, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -555,7 +586,9 @@ s8 sbp_msg_bootloader_handshake_dep_a_encode(
 
 bool sbp_msg_bootloader_handshake_dep_a_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_bootloader_handshake_dep_a_t *msg) {
-  if (!sbp_unterminated_string_decode(&msg->handshake, 255, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->handshake, SBP_MSG_BOOTLOADER_HANDSHAKE_DEP_A_HANDSHAKE_MAX,
+          ctx)) {
     return false;
   }
   return true;

--- a/c/src/v4/file_io.c
+++ b/c/src/v4/file_io.c
@@ -22,66 +22,75 @@ void sbp_msg_fileio_read_req_filename_init(sbp_msg_fileio_read_req_t *msg) {
 
 bool sbp_msg_fileio_read_req_filename_valid(
     const sbp_msg_fileio_read_req_t *msg) {
-  return sbp_null_terminated_string_valid(&msg->filename, 246);
+  return sbp_null_terminated_string_valid(&msg->filename,
+                                          SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX);
 }
 
 int sbp_msg_fileio_read_req_filename_strcmp(
     const sbp_msg_fileio_read_req_t *a, const sbp_msg_fileio_read_req_t *b) {
-  return sbp_null_terminated_string_strcmp(&a->filename, &b->filename, 246);
+  return sbp_null_terminated_string_strcmp(
+      &a->filename, &b->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_read_req_filename_encoded_len(
     const sbp_msg_fileio_read_req_t *msg) {
-  return sbp_null_terminated_string_encoded_len(&msg->filename, 246);
+  return sbp_null_terminated_string_encoded_len(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_read_req_filename_space_remaining(
     const sbp_msg_fileio_read_req_t *msg) {
-  return sbp_null_terminated_string_space_remaining(&msg->filename, 246);
+  return sbp_null_terminated_string_space_remaining(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX);
 }
 bool sbp_msg_fileio_read_req_filename_set(sbp_msg_fileio_read_req_t *msg,
                                           const char *new_str) {
-  return sbp_null_terminated_string_set(&msg->filename, 246, new_str);
+  return sbp_null_terminated_string_set(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, new_str);
 }
 
 bool sbp_msg_fileio_read_req_filename_printf(sbp_msg_fileio_read_req_t *msg,
                                              const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(&msg->filename, 246, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_read_req_filename_vprintf(sbp_msg_fileio_read_req_t *msg,
                                               const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_vprintf(&msg->filename, 246, fmt, ap);
+  return sbp_null_terminated_string_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, fmt, ap);
 }
 
 bool sbp_msg_fileio_read_req_filename_append_printf(
     sbp_msg_fileio_read_req_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_null_terminated_string_append_vprintf(&msg->filename, 246, fmt, ap);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_read_req_filename_append_vprintf(
     sbp_msg_fileio_read_req_t *msg, const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_append_vprintf(&msg->filename, 246, fmt,
-                                                   ap);
+  return sbp_null_terminated_string_append_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, fmt, ap);
 }
 
 const char *sbp_msg_fileio_read_req_filename_get(
     const sbp_msg_fileio_read_req_t *msg) {
-  return sbp_null_terminated_string_get(&msg->filename, 246);
+  return sbp_null_terminated_string_get(&msg->filename,
+                                        SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_read_req_filename_strlen(
     const sbp_msg_fileio_read_req_t *msg) {
-  return sbp_null_terminated_string_strlen(&msg->filename, 246);
+  return sbp_null_terminated_string_strlen(
+      &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX);
 }
 
 bool sbp_msg_fileio_read_req_encode_internal(
@@ -95,7 +104,8 @@ bool sbp_msg_fileio_read_req_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->chunk_size)) {
     return false;
   }
-  if (!sbp_null_terminated_string_encode(&msg->filename, 246, ctx)) {
+  if (!sbp_null_terminated_string_encode(
+          &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, ctx)) {
     return false;
   }
   return true;
@@ -127,7 +137,8 @@ bool sbp_msg_fileio_read_req_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->chunk_size)) {
     return false;
   }
-  if (!sbp_null_terminated_string_decode(&msg->filename, 246, ctx)) {
+  if (!sbp_null_terminated_string_decode(
+          &msg->filename, SBP_MSG_FILEIO_READ_REQ_FILENAME_MAX, ctx)) {
     return false;
   }
   return true;
@@ -289,66 +300,76 @@ void sbp_msg_fileio_read_dir_req_dirname_init(
 
 bool sbp_msg_fileio_read_dir_req_dirname_valid(
     const sbp_msg_fileio_read_dir_req_t *msg) {
-  return sbp_null_terminated_string_valid(&msg->dirname, 247);
+  return sbp_null_terminated_string_valid(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX);
 }
 
 int sbp_msg_fileio_read_dir_req_dirname_strcmp(
     const sbp_msg_fileio_read_dir_req_t *a,
     const sbp_msg_fileio_read_dir_req_t *b) {
-  return sbp_null_terminated_string_strcmp(&a->dirname, &b->dirname, 247);
+  return sbp_null_terminated_string_strcmp(
+      &a->dirname, &b->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX);
 }
 
 size_t sbp_msg_fileio_read_dir_req_dirname_encoded_len(
     const sbp_msg_fileio_read_dir_req_t *msg) {
-  return sbp_null_terminated_string_encoded_len(&msg->dirname, 247);
+  return sbp_null_terminated_string_encoded_len(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX);
 }
 
 size_t sbp_msg_fileio_read_dir_req_dirname_space_remaining(
     const sbp_msg_fileio_read_dir_req_t *msg) {
-  return sbp_null_terminated_string_space_remaining(&msg->dirname, 247);
+  return sbp_null_terminated_string_space_remaining(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX);
 }
 bool sbp_msg_fileio_read_dir_req_dirname_set(sbp_msg_fileio_read_dir_req_t *msg,
                                              const char *new_str) {
-  return sbp_null_terminated_string_set(&msg->dirname, 247, new_str);
+  return sbp_null_terminated_string_set(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, new_str);
 }
 
 bool sbp_msg_fileio_read_dir_req_dirname_printf(
     sbp_msg_fileio_read_dir_req_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(&msg->dirname, 247, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_read_dir_req_dirname_vprintf(
     sbp_msg_fileio_read_dir_req_t *msg, const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_vprintf(&msg->dirname, 247, fmt, ap);
+  return sbp_null_terminated_string_vprintf(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, fmt, ap);
 }
 
 bool sbp_msg_fileio_read_dir_req_dirname_append_printf(
     sbp_msg_fileio_read_dir_req_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_null_terminated_string_append_vprintf(&msg->dirname, 247, fmt, ap);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_read_dir_req_dirname_append_vprintf(
     sbp_msg_fileio_read_dir_req_t *msg, const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_append_vprintf(&msg->dirname, 247, fmt, ap);
+  return sbp_null_terminated_string_append_vprintf(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, fmt, ap);
 }
 
 const char *sbp_msg_fileio_read_dir_req_dirname_get(
     const sbp_msg_fileio_read_dir_req_t *msg) {
-  return sbp_null_terminated_string_get(&msg->dirname, 247);
+  return sbp_null_terminated_string_get(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX);
 }
 
 size_t sbp_msg_fileio_read_dir_req_dirname_strlen(
     const sbp_msg_fileio_read_dir_req_t *msg) {
-  return sbp_null_terminated_string_strlen(&msg->dirname, 247);
+  return sbp_null_terminated_string_strlen(
+      &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX);
 }
 
 bool sbp_msg_fileio_read_dir_req_encode_internal(
@@ -359,7 +380,8 @@ bool sbp_msg_fileio_read_dir_req_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->offset)) {
     return false;
   }
-  if (!sbp_null_terminated_string_encode(&msg->dirname, 247, ctx)) {
+  if (!sbp_null_terminated_string_encode(
+          &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, ctx)) {
     return false;
   }
   return true;
@@ -389,7 +411,8 @@ bool sbp_msg_fileio_read_dir_req_decode_internal(
   if (!sbp_u32_decode(ctx, &msg->offset)) {
     return false;
   }
-  if (!sbp_null_terminated_string_decode(&msg->dirname, 247, ctx)) {
+  if (!sbp_null_terminated_string_decode(
+          &msg->dirname, SBP_MSG_FILEIO_READ_DIR_REQ_DIRNAME_MAX, ctx)) {
     return false;
   }
   return true;
@@ -453,76 +476,88 @@ void sbp_msg_fileio_read_dir_resp_contents_init(
 
 bool sbp_msg_fileio_read_dir_resp_contents_valid(
     const sbp_msg_fileio_read_dir_resp_t *msg) {
-  return sbp_multipart_string_valid(&msg->contents, 251);
+  return sbp_multipart_string_valid(&msg->contents,
+                                    SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX);
 }
 
 int sbp_msg_fileio_read_dir_resp_contents_strcmp(
     const sbp_msg_fileio_read_dir_resp_t *a,
     const sbp_msg_fileio_read_dir_resp_t *b) {
-  return sbp_multipart_string_strcmp(&a->contents, &b->contents, 251);
+  return sbp_multipart_string_strcmp(&a->contents, &b->contents,
+                                     SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX);
 }
 
 size_t sbp_msg_fileio_read_dir_resp_contents_encoded_len(
     const sbp_msg_fileio_read_dir_resp_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->contents, 251);
+  return sbp_multipart_string_encoded_len(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX);
 }
 
 size_t sbp_msg_fileio_read_dir_resp_contents_space_remaining(
     const sbp_msg_fileio_read_dir_resp_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->contents, 251);
+  return sbp_multipart_string_space_remaining(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX);
 }
 size_t sbp_msg_fileio_read_dir_resp_contents_count_sections(
     const sbp_msg_fileio_read_dir_resp_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->contents, 251);
+  return sbp_multipart_string_count_sections(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX);
 }
 
 bool sbp_msg_fileio_read_dir_resp_contents_add_section(
     sbp_msg_fileio_read_dir_resp_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->contents, 251, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, new_str);
 }
 
 bool sbp_msg_fileio_read_dir_resp_contents_add_section_printf(
     sbp_msg_fileio_read_dir_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->contents, 251, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_read_dir_resp_contents_add_section_vprintf(
     sbp_msg_fileio_read_dir_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->contents, 251, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, fmt, ap);
 }
 
 bool sbp_msg_fileio_read_dir_resp_contents_append(
     sbp_msg_fileio_read_dir_resp_t *msg, const char *str) {
-  return sbp_multipart_string_append(&msg->contents, 251, str);
+  return sbp_multipart_string_append(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, str);
 }
 
 bool sbp_msg_fileio_read_dir_resp_contents_append_printf(
     sbp_msg_fileio_read_dir_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->contents, 251, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_read_dir_resp_contents_append_vprintf(
     sbp_msg_fileio_read_dir_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->contents, 251, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, fmt, ap);
 }
 
 const char *sbp_msg_fileio_read_dir_resp_contents_get_section(
     const sbp_msg_fileio_read_dir_resp_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->contents, 251, section);
+  return sbp_multipart_string_get_section(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, section);
 }
 
 size_t sbp_msg_fileio_read_dir_resp_contents_section_strlen(
     const sbp_msg_fileio_read_dir_resp_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->contents, 251, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, section);
 }
 
 bool sbp_msg_fileio_read_dir_resp_encode_internal(
@@ -530,7 +565,8 @@ bool sbp_msg_fileio_read_dir_resp_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->sequence)) {
     return false;
   }
-  if (!sbp_multipart_string_encode(&msg->contents, 251, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, ctx)) {
     return false;
   }
   return true;
@@ -557,7 +593,8 @@ bool sbp_msg_fileio_read_dir_resp_decode_internal(
   if (!sbp_u32_decode(ctx, &msg->sequence)) {
     return false;
   }
-  if (!sbp_multipart_string_decode(&msg->contents, 251, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->contents, SBP_MSG_FILEIO_READ_DIR_RESP_CONTENTS_MAX, ctx)) {
     return false;
   }
   return true;
@@ -614,48 +651,55 @@ void sbp_msg_fileio_remove_filename_init(sbp_msg_fileio_remove_t *msg) {
 }
 
 bool sbp_msg_fileio_remove_filename_valid(const sbp_msg_fileio_remove_t *msg) {
-  return sbp_null_terminated_string_valid(&msg->filename, 255);
+  return sbp_null_terminated_string_valid(&msg->filename,
+                                          SBP_MSG_FILEIO_REMOVE_FILENAME_MAX);
 }
 
 int sbp_msg_fileio_remove_filename_strcmp(const sbp_msg_fileio_remove_t *a,
                                           const sbp_msg_fileio_remove_t *b) {
-  return sbp_null_terminated_string_strcmp(&a->filename, &b->filename, 255);
+  return sbp_null_terminated_string_strcmp(&a->filename, &b->filename,
+                                           SBP_MSG_FILEIO_REMOVE_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_remove_filename_encoded_len(
     const sbp_msg_fileio_remove_t *msg) {
-  return sbp_null_terminated_string_encoded_len(&msg->filename, 255);
+  return sbp_null_terminated_string_encoded_len(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_remove_filename_space_remaining(
     const sbp_msg_fileio_remove_t *msg) {
-  return sbp_null_terminated_string_space_remaining(&msg->filename, 255);
+  return sbp_null_terminated_string_space_remaining(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX);
 }
 bool sbp_msg_fileio_remove_filename_set(sbp_msg_fileio_remove_t *msg,
                                         const char *new_str) {
-  return sbp_null_terminated_string_set(&msg->filename, 255, new_str);
+  return sbp_null_terminated_string_set(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, new_str);
 }
 
 bool sbp_msg_fileio_remove_filename_printf(sbp_msg_fileio_remove_t *msg,
                                            const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(&msg->filename, 255, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_remove_filename_vprintf(sbp_msg_fileio_remove_t *msg,
                                             const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_vprintf(&msg->filename, 255, fmt, ap);
+  return sbp_null_terminated_string_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, fmt, ap);
 }
 
 bool sbp_msg_fileio_remove_filename_append_printf(sbp_msg_fileio_remove_t *msg,
                                                   const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_null_terminated_string_append_vprintf(&msg->filename, 255, fmt, ap);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
@@ -663,23 +707,26 @@ bool sbp_msg_fileio_remove_filename_append_printf(sbp_msg_fileio_remove_t *msg,
 bool sbp_msg_fileio_remove_filename_append_vprintf(sbp_msg_fileio_remove_t *msg,
                                                    const char *fmt,
                                                    va_list ap) {
-  return sbp_null_terminated_string_append_vprintf(&msg->filename, 255, fmt,
-                                                   ap);
+  return sbp_null_terminated_string_append_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, fmt, ap);
 }
 
 const char *sbp_msg_fileio_remove_filename_get(
     const sbp_msg_fileio_remove_t *msg) {
-  return sbp_null_terminated_string_get(&msg->filename, 255);
+  return sbp_null_terminated_string_get(&msg->filename,
+                                        SBP_MSG_FILEIO_REMOVE_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_remove_filename_strlen(
     const sbp_msg_fileio_remove_t *msg) {
-  return sbp_null_terminated_string_strlen(&msg->filename, 255);
+  return sbp_null_terminated_string_strlen(&msg->filename,
+                                           SBP_MSG_FILEIO_REMOVE_FILENAME_MAX);
 }
 
 bool sbp_msg_fileio_remove_encode_internal(sbp_encode_ctx_t *ctx,
                                            const sbp_msg_fileio_remove_t *msg) {
-  if (!sbp_null_terminated_string_encode(&msg->filename, 255, ctx)) {
+  if (!sbp_null_terminated_string_encode(
+          &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, ctx)) {
     return false;
   }
   return true;
@@ -702,7 +749,8 @@ s8 sbp_msg_fileio_remove_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_fileio_remove_decode_internal(sbp_decode_ctx_t *ctx,
                                            sbp_msg_fileio_remove_t *msg) {
-  if (!sbp_null_terminated_string_decode(&msg->filename, 255, ctx)) {
+  if (!sbp_null_terminated_string_decode(
+          &msg->filename, SBP_MSG_FILEIO_REMOVE_FILENAME_MAX, ctx)) {
     return false;
   }
   return true;
@@ -754,66 +802,75 @@ void sbp_msg_fileio_write_req_filename_init(sbp_msg_fileio_write_req_t *msg) {
 
 bool sbp_msg_fileio_write_req_filename_valid(
     const sbp_msg_fileio_write_req_t *msg) {
-  return sbp_null_terminated_string_valid(&msg->filename, 247);
+  return sbp_null_terminated_string_valid(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX);
 }
 
 int sbp_msg_fileio_write_req_filename_strcmp(
     const sbp_msg_fileio_write_req_t *a, const sbp_msg_fileio_write_req_t *b) {
-  return sbp_null_terminated_string_strcmp(&a->filename, &b->filename, 247);
+  return sbp_null_terminated_string_strcmp(
+      &a->filename, &b->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_write_req_filename_encoded_len(
     const sbp_msg_fileio_write_req_t *msg) {
-  return sbp_null_terminated_string_encoded_len(&msg->filename, 247);
+  return sbp_null_terminated_string_encoded_len(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_write_req_filename_space_remaining(
     const sbp_msg_fileio_write_req_t *msg) {
-  return sbp_null_terminated_string_space_remaining(&msg->filename, 247);
+  return sbp_null_terminated_string_space_remaining(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX);
 }
 bool sbp_msg_fileio_write_req_filename_set(sbp_msg_fileio_write_req_t *msg,
                                            const char *new_str) {
-  return sbp_null_terminated_string_set(&msg->filename, 247, new_str);
+  return sbp_null_terminated_string_set(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, new_str);
 }
 
 bool sbp_msg_fileio_write_req_filename_printf(sbp_msg_fileio_write_req_t *msg,
                                               const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(&msg->filename, 247, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_write_req_filename_vprintf(sbp_msg_fileio_write_req_t *msg,
                                                const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_vprintf(&msg->filename, 247, fmt, ap);
+  return sbp_null_terminated_string_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, fmt, ap);
 }
 
 bool sbp_msg_fileio_write_req_filename_append_printf(
     sbp_msg_fileio_write_req_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_null_terminated_string_append_vprintf(&msg->filename, 247, fmt, ap);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_fileio_write_req_filename_append_vprintf(
     sbp_msg_fileio_write_req_t *msg, const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_append_vprintf(&msg->filename, 247, fmt,
-                                                   ap);
+  return sbp_null_terminated_string_append_vprintf(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, fmt, ap);
 }
 
 const char *sbp_msg_fileio_write_req_filename_get(
     const sbp_msg_fileio_write_req_t *msg) {
-  return sbp_null_terminated_string_get(&msg->filename, 247);
+  return sbp_null_terminated_string_get(&msg->filename,
+                                        SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX);
 }
 
 size_t sbp_msg_fileio_write_req_filename_strlen(
     const sbp_msg_fileio_write_req_t *msg) {
-  return sbp_null_terminated_string_strlen(&msg->filename, 247);
+  return sbp_null_terminated_string_strlen(
+      &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX);
 }
 
 bool sbp_msg_fileio_write_req_encode_internal(
@@ -824,7 +881,8 @@ bool sbp_msg_fileio_write_req_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->offset)) {
     return false;
   }
-  if (!sbp_null_terminated_string_encode(&msg->filename, 247, ctx)) {
+  if (!sbp_null_terminated_string_encode(
+          &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, ctx)) {
     return false;
   }
   for (size_t i = 0; i < msg->n_data; i++) {
@@ -859,7 +917,8 @@ bool sbp_msg_fileio_write_req_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->offset)) {
     return false;
   }
-  if (!sbp_null_terminated_string_decode(&msg->filename, 247, ctx)) {
+  if (!sbp_null_terminated_string_decode(
+          &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, ctx)) {
     return false;
   }
   msg->n_data = (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);

--- a/c/src/v4/flash.c
+++ b/c/src/v4/flash.c
@@ -21,7 +21,7 @@ bool sbp_msg_flash_program_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u8_encode(ctx, &msg->target)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_FLASH_PROGRAM_ADDR_START_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -57,7 +57,7 @@ bool sbp_msg_flash_program_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_FLASH_PROGRAM_ADDR_START_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -112,7 +112,8 @@ int sbp_msg_flash_program_cmp(const sbp_msg_flash_program_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_FLASH_PROGRAM_ADDR_START_MAX;
+       i++) {
     ret = sbp_u8_cmp(&a->addr_start[i], &b->addr_start[i]);
   }
   if (ret != 0) {
@@ -210,7 +211,7 @@ bool sbp_msg_flash_read_req_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->target)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_FLASH_READ_REQ_ADDR_START_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -241,7 +242,7 @@ bool sbp_msg_flash_read_req_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_FLASH_READ_REQ_ADDR_START_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -291,7 +292,8 @@ int sbp_msg_flash_read_req_cmp(const sbp_msg_flash_read_req_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_FLASH_READ_REQ_ADDR_START_MAX;
+       i++) {
     ret = sbp_u8_cmp(&a->addr_start[i], &b->addr_start[i]);
   }
   if (ret != 0) {
@@ -310,7 +312,7 @@ bool sbp_msg_flash_read_resp_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->target)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_FLASH_READ_RESP_ADDR_START_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -341,7 +343,7 @@ bool sbp_msg_flash_read_resp_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->target)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_FLASH_READ_RESP_ADDR_START_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->addr_start[i])) {
       return false;
     }
@@ -391,7 +393,8 @@ int sbp_msg_flash_read_resp_cmp(const sbp_msg_flash_read_resp_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_FLASH_READ_RESP_ADDR_START_MAX;
+       i++) {
     ret = sbp_u8_cmp(&a->addr_start[i], &b->addr_start[i]);
   }
   if (ret != 0) {
@@ -705,7 +708,7 @@ int sbp_msg_stm_unique_id_req_cmp(const sbp_msg_stm_unique_id_req_t *a,
 
 bool sbp_msg_stm_unique_id_resp_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_stm_unique_id_resp_t *msg) {
-  for (size_t i = 0; i < 12; i++) {
+  for (size_t i = 0; i < SBP_MSG_STM_UNIQUE_ID_RESP_STM_ID_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->stm_id[i])) {
       return false;
     }
@@ -731,7 +734,7 @@ s8 sbp_msg_stm_unique_id_resp_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_stm_unique_id_resp_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_stm_unique_id_resp_t *msg) {
-  for (uint8_t i = 0; i < 12; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_STM_UNIQUE_ID_RESP_STM_ID_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->stm_id[i])) {
       return false;
     }
@@ -773,7 +776,8 @@ int sbp_msg_stm_unique_id_resp_cmp(const sbp_msg_stm_unique_id_resp_t *a,
                                    const sbp_msg_stm_unique_id_resp_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; ret == 0 && i < 12; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_STM_UNIQUE_ID_RESP_STM_ID_MAX;
+       i++) {
     ret = sbp_u8_cmp(&a->stm_id[i], &b->stm_id[i]);
   }
   if (ret != 0) {
@@ -784,7 +788,7 @@ int sbp_msg_stm_unique_id_resp_cmp(const sbp_msg_stm_unique_id_resp_t *a,
 
 bool sbp_msg_m25_flash_write_status_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_m25_flash_write_status_t *msg) {
-  for (size_t i = 0; i < 1; i++) {
+  for (size_t i = 0; i < SBP_MSG_M25_FLASH_WRITE_STATUS_STATUS_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->status[i])) {
       return false;
     }
@@ -810,7 +814,7 @@ s8 sbp_msg_m25_flash_write_status_encode(
 
 bool sbp_msg_m25_flash_write_status_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_m25_flash_write_status_t *msg) {
-  for (uint8_t i = 0; i < 1; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_M25_FLASH_WRITE_STATUS_STATUS_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->status[i])) {
       return false;
     }
@@ -853,7 +857,8 @@ int sbp_msg_m25_flash_write_status_cmp(
     const sbp_msg_m25_flash_write_status_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; ret == 0 && i < 1; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_M25_FLASH_WRITE_STATUS_STATUS_MAX;
+       i++) {
     ret = sbp_u8_cmp(&a->status[i], &b->status[i]);
   }
   if (ret != 0) {

--- a/c/src/v4/linux.c
+++ b/c/src/v4/linux.c
@@ -23,66 +23,76 @@ void sbp_msg_linux_cpu_state_dep_a_cmdline_init(
 
 bool sbp_msg_linux_cpu_state_dep_a_cmdline_valid(
     const sbp_msg_linux_cpu_state_dep_a_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 236);
+  return sbp_unterminated_string_valid(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_cpu_state_dep_a_cmdline_strcmp(
     const sbp_msg_linux_cpu_state_dep_a_t *a,
     const sbp_msg_linux_cpu_state_dep_a_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 236);
+  return sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_cpu_state_dep_a_cmdline_encoded_len(
     const sbp_msg_linux_cpu_state_dep_a_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 236);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_cpu_state_dep_a_cmdline_space_remaining(
     const sbp_msg_linux_cpu_state_dep_a_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 236);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX);
 }
 bool sbp_msg_linux_cpu_state_dep_a_cmdline_set(
     sbp_msg_linux_cpu_state_dep_a_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 236, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_cpu_state_dep_a_cmdline_printf(
     sbp_msg_linux_cpu_state_dep_a_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 236, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_cpu_state_dep_a_cmdline_vprintf(
     sbp_msg_linux_cpu_state_dep_a_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 236, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_cpu_state_dep_a_cmdline_append_printf(
     sbp_msg_linux_cpu_state_dep_a_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 236, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_cpu_state_dep_a_cmdline_append_vprintf(
     sbp_msg_linux_cpu_state_dep_a_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 236, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_cpu_state_dep_a_cmdline_get(
     const sbp_msg_linux_cpu_state_dep_a_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 236);
+  return sbp_unterminated_string_get(&msg->cmdline,
+                                     SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_cpu_state_dep_a_cmdline_strlen(
     const sbp_msg_linux_cpu_state_dep_a_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 236);
+  return sbp_unterminated_string_strlen(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_cpu_state_dep_a_encode_internal(
@@ -96,12 +106,13 @@ bool sbp_msg_linux_cpu_state_dep_a_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->pcpu)) {
     return false;
   }
-  for (size_t i = 0; i < 15; i++) {
+  for (size_t i = 0; i < SBP_MSG_LINUX_CPU_STATE_DEP_A_TNAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 236, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -134,12 +145,13 @@ bool sbp_msg_linux_cpu_state_dep_a_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->pcpu)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_LINUX_CPU_STATE_DEP_A_TNAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 236, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_DEP_A_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -195,7 +207,8 @@ int sbp_msg_linux_cpu_state_dep_a_cmp(
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_LINUX_CPU_STATE_DEP_A_TNAME_MAX;
+       i++) {
     ret = sbp_char_cmp(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
@@ -216,66 +229,76 @@ void sbp_msg_linux_mem_state_dep_a_cmdline_init(
 
 bool sbp_msg_linux_mem_state_dep_a_cmdline_valid(
     const sbp_msg_linux_mem_state_dep_a_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 236);
+  return sbp_unterminated_string_valid(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_mem_state_dep_a_cmdline_strcmp(
     const sbp_msg_linux_mem_state_dep_a_t *a,
     const sbp_msg_linux_mem_state_dep_a_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 236);
+  return sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_mem_state_dep_a_cmdline_encoded_len(
     const sbp_msg_linux_mem_state_dep_a_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 236);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_mem_state_dep_a_cmdline_space_remaining(
     const sbp_msg_linux_mem_state_dep_a_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 236);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX);
 }
 bool sbp_msg_linux_mem_state_dep_a_cmdline_set(
     sbp_msg_linux_mem_state_dep_a_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 236, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_mem_state_dep_a_cmdline_printf(
     sbp_msg_linux_mem_state_dep_a_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 236, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_mem_state_dep_a_cmdline_vprintf(
     sbp_msg_linux_mem_state_dep_a_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 236, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_mem_state_dep_a_cmdline_append_printf(
     sbp_msg_linux_mem_state_dep_a_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 236, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_mem_state_dep_a_cmdline_append_vprintf(
     sbp_msg_linux_mem_state_dep_a_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 236, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_mem_state_dep_a_cmdline_get(
     const sbp_msg_linux_mem_state_dep_a_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 236);
+  return sbp_unterminated_string_get(&msg->cmdline,
+                                     SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_mem_state_dep_a_cmdline_strlen(
     const sbp_msg_linux_mem_state_dep_a_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 236);
+  return sbp_unterminated_string_strlen(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_mem_state_dep_a_encode_internal(
@@ -289,12 +312,13 @@ bool sbp_msg_linux_mem_state_dep_a_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->pmem)) {
     return false;
   }
-  for (size_t i = 0; i < 15; i++) {
+  for (size_t i = 0; i < SBP_MSG_LINUX_MEM_STATE_DEP_A_TNAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 236, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -327,12 +351,13 @@ bool sbp_msg_linux_mem_state_dep_a_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->pmem)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_LINUX_MEM_STATE_DEP_A_TNAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 236, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_DEP_A_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -388,7 +413,8 @@ int sbp_msg_linux_mem_state_dep_a_cmp(
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_LINUX_MEM_STATE_DEP_A_TNAME_MAX;
+       i++) {
     ret = sbp_char_cmp(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
@@ -538,66 +564,77 @@ void sbp_msg_linux_process_socket_counts_cmdline_init(
 
 bool sbp_msg_linux_process_socket_counts_cmdline_valid(
     const sbp_msg_linux_process_socket_counts_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 246);
+  return sbp_unterminated_string_valid(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_process_socket_counts_cmdline_strcmp(
     const sbp_msg_linux_process_socket_counts_t *a,
     const sbp_msg_linux_process_socket_counts_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 246);
+  return sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline,
+      SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_socket_counts_cmdline_encoded_len(
     const sbp_msg_linux_process_socket_counts_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 246);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_socket_counts_cmdline_space_remaining(
     const sbp_msg_linux_process_socket_counts_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 246);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX);
 }
 bool sbp_msg_linux_process_socket_counts_cmdline_set(
     sbp_msg_linux_process_socket_counts_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 246, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_process_socket_counts_cmdline_printf(
     sbp_msg_linux_process_socket_counts_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 246, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_socket_counts_cmdline_vprintf(
     sbp_msg_linux_process_socket_counts_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 246, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_process_socket_counts_cmdline_append_printf(
     sbp_msg_linux_process_socket_counts_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 246, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_socket_counts_cmdline_append_vprintf(
     sbp_msg_linux_process_socket_counts_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 246, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_process_socket_counts_cmdline_get(
     const sbp_msg_linux_process_socket_counts_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 246);
+  return sbp_unterminated_string_get(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_socket_counts_cmdline_strlen(
     const sbp_msg_linux_process_socket_counts_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 246);
+  return sbp_unterminated_string_strlen(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_process_socket_counts_encode_internal(
@@ -617,7 +654,9 @@ bool sbp_msg_linux_process_socket_counts_encode_internal(
   if (!sbp_u16_encode(ctx, &msg->socket_states)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 246, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -656,7 +695,9 @@ bool sbp_msg_linux_process_socket_counts_decode_internal(
   if (!sbp_u16_decode(ctx, &msg->socket_states)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 246, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_COUNTS_CMDLINE_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -736,66 +777,77 @@ void sbp_msg_linux_process_socket_queues_cmdline_init(
 
 bool sbp_msg_linux_process_socket_queues_cmdline_valid(
     const sbp_msg_linux_process_socket_queues_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 180);
+  return sbp_unterminated_string_valid(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_process_socket_queues_cmdline_strcmp(
     const sbp_msg_linux_process_socket_queues_t *a,
     const sbp_msg_linux_process_socket_queues_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 180);
+  return sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline,
+      SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_socket_queues_cmdline_encoded_len(
     const sbp_msg_linux_process_socket_queues_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 180);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_socket_queues_cmdline_space_remaining(
     const sbp_msg_linux_process_socket_queues_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 180);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX);
 }
 bool sbp_msg_linux_process_socket_queues_cmdline_set(
     sbp_msg_linux_process_socket_queues_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 180, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_process_socket_queues_cmdline_printf(
     sbp_msg_linux_process_socket_queues_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 180, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_socket_queues_cmdline_vprintf(
     sbp_msg_linux_process_socket_queues_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 180, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_process_socket_queues_cmdline_append_printf(
     sbp_msg_linux_process_socket_queues_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 180, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_socket_queues_cmdline_append_vprintf(
     sbp_msg_linux_process_socket_queues_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 180, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_process_socket_queues_cmdline_get(
     const sbp_msg_linux_process_socket_queues_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 180);
+  return sbp_unterminated_string_get(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_socket_queues_cmdline_strlen(
     const sbp_msg_linux_process_socket_queues_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 180);
+  return sbp_unterminated_string_strlen(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_process_socket_queues_encode_internal(
@@ -818,12 +870,15 @@ bool sbp_msg_linux_process_socket_queues_encode_internal(
   if (!sbp_u16_encode(ctx, &msg->socket_states)) {
     return false;
   }
-  for (size_t i = 0; i < 64; i++) {
+  for (size_t i = 0;
+       i < SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_ADDRESS_OF_LARGEST_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->address_of_largest[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 180, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -865,12 +920,15 @@ bool sbp_msg_linux_process_socket_queues_decode_internal(
   if (!sbp_u16_decode(ctx, &msg->socket_states)) {
     return false;
   }
-  for (uint8_t i = 0; i < 64; i++) {
+  for (uint8_t i = 0;
+       i < SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_ADDRESS_OF_LARGEST_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->address_of_largest[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 180, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_CMDLINE_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -941,7 +999,10 @@ int sbp_msg_linux_process_socket_queues_cmp(
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 64; i++) {
+  for (uint8_t i = 0;
+       ret == 0 &&
+       i < SBP_MSG_LINUX_PROCESS_SOCKET_QUEUES_ADDRESS_OF_LARGEST_MAX;
+       i++) {
     ret = sbp_char_cmp(&a->address_of_largest[i], &b->address_of_largest[i]);
   }
   if (ret != 0) {
@@ -963,12 +1024,14 @@ bool sbp_msg_linux_socket_usage_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->max_queue_depth)) {
     return false;
   }
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_STATE_COUNTS_MAX;
+       i++) {
     if (!sbp_u16_encode(ctx, &msg->socket_state_counts[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_TYPE_COUNTS_MAX;
+       i++) {
     if (!sbp_u16_encode(ctx, &msg->socket_type_counts[i])) {
       return false;
     }
@@ -1000,12 +1063,14 @@ bool sbp_msg_linux_socket_usage_decode_internal(
   if (!sbp_u32_decode(ctx, &msg->max_queue_depth)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_STATE_COUNTS_MAX;
+       i++) {
     if (!sbp_u16_decode(ctx, &msg->socket_state_counts[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_TYPE_COUNTS_MAX;
+       i++) {
     if (!sbp_u16_decode(ctx, &msg->socket_type_counts[i])) {
       return false;
     }
@@ -1057,14 +1122,17 @@ int sbp_msg_linux_socket_usage_cmp(const sbp_msg_linux_socket_usage_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0;
+       ret == 0 && i < SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_STATE_COUNTS_MAX;
+       i++) {
     ret = sbp_u16_cmp(&a->socket_state_counts[i], &b->socket_state_counts[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0;
+       ret == 0 && i < SBP_MSG_LINUX_SOCKET_USAGE_SOCKET_TYPE_COUNTS_MAX; i++) {
     ret = sbp_u16_cmp(&a->socket_type_counts[i], &b->socket_type_counts[i]);
   }
   if (ret != 0) {
@@ -1080,66 +1148,76 @@ void sbp_msg_linux_process_fd_count_cmdline_init(
 
 bool sbp_msg_linux_process_fd_count_cmdline_valid(
     const sbp_msg_linux_process_fd_count_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 250);
+  return sbp_unterminated_string_valid(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_process_fd_count_cmdline_strcmp(
     const sbp_msg_linux_process_fd_count_t *a,
     const sbp_msg_linux_process_fd_count_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 250);
+  return sbp_unterminated_string_strcmp(
+      &a->cmdline, &b->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_fd_count_cmdline_encoded_len(
     const sbp_msg_linux_process_fd_count_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 250);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_fd_count_cmdline_space_remaining(
     const sbp_msg_linux_process_fd_count_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 250);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX);
 }
 bool sbp_msg_linux_process_fd_count_cmdline_set(
     sbp_msg_linux_process_fd_count_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 250, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_process_fd_count_cmdline_printf(
     sbp_msg_linux_process_fd_count_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 250, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_fd_count_cmdline_vprintf(
     sbp_msg_linux_process_fd_count_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 250, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_process_fd_count_cmdline_append_printf(
     sbp_msg_linux_process_fd_count_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 250, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_fd_count_cmdline_append_vprintf(
     sbp_msg_linux_process_fd_count_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 250, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_process_fd_count_cmdline_get(
     const sbp_msg_linux_process_fd_count_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 250);
+  return sbp_unterminated_string_get(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_process_fd_count_cmdline_strlen(
     const sbp_msg_linux_process_fd_count_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 250);
+  return sbp_unterminated_string_strlen(
+      &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_process_fd_count_encode_internal(
@@ -1153,7 +1231,8 @@ bool sbp_msg_linux_process_fd_count_encode_internal(
   if (!sbp_u16_encode(ctx, &msg->fd_count)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 250, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1186,7 +1265,8 @@ bool sbp_msg_linux_process_fd_count_decode_internal(
   if (!sbp_u16_decode(ctx, &msg->fd_count)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 250, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_PROCESS_FD_COUNT_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1256,36 +1336,40 @@ void sbp_msg_linux_process_fd_summary_most_opened_init(
 
 bool sbp_msg_linux_process_fd_summary_most_opened_valid(
     const sbp_msg_linux_process_fd_summary_t *msg) {
-  return sbp_double_null_terminated_string_valid(&msg->most_opened, 251);
+  return sbp_double_null_terminated_string_valid(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX);
 }
 
 int sbp_msg_linux_process_fd_summary_most_opened_strcmp(
     const sbp_msg_linux_process_fd_summary_t *a,
     const sbp_msg_linux_process_fd_summary_t *b) {
-  return sbp_double_null_terminated_string_strcmp(&a->most_opened,
-                                                  &b->most_opened, 251);
+  return sbp_double_null_terminated_string_strcmp(
+      &a->most_opened, &b->most_opened,
+      SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX);
 }
 
 size_t sbp_msg_linux_process_fd_summary_most_opened_encoded_len(
     const sbp_msg_linux_process_fd_summary_t *msg) {
-  return sbp_double_null_terminated_string_encoded_len(&msg->most_opened, 251);
+  return sbp_double_null_terminated_string_encoded_len(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX);
 }
 
 size_t sbp_msg_linux_process_fd_summary_most_opened_space_remaining(
     const sbp_msg_linux_process_fd_summary_t *msg) {
-  return sbp_double_null_terminated_string_space_remaining(&msg->most_opened,
-                                                           251);
+  return sbp_double_null_terminated_string_space_remaining(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX);
 }
 size_t sbp_msg_linux_process_fd_summary_most_opened_count_sections(
     const sbp_msg_linux_process_fd_summary_t *msg) {
-  return sbp_double_null_terminated_string_count_sections(&msg->most_opened,
-                                                          251);
+  return sbp_double_null_terminated_string_count_sections(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX);
 }
 
 bool sbp_msg_linux_process_fd_summary_most_opened_add_section(
     sbp_msg_linux_process_fd_summary_t *msg, const char *new_str) {
-  return sbp_double_null_terminated_string_add_section(&msg->most_opened, 251,
-                                                       new_str);
+  return sbp_double_null_terminated_string_add_section(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX,
+      new_str);
 }
 
 bool sbp_msg_linux_process_fd_summary_most_opened_add_section_printf(
@@ -1293,7 +1377,8 @@ bool sbp_msg_linux_process_fd_summary_most_opened_add_section_printf(
   va_list ap;
   va_start(ap, fmt);
   bool ret = sbp_double_null_terminated_string_add_section_vprintf(
-      &msg->most_opened, 251, fmt, ap);
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX, fmt,
+      ap);
   va_end(ap);
   return ret;
 }
@@ -1301,40 +1386,46 @@ bool sbp_msg_linux_process_fd_summary_most_opened_add_section_printf(
 bool sbp_msg_linux_process_fd_summary_most_opened_add_section_vprintf(
     sbp_msg_linux_process_fd_summary_t *msg, const char *fmt, va_list ap) {
   return sbp_double_null_terminated_string_add_section_vprintf(
-      &msg->most_opened, 251, fmt, ap);
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX, fmt,
+      ap);
 }
 
 bool sbp_msg_linux_process_fd_summary_most_opened_append(
     sbp_msg_linux_process_fd_summary_t *msg, const char *str) {
-  return sbp_double_null_terminated_string_append(&msg->most_opened, 251, str);
+  return sbp_double_null_terminated_string_append(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX, str);
 }
 
 bool sbp_msg_linux_process_fd_summary_most_opened_append_printf(
     sbp_msg_linux_process_fd_summary_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_double_null_terminated_string_append_vprintf(&msg->most_opened,
-                                                              251, fmt, ap);
+  bool ret = sbp_double_null_terminated_string_append_vprintf(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX, fmt,
+      ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_process_fd_summary_most_opened_append_vprintf(
     sbp_msg_linux_process_fd_summary_t *msg, const char *fmt, va_list ap) {
-  return sbp_double_null_terminated_string_append_vprintf(&msg->most_opened,
-                                                          251, fmt, ap);
+  return sbp_double_null_terminated_string_append_vprintf(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX, fmt,
+      ap);
 }
 
 const char *sbp_msg_linux_process_fd_summary_most_opened_get_section(
     const sbp_msg_linux_process_fd_summary_t *msg, size_t section) {
-  return sbp_double_null_terminated_string_get_section(&msg->most_opened, 251,
-                                                       section);
+  return sbp_double_null_terminated_string_get_section(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX,
+      section);
 }
 
 size_t sbp_msg_linux_process_fd_summary_most_opened_section_strlen(
     const sbp_msg_linux_process_fd_summary_t *msg, size_t section) {
-  return sbp_double_null_terminated_string_section_strlen(&msg->most_opened,
-                                                          251, section);
+  return sbp_double_null_terminated_string_section_strlen(
+      &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX,
+      section);
 }
 
 bool sbp_msg_linux_process_fd_summary_encode_internal(
@@ -1342,7 +1433,9 @@ bool sbp_msg_linux_process_fd_summary_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->sys_fd_count)) {
     return false;
   }
-  if (!sbp_double_null_terminated_string_encode(&msg->most_opened, 251, ctx)) {
+  if (!sbp_double_null_terminated_string_encode(
+          &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -1369,7 +1462,9 @@ bool sbp_msg_linux_process_fd_summary_decode_internal(
   if (!sbp_u32_decode(ctx, &msg->sys_fd_count)) {
     return false;
   }
-  if (!sbp_double_null_terminated_string_decode(&msg->most_opened, 251, ctx)) {
+  if (!sbp_double_null_terminated_string_decode(
+          &msg->most_opened, SBP_MSG_LINUX_PROCESS_FD_SUMMARY_MOST_OPENED_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -1428,65 +1523,75 @@ void sbp_msg_linux_cpu_state_cmdline_init(sbp_msg_linux_cpu_state_t *msg) {
 
 bool sbp_msg_linux_cpu_state_cmdline_valid(
     const sbp_msg_linux_cpu_state_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 231);
+  return sbp_unterminated_string_valid(&msg->cmdline,
+                                       SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_cpu_state_cmdline_strcmp(const sbp_msg_linux_cpu_state_t *a,
                                            const sbp_msg_linux_cpu_state_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 231);
+  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline,
+                                        SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_cpu_state_cmdline_encoded_len(
     const sbp_msg_linux_cpu_state_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 231);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_cpu_state_cmdline_space_remaining(
     const sbp_msg_linux_cpu_state_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 231);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX);
 }
 bool sbp_msg_linux_cpu_state_cmdline_set(sbp_msg_linux_cpu_state_t *msg,
                                          const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 231, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_cpu_state_cmdline_printf(sbp_msg_linux_cpu_state_t *msg,
                                             const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 231, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_cpu_state_cmdline_vprintf(sbp_msg_linux_cpu_state_t *msg,
                                              const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 231, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_cpu_state_cmdline_append_printf(
     sbp_msg_linux_cpu_state_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 231, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_cpu_state_cmdline_append_vprintf(
     sbp_msg_linux_cpu_state_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 231, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_cpu_state_cmdline_get(
     const sbp_msg_linux_cpu_state_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 231);
+  return sbp_unterminated_string_get(&msg->cmdline,
+                                     SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_cpu_state_cmdline_strlen(
     const sbp_msg_linux_cpu_state_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 231);
+  return sbp_unterminated_string_strlen(&msg->cmdline,
+                                        SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_cpu_state_encode_internal(
@@ -1506,12 +1611,13 @@ bool sbp_msg_linux_cpu_state_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->flags)) {
     return false;
   }
-  for (size_t i = 0; i < 15; i++) {
+  for (size_t i = 0; i < SBP_MSG_LINUX_CPU_STATE_TNAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 231, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1549,12 +1655,13 @@ bool sbp_msg_linux_cpu_state_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->flags)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_LINUX_CPU_STATE_TNAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 231, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_CPU_STATE_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1619,7 +1726,7 @@ int sbp_msg_linux_cpu_state_cmp(const sbp_msg_linux_cpu_state_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_LINUX_CPU_STATE_TNAME_MAX; i++) {
     ret = sbp_char_cmp(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {
@@ -1639,65 +1746,75 @@ void sbp_msg_linux_mem_state_cmdline_init(sbp_msg_linux_mem_state_t *msg) {
 
 bool sbp_msg_linux_mem_state_cmdline_valid(
     const sbp_msg_linux_mem_state_t *msg) {
-  return sbp_unterminated_string_valid(&msg->cmdline, 231);
+  return sbp_unterminated_string_valid(&msg->cmdline,
+                                       SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX);
 }
 
 int sbp_msg_linux_mem_state_cmdline_strcmp(const sbp_msg_linux_mem_state_t *a,
                                            const sbp_msg_linux_mem_state_t *b) {
-  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline, 231);
+  return sbp_unterminated_string_strcmp(&a->cmdline, &b->cmdline,
+                                        SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_mem_state_cmdline_encoded_len(
     const sbp_msg_linux_mem_state_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->cmdline, 231);
+  return sbp_unterminated_string_encoded_len(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_mem_state_cmdline_space_remaining(
     const sbp_msg_linux_mem_state_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->cmdline, 231);
+  return sbp_unterminated_string_space_remaining(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX);
 }
 bool sbp_msg_linux_mem_state_cmdline_set(sbp_msg_linux_mem_state_t *msg,
                                          const char *new_str) {
-  return sbp_unterminated_string_set(&msg->cmdline, 231, new_str);
+  return sbp_unterminated_string_set(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, new_str);
 }
 
 bool sbp_msg_linux_mem_state_cmdline_printf(sbp_msg_linux_mem_state_t *msg,
                                             const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->cmdline, 231, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_mem_state_cmdline_vprintf(sbp_msg_linux_mem_state_t *msg,
                                              const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->cmdline, 231, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_linux_mem_state_cmdline_append_printf(
     sbp_msg_linux_mem_state_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->cmdline, 231, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_linux_mem_state_cmdline_append_vprintf(
     sbp_msg_linux_mem_state_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->cmdline, 231, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_linux_mem_state_cmdline_get(
     const sbp_msg_linux_mem_state_t *msg) {
-  return sbp_unterminated_string_get(&msg->cmdline, 231);
+  return sbp_unterminated_string_get(&msg->cmdline,
+                                     SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX);
 }
 
 size_t sbp_msg_linux_mem_state_cmdline_strlen(
     const sbp_msg_linux_mem_state_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->cmdline, 231);
+  return sbp_unterminated_string_strlen(&msg->cmdline,
+                                        SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX);
 }
 
 bool sbp_msg_linux_mem_state_encode_internal(
@@ -1717,12 +1834,13 @@ bool sbp_msg_linux_mem_state_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->flags)) {
     return false;
   }
-  for (size_t i = 0; i < 15; i++) {
+  for (size_t i = 0; i < SBP_MSG_LINUX_MEM_STATE_TNAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_encode(&msg->cmdline, 231, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1760,12 +1878,13 @@ bool sbp_msg_linux_mem_state_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->flags)) {
     return false;
   }
-  for (uint8_t i = 0; i < 15; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_LINUX_MEM_STATE_TNAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->tname[i])) {
       return false;
     }
   }
-  if (!sbp_unterminated_string_decode(&msg->cmdline, 231, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->cmdline, SBP_MSG_LINUX_MEM_STATE_CMDLINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1830,7 +1949,7 @@ int sbp_msg_linux_mem_state_cmp(const sbp_msg_linux_mem_state_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 15; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_LINUX_MEM_STATE_TNAME_MAX; i++) {
     ret = sbp_char_cmp(&a->tname[i], &b->tname[i]);
   }
   if (ret != 0) {

--- a/c/src/v4/logging.c
+++ b/c/src/v4/logging.c
@@ -21,55 +21,61 @@ void sbp_msg_log_text_init(sbp_msg_log_t *msg) {
 }
 
 bool sbp_msg_log_text_valid(const sbp_msg_log_t *msg) {
-  return sbp_unterminated_string_valid(&msg->text, 254);
+  return sbp_unterminated_string_valid(&msg->text, SBP_MSG_LOG_TEXT_MAX);
 }
 
 int sbp_msg_log_text_strcmp(const sbp_msg_log_t *a, const sbp_msg_log_t *b) {
-  return sbp_unterminated_string_strcmp(&a->text, &b->text, 254);
+  return sbp_unterminated_string_strcmp(&a->text, &b->text,
+                                        SBP_MSG_LOG_TEXT_MAX);
 }
 
 size_t sbp_msg_log_text_encoded_len(const sbp_msg_log_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->text, 254);
+  return sbp_unterminated_string_encoded_len(&msg->text, SBP_MSG_LOG_TEXT_MAX);
 }
 
 size_t sbp_msg_log_text_space_remaining(const sbp_msg_log_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->text, 254);
+  return sbp_unterminated_string_space_remaining(&msg->text,
+                                                 SBP_MSG_LOG_TEXT_MAX);
 }
 bool sbp_msg_log_text_set(sbp_msg_log_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->text, 254, new_str);
+  return sbp_unterminated_string_set(&msg->text, SBP_MSG_LOG_TEXT_MAX, new_str);
 }
 
 bool sbp_msg_log_text_printf(sbp_msg_log_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->text, 254, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(&msg->text, SBP_MSG_LOG_TEXT_MAX,
+                                             fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_log_text_vprintf(sbp_msg_log_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->text, 254, fmt, ap);
+  return sbp_unterminated_string_vprintf(&msg->text, SBP_MSG_LOG_TEXT_MAX, fmt,
+                                         ap);
 }
 
 bool sbp_msg_log_text_append_printf(sbp_msg_log_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(&msg->text, 254, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->text, SBP_MSG_LOG_TEXT_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_log_text_append_vprintf(sbp_msg_log_t *msg, const char *fmt,
                                      va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->text, 254, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(&msg->text,
+                                                SBP_MSG_LOG_TEXT_MAX, fmt, ap);
 }
 
 const char *sbp_msg_log_text_get(const sbp_msg_log_t *msg) {
-  return sbp_unterminated_string_get(&msg->text, 254);
+  return sbp_unterminated_string_get(&msg->text, SBP_MSG_LOG_TEXT_MAX);
 }
 
 size_t sbp_msg_log_text_strlen(const sbp_msg_log_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->text, 254);
+  return sbp_unterminated_string_strlen(&msg->text, SBP_MSG_LOG_TEXT_MAX);
 }
 
 bool sbp_msg_log_encode_internal(sbp_encode_ctx_t *ctx,
@@ -77,7 +83,7 @@ bool sbp_msg_log_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u8_encode(ctx, &msg->level)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->text, 254, ctx)) {
+  if (!sbp_unterminated_string_encode(&msg->text, SBP_MSG_LOG_TEXT_MAX, ctx)) {
     return false;
   }
   return true;
@@ -102,7 +108,7 @@ bool sbp_msg_log_decode_internal(sbp_decode_ctx_t *ctx, sbp_msg_log_t *msg) {
   if (!sbp_u8_decode(ctx, &msg->level)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->text, 254, ctx)) {
+  if (!sbp_unterminated_string_decode(&msg->text, SBP_MSG_LOG_TEXT_MAX, ctx)) {
     return false;
   }
   return true;
@@ -253,64 +259,73 @@ void sbp_msg_print_dep_text_init(sbp_msg_print_dep_t *msg) {
 }
 
 bool sbp_msg_print_dep_text_valid(const sbp_msg_print_dep_t *msg) {
-  return sbp_unterminated_string_valid(&msg->text, 255);
+  return sbp_unterminated_string_valid(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX);
 }
 
 int sbp_msg_print_dep_text_strcmp(const sbp_msg_print_dep_t *a,
                                   const sbp_msg_print_dep_t *b) {
-  return sbp_unterminated_string_strcmp(&a->text, &b->text, 255);
+  return sbp_unterminated_string_strcmp(&a->text, &b->text,
+                                        SBP_MSG_PRINT_DEP_TEXT_MAX);
 }
 
 size_t sbp_msg_print_dep_text_encoded_len(const sbp_msg_print_dep_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->text, 255);
+  return sbp_unterminated_string_encoded_len(&msg->text,
+                                             SBP_MSG_PRINT_DEP_TEXT_MAX);
 }
 
 size_t sbp_msg_print_dep_text_space_remaining(const sbp_msg_print_dep_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->text, 255);
+  return sbp_unterminated_string_space_remaining(&msg->text,
+                                                 SBP_MSG_PRINT_DEP_TEXT_MAX);
 }
 bool sbp_msg_print_dep_text_set(sbp_msg_print_dep_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->text, 255, new_str);
+  return sbp_unterminated_string_set(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX,
+                                     new_str);
 }
 
 bool sbp_msg_print_dep_text_printf(sbp_msg_print_dep_t *msg, const char *fmt,
                                    ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->text, 255, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_print_dep_text_vprintf(sbp_msg_print_dep_t *msg, const char *fmt,
                                     va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->text, 255, fmt, ap);
+  return sbp_unterminated_string_vprintf(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX,
+                                         fmt, ap);
 }
 
 bool sbp_msg_print_dep_text_append_printf(sbp_msg_print_dep_t *msg,
                                           const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(&msg->text, 255, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_print_dep_text_append_vprintf(sbp_msg_print_dep_t *msg,
                                            const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->text, 255, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX, fmt, ap);
 }
 
 const char *sbp_msg_print_dep_text_get(const sbp_msg_print_dep_t *msg) {
-  return sbp_unterminated_string_get(&msg->text, 255);
+  return sbp_unterminated_string_get(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX);
 }
 
 size_t sbp_msg_print_dep_text_strlen(const sbp_msg_print_dep_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->text, 255);
+  return sbp_unterminated_string_strlen(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX);
 }
 
 bool sbp_msg_print_dep_encode_internal(sbp_encode_ctx_t *ctx,
                                        const sbp_msg_print_dep_t *msg) {
-  if (!sbp_unterminated_string_encode(&msg->text, 255, ctx)) {
+  if (!sbp_unterminated_string_encode(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX,
+                                      ctx)) {
     return false;
   }
   return true;
@@ -333,7 +348,8 @@ s8 sbp_msg_print_dep_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_print_dep_decode_internal(sbp_decode_ctx_t *ctx,
                                        sbp_msg_print_dep_t *msg) {
-  if (!sbp_unterminated_string_decode(&msg->text, 255, ctx)) {
+  if (!sbp_unterminated_string_decode(&msg->text, SBP_MSG_PRINT_DEP_TEXT_MAX,
+                                      ctx)) {
     return false;
   }
   return true;

--- a/c/src/v4/observation.c
+++ b/c/src/v4/observation.c
@@ -3274,17 +3274,17 @@ bool sbp_msg_ephemeris_sbas_dep_a_encode_internal(
   if (!sbp_ephemeris_common_content_dep_a_encode_internal(ctx, &msg->common)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_ACC_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3319,17 +3319,17 @@ bool sbp_msg_ephemeris_sbas_dep_a_decode_internal(
   if (!sbp_ephemeris_common_content_dep_a_decode_internal(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_ACC_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3382,21 +3382,24 @@ int sbp_msg_ephemeris_sbas_dep_a_cmp(const sbp_msg_ephemeris_sbas_dep_a_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_POS_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_VEL_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_DEP_A_ACC_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -3426,17 +3429,17 @@ bool sbp_msg_ephemeris_glo_dep_a_encode_internal(
   if (!sbp_double_encode(ctx, &msg->tau)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_A_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_A_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_A_ACC_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3471,17 +3474,17 @@ bool sbp_msg_ephemeris_glo_dep_a_decode_internal(
   if (!sbp_double_decode(ctx, &msg->tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_A_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_A_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_A_ACC_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3538,21 +3541,24 @@ int sbp_msg_ephemeris_glo_dep_a_cmp(const sbp_msg_ephemeris_glo_dep_a_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_A_POS_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_A_VEL_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_A_ACC_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -3566,17 +3572,17 @@ bool sbp_msg_ephemeris_sbas_dep_b_encode_internal(
   if (!sbp_ephemeris_common_content_dep_b_encode_internal(ctx, &msg->common)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_ACC_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3611,17 +3617,17 @@ bool sbp_msg_ephemeris_sbas_dep_b_decode_internal(
   if (!sbp_ephemeris_common_content_dep_b_decode_internal(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_ACC_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3674,21 +3680,24 @@ int sbp_msg_ephemeris_sbas_dep_b_cmp(const sbp_msg_ephemeris_sbas_dep_b_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_POS_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_VEL_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_DEP_B_ACC_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -3712,17 +3721,17 @@ bool sbp_msg_ephemeris_sbas_encode_internal(
   if (!sbp_ephemeris_common_content_encode_internal(ctx, &msg->common)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_VEL_MAX; i++) {
     if (!sbp_float_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_ACC_MAX; i++) {
     if (!sbp_float_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3756,17 +3765,17 @@ bool sbp_msg_ephemeris_sbas_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_ephemeris_common_content_decode_internal(ctx, &msg->common)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_VEL_MAX; i++) {
     if (!sbp_float_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_SBAS_ACC_MAX; i++) {
     if (!sbp_float_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3819,21 +3828,21 @@ int sbp_msg_ephemeris_sbas_cmp(const sbp_msg_ephemeris_sbas_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_POS_MAX; i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_VEL_MAX; i++) {
     ret = sbp_float_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_SBAS_ACC_MAX; i++) {
     ret = sbp_float_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -3863,17 +3872,17 @@ bool sbp_msg_ephemeris_glo_dep_b_encode_internal(
   if (!sbp_double_encode(ctx, &msg->tau)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_B_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_B_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_B_ACC_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3908,17 +3917,17 @@ bool sbp_msg_ephemeris_glo_dep_b_decode_internal(
   if (!sbp_double_decode(ctx, &msg->tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_B_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_B_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_B_ACC_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -3975,21 +3984,24 @@ int sbp_msg_ephemeris_glo_dep_b_cmp(const sbp_msg_ephemeris_glo_dep_b_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_B_POS_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_B_VEL_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_B_ACC_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4012,17 +4024,17 @@ bool sbp_msg_ephemeris_glo_dep_c_encode_internal(
   if (!sbp_double_encode(ctx, &msg->d_tau)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_C_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_C_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_C_ACC_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4063,17 +4075,17 @@ bool sbp_msg_ephemeris_glo_dep_c_decode_internal(
   if (!sbp_double_decode(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_C_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_C_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_C_ACC_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4138,21 +4150,24 @@ int sbp_msg_ephemeris_glo_dep_c_cmp(const sbp_msg_ephemeris_glo_dep_c_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_C_POS_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_C_VEL_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_C_ACC_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4180,17 +4195,17 @@ bool sbp_msg_ephemeris_glo_dep_d_encode_internal(
   if (!sbp_double_encode(ctx, &msg->d_tau)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_D_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_D_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_D_ACC_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4234,17 +4249,17 @@ bool sbp_msg_ephemeris_glo_dep_d_decode_internal(
   if (!sbp_double_decode(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_D_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_D_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_DEP_D_ACC_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4312,21 +4327,24 @@ int sbp_msg_ephemeris_glo_dep_d_cmp(const sbp_msg_ephemeris_glo_dep_d_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_D_POS_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_D_VEL_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_DEP_D_ACC_MAX;
+       i++) {
     ret = sbp_double_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {
@@ -4359,17 +4377,17 @@ bool sbp_msg_ephemeris_glo_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_float_encode(ctx, &msg->d_tau)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_POS_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_VEL_MAX; i++) {
     if (!sbp_double_encode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_ACC_MAX; i++) {
     if (!sbp_float_encode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4412,17 +4430,17 @@ bool sbp_msg_ephemeris_glo_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_float_decode(ctx, &msg->d_tau)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_POS_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->pos[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_VEL_MAX; i++) {
     if (!sbp_double_decode(ctx, &msg->vel[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_EPHEMERIS_GLO_ACC_MAX; i++) {
     if (!sbp_float_decode(ctx, &msg->acc[i])) {
       return false;
     }
@@ -4489,21 +4507,21 @@ int sbp_msg_ephemeris_glo_cmp(const sbp_msg_ephemeris_glo_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_POS_MAX; i++) {
     ret = sbp_double_cmp(&a->pos[i], &b->pos[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_VEL_MAX; i++) {
     ret = sbp_double_cmp(&a->vel[i], &b->vel[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_EPHEMERIS_GLO_ACC_MAX; i++) {
     ret = sbp_float_cmp(&a->acc[i], &b->acc[i]);
   }
   if (ret != 0) {

--- a/c/src/v4/piksi.c
+++ b/c/src/v4/piksi.c
@@ -547,7 +547,7 @@ int sbp_msg_init_base_dep_cmp(const sbp_msg_init_base_dep_t *a,
 
 bool sbp_msg_thread_state_encode_internal(sbp_encode_ctx_t *ctx,
                                           const sbp_msg_thread_state_t *msg) {
-  for (size_t i = 0; i < 20; i++) {
+  for (size_t i = 0; i < SBP_MSG_THREAD_STATE_NAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->name[i])) {
       return false;
     }
@@ -578,7 +578,7 @@ s8 sbp_msg_thread_state_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_thread_state_decode_internal(sbp_decode_ctx_t *ctx,
                                           sbp_msg_thread_state_t *msg) {
-  for (uint8_t i = 0; i < 20; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_THREAD_STATE_NAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->name[i])) {
       return false;
     }
@@ -625,7 +625,7 @@ int sbp_msg_thread_state_cmp(const sbp_msg_thread_state_t *a,
                              const sbp_msg_thread_state_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; ret == 0 && i < 20; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_THREAD_STATE_NAME_MAX; i++) {
     ret = sbp_char_cmp(&a->name[i], &b->name[i]);
   }
   if (ret != 0) {
@@ -1511,63 +1511,73 @@ void sbp_msg_command_req_command_init(sbp_msg_command_req_t *msg) {
 }
 
 bool sbp_msg_command_req_command_valid(const sbp_msg_command_req_t *msg) {
-  return sbp_null_terminated_string_valid(&msg->command, 251);
+  return sbp_null_terminated_string_valid(&msg->command,
+                                          SBP_MSG_COMMAND_REQ_COMMAND_MAX);
 }
 
 int sbp_msg_command_req_command_strcmp(const sbp_msg_command_req_t *a,
                                        const sbp_msg_command_req_t *b) {
-  return sbp_null_terminated_string_strcmp(&a->command, &b->command, 251);
+  return sbp_null_terminated_string_strcmp(&a->command, &b->command,
+                                           SBP_MSG_COMMAND_REQ_COMMAND_MAX);
 }
 
 size_t sbp_msg_command_req_command_encoded_len(
     const sbp_msg_command_req_t *msg) {
-  return sbp_null_terminated_string_encoded_len(&msg->command, 251);
+  return sbp_null_terminated_string_encoded_len(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX);
 }
 
 size_t sbp_msg_command_req_command_space_remaining(
     const sbp_msg_command_req_t *msg) {
-  return sbp_null_terminated_string_space_remaining(&msg->command, 251);
+  return sbp_null_terminated_string_space_remaining(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX);
 }
 bool sbp_msg_command_req_command_set(sbp_msg_command_req_t *msg,
                                      const char *new_str) {
-  return sbp_null_terminated_string_set(&msg->command, 251, new_str);
+  return sbp_null_terminated_string_set(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, new_str);
 }
 
 bool sbp_msg_command_req_command_printf(sbp_msg_command_req_t *msg,
                                         const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_null_terminated_string_vprintf(&msg->command, 251, fmt, ap);
+  bool ret = sbp_null_terminated_string_vprintf(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_command_req_command_vprintf(sbp_msg_command_req_t *msg,
                                          const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_vprintf(&msg->command, 251, fmt, ap);
+  return sbp_null_terminated_string_vprintf(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, fmt, ap);
 }
 
 bool sbp_msg_command_req_command_append_printf(sbp_msg_command_req_t *msg,
                                                const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_null_terminated_string_append_vprintf(&msg->command, 251, fmt, ap);
+  bool ret = sbp_null_terminated_string_append_vprintf(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_command_req_command_append_vprintf(sbp_msg_command_req_t *msg,
                                                 const char *fmt, va_list ap) {
-  return sbp_null_terminated_string_append_vprintf(&msg->command, 251, fmt, ap);
+  return sbp_null_terminated_string_append_vprintf(
+      &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, fmt, ap);
 }
 
 const char *sbp_msg_command_req_command_get(const sbp_msg_command_req_t *msg) {
-  return sbp_null_terminated_string_get(&msg->command, 251);
+  return sbp_null_terminated_string_get(&msg->command,
+                                        SBP_MSG_COMMAND_REQ_COMMAND_MAX);
 }
 
 size_t sbp_msg_command_req_command_strlen(const sbp_msg_command_req_t *msg) {
-  return sbp_null_terminated_string_strlen(&msg->command, 251);
+  return sbp_null_terminated_string_strlen(&msg->command,
+                                           SBP_MSG_COMMAND_REQ_COMMAND_MAX);
 }
 
 bool sbp_msg_command_req_encode_internal(sbp_encode_ctx_t *ctx,
@@ -1575,7 +1585,8 @@ bool sbp_msg_command_req_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u32_encode(ctx, &msg->sequence)) {
     return false;
   }
-  if (!sbp_null_terminated_string_encode(&msg->command, 251, ctx)) {
+  if (!sbp_null_terminated_string_encode(
+          &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1601,7 +1612,8 @@ bool sbp_msg_command_req_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->sequence)) {
     return false;
   }
-  if (!sbp_null_terminated_string_decode(&msg->command, 251, ctx)) {
+  if (!sbp_null_terminated_string_decode(
+          &msg->command, SBP_MSG_COMMAND_REQ_COMMAND_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1739,63 +1751,74 @@ void sbp_msg_command_output_line_init(sbp_msg_command_output_t *msg) {
 }
 
 bool sbp_msg_command_output_line_valid(const sbp_msg_command_output_t *msg) {
-  return sbp_unterminated_string_valid(&msg->line, 251);
+  return sbp_unterminated_string_valid(&msg->line,
+                                       SBP_MSG_COMMAND_OUTPUT_LINE_MAX);
 }
 
 int sbp_msg_command_output_line_strcmp(const sbp_msg_command_output_t *a,
                                        const sbp_msg_command_output_t *b) {
-  return sbp_unterminated_string_strcmp(&a->line, &b->line, 251);
+  return sbp_unterminated_string_strcmp(&a->line, &b->line,
+                                        SBP_MSG_COMMAND_OUTPUT_LINE_MAX);
 }
 
 size_t sbp_msg_command_output_line_encoded_len(
     const sbp_msg_command_output_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->line, 251);
+  return sbp_unterminated_string_encoded_len(&msg->line,
+                                             SBP_MSG_COMMAND_OUTPUT_LINE_MAX);
 }
 
 size_t sbp_msg_command_output_line_space_remaining(
     const sbp_msg_command_output_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->line, 251);
+  return sbp_unterminated_string_space_remaining(
+      &msg->line, SBP_MSG_COMMAND_OUTPUT_LINE_MAX);
 }
 bool sbp_msg_command_output_line_set(sbp_msg_command_output_t *msg,
                                      const char *new_str) {
-  return sbp_unterminated_string_set(&msg->line, 251, new_str);
+  return sbp_unterminated_string_set(&msg->line,
+                                     SBP_MSG_COMMAND_OUTPUT_LINE_MAX, new_str);
 }
 
 bool sbp_msg_command_output_line_printf(sbp_msg_command_output_t *msg,
                                         const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->line, 251, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->line, SBP_MSG_COMMAND_OUTPUT_LINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_command_output_line_vprintf(sbp_msg_command_output_t *msg,
                                          const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->line, 251, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->line, SBP_MSG_COMMAND_OUTPUT_LINE_MAX, fmt, ap);
 }
 
 bool sbp_msg_command_output_line_append_printf(sbp_msg_command_output_t *msg,
                                                const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(&msg->line, 251, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->line, SBP_MSG_COMMAND_OUTPUT_LINE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_command_output_line_append_vprintf(sbp_msg_command_output_t *msg,
                                                 const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->line, 251, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->line, SBP_MSG_COMMAND_OUTPUT_LINE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_command_output_line_get(
     const sbp_msg_command_output_t *msg) {
-  return sbp_unterminated_string_get(&msg->line, 251);
+  return sbp_unterminated_string_get(&msg->line,
+                                     SBP_MSG_COMMAND_OUTPUT_LINE_MAX);
 }
 
 size_t sbp_msg_command_output_line_strlen(const sbp_msg_command_output_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->line, 251);
+  return sbp_unterminated_string_strlen(&msg->line,
+                                        SBP_MSG_COMMAND_OUTPUT_LINE_MAX);
 }
 
 bool sbp_msg_command_output_encode_internal(
@@ -1803,7 +1826,8 @@ bool sbp_msg_command_output_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->sequence)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->line, 251, ctx)) {
+  if (!sbp_unterminated_string_encode(&msg->line,
+                                      SBP_MSG_COMMAND_OUTPUT_LINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1829,7 +1853,8 @@ bool sbp_msg_command_output_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->sequence)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->line, 251, ctx)) {
+  if (!sbp_unterminated_string_decode(&msg->line,
+                                      SBP_MSG_COMMAND_OUTPUT_LINE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1951,7 +1976,7 @@ int sbp_msg_network_state_req_cmp(const sbp_msg_network_state_req_t *a,
 
 bool sbp_msg_network_state_resp_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_network_state_resp_t *msg) {
-  for (size_t i = 0; i < 4; i++) {
+  for (size_t i = 0; i < SBP_MSG_NETWORK_STATE_RESP_IPV4_ADDRESS_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->ipv4_address[i])) {
       return false;
     }
@@ -1959,7 +1984,7 @@ bool sbp_msg_network_state_resp_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->ipv4_mask_size)) {
     return false;
   }
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < SBP_MSG_NETWORK_STATE_RESP_IPV6_ADDRESS_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->ipv6_address[i])) {
       return false;
     }
@@ -1973,7 +1998,7 @@ bool sbp_msg_network_state_resp_encode_internal(
   if (!sbp_u32_encode(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < SBP_MSG_NETWORK_STATE_RESP_INTERFACE_NAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2002,7 +2027,7 @@ s8 sbp_msg_network_state_resp_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_network_state_resp_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_network_state_resp_t *msg) {
-  for (uint8_t i = 0; i < 4; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_NETWORK_STATE_RESP_IPV4_ADDRESS_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->ipv4_address[i])) {
       return false;
     }
@@ -2010,7 +2035,7 @@ bool sbp_msg_network_state_resp_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->ipv4_mask_size)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_NETWORK_STATE_RESP_IPV6_ADDRESS_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->ipv6_address[i])) {
       return false;
     }
@@ -2024,7 +2049,7 @@ bool sbp_msg_network_state_resp_decode_internal(
   if (!sbp_u32_decode(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_NETWORK_STATE_RESP_INTERFACE_NAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2069,7 +2094,8 @@ int sbp_msg_network_state_resp_cmp(const sbp_msg_network_state_resp_t *a,
                                    const sbp_msg_network_state_resp_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
+  for (uint8_t i = 0;
+       ret == 0 && i < SBP_MSG_NETWORK_STATE_RESP_IPV4_ADDRESS_MAX; i++) {
     ret = sbp_u8_cmp(&a->ipv4_address[i], &b->ipv4_address[i]);
   }
   if (ret != 0) {
@@ -2081,7 +2107,8 @@ int sbp_msg_network_state_resp_cmp(const sbp_msg_network_state_resp_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0;
+       ret == 0 && i < SBP_MSG_NETWORK_STATE_RESP_IPV6_ADDRESS_MAX; i++) {
     ret = sbp_u8_cmp(&a->ipv6_address[i], &b->ipv6_address[i]);
   }
   if (ret != 0) {
@@ -2103,7 +2130,8 @@ int sbp_msg_network_state_resp_cmp(const sbp_msg_network_state_resp_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0;
+       ret == 0 && i < SBP_MSG_NETWORK_STATE_RESP_INTERFACE_NAME_MAX; i++) {
     ret = sbp_char_cmp(&a->interface_name[i], &b->interface_name[i]);
   }
   if (ret != 0) {
@@ -2131,7 +2159,7 @@ bool sbp_network_usage_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u32_encode(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (size_t i = 0; i < 16; i++) {
+  for (size_t i = 0; i < SBP_NETWORK_USAGE_INTERFACE_NAME_MAX; i++) {
     if (!sbp_char_encode(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2168,7 +2196,7 @@ bool sbp_network_usage_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->tx_bytes)) {
     return false;
   }
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; i < SBP_NETWORK_USAGE_INTERFACE_NAME_MAX; i++) {
     if (!sbp_char_decode(ctx, &msg->interface_name[i])) {
       return false;
     }
@@ -2215,7 +2243,8 @@ int sbp_network_usage_cmp(const sbp_network_usage_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 16; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_NETWORK_USAGE_INTERFACE_NAME_MAX;
+       i++) {
     ret = sbp_char_cmp(&a->interface_name[i], &b->interface_name[i]);
   }
   if (ret != 0) {
@@ -2702,12 +2731,12 @@ int sbp_msg_specan_cmp(const sbp_msg_specan_t *a, const sbp_msg_specan_t *b) {
 
 bool sbp_msg_front_end_gain_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_front_end_gain_t *msg) {
-  for (size_t i = 0; i < 8; i++) {
+  for (size_t i = 0; i < SBP_MSG_FRONT_END_GAIN_RF_GAIN_MAX; i++) {
     if (!sbp_s8_encode(ctx, &msg->rf_gain[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 8; i++) {
+  for (size_t i = 0; i < SBP_MSG_FRONT_END_GAIN_IF_GAIN_MAX; i++) {
     if (!sbp_s8_encode(ctx, &msg->if_gain[i])) {
       return false;
     }
@@ -2732,12 +2761,12 @@ s8 sbp_msg_front_end_gain_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_front_end_gain_decode_internal(sbp_decode_ctx_t *ctx,
                                             sbp_msg_front_end_gain_t *msg) {
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_FRONT_END_GAIN_RF_GAIN_MAX; i++) {
     if (!sbp_s8_decode(ctx, &msg->rf_gain[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_FRONT_END_GAIN_IF_GAIN_MAX; i++) {
     if (!sbp_s8_decode(ctx, &msg->if_gain[i])) {
       return false;
     }
@@ -2779,14 +2808,14 @@ int sbp_msg_front_end_gain_cmp(const sbp_msg_front_end_gain_t *a,
                                const sbp_msg_front_end_gain_t *b) {
   int ret = 0;
 
-  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_FRONT_END_GAIN_RF_GAIN_MAX; i++) {
     ret = sbp_s8_cmp(&a->rf_gain[i], &b->rf_gain[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 8; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_FRONT_END_GAIN_IF_GAIN_MAX; i++) {
     ret = sbp_s8_cmp(&a->if_gain[i], &b->if_gain[i]);
   }
   if (ret != 0) {

--- a/c/src/v4/sbas.c
+++ b/c/src/v4/sbas.c
@@ -27,7 +27,7 @@ bool sbp_msg_sbas_raw_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u8_encode(ctx, &msg->message_type)) {
     return false;
   }
-  for (size_t i = 0; i < 27; i++) {
+  for (size_t i = 0; i < SBP_MSG_SBAS_RAW_DATA_MAX; i++) {
     if (!sbp_u8_encode(ctx, &msg->data[i])) {
       return false;
     }
@@ -61,7 +61,7 @@ bool sbp_msg_sbas_raw_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->message_type)) {
     return false;
   }
-  for (uint8_t i = 0; i < 27; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_SBAS_RAW_DATA_MAX; i++) {
     if (!sbp_u8_decode(ctx, &msg->data[i])) {
       return false;
     }
@@ -115,7 +115,7 @@ int sbp_msg_sbas_raw_cmp(const sbp_msg_sbas_raw_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 27; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_SBAS_RAW_DATA_MAX; i++) {
     ret = sbp_u8_cmp(&a->data[i], &b->data[i]);
   }
   if (ret != 0) {

--- a/c/src/v4/settings.c
+++ b/c/src/v4/settings.c
@@ -87,80 +87,93 @@ void sbp_msg_settings_write_setting_init(sbp_msg_settings_write_t *msg) {
 }
 
 bool sbp_msg_settings_write_setting_valid(const sbp_msg_settings_write_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 255);
+  return sbp_multipart_string_valid(&msg->setting,
+                                    SBP_MSG_SETTINGS_WRITE_SETTING_MAX);
 }
 
 int sbp_msg_settings_write_setting_strcmp(const sbp_msg_settings_write_t *a,
                                           const sbp_msg_settings_write_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 255);
+  return sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                     SBP_MSG_SETTINGS_WRITE_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_write_setting_encoded_len(
     const sbp_msg_settings_write_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 255);
+  return sbp_multipart_string_encoded_len(&msg->setting,
+                                          SBP_MSG_SETTINGS_WRITE_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_write_setting_space_remaining(
     const sbp_msg_settings_write_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 255);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX);
 }
 size_t sbp_msg_settings_write_setting_count_sections(
     const sbp_msg_settings_write_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 255);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX);
 }
 
 bool sbp_msg_settings_write_setting_add_section(sbp_msg_settings_write_t *msg,
                                                 const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 255, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_write_setting_add_section_printf(
     sbp_msg_settings_write_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_write_setting_add_section_vprintf(
     sbp_msg_settings_write_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_write_setting_append(sbp_msg_settings_write_t *msg,
                                            const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 255, str);
+  return sbp_multipart_string_append(&msg->setting,
+                                     SBP_MSG_SETTINGS_WRITE_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_write_setting_append_printf(sbp_msg_settings_write_t *msg,
                                                   const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_write_setting_append_vprintf(
     sbp_msg_settings_write_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_write_setting_get_section(
     const sbp_msg_settings_write_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 255, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_write_setting_section_strlen(
     const sbp_msg_settings_write_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 255, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_write_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_write_t *msg) {
-  if (!sbp_multipart_string_encode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_encode(&msg->setting,
+                                   SBP_MSG_SETTINGS_WRITE_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -183,7 +196,8 @@ s8 sbp_msg_settings_write_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_settings_write_decode_internal(sbp_decode_ctx_t *ctx,
                                             sbp_msg_settings_write_t *msg) {
-  if (!sbp_multipart_string_decode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_decode(&msg->setting,
+                                   SBP_MSG_SETTINGS_WRITE_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -237,76 +251,88 @@ void sbp_msg_settings_write_resp_setting_init(
 
 bool sbp_msg_settings_write_resp_setting_valid(
     const sbp_msg_settings_write_resp_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 254);
+  return sbp_multipart_string_valid(&msg->setting,
+                                    SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX);
 }
 
 int sbp_msg_settings_write_resp_setting_strcmp(
     const sbp_msg_settings_write_resp_t *a,
     const sbp_msg_settings_write_resp_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 254);
+  return sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                     SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_write_resp_setting_encoded_len(
     const sbp_msg_settings_write_resp_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 254);
+  return sbp_multipart_string_encoded_len(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_write_resp_setting_space_remaining(
     const sbp_msg_settings_write_resp_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 254);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX);
 }
 size_t sbp_msg_settings_write_resp_setting_count_sections(
     const sbp_msg_settings_write_resp_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 254);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX);
 }
 
 bool sbp_msg_settings_write_resp_setting_add_section(
     sbp_msg_settings_write_resp_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 254, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_write_resp_setting_add_section_printf(
     sbp_msg_settings_write_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 254, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_write_resp_setting_add_section_vprintf(
     sbp_msg_settings_write_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 254, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_write_resp_setting_append(
     sbp_msg_settings_write_resp_t *msg, const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 254, str);
+  return sbp_multipart_string_append(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_write_resp_setting_append_printf(
     sbp_msg_settings_write_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 254, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_write_resp_setting_append_vprintf(
     sbp_msg_settings_write_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 254, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_write_resp_setting_get_section(
     const sbp_msg_settings_write_resp_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 254, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_write_resp_setting_section_strlen(
     const sbp_msg_settings_write_resp_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 254, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_write_resp_encode_internal(
@@ -314,7 +340,8 @@ bool sbp_msg_settings_write_resp_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->status)) {
     return false;
   }
-  if (!sbp_multipart_string_encode(&msg->setting, 254, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -341,7 +368,8 @@ bool sbp_msg_settings_write_resp_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->status)) {
     return false;
   }
-  if (!sbp_multipart_string_decode(&msg->setting, 254, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->setting, SBP_MSG_SETTINGS_WRITE_RESP_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -399,81 +427,94 @@ void sbp_msg_settings_read_req_setting_init(sbp_msg_settings_read_req_t *msg) {
 
 bool sbp_msg_settings_read_req_setting_valid(
     const sbp_msg_settings_read_req_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 255);
+  return sbp_multipart_string_valid(&msg->setting,
+                                    SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX);
 }
 
 int sbp_msg_settings_read_req_setting_strcmp(
     const sbp_msg_settings_read_req_t *a,
     const sbp_msg_settings_read_req_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 255);
+  return sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                     SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_read_req_setting_encoded_len(
     const sbp_msg_settings_read_req_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 255);
+  return sbp_multipart_string_encoded_len(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_read_req_setting_space_remaining(
     const sbp_msg_settings_read_req_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 255);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX);
 }
 size_t sbp_msg_settings_read_req_setting_count_sections(
     const sbp_msg_settings_read_req_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 255);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX);
 }
 
 bool sbp_msg_settings_read_req_setting_add_section(
     sbp_msg_settings_read_req_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 255, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_read_req_setting_add_section_printf(
     sbp_msg_settings_read_req_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_read_req_setting_add_section_vprintf(
     sbp_msg_settings_read_req_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_read_req_setting_append(sbp_msg_settings_read_req_t *msg,
                                               const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 255, str);
+  return sbp_multipart_string_append(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_read_req_setting_append_printf(
     sbp_msg_settings_read_req_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_read_req_setting_append_vprintf(
     sbp_msg_settings_read_req_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_read_req_setting_get_section(
     const sbp_msg_settings_read_req_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 255, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_read_req_setting_section_strlen(
     const sbp_msg_settings_read_req_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 255, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_read_req_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_req_t *msg) {
-  if (!sbp_multipart_string_encode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -497,7 +538,8 @@ s8 sbp_msg_settings_read_req_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_settings_read_req_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_read_req_t *msg) {
-  if (!sbp_multipart_string_decode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->setting, SBP_MSG_SETTINGS_READ_REQ_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -551,81 +593,94 @@ void sbp_msg_settings_read_resp_setting_init(
 
 bool sbp_msg_settings_read_resp_setting_valid(
     const sbp_msg_settings_read_resp_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 255);
+  return sbp_multipart_string_valid(&msg->setting,
+                                    SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX);
 }
 
 int sbp_msg_settings_read_resp_setting_strcmp(
     const sbp_msg_settings_read_resp_t *a,
     const sbp_msg_settings_read_resp_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 255);
+  return sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                     SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_read_resp_setting_encoded_len(
     const sbp_msg_settings_read_resp_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 255);
+  return sbp_multipart_string_encoded_len(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_read_resp_setting_space_remaining(
     const sbp_msg_settings_read_resp_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 255);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX);
 }
 size_t sbp_msg_settings_read_resp_setting_count_sections(
     const sbp_msg_settings_read_resp_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 255);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX);
 }
 
 bool sbp_msg_settings_read_resp_setting_add_section(
     sbp_msg_settings_read_resp_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 255, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_read_resp_setting_add_section_printf(
     sbp_msg_settings_read_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_read_resp_setting_add_section_vprintf(
     sbp_msg_settings_read_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_read_resp_setting_append(
     sbp_msg_settings_read_resp_t *msg, const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 255, str);
+  return sbp_multipart_string_append(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_read_resp_setting_append_printf(
     sbp_msg_settings_read_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_read_resp_setting_append_vprintf(
     sbp_msg_settings_read_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_read_resp_setting_get_section(
     const sbp_msg_settings_read_resp_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 255, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_read_resp_setting_section_strlen(
     const sbp_msg_settings_read_resp_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 255, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_read_resp_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_read_resp_t *msg) {
-  if (!sbp_multipart_string_encode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -649,7 +704,8 @@ s8 sbp_msg_settings_read_resp_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_settings_read_resp_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_read_resp_t *msg) {
-  if (!sbp_multipart_string_decode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->setting, SBP_MSG_SETTINGS_READ_RESP_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -777,76 +833,89 @@ void sbp_msg_settings_read_by_index_resp_setting_init(
 
 bool sbp_msg_settings_read_by_index_resp_setting_valid(
     const sbp_msg_settings_read_by_index_resp_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 253);
+  return sbp_multipart_string_valid(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX);
 }
 
 int sbp_msg_settings_read_by_index_resp_setting_strcmp(
     const sbp_msg_settings_read_by_index_resp_t *a,
     const sbp_msg_settings_read_by_index_resp_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 253);
+  return sbp_multipart_string_strcmp(
+      &a->setting, &b->setting,
+      SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_read_by_index_resp_setting_encoded_len(
     const sbp_msg_settings_read_by_index_resp_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 253);
+  return sbp_multipart_string_encoded_len(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_read_by_index_resp_setting_space_remaining(
     const sbp_msg_settings_read_by_index_resp_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 253);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX);
 }
 size_t sbp_msg_settings_read_by_index_resp_setting_count_sections(
     const sbp_msg_settings_read_by_index_resp_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 253);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX);
 }
 
 bool sbp_msg_settings_read_by_index_resp_setting_add_section(
     sbp_msg_settings_read_by_index_resp_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 253, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_read_by_index_resp_setting_add_section_printf(
     sbp_msg_settings_read_by_index_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 253, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_read_by_index_resp_setting_add_section_vprintf(
     sbp_msg_settings_read_by_index_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 253, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_read_by_index_resp_setting_append(
     sbp_msg_settings_read_by_index_resp_t *msg, const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 253, str);
+  return sbp_multipart_string_append(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_read_by_index_resp_setting_append_printf(
     sbp_msg_settings_read_by_index_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 253, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_read_by_index_resp_setting_append_vprintf(
     sbp_msg_settings_read_by_index_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 253, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_read_by_index_resp_setting_get_section(
     const sbp_msg_settings_read_by_index_resp_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 253, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_read_by_index_resp_setting_section_strlen(
     const sbp_msg_settings_read_by_index_resp_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 253, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_read_by_index_resp_encode_internal(
@@ -854,7 +923,9 @@ bool sbp_msg_settings_read_by_index_resp_encode_internal(
   if (!sbp_u16_encode(ctx, &msg->index)) {
     return false;
   }
-  if (!sbp_multipart_string_encode(&msg->setting, 253, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -881,7 +952,9 @@ bool sbp_msg_settings_read_by_index_resp_decode_internal(
   if (!sbp_u16_decode(ctx, &msg->index)) {
     return false;
   }
-  if (!sbp_multipart_string_decode(&msg->setting, 253, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->setting, SBP_MSG_SETTINGS_READ_BY_INDEX_RESP_SETTING_MAX,
+          ctx)) {
     return false;
   }
   return true;
@@ -1009,81 +1082,94 @@ void sbp_msg_settings_register_setting_init(sbp_msg_settings_register_t *msg) {
 
 bool sbp_msg_settings_register_setting_valid(
     const sbp_msg_settings_register_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 255);
+  return sbp_multipart_string_valid(&msg->setting,
+                                    SBP_MSG_SETTINGS_REGISTER_SETTING_MAX);
 }
 
 int sbp_msg_settings_register_setting_strcmp(
     const sbp_msg_settings_register_t *a,
     const sbp_msg_settings_register_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 255);
+  return sbp_multipart_string_strcmp(&a->setting, &b->setting,
+                                     SBP_MSG_SETTINGS_REGISTER_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_register_setting_encoded_len(
     const sbp_msg_settings_register_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 255);
+  return sbp_multipart_string_encoded_len(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_register_setting_space_remaining(
     const sbp_msg_settings_register_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 255);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX);
 }
 size_t sbp_msg_settings_register_setting_count_sections(
     const sbp_msg_settings_register_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 255);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX);
 }
 
 bool sbp_msg_settings_register_setting_add_section(
     sbp_msg_settings_register_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 255, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_register_setting_add_section_printf(
     sbp_msg_settings_register_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_register_setting_add_section_vprintf(
     sbp_msg_settings_register_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_register_setting_append(sbp_msg_settings_register_t *msg,
                                               const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 255, str);
+  return sbp_multipart_string_append(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_register_setting_append_printf(
     sbp_msg_settings_register_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_register_setting_append_vprintf(
     sbp_msg_settings_register_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 255, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_register_setting_get_section(
     const sbp_msg_settings_register_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 255, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_register_setting_section_strlen(
     const sbp_msg_settings_register_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 255, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_register_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_msg_settings_register_t *msg) {
-  if (!sbp_multipart_string_encode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1107,7 +1193,8 @@ s8 sbp_msg_settings_register_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_settings_register_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_settings_register_t *msg) {
-  if (!sbp_multipart_string_decode(&msg->setting, 255, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->setting, SBP_MSG_SETTINGS_REGISTER_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1161,76 +1248,88 @@ void sbp_msg_settings_register_resp_setting_init(
 
 bool sbp_msg_settings_register_resp_setting_valid(
     const sbp_msg_settings_register_resp_t *msg) {
-  return sbp_multipart_string_valid(&msg->setting, 254);
+  return sbp_multipart_string_valid(&msg->setting,
+                                    SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX);
 }
 
 int sbp_msg_settings_register_resp_setting_strcmp(
     const sbp_msg_settings_register_resp_t *a,
     const sbp_msg_settings_register_resp_t *b) {
-  return sbp_multipart_string_strcmp(&a->setting, &b->setting, 254);
+  return sbp_multipart_string_strcmp(
+      &a->setting, &b->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_register_resp_setting_encoded_len(
     const sbp_msg_settings_register_resp_t *msg) {
-  return sbp_multipart_string_encoded_len(&msg->setting, 254);
+  return sbp_multipart_string_encoded_len(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX);
 }
 
 size_t sbp_msg_settings_register_resp_setting_space_remaining(
     const sbp_msg_settings_register_resp_t *msg) {
-  return sbp_multipart_string_space_remaining(&msg->setting, 254);
+  return sbp_multipart_string_space_remaining(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX);
 }
 size_t sbp_msg_settings_register_resp_setting_count_sections(
     const sbp_msg_settings_register_resp_t *msg) {
-  return sbp_multipart_string_count_sections(&msg->setting, 254);
+  return sbp_multipart_string_count_sections(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX);
 }
 
 bool sbp_msg_settings_register_resp_setting_add_section(
     sbp_msg_settings_register_resp_t *msg, const char *new_str) {
-  return sbp_multipart_string_add_section(&msg->setting, 254, new_str);
+  return sbp_multipart_string_add_section(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, new_str);
 }
 
 bool sbp_msg_settings_register_resp_setting_add_section_printf(
     sbp_msg_settings_register_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_multipart_string_add_section_vprintf(&msg->setting, 254, fmt, ap);
+  bool ret = sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_register_resp_setting_add_section_vprintf(
     sbp_msg_settings_register_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_add_section_vprintf(&msg->setting, 254, fmt, ap);
+  return sbp_multipart_string_add_section_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, fmt, ap);
 }
 
 bool sbp_msg_settings_register_resp_setting_append(
     sbp_msg_settings_register_resp_t *msg, const char *str) {
-  return sbp_multipart_string_append(&msg->setting, 254, str);
+  return sbp_multipart_string_append(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, str);
 }
 
 bool sbp_msg_settings_register_resp_setting_append_printf(
     sbp_msg_settings_register_resp_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_multipart_string_append_vprintf(&msg->setting, 254, fmt, ap);
+  bool ret = sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_settings_register_resp_setting_append_vprintf(
     sbp_msg_settings_register_resp_t *msg, const char *fmt, va_list ap) {
-  return sbp_multipart_string_append_vprintf(&msg->setting, 254, fmt, ap);
+  return sbp_multipart_string_append_vprintf(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, fmt, ap);
 }
 
 const char *sbp_msg_settings_register_resp_setting_get_section(
     const sbp_msg_settings_register_resp_t *msg, size_t section) {
-  return sbp_multipart_string_get_section(&msg->setting, 254, section);
+  return sbp_multipart_string_get_section(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, section);
 }
 
 size_t sbp_msg_settings_register_resp_setting_section_strlen(
     const sbp_msg_settings_register_resp_t *msg, size_t section) {
-  return sbp_multipart_string_section_strlen(&msg->setting, 254, section);
+  return sbp_multipart_string_section_strlen(
+      &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, section);
 }
 
 bool sbp_msg_settings_register_resp_encode_internal(
@@ -1238,7 +1337,8 @@ bool sbp_msg_settings_register_resp_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->status)) {
     return false;
   }
-  if (!sbp_multipart_string_encode(&msg->setting, 254, ctx)) {
+  if (!sbp_multipart_string_encode(
+          &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, ctx)) {
     return false;
   }
   return true;
@@ -1265,7 +1365,8 @@ bool sbp_msg_settings_register_resp_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->status)) {
     return false;
   }
-  if (!sbp_multipart_string_decode(&msg->setting, 254, ctx)) {
+  if (!sbp_multipart_string_decode(
+          &msg->setting, SBP_MSG_SETTINGS_REGISTER_RESP_SETTING_MAX, ctx)) {
     return false;
   }
   return true;

--- a/c/src/v4/ssr.c
+++ b/c/src/v4/ssr.c
@@ -457,7 +457,7 @@ bool sbp_stec_sat_element_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u8_encode(ctx, &msg->stec_quality_indicator)) {
     return false;
   }
-  for (size_t i = 0; i < 4; i++) {
+  for (size_t i = 0; i < SBP_STEC_SAT_ELEMENT_STEC_COEFF_MAX; i++) {
     if (!sbp_s16_encode(ctx, &msg->stec_coeff[i])) {
       return false;
     }
@@ -488,7 +488,7 @@ bool sbp_stec_sat_element_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->stec_quality_indicator)) {
     return false;
   }
-  for (uint8_t i = 0; i < 4; i++) {
+  for (uint8_t i = 0; i < SBP_STEC_SAT_ELEMENT_STEC_COEFF_MAX; i++) {
     if (!sbp_s16_decode(ctx, &msg->stec_coeff[i])) {
       return false;
     }
@@ -525,7 +525,8 @@ int sbp_stec_sat_element_cmp(const sbp_stec_sat_element_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 4; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_STEC_SAT_ELEMENT_STEC_COEFF_MAX;
+       i++) {
     ret = sbp_s16_cmp(&a->stec_coeff[i], &b->stec_coeff[i]);
   }
   if (ret != 0) {
@@ -1731,12 +1732,12 @@ bool sbp_satellite_apc_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u16_encode(ctx, &msg->svn)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_SATELLITE_APC_PCO_MAX; i++) {
     if (!sbp_s16_encode(ctx, &msg->pco[i])) {
       return false;
     }
   }
-  for (size_t i = 0; i < 21; i++) {
+  for (size_t i = 0; i < SBP_SATELLITE_APC_PCV_MAX; i++) {
     if (!sbp_s8_encode(ctx, &msg->pcv[i])) {
       return false;
     }
@@ -1770,12 +1771,12 @@ bool sbp_satellite_apc_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u16_decode(ctx, &msg->svn)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_SATELLITE_APC_PCO_MAX; i++) {
     if (!sbp_s16_decode(ctx, &msg->pco[i])) {
       return false;
     }
   }
-  for (uint8_t i = 0; i < 21; i++) {
+  for (uint8_t i = 0; i < SBP_SATELLITE_APC_PCV_MAX; i++) {
     if (!sbp_s8_decode(ctx, &msg->pcv[i])) {
       return false;
     }
@@ -1817,14 +1818,14 @@ int sbp_satellite_apc_cmp(const sbp_satellite_apc_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_SATELLITE_APC_PCO_MAX; i++) {
     ret = sbp_s16_cmp(&a->pco[i], &b->pco[i]);
   }
   if (ret != 0) {
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 21; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_SATELLITE_APC_PCV_MAX; i++) {
     ret = sbp_s8_cmp(&a->pcv[i], &b->pcv[i]);
   }
   if (ret != 0) {

--- a/c/src/v4/system.c
+++ b/c/src/v4/system.c
@@ -112,62 +112,73 @@ void sbp_msg_dgnss_status_source_init(sbp_msg_dgnss_status_t *msg) {
 }
 
 bool sbp_msg_dgnss_status_source_valid(const sbp_msg_dgnss_status_t *msg) {
-  return sbp_unterminated_string_valid(&msg->source, 251);
+  return sbp_unterminated_string_valid(&msg->source,
+                                       SBP_MSG_DGNSS_STATUS_SOURCE_MAX);
 }
 
 int sbp_msg_dgnss_status_source_strcmp(const sbp_msg_dgnss_status_t *a,
                                        const sbp_msg_dgnss_status_t *b) {
-  return sbp_unterminated_string_strcmp(&a->source, &b->source, 251);
+  return sbp_unterminated_string_strcmp(&a->source, &b->source,
+                                        SBP_MSG_DGNSS_STATUS_SOURCE_MAX);
 }
 
 size_t sbp_msg_dgnss_status_source_encoded_len(
     const sbp_msg_dgnss_status_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->source, 251);
+  return sbp_unterminated_string_encoded_len(&msg->source,
+                                             SBP_MSG_DGNSS_STATUS_SOURCE_MAX);
 }
 
 size_t sbp_msg_dgnss_status_source_space_remaining(
     const sbp_msg_dgnss_status_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->source, 251);
+  return sbp_unterminated_string_space_remaining(
+      &msg->source, SBP_MSG_DGNSS_STATUS_SOURCE_MAX);
 }
 bool sbp_msg_dgnss_status_source_set(sbp_msg_dgnss_status_t *msg,
                                      const char *new_str) {
-  return sbp_unterminated_string_set(&msg->source, 251, new_str);
+  return sbp_unterminated_string_set(&msg->source,
+                                     SBP_MSG_DGNSS_STATUS_SOURCE_MAX, new_str);
 }
 
 bool sbp_msg_dgnss_status_source_printf(sbp_msg_dgnss_status_t *msg,
                                         const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->source, 251, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->source, SBP_MSG_DGNSS_STATUS_SOURCE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_dgnss_status_source_vprintf(sbp_msg_dgnss_status_t *msg,
                                          const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->source, 251, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->source, SBP_MSG_DGNSS_STATUS_SOURCE_MAX, fmt, ap);
 }
 
 bool sbp_msg_dgnss_status_source_append_printf(sbp_msg_dgnss_status_t *msg,
                                                const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(&msg->source, 251, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->source, SBP_MSG_DGNSS_STATUS_SOURCE_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_dgnss_status_source_append_vprintf(sbp_msg_dgnss_status_t *msg,
                                                 const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->source, 251, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->source, SBP_MSG_DGNSS_STATUS_SOURCE_MAX, fmt, ap);
 }
 
 const char *sbp_msg_dgnss_status_source_get(const sbp_msg_dgnss_status_t *msg) {
-  return sbp_unterminated_string_get(&msg->source, 251);
+  return sbp_unterminated_string_get(&msg->source,
+                                     SBP_MSG_DGNSS_STATUS_SOURCE_MAX);
 }
 
 size_t sbp_msg_dgnss_status_source_strlen(const sbp_msg_dgnss_status_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->source, 251);
+  return sbp_unterminated_string_strlen(&msg->source,
+                                        SBP_MSG_DGNSS_STATUS_SOURCE_MAX);
 }
 
 bool sbp_msg_dgnss_status_encode_internal(sbp_encode_ctx_t *ctx,
@@ -181,7 +192,8 @@ bool sbp_msg_dgnss_status_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_u8_encode(ctx, &msg->num_signals)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->source, 251, ctx)) {
+  if (!sbp_unterminated_string_encode(&msg->source,
+                                      SBP_MSG_DGNSS_STATUS_SOURCE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -213,7 +225,8 @@ bool sbp_msg_dgnss_status_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->num_signals)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->source, 251, ctx)) {
+  if (!sbp_unterminated_string_decode(&msg->source,
+                                      SBP_MSG_DGNSS_STATUS_SOURCE_MAX, ctx)) {
     return false;
   }
   return true;
@@ -625,65 +638,75 @@ void sbp_msg_csac_telemetry_telemetry_init(sbp_msg_csac_telemetry_t *msg) {
 
 bool sbp_msg_csac_telemetry_telemetry_valid(
     const sbp_msg_csac_telemetry_t *msg) {
-  return sbp_unterminated_string_valid(&msg->telemetry, 254);
+  return sbp_unterminated_string_valid(&msg->telemetry,
+                                       SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX);
 }
 
 int sbp_msg_csac_telemetry_telemetry_strcmp(const sbp_msg_csac_telemetry_t *a,
                                             const sbp_msg_csac_telemetry_t *b) {
-  return sbp_unterminated_string_strcmp(&a->telemetry, &b->telemetry, 254);
+  return sbp_unterminated_string_strcmp(&a->telemetry, &b->telemetry,
+                                        SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX);
 }
 
 size_t sbp_msg_csac_telemetry_telemetry_encoded_len(
     const sbp_msg_csac_telemetry_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->telemetry, 254);
+  return sbp_unterminated_string_encoded_len(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX);
 }
 
 size_t sbp_msg_csac_telemetry_telemetry_space_remaining(
     const sbp_msg_csac_telemetry_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->telemetry, 254);
+  return sbp_unterminated_string_space_remaining(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX);
 }
 bool sbp_msg_csac_telemetry_telemetry_set(sbp_msg_csac_telemetry_t *msg,
                                           const char *new_str) {
-  return sbp_unterminated_string_set(&msg->telemetry, 254, new_str);
+  return sbp_unterminated_string_set(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, new_str);
 }
 
 bool sbp_msg_csac_telemetry_telemetry_printf(sbp_msg_csac_telemetry_t *msg,
                                              const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_vprintf(&msg->telemetry, 254, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_csac_telemetry_telemetry_vprintf(sbp_msg_csac_telemetry_t *msg,
                                               const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->telemetry, 254, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, fmt, ap);
 }
 
 bool sbp_msg_csac_telemetry_telemetry_append_printf(
     sbp_msg_csac_telemetry_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_append_vprintf(&msg->telemetry, 254, fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_csac_telemetry_telemetry_append_vprintf(
     sbp_msg_csac_telemetry_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->telemetry, 254, fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, fmt, ap);
 }
 
 const char *sbp_msg_csac_telemetry_telemetry_get(
     const sbp_msg_csac_telemetry_t *msg) {
-  return sbp_unterminated_string_get(&msg->telemetry, 254);
+  return sbp_unterminated_string_get(&msg->telemetry,
+                                     SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX);
 }
 
 size_t sbp_msg_csac_telemetry_telemetry_strlen(
     const sbp_msg_csac_telemetry_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->telemetry, 254);
+  return sbp_unterminated_string_strlen(&msg->telemetry,
+                                        SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX);
 }
 
 bool sbp_msg_csac_telemetry_encode_internal(
@@ -691,7 +714,8 @@ bool sbp_msg_csac_telemetry_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->id)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->telemetry, 254, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, ctx)) {
     return false;
   }
   return true;
@@ -717,7 +741,8 @@ bool sbp_msg_csac_telemetry_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->id)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->telemetry, 254, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->telemetry, SBP_MSG_CSAC_TELEMETRY_TELEMETRY_MAX, ctx)) {
     return false;
   }
   return true;
@@ -776,69 +801,87 @@ void sbp_msg_csac_telemetry_labels_telemetry_labels_init(
 
 bool sbp_msg_csac_telemetry_labels_telemetry_labels_valid(
     const sbp_msg_csac_telemetry_labels_t *msg) {
-  return sbp_unterminated_string_valid(&msg->telemetry_labels, 254);
+  return sbp_unterminated_string_valid(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX);
 }
 
 int sbp_msg_csac_telemetry_labels_telemetry_labels_strcmp(
     const sbp_msg_csac_telemetry_labels_t *a,
     const sbp_msg_csac_telemetry_labels_t *b) {
-  return sbp_unterminated_string_strcmp(&a->telemetry_labels,
-                                        &b->telemetry_labels, 254);
+  return sbp_unterminated_string_strcmp(
+      &a->telemetry_labels, &b->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX);
 }
 
 size_t sbp_msg_csac_telemetry_labels_telemetry_labels_encoded_len(
     const sbp_msg_csac_telemetry_labels_t *msg) {
-  return sbp_unterminated_string_encoded_len(&msg->telemetry_labels, 254);
+  return sbp_unterminated_string_encoded_len(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX);
 }
 
 size_t sbp_msg_csac_telemetry_labels_telemetry_labels_space_remaining(
     const sbp_msg_csac_telemetry_labels_t *msg) {
-  return sbp_unterminated_string_space_remaining(&msg->telemetry_labels, 254);
+  return sbp_unterminated_string_space_remaining(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX);
 }
 bool sbp_msg_csac_telemetry_labels_telemetry_labels_set(
     sbp_msg_csac_telemetry_labels_t *msg, const char *new_str) {
-  return sbp_unterminated_string_set(&msg->telemetry_labels, 254, new_str);
+  return sbp_unterminated_string_set(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, new_str);
 }
 
 bool sbp_msg_csac_telemetry_labels_telemetry_labels_printf(
     sbp_msg_csac_telemetry_labels_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret =
-      sbp_unterminated_string_vprintf(&msg->telemetry_labels, 254, fmt, ap);
+  bool ret = sbp_unterminated_string_vprintf(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_csac_telemetry_labels_telemetry_labels_vprintf(
     sbp_msg_csac_telemetry_labels_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_vprintf(&msg->telemetry_labels, 254, fmt, ap);
+  return sbp_unterminated_string_vprintf(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, fmt, ap);
 }
 
 bool sbp_msg_csac_telemetry_labels_telemetry_labels_append_printf(
     sbp_msg_csac_telemetry_labels_t *msg, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = sbp_unterminated_string_append_vprintf(&msg->telemetry_labels, 254,
-                                                    fmt, ap);
+  bool ret = sbp_unterminated_string_append_vprintf(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool sbp_msg_csac_telemetry_labels_telemetry_labels_append_vprintf(
     sbp_msg_csac_telemetry_labels_t *msg, const char *fmt, va_list ap) {
-  return sbp_unterminated_string_append_vprintf(&msg->telemetry_labels, 254,
-                                                fmt, ap);
+  return sbp_unterminated_string_append_vprintf(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, fmt, ap);
 }
 
 const char *sbp_msg_csac_telemetry_labels_telemetry_labels_get(
     const sbp_msg_csac_telemetry_labels_t *msg) {
-  return sbp_unterminated_string_get(&msg->telemetry_labels, 254);
+  return sbp_unterminated_string_get(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX);
 }
 
 size_t sbp_msg_csac_telemetry_labels_telemetry_labels_strlen(
     const sbp_msg_csac_telemetry_labels_t *msg) {
-  return sbp_unterminated_string_strlen(&msg->telemetry_labels, 254);
+  return sbp_unterminated_string_strlen(
+      &msg->telemetry_labels,
+      SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX);
 }
 
 bool sbp_msg_csac_telemetry_labels_encode_internal(
@@ -846,7 +889,9 @@ bool sbp_msg_csac_telemetry_labels_encode_internal(
   if (!sbp_u8_encode(ctx, &msg->id)) {
     return false;
   }
-  if (!sbp_unterminated_string_encode(&msg->telemetry_labels, 254, ctx)) {
+  if (!sbp_unterminated_string_encode(
+          &msg->telemetry_labels,
+          SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, ctx)) {
     return false;
   }
   return true;
@@ -873,7 +918,9 @@ bool sbp_msg_csac_telemetry_labels_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->id)) {
     return false;
   }
-  if (!sbp_unterminated_string_decode(&msg->telemetry_labels, 254, ctx)) {
+  if (!sbp_unterminated_string_decode(
+          &msg->telemetry_labels,
+          SBP_MSG_CSAC_TELEMETRY_LABELS_TELEMETRY_LABELS_MAX, ctx)) {
     return false;
   }
   return true;

--- a/c/src/v4/tracking.c
+++ b/c/src/v4/tracking.c
@@ -995,7 +995,7 @@ bool sbp_msg_tracking_iq_encode_internal(sbp_encode_ctx_t *ctx,
   if (!sbp_v4_gnss_signal_encode_internal(ctx, &msg->sid)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_TRACKING_IQ_CORRS_MAX; i++) {
     if (!sbp_tracking_channel_correlation_encode_internal(ctx,
                                                           &msg->corrs[i])) {
       return false;
@@ -1027,7 +1027,7 @@ bool sbp_msg_tracking_iq_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_v4_gnss_signal_decode_internal(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_TRACKING_IQ_CORRS_MAX; i++) {
     if (!sbp_tracking_channel_correlation_decode_internal(ctx,
                                                           &msg->corrs[i])) {
       return false;
@@ -1079,7 +1079,7 @@ int sbp_msg_tracking_iq_cmp(const sbp_msg_tracking_iq_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_TRACKING_IQ_CORRS_MAX; i++) {
     ret = sbp_tracking_channel_correlation_cmp(&a->corrs[i], &b->corrs[i]);
   }
   if (ret != 0) {
@@ -1167,7 +1167,7 @@ bool sbp_msg_tracking_iq_dep_b_encode_internal(
   if (!sbp_v4_gnss_signal_encode_internal(ctx, &msg->sid)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_TRACKING_IQ_DEP_B_CORRS_MAX; i++) {
     if (!sbp_tracking_channel_correlation_dep_encode_internal(ctx,
                                                               &msg->corrs[i])) {
       return false;
@@ -1200,7 +1200,7 @@ bool sbp_msg_tracking_iq_dep_b_decode_internal(
   if (!sbp_v4_gnss_signal_decode_internal(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_TRACKING_IQ_DEP_B_CORRS_MAX; i++) {
     if (!sbp_tracking_channel_correlation_dep_decode_internal(ctx,
                                                               &msg->corrs[i])) {
       return false;
@@ -1253,7 +1253,8 @@ int sbp_msg_tracking_iq_dep_b_cmp(const sbp_msg_tracking_iq_dep_b_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_TRACKING_IQ_DEP_B_CORRS_MAX;
+       i++) {
     ret = sbp_tracking_channel_correlation_dep_cmp(&a->corrs[i], &b->corrs[i]);
   }
   if (ret != 0) {
@@ -1270,7 +1271,7 @@ bool sbp_msg_tracking_iq_dep_a_encode_internal(
   if (!sbp_gnss_signal_dep_encode_internal(ctx, &msg->sid)) {
     return false;
   }
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SBP_MSG_TRACKING_IQ_DEP_A_CORRS_MAX; i++) {
     if (!sbp_tracking_channel_correlation_dep_encode_internal(ctx,
                                                               &msg->corrs[i])) {
       return false;
@@ -1303,7 +1304,7 @@ bool sbp_msg_tracking_iq_dep_a_decode_internal(
   if (!sbp_gnss_signal_dep_decode_internal(ctx, &msg->sid)) {
     return false;
   }
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < SBP_MSG_TRACKING_IQ_DEP_A_CORRS_MAX; i++) {
     if (!sbp_tracking_channel_correlation_dep_decode_internal(ctx,
                                                               &msg->corrs[i])) {
       return false;
@@ -1356,7 +1357,8 @@ int sbp_msg_tracking_iq_dep_a_cmp(const sbp_msg_tracking_iq_dep_a_t *a,
     return ret;
   }
 
-  for (uint8_t i = 0; ret == 0 && i < 3; i++) {
+  for (uint8_t i = 0; ret == 0 && i < SBP_MSG_TRACKING_IQ_DEP_A_CORRS_MAX;
+       i++) {
     ret = sbp_tracking_channel_correlation_dep_cmp(&a->corrs[i], &b->corrs[i]);
   }
   if (ret != 0) {

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -273,6 +273,19 @@ def get_max_possible_items(msg, field, package_specs):
     return int(available_space / elem_size)
 
 
+def get_max_possible_items_macro(msg, field):
+    """
+    Get the name of the macro which will define the maximum number of items that can be stored in a field
+    """
+    assert field.type_id == "array" or field.type_id == "string"
+    macro_name = get_v4_basename(msg.identifier)
+    if macro_name[:7] == "sbp_v4_":
+        macro_name = "sbp_" + macro_name[7:]
+    macro_name = macro_name + "_" + field.identifier + "_MAX"
+    return macro_name.upper()
+
+
+
 def get_bitfield_basename(msg, item):
     bitfield_name = item.get("desc", "").replace(" ", "_").upper()
     base_string = "SBP_{}_{}".format(msg.upper().replace("MSG_", ""), bitfield_name)
@@ -354,11 +367,13 @@ class FieldItem(object):
             self.encoded_len_value = get_encoded_len_value(self.basetype, package_specs)
             self.cmp_fn = get_cmp_fn(self.basetype)
             self.max_items = field.options["size"].value
+            self.max_items_macro = get_max_possible_items_macro(msg, field)
             self.options = field.options
         elif type_id == "string" or "encoding" in field.options:
             self.packing = "packed-string"
             self.basetype = "char"
             self.max_items = get_max_possible_items(msg, field, package_specs)
+            self.max_items_macro = get_max_possible_items_macro(msg, field)
             self.options = field.options
             self.encoding = field.options["encoding"].value
             self.is_fixed_size = False
@@ -373,6 +388,7 @@ class FieldItem(object):
             self.encoded_len_macro = get_encoded_len_macro(self.basetype, True)
             self.encoded_len_value = get_encoded_len_value(self.basetype, package_specs)
             self.max_items = field.options["size"].value
+            self.max_items_macro = get_max_possible_items_macro(msg, field)
             self.options = field.options
         elif type_id == "array":
             self.packing = "variable-array"
@@ -385,6 +401,7 @@ class FieldItem(object):
             self.encoded_len_macro = get_encoded_len_macro(self.basetype, True)
             self.encoded_len_value = get_encoded_len_value(self.basetype, package_specs)
             self.max_items = get_max_possible_items(msg, field, package_specs)
+            self.max_items_macro = get_max_possible_items_macro(msg, field)
             if "size_fn" in field.options:
                 self.size_fn = field.options["size_fn"].value
                 self.generate_size_fn = False

--- a/generator/sbpg/targets/resources/c/sbp_messages_macros_template.h
+++ b/generator/sbpg/targets/resources/c/sbp_messages_macros_template.h
@@ -26,6 +26,13 @@
 ((*- if f.options.fields *))
 (((f|create_bitfield_macros(m.name))))
 ((*- endif*))
+((*- if f.packing != "single" *))
+/**
+ * The maximum number of items that can be stored in (((m.type_name)))::(((f.name))) (V4 API) or (((m.legacy_type_name)))::(((f.name))) (legacy API) before the maximum SBP message size is exceeded
+ */
+#define (((f.max_items_macro))) (((f.max_items)))u
+
+((* endif *))
 ((*- endfor *))
 /**
  * Encoded length of (((m.type_name))) (V4 API) and 

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -29,120 +29,120 @@ void (((f.fn_prefix)))_init( (((-m.type_name))) *msg)
 
 bool (((f.fn_prefix)))_valid(const (((m.type_name))) *msg)
 {
-  return (((string_prefix)))_valid(&msg->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_valid(&msg->(((f.name))), (((f.max_items_macro))));
 }
 
 int (((f.fn_prefix)))_strcmp(const (((m.type_name))) *a, const (((m.type_name))) *b)
 {
-  return (((string_prefix)))_strcmp(&a->(((f.name))), &b->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_strcmp(&a->(((f.name))), &b->(((f.name))), (((f.max_items_macro))));
 }
 
 size_t (((f.fn_prefix)))_encoded_len(const (((m.type_name))) *msg)
 {
-  return (((string_prefix)))_encoded_len(&msg->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_encoded_len(&msg->(((f.name))), (((f.max_items_macro))));
 }
 
 size_t (((f.fn_prefix)))_space_remaining(const (((m.type_name))) *msg)
 {
-  return (((string_prefix)))_space_remaining(&msg->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_space_remaining(&msg->(((f.name))), (((f.max_items_macro))));
 }
 
 ((*- if f.encoding == "unterminated" or f.encoding == "null_terminated" *))
  bool (((f.fn_prefix)))_set( (((-m.type_name))) *msg, const char *new_str)
 {
-  return (((string_prefix)))_set(&msg->(((f.name))), (((f.max_items))), new_str);
+  return (((string_prefix)))_set(&msg->(((f.name))), (((f.max_items_macro))), new_str);
 }
 
 bool (((f.fn_prefix)))_printf( (((-m.type_name))) *msg, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = (((string_prefix)))_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  bool ret = (((string_prefix)))_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
  bool (((f.fn_prefix)))_vprintf( (((-m.type_name))) *msg, const char *fmt, va_list ap)
 {
-  return (((string_prefix)))_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  return (((string_prefix)))_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
 }
 
 bool (((f.fn_prefix)))_append_printf( (((-m.type_name))) *msg, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  bool ret = (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
   bool (((f.fn_prefix)))_append_vprintf( (((-m.type_name))) *msg, const char *fmt, va_list ap)
 {
-  return (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  return (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
 }
 
 const char *(((f.fn_prefix)))_get(const (((m.type_name))) *msg)
 {
-  return (((string_prefix)))_get(&msg->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_get(&msg->(((f.name))), (((f.max_items_macro))));
 }
 
 size_t (((f.fn_prefix)))_strlen(const (((m.type_name))) *msg)
 {
-  return (((string_prefix)))_strlen(&msg->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_strlen(&msg->(((f.name))), (((f.max_items_macro))));
 }
 
 ((*- elif f.encoding == "multipart" or f.encoding == "double_null_terminated" *))
 size_t (((f.fn_prefix)))_count_sections(const (((m.type_name))) *msg)
 {
-  return (((string_prefix)))_count_sections(&msg->(((f.name))), (((f.max_items))));
+  return (((string_prefix)))_count_sections(&msg->(((f.name))), (((f.max_items_macro))));
 }
 
 bool (((f.fn_prefix)))_add_section( (((-m.type_name))) *msg, const char *new_str)
 {
-  return (((string_prefix)))_add_section(&msg->(((f.name))), (((f.max_items))), new_str);
+  return (((string_prefix)))_add_section(&msg->(((f.name))), (((f.max_items_macro))), new_str);
 }
 
 bool (((f.fn_prefix)))_add_section_printf( (((-m.type_name))) *msg, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = (((string_prefix)))_add_section_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  bool ret = (((string_prefix)))_add_section_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool (((f.fn_prefix)))_add_section_vprintf( (((-m.type_name))) *msg, const char *fmt, va_list ap)
 {
-  return (((string_prefix)))_add_section_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  return (((string_prefix)))_add_section_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
 }
 
 bool (((f.fn_prefix)))_append( (((-m.type_name))) *msg, const char *str)
 {
-  return (((string_prefix)))_append(&msg->(((f.name))), (((f.max_items))), str);
+  return (((string_prefix)))_append(&msg->(((f.name))), (((f.max_items_macro))), str);
 }
 
 bool (((f.fn_prefix)))_append_printf( (((-m.type_name))) *msg, const char *fmt, ...) 
 {
   va_list ap;
   va_start(ap, fmt);
-  bool ret = (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  bool ret = (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
   va_end(ap);
   return ret;
 }
 
 bool (((f.fn_prefix)))_append_vprintf( (((-m.type_name))) *msg, const char *fmt, va_list ap)
 {
-  return (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items))), fmt, ap);
+  return (((string_prefix)))_append_vprintf(&msg->(((f.name))), (((f.max_items_macro))), fmt, ap);
 }
 
 const char *(((f.fn_prefix)))_get_section(const (((m.type_name))) *msg, size_t section)
 {
-  return (((string_prefix)))_get_section(&msg->(((f.name))), (((f.max_items))), section);
+  return (((string_prefix)))_get_section(&msg->(((f.name))), (((f.max_items_macro))), section);
 }
 
 size_t (((f.fn_prefix)))_section_strlen(const (((m.type_name))) *msg, size_t section)
 {
-  return (((string_prefix)))_section_strlen(&msg->(((f.name))), (((f.max_items))), section);
+  return (((string_prefix)))_section_strlen(&msg->(((f.name))), (((f.max_items_macro))), section);
 }
 
 ((*- else *))
@@ -161,12 +161,12 @@ bool (((m.internal_encode_fn)))(sbp_encode_ctx_t *ctx, const (((m.type_name))) *
   ((*- for f in m.fields *))
   ((*- set field = "msg->" + f.name *))
   ((*- if f.packing == "packed-string" *))
-  if (!sbp_(((f.encoding)))_string_encode(&(((field))), (((f.max_items))), ctx)) { return false; }
+  if (!sbp_(((f.encoding)))_string_encode(&(((field))), (((f.max_items_macro))), ctx)) { return false; }
   ((*- elif f.packing == "single" *))
   if (!(((f.encode_fn)))(ctx, &(((field))))) { return false; }
   ((*- else *))
   ((*- if f.packing == "fixed-array" *))
-  ((*- set max_loop = f.max_items *))
+  ((*- set max_loop = f.max_items_macro *))
   ((*- else *))
   ((*- set max_loop = "msg->" + f.size_fn *))
   ((*- endif *))
@@ -204,11 +204,11 @@ bool (((m.internal_decode_fn)))(sbp_decode_ctx_t *ctx, (((m.type_name))) *msg)
   ((*- for f in m.fields *))
   ((*- set field = "msg->" + f.name *))
   ((*- if f.packing == "packed-string" *))
-  if (!sbp_(((f.encoding)))_string_decode(&(((field))), (((f.max_items))), ctx)) { return false; }
+  if (!sbp_(((f.encoding)))_string_decode(&(((field))), (((f.max_items_macro))), ctx)) { return false; }
   ((*- elif f.packing == "single" *))
   if (!(((f.decode_fn)))(ctx, &(((field))))) { return false; }
   ((*- elif f.packing == "fixed-array" *))
-  for (uint8_t i = 0; i < (((f.max_items))); i++) {
+  for (uint8_t i = 0; i < (((f.max_items_macro))); i++) {
     if (!(((f.decode_fn)))(ctx, &(((field)))[i])) { return false; }
   }
   ((*- elif f.packing == "variable-array" *))
@@ -263,7 +263,7 @@ int (((m.cmp_fn)))(const (((m.type_name))) *a, const (((m.type_name))) *b) {
   ret = sbp_u8_cmp(&a->(((f.size_fn))), &b->(((f.size_fn))));
   ((*- endif *))
   ((*- if f.packing == "fixed-array" *))
-  ((*- set max_loop = f.max_items *))
+  ((*- set max_loop = f.max_items_macro *))
   ((*- else *))
   ((*- set max_loop = "a->" + f.size_fn *))
   ((*- endif *))

--- a/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/v4/sbp_messages_template.h
@@ -63,7 +63,7 @@ typedef struct {
   ((*- elif f.packing == "single" *))
   (((f.basetype))) (((f.name)));
   ((*- else *))
-  (((f.basetype))) (((f.name)))[(((f.max_items)))];
+  (((f.basetype))) (((f.name)))[(((f.max_items_macro)))];
   ((*- if f.generate_size_fn *))
   /**
    * Number of elements in (((f.name)))


### PR DESCRIPTION
Applies to all array and string type fields both variable and fixed lengths. Generate a new `#define` for the maximum number of items in the array/string and use it in type definitions. Only used form the V4 API, legacy API is unaltered and still uses magic numbers of type definitions.