### PR TITLE
Dockerfile: Use Ubuntu focal

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,6 +8,12 @@ on:
       - .github/workflows/docker.yaml
 jobs:
   build:
+    strategy:
+      matrix:
+        ubuntu-release:
+          - bionic
+          - focal
+          - groovy
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
@@ -18,11 +24,12 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -t libsbp-build --build-arg UID=$(id -u) - <Dockerfile
+          docker build -t libsbp-build --build-arg UID=$(id -u) --build-arg UBUNTU_RELEASE=${{ matrix.ubuntu-release }} - <Dockerfile
 
       - name: List images
         run: docker images
 
       - name: Run make all inside image
+        if: matrix.ubuntu-release != 'groovy'
         run: |
           docker run --rm -v $PWD:/mnt/workspace -t libsbp-build:latest make all

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,10 +76,10 @@ RUN \
       libpython3.8-stdlib \
       python-is-python3 \
       python3-pip \
-      python3.5-dev \
-      python3.6-dev \
-      python3.7-dev \
-      python3.9-dev python3.9-dist \
+      python3.5 \
+      python3.6 \
+      python3.7\
+      python3.9 \
   && pip3 install tox sphinx tox-run-command \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path \
   && rustup component add rustfmt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ ENV PATH=/usr/lib/ccache:/cargo/bin:/rust/bin:${PATH}
 
 RUN \
      apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
+      gnupg \
+      netbase \
       git \
       sudo \
       software-properties-common \
@@ -39,6 +41,7 @@ RUN \
       curl \
       libudev-dev \
       uuid-dev \
+      libffi-dev \
       libgmp-dev \
       zlib1g-dev \
       zip unzip \
@@ -47,14 +50,14 @@ RUN \
       pandoc \
       llvm \
       clang \
-      texlive-science \
       texlive-fonts-extra \
+      texlive-latex-extra \
+      texlive-science \
       check \
       ccache \
       pkg-config \
       doxygen \
       graphviz \
-      texlive-latex-base \
       imagemagick \
       clang-format-6.0 \
   && rm -rf /var/lib/apt/lists/* \
@@ -71,7 +74,7 @@ RUN \
   && gradle --version \
   && add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
       libpython2.7-stdlib \
       libpython3.8-stdlib \
       python-is-python3 \
@@ -92,7 +95,7 @@ RUN \
      wget -O - ${KITWARE_KEY_URL} 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
   && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
   && apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     cmake \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,25 @@ ENV SDKMAN_DIR=/opt/sdkman
 
 ENV PATH=/usr/lib/ccache:/cargo/bin:/rust/bin:${PATH}
 
+ARG KITWARE_KEY_URL=https://apt.kitware.com/keys/kitware-archive-latest.asc
+
 RUN \
      apt-get update \
   && apt-get install -y --no-install-recommends \
-      gnupg \
-      netbase \
-      git \
-      sudo \
-      software-properties-common \
       apt-utils \
+      gnupg \
+      gpg \
+      netbase \
+      software-properties-common \
+      sudo \
       wget \
+  && add-apt-repository ppa:deadsnakes/ppa \
+  && echo $KITWARE_KEY_URL \
+  && wget -O - ${KITWARE_KEY_URL} 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+  && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+      git \
       curl \
       libudev-dev \
       uuid-dev \
@@ -48,6 +57,10 @@ RUN \
       build-essential \
       $CC $CXX \
       pandoc \
+      libpython2.7-stdlib \
+      libpython3.8-stdlib \
+      python-is-python3 \
+      python3-pip \
       llvm \
       clang \
       texlive-fonts-extra \
@@ -60,6 +73,34 @@ RUN \
       graphviz \
       imagemagick \
       clang-format-6.0 \
+      # from deadsnakes
+      python3.5 \
+      python3.6 \
+      python3.7\
+      python3.9 \
+      # from kitware
+      cmake \
+  && curl -sSL https://get.haskellstack.org/ | sh \
+  && apt remove -y \
+      gnupg \
+      gpg \
+      netbase \
+      packagekit \
+      software-properties-common \
+      wget \
+  && apt autoremove -y \
+  && apt remove -y --allow-remove-essential \
+      apt \
+  && sudo dpkg -r --force-depends \
+      dpkg-dev \
+      git-man \
+      fontconfig-config \
+      libcommons-logging-java \
+      libcommons-parent-java \
+      libdpkg-perl \
+      libfontbox-java \
+      libpdfbox-java \
+      libthai-data \
   && rm -rf /var/lib/apt/lists/* \
   && curl -s "https://get.sdkman.io" | bash \
   && bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh; \
@@ -72,32 +113,9 @@ ENV PATH=${SDKMAN_DIR}/candidates/gradle/current/bin:${PATH}
 RUN \
      java --version \
   && gradle --version \
-  && add-apt-repository ppa:deadsnakes/ppa \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-      libpython2.7-stdlib \
-      libpython3.8-stdlib \
-      python-is-python3 \
-      python3-pip \
-      python3.5 \
-      python3.6 \
-      python3.7\
-      python3.9 \
   && pip3 install tox sphinx tox-run-command \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path \
-  && rustup component add rustfmt \
-  && curl -sSL https://get.haskellstack.org/ | sh \
-  && rm -rf /var/lib/apt/lists/*
-
-ARG KITWARE_KEY_URL=https://apt.kitware.com/keys/kitware-archive-latest.asc
-
-RUN \
-     wget -O - ${KITWARE_KEY_URL} 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
-  && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-    cmake \
-  && rm -rf /var/lib/apt/lists/*
+  && rustup component add rustfmt
 
 ENV NVM_DIR=/opt/nvm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN \
       python3.7-dev \
       python3.9-dev python3.9-dist \
   && pip3 install tox sphinx tox-run-command \
-  && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --no-modify-path \
+  && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path \
+  && rustup component add rustfmt \
   && curl -sSL https://get.haskellstack.org/ | sh \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,8 @@ RUN \
   && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
   && apt-get update \
   && apt-get install -y \
-    cmake
+    cmake \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV NVM_DIR=/opt/nvm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Swift Navigation Inc.
+# Copyright (C) 2020-2021 Swift Navigation Inc.
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -11,13 +11,15 @@
 # This describes an image that should be able to generate libsbp bindings.
 # See the README.md for instructions on how to use it.
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV NODE_VERSION=v14.17.3
 ENV JAVA_VERSION=11.0.11.hs-adpt
 ENV GRADLE_VERSION=7.1.1
+ENV CC=gcc-7
+ENV CXX=g++-7
 
 ENV RUSTUP_HOME=/rust
 ENV CARGO_HOME=/cargo
@@ -41,6 +43,7 @@ RUN \
       zlib1g-dev \
       zip unzip \
       build-essential \
+      $CC $CXX \
       pandoc \
       llvm \
       clang \
@@ -69,12 +72,13 @@ RUN \
   && add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \
   && apt-get install -y \
-      python-pip \
+      libpython2.7-stdlib \
+      libpython3.8-stdlib \
+      python-is-python3 \
       python3-pip \
       python3.5-dev \
       python3.6-dev \
       python3.7-dev \
-      python3.8-dev \
       python3.9-dev python3.9-dist \
   && pip3 install tox sphinx tox-run-command \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --no-modify-path \
@@ -85,7 +89,7 @@ ARG KITWARE_KEY_URL=https://apt.kitware.com/keys/kitware-archive-latest.asc
 
 RUN \
      wget -O - ${KITWARE_KEY_URL} 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
-  && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' \ 
+  && add-apt-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
   && apt-get update \
   && apt-get install -y \
     cmake

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN \
       libfontbox-java \
       libpdfbox-java \
       libthai-data \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /tmp/* \
   && curl -s "https://get.sdkman.io" | bash \
   && bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh; \
               sdk install java $JAVA_VERSION; sdk install gradle $GRADLE_VERSION; \
@@ -128,7 +128,7 @@ RUN \
 ENV NODE_PATH=$NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
 ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:${PATH}
 
-RUN npm install npm@latest mocha quicktype -g
+RUN npm install npm@latest mocha quicktype -g && sudo rm -rf /tmp/*
 
 ARG UID=1000
 
@@ -145,7 +145,10 @@ RUN \
 WORKDIR /mnt/workspace
 USER dockerdev
 
-RUN stack install --resolver lts-10.10 sbp
+RUN \
+  if [ "$(ls /tmp)" ]; then ls /tmp; false; fi \
+  && stack install --resolver lts-10.10 sbp \
+  && rm -rf /tmp/*
 
 CMD ["make", "all"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ RUN \
       zip unzip \
       build-essential \
       $CC $CXX \
-      pandoc \
       libpython2.7-stdlib \
       libpython3.8-stdlib \
       $(test $UBUNTU_RELEASE = focal && echo python-is-python3) \

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ verify-prereq-python: verify-prereq-generator
 	@command -v python 1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`python\` but it's not installed. Aborting.\n\nHave you installed Python? See the Python readme at \`python/README.rst\` for setup instructions.\n"; exit 1; }
 	@command -v pip 1>/dev/null 2>/dev/null    || { echo >&2 -e "I require \`pip\` but it's not installed. Aborting.\n\nHave you installed pip? See the Python readme at \`python/README.rst\` for setup instructions.\n"; exit 1; }
 	@command -v tox 1>/dev/null 2>/dev/null    || { echo >&2 -e "I require \`tox\` but it's not installed. Aborting.\n\nHave you installed tox? See the Python readme at \`python/README.rst\` for setup instructions.\n"; exit 1; }
-	@command -v pandoc 1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`pandoc\` but it's not installed. Aborting.\n\nHave you installed pandoc? See the Python readme at \`python/README.rst\` for setup instructions.\n"; exit 1; }
 
 verify-prereq-javascript: verify-prereq-generator
 	@command -v node   1>/dev/null 2>/dev/null || { echo >&2 -e "I require \`node\` but it's not installed. Aborting.\n\nHave you installed Node.js? See the JavaScript readme at \`javascript/README.md\` for setup instructions.\n"; exit 1; }


### PR DESCRIPTION
https://github.com/swift-nav/libsbp/pull/1058 depends on having a word dictionary, and the bionic dictionaries are missing words used in the specs that are in present in the GitHub ubuntu-latest workers used by https://github.com/swift-nav/libsbp/blob/641eda5/.github/workflows/generator.yaml#L20  .
The more recent the default wordlists used in the docker, the lower the chance that spec updates will require adding to the custom wordlist.

focal is the last ubuntu which includes https://packages.ubuntu.com/focal/clang-format-6.0 ; that could be sourced from somewhere else, but there are other issues to be solved moving to a release after focal.  Not especially relevant at present, is this is also the last release which supports https://packages.ubuntu.com/focal/clang-6.0 .  The portability project should mean that gcc-8 and beyond are usable with the current warning settings, so more flexibility should be coming soon.

Using groovy or hirsute instead of focal(LTS) will mean a less stable base, and requires an alternative for the deadsnakes ppa which only supports LTS.
c.f. https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa & https://github.com/deadsnakes/issues/issues/169

* Previous image size: 8.63GB per https://github.com/swift-nav/libsbp/runs/3089280215?check_suite_focus=true
* Switch to focal: 9.42GB per https://github.com/swift-nav/libsbp/pull/1059/checks?check_run_id=3208048893
* Remove rust-docs, `/var/lib/apt/lists/` and use apt-get `--no-install-recommends` (for secondary fetches) https://github.com/swift-nav/libsbp/pull/1059/commits/88818e06a5fbc3cb4025d58f4fa0b493d0ec8501 : 8.44GB
* Use apt-get `--no-install-recommends` (primary): 7.71Gb https://github.com/swift-nav/libsbp/runs/3209384503?check_suite_focus=true
* Remove deadsnakes `*-dev`: 7.61GB - https://github.com/swift-nav/libsbp/pull/1059/checks?check_run_id=3209737607#step:5:15147 - tox summary
* Merge apt-get: 7.56GB https://github.com/swift-nav/libsbp/runs/3213388487?check_suite_focus=true