### PR TITLE
docker: sync with github actions [DEVINFRA-486]

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,15 +18,11 @@ jobs:
 
       - name: Build image
         run: |
-          mkdir docker-build
-          cd docker-build
-          docker build -f ../Dockerfile -t libsbp-build .
-          cd ..
+          docker build -t libsbp-build --build-arg UID=$(id -u) - <Dockerfile
 
       - name: List images
         run: docker images
 
       - name: Run make all inside image
-        # javascript fails due to permissions
-        # rust fails due to missing stdbool.h
-        run: docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest sudo --preserve-env=PATH,RUSTUP_HOME,CARGO_HOME,NVM_DIR,NODE_PATH make c python gen-javascript java docs haskell protobuf rust jsonschema quicktype
+        run: |
+          docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest make all

--- a/README.md
+++ b/README.md
@@ -127,32 +127,38 @@ Otherwise, the `Dockerfile` will create a docker image that contains all the
 necessary dependencies to build libsbp.  You can make a local image fresh from
 this file by running `docker build` as such:
 
-`mkdir docker-build; cd docker-build`
+    docker build -t libsbp-build - <Dockerfile
 
-This dummy directory is to prevent docker from sucking up the whole
-repo into the local context (which is then immediately discarded
-anyway).  Next create the docker image:
+Reading the Dockerfile from STDIN prevents docker from pulling in the whole
+repostory into the build context (which is then immediately discarded anyway).
+You can customize the UID of the user that's created with the docker image
+by passing the desired `UID` value to the build:
 
-`docker build -f ../Dockerfile -t libsbp-build .`
+    docker build -t libsbp-build --build-arg UID=1234 - <Dockerfile
 
 You can then make this image operate on your local workspace like this:
 
-`cd ..`  (back up to the root of the repo)
-
-``docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:latest``
+    docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:latest /bin/bash
 
 #### Using the docker image
 
 Once in the image, simply type `make all` to generate all the libsbp bindings.
-This could take several hours to run.
+This could take several hours to run.  Alternately, the docker image will run
+the `make all` command by default, so you can kick off the `make all` process
+by simply running the following command:
 
-When you are finished, quit Docker so that it would not unnecessarily use up resources on your machine. 
+    docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:latest
 
-If you run into issues during the generation process, try running `make clean`. 
-Alternatively, you could recompile from a clean, newly-cloned libsbp repository on your machine,
-which would minimize the chance of running into compilation issues from an old build.
+When you are finished, quit Docker so that it would not unnecessarily use up
+resources on your machine.
+
+If you run into issues during the generation process, try running `make clean`.
+Alternatively, you could recompile from a clean, newly-cloned libsbp repository
+on your machine, which would minimize the chance of running into compilation
+issues from an old build.
 
 ### Installing from package managers
+
 Some bindings are available on package managers:
 
 * [`python`](https://github.com/swift-nav/libsbp/tree/HEAD/python): available on pip


### PR DESCRIPTION
The libsbp-build image has gotten out of sync with GitHub actions such
as Java and JavaScript where no longer passing when building locally.

Update the libsbp-bulid image so it more closely matches the GitHub
actions environment.

Specifically Java was failing with the following error:

```
*** java.lang.instrument ASSERTION FAILED ***: "result" with message agent load/premain call failed at src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 422
FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
Process 'Gradle Test Executor 12' finished with non-zero exit value 134
org.gradle.process.internal.ExecException: Process 'Gradle Test Executor 12' finished with non-zero exit value 134
        at org.gradle.process.internal.DefaultExecHandle$ExecResultImpl.assertNormalExitValue(DefaultExecHandle.java:382)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.onProcessStop(DefaultWorkerProcess.java:118)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.access$000(DefaultWorkerProcess.java:41)
        at org.gradle.process.internal.worker.DefaultWorkerProcess$1.executionFinished(DefaultWorkerProcess.java:74)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:42)
        at org.gradle.internal.event.BroadcastDispatch$SingletonDispatch.dispatch(BroadcastDispatch.java:230)
        at org.gradle.internal.event.BroadcastDispatch$SingletonDispatch.dispatch(BroadcastDispatch.java:149)
        at org.gradle.internal.event.ListenerBroadcast.dispatch(ListenerBroadcast.java:140)
        at org.gradle.internal.event.ListenerBroadcast.dispatch(ListenerBroadcast.java:37)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy78.executionFinished(Unknown Source)
        at org.gradle.process.internal.DefaultExecHandle.setEndStateInfo(DefaultExecHandle.java:215)
        at org.gradle.process.internal.DefaultExecHandle.finished(DefaultExecHandle.java:327)
        at org.gradle.process.internal.ExecHandleRunner.completed(ExecHandleRunner.java:103)
        at org.gradle.process.internal.ExecHandleRunner.run(ExecHandleRunner.java:83)
        at org.gradle.internal.operations.BuildOperationIdentifierPreservingRunnable.run(BuildOperationIdentifierPreservingRunnable.java:39)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

JavaScript was failing with the following error:

```
  3019 passing (14s)
  1 failing

  1) dispatcher
       should read stream of bytes and dispatch callback for one valid message, ignore corrupt preamble:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/mnt/workspace/javascript/tests/test_dispatch.js)
      at listOnTimeout (internal/timers.js:554:17)
      at processTimers (internal/timers.js:497:7)
```
