### PR TITLE
ESD-2195 buffer overflow on SBP string decoding

### DIFF
--- a/c/src/v4/string/sbp_string.c
+++ b/c/src/v4/string/sbp_string.c
@@ -92,6 +92,9 @@ bool sbp_string_decode(sbp_string_t *s, size_t maxlen,
   if (available > maxlen) {
     return false;
   }
+  if (params->inject_missing_terminator && available == 0) {
+    return false;
+  }
   memcpy(s->data, ctx->buf + ctx->offset, available);
   s->encoded_len = available;
   if (params->inject_missing_terminator) {


### PR DESCRIPTION
## Changes
Fixes a buffer overflow issue that takes place in SBP string decoding

## Related PR
* https://github.com/swift-nav/gnss-converters-private/pull/944