### PR TITLE
expose parsing messages from frames

### DIFF
--- a/generator/sbpg/targets/resources/sbp-cargo.toml
+++ b/generator/sbpg/targets/resources/sbp-cargo.toml
@@ -15,6 +15,7 @@ license = "MIT"
 categories = ["parsing"]
 edition = "2018"
 keywords = ["encoding", "parsing"]
+readme = "../../README.md"
 
 [features]
 default = []

--- a/generator/sbpg/targets/resources/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/sbp_messages_template.rs
@@ -100,12 +100,12 @@ impl WireFormat for (((m.identifier|camel_case))) {
         ((*- endfor *))
         ((*- endif *))
     }
-    fn write(&self, ((*- if not m.fields *)) _buf ((*- else *)) buf ((*- endif *)): &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, ((*- if not m.fields *)) _buf ((*- else *)) buf ((*- endif *)): &mut B) {
         ((*- for f in m.fields *))
         WireFormat::write( &self.(((f.identifier|snake_case))), buf);
         ((*- endfor *))
     }
-    fn parse_unchecked( ((*- if not m.fields *)) _buf ((*- else *)) buf ((*- endif *)): &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>( ((*- if not m.fields *)) _buf ((*- else *)) buf ((*- endif *)): &mut B) -> Self {
         (((m.identifier|camel_case))) {
         ((*- if m.is_real_message *))
         sender_id: None,

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -15,6 +15,7 @@ license = "MIT"
 categories = ["parsing"]
 edition = "2018"
 keywords = ["encoding", "parsing"]
+readme = "../../README.md"
 
 [features]
 default = []

--- a/rust/sbp/src/de.rs
+++ b/rust/sbp/src/de.rs
@@ -49,7 +49,7 @@ pub fn stream_messages<R: futures::AsyncRead + Unpin>(
     SbpDecoder::framed(input)
 }
 
-pub fn parse_frame(buf: &mut BytesMut) -> Option<Result<Frame, CrcError>> {
+pub fn parse_frame(buf: &mut BytesMut) -> Option<Result<Frame<BytesMut>, CrcError>> {
     if buf.len() < HEADER_LEN {
         return None;
     }
@@ -89,11 +89,12 @@ fn check_crc(msg_type: u16, sender_id: u16, payload: &[u8], crc_in: u16) -> bool
     crc.get() == crc_in
 }
 
+/// The wire representation of an SBP message.
 #[derive(Debug)]
-pub struct Frame {
+pub struct Frame<B> {
     pub msg_type: u16,
     pub sender_id: u16,
-    pub payload: BytesMut,
+    pub payload: B,
 }
 
 /// All errors that can occur while reading messages.

--- a/rust/sbp/src/lib.rs
+++ b/rust/sbp/src/lib.rs
@@ -110,7 +110,7 @@ pub use crate::messages::SbpMessage;
 pub use ser::{to_vec, to_writer, Error as SerializeError, SbpEncoder};
 
 #[doc(inline)]
-pub use de::{iter_messages, Error as DeserializeError};
+pub use de::{iter_messages, Error as DeserializeError, Frame};
 
 #[cfg(feature = "async")]
 #[doc(inline)]

--- a/rust/sbp/src/messages/acquisition.rs
+++ b/rust/sbp/src/messages/acquisition.rs
@@ -92,7 +92,7 @@ impl WireFormat for AcqSvProfile {
             + WireFormat::encoded_len(&self.cf)
             + WireFormat::encoded_len(&self.cp)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.job_type, buf);
         WireFormat::write(&self.status, buf);
         WireFormat::write(&self.cn0, buf);
@@ -106,7 +106,7 @@ impl WireFormat for AcqSvProfile {
         WireFormat::write(&self.cf, buf);
         WireFormat::write(&self.cp, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         AcqSvProfile {
             job_type: WireFormat::parse_unchecked(buf),
             status: WireFormat::parse_unchecked(buf),
@@ -196,7 +196,7 @@ impl WireFormat for AcqSvProfileDep {
             + WireFormat::encoded_len(&self.cf)
             + WireFormat::encoded_len(&self.cp)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.job_type, buf);
         WireFormat::write(&self.status, buf);
         WireFormat::write(&self.cn0, buf);
@@ -210,7 +210,7 @@ impl WireFormat for AcqSvProfileDep {
         WireFormat::write(&self.cf, buf);
         WireFormat::write(&self.cp, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         AcqSvProfileDep {
             job_type: WireFormat::parse_unchecked(buf),
             status: WireFormat::parse_unchecked(buf),
@@ -296,13 +296,13 @@ impl WireFormat for MsgAcqResult {
             + WireFormat::encoded_len(&self.cf)
             + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.cn0, buf);
         WireFormat::write(&self.cp, buf);
         WireFormat::write(&self.cf, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAcqResult {
             sender_id: None,
             cn0: WireFormat::parse_unchecked(buf),
@@ -380,13 +380,13 @@ impl WireFormat for MsgAcqResultDepA {
             + WireFormat::encoded_len(&self.cf)
             + WireFormat::encoded_len(&self.prn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.snr, buf);
         WireFormat::write(&self.cp, buf);
         WireFormat::write(&self.cf, buf);
         WireFormat::write(&self.prn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAcqResultDepA {
             sender_id: None,
             snr: WireFormat::parse_unchecked(buf),
@@ -463,13 +463,13 @@ impl WireFormat for MsgAcqResultDepB {
             + WireFormat::encoded_len(&self.cf)
             + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.snr, buf);
         WireFormat::write(&self.cp, buf);
         WireFormat::write(&self.cf, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAcqResultDepB {
             sender_id: None,
             snr: WireFormat::parse_unchecked(buf),
@@ -545,13 +545,13 @@ impl WireFormat for MsgAcqResultDepC {
             + WireFormat::encoded_len(&self.cf)
             + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.cn0, buf);
         WireFormat::write(&self.cp, buf);
         WireFormat::write(&self.cf, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAcqResultDepC {
             sender_id: None,
             cn0: WireFormat::parse_unchecked(buf),
@@ -613,10 +613,10 @@ impl WireFormat for MsgAcqSvProfile {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.acq_sv_profile)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.acq_sv_profile, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAcqSvProfile {
             sender_id: None,
             acq_sv_profile: WireFormat::parse_unchecked(buf),
@@ -674,10 +674,10 @@ impl WireFormat for MsgAcqSvProfileDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.acq_sv_profile)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.acq_sv_profile, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAcqSvProfileDep {
             sender_id: None,
             acq_sv_profile: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/bootload.rs
+++ b/rust/sbp/src/messages/bootload.rs
@@ -70,10 +70,10 @@ impl WireFormat for MsgBootloaderHandshakeDepA {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.handshake)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.handshake, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBootloaderHandshakeDepA {
             sender_id: None,
             handshake: WireFormat::parse_unchecked(buf),
@@ -130,8 +130,8 @@ impl WireFormat for MsgBootloaderHandshakeReq {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgBootloaderHandshakeReq { sender_id: None }
     }
 }
@@ -193,11 +193,11 @@ impl WireFormat for MsgBootloaderHandshakeResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags) + WireFormat::encoded_len(&self.version)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.version, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBootloaderHandshakeResp {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -256,10 +256,10 @@ impl WireFormat for MsgBootloaderJumpToApp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.jump)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.jump, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBootloaderJumpToApp {
             sender_id: None,
             jump: WireFormat::parse_unchecked(buf),
@@ -319,8 +319,8 @@ impl WireFormat for MsgNapDeviceDnaReq {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgNapDeviceDnaReq { sender_id: None }
     }
 }
@@ -380,10 +380,10 @@ impl WireFormat for MsgNapDeviceDnaResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.dna)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.dna, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgNapDeviceDnaResp {
             sender_id: None,
             dna: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/ext_events.rs
+++ b/rust/sbp/src/messages/ext_events.rs
@@ -103,14 +103,14 @@ impl WireFormat for MsgExtEvent {
             + WireFormat::encoded_len(&self.flags)
             + WireFormat::encoded_len(&self.pin)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.wn, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.ns_residual, buf);
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.pin, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgExtEvent {
             sender_id: None,
             wn: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/file_io.rs
+++ b/rust/sbp/src/messages/file_io.rs
@@ -76,10 +76,10 @@ impl WireFormat for MsgFileioConfigReq {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioConfigReq {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -156,13 +156,13 @@ impl WireFormat for MsgFileioConfigResp {
             + WireFormat::encoded_len(&self.batch_size)
             + WireFormat::encoded_len(&self.fileio_version)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.window_size, buf);
         WireFormat::write(&self.batch_size, buf);
         WireFormat::write(&self.fileio_version, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioConfigResp {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -241,12 +241,12 @@ impl WireFormat for MsgFileioReadDirReq {
             + WireFormat::encoded_len(&self.offset)
             + WireFormat::encoded_len(&self.dirname)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.offset, buf);
         WireFormat::write(&self.dirname, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioReadDirReq {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -314,11 +314,11 @@ impl WireFormat for MsgFileioReadDirResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence) + WireFormat::encoded_len(&self.contents)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.contents, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioReadDirResp {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -398,13 +398,13 @@ impl WireFormat for MsgFileioReadReq {
             + WireFormat::encoded_len(&self.chunk_size)
             + WireFormat::encoded_len(&self.filename)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.offset, buf);
         WireFormat::write(&self.chunk_size, buf);
         WireFormat::write(&self.filename, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioReadReq {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -472,11 +472,11 @@ impl WireFormat for MsgFileioReadResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence) + WireFormat::encoded_len(&self.contents)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.contents, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioReadResp {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -539,10 +539,10 @@ impl WireFormat for MsgFileioRemove {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.filename)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.filename, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioRemove {
             sender_id: None,
             filename: WireFormat::parse_unchecked(buf),
@@ -621,13 +621,13 @@ impl WireFormat for MsgFileioWriteReq {
             + WireFormat::encoded_len(&self.filename)
             + WireFormat::encoded_len(&self.data)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.offset, buf);
         WireFormat::write(&self.filename, buf);
         WireFormat::write(&self.data, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioWriteReq {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -691,10 +691,10 @@ impl WireFormat for MsgFileioWriteResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFileioWriteResp {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/flash.rs
+++ b/rust/sbp/src/messages/flash.rs
@@ -72,10 +72,10 @@ impl WireFormat for MsgFlashDone {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.response)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.response, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFlashDone {
             sender_id: None,
             response: WireFormat::parse_unchecked(buf),
@@ -140,11 +140,11 @@ impl WireFormat for MsgFlashErase {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.target) + WireFormat::encoded_len(&self.sector_num)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.target, buf);
         WireFormat::write(&self.sector_num, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFlashErase {
             sender_id: None,
             target: WireFormat::parse_unchecked(buf),
@@ -222,13 +222,13 @@ impl WireFormat for MsgFlashProgram {
             + WireFormat::encoded_len(&self.addr_len)
             + WireFormat::encoded_len(&self.data)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.target, buf);
         WireFormat::write(&self.addr_start, buf);
         WireFormat::write(&self.addr_len, buf);
         WireFormat::write(&self.data, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFlashProgram {
             sender_id: None,
             target: WireFormat::parse_unchecked(buf),
@@ -304,12 +304,12 @@ impl WireFormat for MsgFlashReadReq {
             + WireFormat::encoded_len(&self.addr_start)
             + WireFormat::encoded_len(&self.addr_len)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.target, buf);
         WireFormat::write(&self.addr_start, buf);
         WireFormat::write(&self.addr_len, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFlashReadReq {
             sender_id: None,
             target: WireFormat::parse_unchecked(buf),
@@ -384,12 +384,12 @@ impl WireFormat for MsgFlashReadResp {
             + WireFormat::encoded_len(&self.addr_start)
             + WireFormat::encoded_len(&self.addr_len)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.target, buf);
         WireFormat::write(&self.addr_start, buf);
         WireFormat::write(&self.addr_len, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFlashReadResp {
             sender_id: None,
             target: WireFormat::parse_unchecked(buf),
@@ -450,10 +450,10 @@ impl WireFormat for MsgM25FlashWriteStatus {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.status)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.status, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgM25FlashWriteStatus {
             sender_id: None,
             status: WireFormat::parse_unchecked(buf),
@@ -512,10 +512,10 @@ impl WireFormat for MsgStmFlashLockSector {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sector)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sector, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgStmFlashLockSector {
             sender_id: None,
             sector: WireFormat::parse_unchecked(buf),
@@ -574,10 +574,10 @@ impl WireFormat for MsgStmFlashUnlockSector {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sector)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sector, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgStmFlashUnlockSector {
             sender_id: None,
             sector: WireFormat::parse_unchecked(buf),
@@ -635,8 +635,8 @@ impl WireFormat for MsgStmUniqueIdReq {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgStmUniqueIdReq { sender_id: None }
     }
 }
@@ -694,10 +694,10 @@ impl WireFormat for MsgStmUniqueIdResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.stm_id)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.stm_id, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgStmUniqueIdResp {
             sender_id: None,
             stm_id: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/gnss.rs
+++ b/rust/sbp/src/messages/gnss.rs
@@ -39,11 +39,11 @@ impl WireFormat for CarrierPhase {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.i) + WireFormat::encoded_len(&self.f)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.i, buf);
         WireFormat::write(&self.f, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         CarrierPhase {
             i: WireFormat::parse_unchecked(buf),
             f: WireFormat::parse_unchecked(buf),
@@ -81,12 +81,12 @@ impl WireFormat for GpsTime {
             + WireFormat::encoded_len(&self.ns_residual)
             + WireFormat::encoded_len(&self.wn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.ns_residual, buf);
         WireFormat::write(&self.wn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GpsTime {
             tow: WireFormat::parse_unchecked(buf),
             ns_residual: WireFormat::parse_unchecked(buf),
@@ -117,11 +117,11 @@ impl WireFormat for GpsTimeDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.tow) + WireFormat::encoded_len(&self.wn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.wn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GpsTimeDep {
             tow: WireFormat::parse_unchecked(buf),
             wn: WireFormat::parse_unchecked(buf),
@@ -151,11 +151,11 @@ impl WireFormat for GpsTimeSec {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.tow) + WireFormat::encoded_len(&self.wn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.wn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GpsTimeSec {
             tow: WireFormat::parse_unchecked(buf),
             wn: WireFormat::parse_unchecked(buf),
@@ -186,11 +186,11 @@ impl WireFormat for GnssSignal {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sat) + WireFormat::encoded_len(&self.code)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sat, buf);
         WireFormat::write(&self.code, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GnssSignal {
             sat: WireFormat::parse_unchecked(buf),
             code: WireFormat::parse_unchecked(buf),
@@ -228,12 +228,12 @@ impl WireFormat for GnssSignalDep {
             + WireFormat::encoded_len(&self.code)
             + WireFormat::encoded_len(&self.reserved)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sat, buf);
         WireFormat::write(&self.code, buf);
         WireFormat::write(&self.reserved, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GnssSignalDep {
             sat: WireFormat::parse_unchecked(buf),
             code: WireFormat::parse_unchecked(buf),
@@ -264,11 +264,11 @@ impl WireFormat for SvId {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sat_id) + WireFormat::encoded_len(&self.constellation)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sat_id, buf);
         WireFormat::write(&self.constellation, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         SvId {
             sat_id: WireFormat::parse_unchecked(buf),
             constellation: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/imu.rs
+++ b/rust/sbp/src/messages/imu.rs
@@ -78,12 +78,12 @@ impl WireFormat for MsgImuAux {
             + WireFormat::encoded_len(&self.temp)
             + WireFormat::encoded_len(&self.imu_conf)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.imu_type, buf);
         WireFormat::write(&self.temp, buf);
         WireFormat::write(&self.imu_conf, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgImuAux {
             sender_id: None,
             imu_type: WireFormat::parse_unchecked(buf),
@@ -200,7 +200,7 @@ impl WireFormat for MsgImuRaw {
             + WireFormat::encoded_len(&self.gyr_y)
             + WireFormat::encoded_len(&self.gyr_z)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.tow_f, buf);
         WireFormat::write(&self.acc_x, buf);
@@ -210,7 +210,7 @@ impl WireFormat for MsgImuRaw {
         WireFormat::write(&self.gyr_y, buf);
         WireFormat::write(&self.gyr_z, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgImuRaw {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/linux.rs
+++ b/rust/sbp/src/messages/linux.rs
@@ -97,7 +97,7 @@ impl WireFormat for MsgLinuxCpuState {
             + WireFormat::encoded_len(&self.tname)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.pcpu, buf);
@@ -106,7 +106,7 @@ impl WireFormat for MsgLinuxCpuState {
         WireFormat::write(&self.tname, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxCpuState {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -191,14 +191,14 @@ impl WireFormat for MsgLinuxCpuStateDepA {
             + WireFormat::encoded_len(&self.tname)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.pcpu, buf);
         WireFormat::write(&self.tname, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxCpuStateDepA {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -291,7 +291,7 @@ impl WireFormat for MsgLinuxMemState {
             + WireFormat::encoded_len(&self.tname)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.pmem, buf);
@@ -300,7 +300,7 @@ impl WireFormat for MsgLinuxMemState {
         WireFormat::write(&self.tname, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxMemState {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -385,14 +385,14 @@ impl WireFormat for MsgLinuxMemStateDepA {
             + WireFormat::encoded_len(&self.tname)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.pmem, buf);
         WireFormat::write(&self.tname, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxMemStateDepA {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -469,13 +469,13 @@ impl WireFormat for MsgLinuxProcessFdCount {
             + WireFormat::encoded_len(&self.fd_count)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.fd_count, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxProcessFdCount {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -544,11 +544,11 @@ impl WireFormat for MsgLinuxProcessFdSummary {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sys_fd_count) + WireFormat::encoded_len(&self.most_opened)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sys_fd_count, buf);
         WireFormat::write(&self.most_opened, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxProcessFdSummary {
             sender_id: None,
             sys_fd_count: WireFormat::parse_unchecked(buf),
@@ -636,7 +636,7 @@ impl WireFormat for MsgLinuxProcessSocketCounts {
             + WireFormat::encoded_len(&self.socket_states)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.socket_count, buf);
@@ -644,7 +644,7 @@ impl WireFormat for MsgLinuxProcessSocketCounts {
         WireFormat::write(&self.socket_states, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxProcessSocketCounts {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -747,7 +747,7 @@ impl WireFormat for MsgLinuxProcessSocketQueues {
             + WireFormat::encoded_len(&self.address_of_largest)
             + WireFormat::encoded_len(&self.cmdline)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.pid, buf);
         WireFormat::write(&self.recv_queued, buf);
@@ -757,7 +757,7 @@ impl WireFormat for MsgLinuxProcessSocketQueues {
         WireFormat::write(&self.address_of_largest, buf);
         WireFormat::write(&self.cmdline, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxProcessSocketQueues {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -841,13 +841,13 @@ impl WireFormat for MsgLinuxSocketUsage {
             + WireFormat::encoded_len(&self.socket_state_counts)
             + WireFormat::encoded_len(&self.socket_type_counts)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.avg_queue_depth, buf);
         WireFormat::write(&self.max_queue_depth, buf);
         WireFormat::write(&self.socket_state_counts, buf);
         WireFormat::write(&self.socket_type_counts, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxSocketUsage {
             sender_id: None,
             avg_queue_depth: WireFormat::parse_unchecked(buf),
@@ -944,7 +944,7 @@ impl WireFormat for MsgLinuxSysState {
             + WireFormat::encoded_len(&self.time)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.mem_total, buf);
         WireFormat::write(&self.pcpu, buf);
         WireFormat::write(&self.pmem, buf);
@@ -954,7 +954,7 @@ impl WireFormat for MsgLinuxSysState {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxSysState {
             sender_id: None,
             mem_total: WireFormat::parse_unchecked(buf),
@@ -1044,7 +1044,7 @@ impl WireFormat for MsgLinuxSysStateDepA {
             + WireFormat::encoded_len(&self.procs_stopping)
             + WireFormat::encoded_len(&self.pid_count)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.mem_total, buf);
         WireFormat::write(&self.pcpu, buf);
         WireFormat::write(&self.pmem, buf);
@@ -1052,7 +1052,7 @@ impl WireFormat for MsgLinuxSysStateDepA {
         WireFormat::write(&self.procs_stopping, buf);
         WireFormat::write(&self.pid_count, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLinuxSysStateDepA {
             sender_id: None,
             mem_total: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/logging.rs
+++ b/rust/sbp/src/messages/logging.rs
@@ -83,12 +83,12 @@ impl WireFormat for MsgFwd {
             + WireFormat::encoded_len(&self.protocol)
             + WireFormat::encoded_len(&self.fwd_payload)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.source, buf);
         WireFormat::write(&self.protocol, buf);
         WireFormat::write(&self.fwd_payload, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFwd {
             sender_id: None,
             source: WireFormat::parse_unchecked(buf),
@@ -154,11 +154,11 @@ impl WireFormat for MsgLog {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.level) + WireFormat::encoded_len(&self.text)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.level, buf);
         WireFormat::write(&self.text, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgLog {
             sender_id: None,
             level: WireFormat::parse_unchecked(buf),
@@ -218,10 +218,10 @@ impl WireFormat for MsgPrintDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.text)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.text, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPrintDep {
             sender_id: None,
             text: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/mag.rs
+++ b/rust/sbp/src/messages/mag.rs
@@ -96,14 +96,14 @@ impl WireFormat for MsgMagRaw {
             + WireFormat::encoded_len(&self.mag_y)
             + WireFormat::encoded_len(&self.mag_z)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.tow_f, buf);
         WireFormat::write(&self.mag_x, buf);
         WireFormat::write(&self.mag_y, buf);
         WireFormat::write(&self.mag_z, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgMagRaw {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/mod.rs
+++ b/rust/sbp/src/messages/mod.rs
@@ -244,12 +244,13 @@ mod lib {
     pub use crate::sbp_string::{
         DoubleNullTerminated, Multipart, NullTerminated, SbpString, Unterminated,
     };
-    pub use crate::wire_format::{PayloadParseError, WireFormat};
-
     #[cfg(feature = "swiftnav")]
     pub use crate::time;
+    pub use crate::wire_format::{PayloadParseError, WireFormat};
 
     pub use super::{ConcreteMessage, Sbp, SbpMessage, TryFromSbpError};
+
+    pub use bytes::{Buf, BufMut};
 }
 
 use lib::*;
@@ -706,7 +707,32 @@ pub enum Sbp {
 }
 
 impl Sbp {
-    pub(crate) fn from_frame(mut frame: crate::de::Frame) -> Result<Sbp, PayloadParseError> {
+    /// Parse a message from a [Frame](crate::Frame).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::convert::TryInto;
+    ///
+    /// use sbp::messages::logging::MsgLog;
+    /// use sbp::{Frame, Sbp};
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     // log level 1 and with "hello" as the message
+    ///     let payload: &[u8] = &[1, 104, 101, 108, 108, 111];
+    ///     let frame = Frame {
+    ///         msg_type: 1025,
+    ///         sender_id: 1,
+    ///         payload,
+    ///     };
+    ///     let msg: MsgLog = Sbp::from_frame(frame)?.try_into()?;
+    ///     assert_eq!(msg.sender_id, Some(1));
+    ///     assert_eq!(msg.level, 1);
+    ///     assert_eq!(msg.text.as_bytes(), "hello".as_bytes());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_frame<B: Buf>(mut frame: crate::Frame<B>) -> Result<Sbp, PayloadParseError> {
         match frame.msg_type {
             MsgPrintDep::MESSAGE_TYPE => {
                 let mut msg = MsgPrintDep::parse(&mut frame.payload)?;
@@ -2775,11 +2801,11 @@ impl SbpMessage for Sbp {
 impl WireFormat for Sbp {
     const MIN_ENCODED_LEN: usize = crate::MAX_FRAME_LEN;
 
-    fn parse_unchecked(_: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(_: &mut B) -> Self {
         unimplemented!("Sbp must be parsed with Sbp::from_frame");
     }
 
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         match self {
             Sbp::MsgPrintDep(msg) => WireFormat::write(msg, buf),
             Sbp::MsgTrackingStateDetailedDep(msg) => WireFormat::write(msg, buf),

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -66,12 +66,12 @@ impl WireFormat for EstimatedHorizontalErrorEllipse {
             + WireFormat::encoded_len(&self.semi_minor)
             + WireFormat::encoded_len(&self.orientation)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.semi_major, buf);
         WireFormat::write(&self.semi_minor, buf);
         WireFormat::write(&self.orientation, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         EstimatedHorizontalErrorEllipse {
             semi_major: WireFormat::parse_unchecked(buf),
             semi_minor: WireFormat::parse_unchecked(buf),
@@ -144,11 +144,11 @@ impl WireFormat for MsgAgeCorrections {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.tow) + WireFormat::encoded_len(&self.age)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.age, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAgeCorrections {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -249,7 +249,7 @@ impl WireFormat for MsgBaselineEcef {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -258,7 +258,7 @@ impl WireFormat for MsgBaselineEcef {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBaselineEcef {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -364,7 +364,7 @@ impl WireFormat for MsgBaselineEcefDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -373,7 +373,7 @@ impl WireFormat for MsgBaselineEcefDepA {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBaselineEcefDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -463,13 +463,13 @@ impl WireFormat for MsgBaselineHeadingDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.heading, buf);
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBaselineHeadingDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -579,7 +579,7 @@ impl WireFormat for MsgBaselineNed {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -589,7 +589,7 @@ impl WireFormat for MsgBaselineNed {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBaselineNed {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -703,7 +703,7 @@ impl WireFormat for MsgBaselineNedDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -713,7 +713,7 @@ impl WireFormat for MsgBaselineNedDepA {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBaselineNedDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -820,7 +820,7 @@ impl WireFormat for MsgDops {
             + WireFormat::encoded_len(&self.vdop)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.gdop, buf);
         WireFormat::write(&self.pdop, buf);
@@ -829,7 +829,7 @@ impl WireFormat for MsgDops {
         WireFormat::write(&self.vdop, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgDops {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -928,7 +928,7 @@ impl WireFormat for MsgDopsDepA {
             + WireFormat::encoded_len(&self.hdop)
             + WireFormat::encoded_len(&self.vdop)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.gdop, buf);
         WireFormat::write(&self.pdop, buf);
@@ -936,7 +936,7 @@ impl WireFormat for MsgDopsDepA {
         WireFormat::write(&self.hdop, buf);
         WireFormat::write(&self.vdop, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgDopsDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -1039,13 +1039,13 @@ impl WireFormat for MsgGpsTime {
             + WireFormat::encoded_len(&self.ns_residual)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.wn, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.ns_residual, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGpsTime {
             sender_id: None,
             wn: WireFormat::parse_unchecked(buf),
@@ -1146,13 +1146,13 @@ impl WireFormat for MsgGpsTimeDepA {
             + WireFormat::encoded_len(&self.ns_residual)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.wn, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.ns_residual, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGpsTimeDepA {
             sender_id: None,
             wn: WireFormat::parse_unchecked(buf),
@@ -1253,13 +1253,13 @@ impl WireFormat for MsgGpsTimeGnss {
             + WireFormat::encoded_len(&self.ns_residual)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.wn, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.ns_residual, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGpsTimeGnss {
             sender_id: None,
             wn: WireFormat::parse_unchecked(buf),
@@ -1365,7 +1365,7 @@ impl WireFormat for MsgPosEcef {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -1374,7 +1374,7 @@ impl WireFormat for MsgPosEcef {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosEcef {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -1509,7 +1509,7 @@ impl WireFormat for MsgPosEcefCov {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -1523,7 +1523,7 @@ impl WireFormat for MsgPosEcefCov {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosEcefCov {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -1663,7 +1663,7 @@ impl WireFormat for MsgPosEcefCovGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -1677,7 +1677,7 @@ impl WireFormat for MsgPosEcefCovGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosEcefCovGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -1791,7 +1791,7 @@ impl WireFormat for MsgPosEcefDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -1800,7 +1800,7 @@ impl WireFormat for MsgPosEcefDepA {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosEcefDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -1909,7 +1909,7 @@ impl WireFormat for MsgPosEcefGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -1918,7 +1918,7 @@ impl WireFormat for MsgPosEcefGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosEcefGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2032,7 +2032,7 @@ impl WireFormat for MsgPosLlh {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
@@ -2042,7 +2042,7 @@ impl WireFormat for MsgPosLlh {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosLlh {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2193,7 +2193,7 @@ impl WireFormat for MsgPosLlhAcc {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
@@ -2208,7 +2208,7 @@ impl WireFormat for MsgPosLlhAcc {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosLlhAcc {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2349,7 +2349,7 @@ impl WireFormat for MsgPosLlhCov {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
@@ -2363,7 +2363,7 @@ impl WireFormat for MsgPosLlhCov {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosLlhCov {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2503,7 +2503,7 @@ impl WireFormat for MsgPosLlhCovGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
@@ -2517,7 +2517,7 @@ impl WireFormat for MsgPosLlhCovGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosLlhCovGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2636,7 +2636,7 @@ impl WireFormat for MsgPosLlhDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
@@ -2646,7 +2646,7 @@ impl WireFormat for MsgPosLlhDepA {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosLlhDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2761,7 +2761,7 @@ impl WireFormat for MsgPosLlhGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
@@ -2771,7 +2771,7 @@ impl WireFormat for MsgPosLlhGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPosLlhGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -2954,7 +2954,7 @@ impl WireFormat for MsgProtectionLevel {
             + WireFormat::encoded_len(&self.heading)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.wn, buf);
         WireFormat::write(&self.hpl, buf);
@@ -2977,7 +2977,7 @@ impl WireFormat for MsgProtectionLevel {
         WireFormat::write(&self.heading, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgProtectionLevel {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -3096,7 +3096,7 @@ impl WireFormat for MsgProtectionLevelDepA {
             + WireFormat::encoded_len(&self.height)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.vpl, buf);
         WireFormat::write(&self.hpl, buf);
@@ -3105,7 +3105,7 @@ impl WireFormat for MsgProtectionLevelDepA {
         WireFormat::write(&self.height, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgProtectionLevelDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -3220,7 +3220,7 @@ impl WireFormat for MsgUtcTime {
             + WireFormat::encoded_len(&self.seconds)
             + WireFormat::encoded_len(&self.ns)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.year, buf);
@@ -3231,7 +3231,7 @@ impl WireFormat for MsgUtcTime {
         WireFormat::write(&self.seconds, buf);
         WireFormat::write(&self.ns, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgUtcTime {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -3348,7 +3348,7 @@ impl WireFormat for MsgUtcTimeGnss {
             + WireFormat::encoded_len(&self.seconds)
             + WireFormat::encoded_len(&self.ns)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.year, buf);
@@ -3359,7 +3359,7 @@ impl WireFormat for MsgUtcTimeGnss {
         WireFormat::write(&self.seconds, buf);
         WireFormat::write(&self.ns, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgUtcTimeGnss {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -3497,7 +3497,7 @@ impl WireFormat for MsgVelBody {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -3511,7 +3511,7 @@ impl WireFormat for MsgVelBody {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelBody {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -3621,7 +3621,7 @@ impl WireFormat for MsgVelEcef {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -3630,7 +3630,7 @@ impl WireFormat for MsgVelEcef {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelEcef {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -3760,7 +3760,7 @@ impl WireFormat for MsgVelEcefCov {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -3774,7 +3774,7 @@ impl WireFormat for MsgVelEcefCov {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelEcefCov {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -3909,7 +3909,7 @@ impl WireFormat for MsgVelEcefCovGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -3923,7 +3923,7 @@ impl WireFormat for MsgVelEcefCovGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelEcefCovGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4033,7 +4033,7 @@ impl WireFormat for MsgVelEcefDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -4042,7 +4042,7 @@ impl WireFormat for MsgVelEcefDepA {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelEcefDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4147,7 +4147,7 @@ impl WireFormat for MsgVelEcefGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
@@ -4156,7 +4156,7 @@ impl WireFormat for MsgVelEcefGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelEcefGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4267,7 +4267,7 @@ impl WireFormat for MsgVelNed {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -4277,7 +4277,7 @@ impl WireFormat for MsgVelNed {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelNed {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4411,7 +4411,7 @@ impl WireFormat for MsgVelNedCov {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -4425,7 +4425,7 @@ impl WireFormat for MsgVelNedCov {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelNedCov {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4563,7 +4563,7 @@ impl WireFormat for MsgVelNedCovGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -4577,7 +4577,7 @@ impl WireFormat for MsgVelNedCovGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelNedCovGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4693,7 +4693,7 @@ impl WireFormat for MsgVelNedDepA {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -4703,7 +4703,7 @@ impl WireFormat for MsgVelNedDepA {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelNedDepA {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -4815,7 +4815,7 @@ impl WireFormat for MsgVelNedGnss {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.n, buf);
         WireFormat::write(&self.e, buf);
@@ -4825,7 +4825,7 @@ impl WireFormat for MsgVelNedGnss {
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgVelNedGnss {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/ndb.rs
+++ b/rust/sbp/src/messages/ndb.rs
@@ -110,7 +110,7 @@ impl WireFormat for MsgNdbEvent {
             + WireFormat::encoded_len(&self.src_sid)
             + WireFormat::encoded_len(&self.original_sender)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.recv_time, buf);
         WireFormat::write(&self.event, buf);
         WireFormat::write(&self.object_type, buf);
@@ -120,7 +120,7 @@ impl WireFormat for MsgNdbEvent {
         WireFormat::write(&self.src_sid, buf);
         WireFormat::write(&self.original_sender, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgNdbEvent {
             sender_id: None,
             recv_time: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -72,7 +72,7 @@ impl WireFormat for AlmanacCommonContent {
             + WireFormat::encoded_len(&self.valid)
             + WireFormat::encoded_len(&self.health_bits)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.toa, buf);
         WireFormat::write(&self.ura, buf);
@@ -80,7 +80,7 @@ impl WireFormat for AlmanacCommonContent {
         WireFormat::write(&self.valid, buf);
         WireFormat::write(&self.health_bits, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         AlmanacCommonContent {
             sid: WireFormat::parse_unchecked(buf),
             toa: WireFormat::parse_unchecked(buf),
@@ -144,7 +144,7 @@ impl WireFormat for AlmanacCommonContentDep {
             + WireFormat::encoded_len(&self.valid)
             + WireFormat::encoded_len(&self.health_bits)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.toa, buf);
         WireFormat::write(&self.ura, buf);
@@ -152,7 +152,7 @@ impl WireFormat for AlmanacCommonContentDep {
         WireFormat::write(&self.valid, buf);
         WireFormat::write(&self.health_bits, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         AlmanacCommonContentDep {
             sid: WireFormat::parse_unchecked(buf),
             toa: WireFormat::parse_unchecked(buf),
@@ -188,11 +188,11 @@ impl WireFormat for CarrierPhaseDepA {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.i) + WireFormat::encoded_len(&self.f)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.i, buf);
         WireFormat::write(&self.f, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         CarrierPhaseDepA {
             i: WireFormat::parse_unchecked(buf),
             f: WireFormat::parse_unchecked(buf),
@@ -223,11 +223,11 @@ impl WireFormat for Doppler {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.i) + WireFormat::encoded_len(&self.f)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.i, buf);
         WireFormat::write(&self.f, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         Doppler {
             i: WireFormat::parse_unchecked(buf),
             f: WireFormat::parse_unchecked(buf),
@@ -277,7 +277,7 @@ impl WireFormat for EphemerisCommonContent {
             + WireFormat::encoded_len(&self.valid)
             + WireFormat::encoded_len(&self.health_bits)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.toe, buf);
         WireFormat::write(&self.ura, buf);
@@ -285,7 +285,7 @@ impl WireFormat for EphemerisCommonContent {
         WireFormat::write(&self.valid, buf);
         WireFormat::write(&self.health_bits, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         EphemerisCommonContent {
             sid: WireFormat::parse_unchecked(buf),
             toe: WireFormat::parse_unchecked(buf),
@@ -339,7 +339,7 @@ impl WireFormat for EphemerisCommonContentDepA {
             + WireFormat::encoded_len(&self.valid)
             + WireFormat::encoded_len(&self.health_bits)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.toe, buf);
         WireFormat::write(&self.ura, buf);
@@ -347,7 +347,7 @@ impl WireFormat for EphemerisCommonContentDepA {
         WireFormat::write(&self.valid, buf);
         WireFormat::write(&self.health_bits, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         EphemerisCommonContentDepA {
             sid: WireFormat::parse_unchecked(buf),
             toe: WireFormat::parse_unchecked(buf),
@@ -400,7 +400,7 @@ impl WireFormat for EphemerisCommonContentDepB {
             + WireFormat::encoded_len(&self.valid)
             + WireFormat::encoded_len(&self.health_bits)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.toe, buf);
         WireFormat::write(&self.ura, buf);
@@ -408,7 +408,7 @@ impl WireFormat for EphemerisCommonContentDepB {
         WireFormat::write(&self.valid, buf);
         WireFormat::write(&self.health_bits, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         EphemerisCommonContentDepB {
             sid: WireFormat::parse_unchecked(buf),
             toe: WireFormat::parse_unchecked(buf),
@@ -506,7 +506,7 @@ impl WireFormat for GnssCapb {
             + WireFormat::encoded_len(&self.gal_active)
             + WireFormat::encoded_len(&self.gal_e5)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.gps_active, buf);
         WireFormat::write(&self.gps_l2c, buf);
         WireFormat::write(&self.gps_l5, buf);
@@ -523,7 +523,7 @@ impl WireFormat for GnssCapb {
         WireFormat::write(&self.gal_active, buf);
         WireFormat::write(&self.gal_e5, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GnssCapb {
             gps_active: WireFormat::parse_unchecked(buf),
             gps_l2c: WireFormat::parse_unchecked(buf),
@@ -633,7 +633,7 @@ impl WireFormat for MsgAlmanacGlo {
             + WireFormat::encoded_len(&self.epsilon)
             + WireFormat::encoded_len(&self.omega)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.lambda_na, buf);
         WireFormat::write(&self.t_lambda_na, buf);
@@ -643,7 +643,7 @@ impl WireFormat for MsgAlmanacGlo {
         WireFormat::write(&self.epsilon, buf);
         WireFormat::write(&self.omega, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAlmanacGlo {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -747,7 +747,7 @@ impl WireFormat for MsgAlmanacGloDep {
             + WireFormat::encoded_len(&self.epsilon)
             + WireFormat::encoded_len(&self.omega)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.lambda_na, buf);
         WireFormat::write(&self.t_lambda_na, buf);
@@ -757,7 +757,7 @@ impl WireFormat for MsgAlmanacGloDep {
         WireFormat::write(&self.epsilon, buf);
         WireFormat::write(&self.omega, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAlmanacGloDep {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -870,7 +870,7 @@ impl WireFormat for MsgAlmanacGps {
             + WireFormat::encoded_len(&self.af0)
             + WireFormat::encoded_len(&self.af1)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.m0, buf);
         WireFormat::write(&self.ecc, buf);
@@ -882,7 +882,7 @@ impl WireFormat for MsgAlmanacGps {
         WireFormat::write(&self.af0, buf);
         WireFormat::write(&self.af1, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAlmanacGps {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -997,7 +997,7 @@ impl WireFormat for MsgAlmanacGpsDep {
             + WireFormat::encoded_len(&self.af0)
             + WireFormat::encoded_len(&self.af1)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.m0, buf);
         WireFormat::write(&self.ecc, buf);
@@ -1009,7 +1009,7 @@ impl WireFormat for MsgAlmanacGpsDep {
         WireFormat::write(&self.af0, buf);
         WireFormat::write(&self.af1, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAlmanacGpsDep {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -1090,12 +1090,12 @@ impl WireFormat for MsgBasePosEcef {
             + WireFormat::encoded_len(&self.y)
             + WireFormat::encoded_len(&self.z)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
         WireFormat::write(&self.z, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBasePosEcef {
             sender_id: None,
             x: WireFormat::parse_unchecked(buf),
@@ -1168,12 +1168,12 @@ impl WireFormat for MsgBasePosLlh {
             + WireFormat::encoded_len(&self.lon)
             + WireFormat::encoded_len(&self.height)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.lat, buf);
         WireFormat::write(&self.lon, buf);
         WireFormat::write(&self.height, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBasePosLlh {
             sender_id: None,
             lat: WireFormat::parse_unchecked(buf),
@@ -1359,7 +1359,7 @@ impl WireFormat for MsgEphemerisBds {
             + WireFormat::encoded_len(&self.iode)
             + WireFormat::encoded_len(&self.iodc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.tgd1, buf);
         WireFormat::write(&self.tgd2, buf);
@@ -1385,7 +1385,7 @@ impl WireFormat for MsgEphemerisBds {
         WireFormat::write(&self.iode, buf);
         WireFormat::write(&self.iodc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisBds {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -1595,7 +1595,7 @@ impl WireFormat for MsgEphemerisDepA {
             + WireFormat::encoded_len(&self.healthy)
             + WireFormat::encoded_len(&self.prn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
         WireFormat::write(&self.c_rc, buf);
@@ -1623,7 +1623,7 @@ impl WireFormat for MsgEphemerisDepA {
         WireFormat::write(&self.healthy, buf);
         WireFormat::write(&self.prn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisDepA {
             sender_id: None,
             tgd: WireFormat::parse_unchecked(buf),
@@ -1840,7 +1840,7 @@ impl WireFormat for MsgEphemerisDepB {
             + WireFormat::encoded_len(&self.prn)
             + WireFormat::encoded_len(&self.iode)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
         WireFormat::write(&self.c_rc, buf);
@@ -1869,7 +1869,7 @@ impl WireFormat for MsgEphemerisDepB {
         WireFormat::write(&self.prn, buf);
         WireFormat::write(&self.iode, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisDepB {
             sender_id: None,
             tgd: WireFormat::parse_unchecked(buf),
@@ -2100,7 +2100,7 @@ impl WireFormat for MsgEphemerisDepC {
             + WireFormat::encoded_len(&self.iodc)
             + WireFormat::encoded_len(&self.reserved)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
         WireFormat::write(&self.c_rc, buf);
@@ -2131,7 +2131,7 @@ impl WireFormat for MsgEphemerisDepC {
         WireFormat::write(&self.iodc, buf);
         WireFormat::write(&self.reserved, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisDepC {
             sender_id: None,
             tgd: WireFormat::parse_unchecked(buf),
@@ -2364,7 +2364,7 @@ impl WireFormat for MsgEphemerisDepD {
             + WireFormat::encoded_len(&self.iodc)
             + WireFormat::encoded_len(&self.reserved)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
         WireFormat::write(&self.c_rc, buf);
@@ -2395,7 +2395,7 @@ impl WireFormat for MsgEphemerisDepD {
         WireFormat::write(&self.iodc, buf);
         WireFormat::write(&self.reserved, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisDepD {
             sender_id: None,
             tgd: WireFormat::parse_unchecked(buf),
@@ -2608,7 +2608,7 @@ impl WireFormat for MsgEphemerisGal {
             + WireFormat::encoded_len(&self.iodc)
             + WireFormat::encoded_len(&self.source)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.bgd_e1e5a, buf);
         WireFormat::write(&self.bgd_e1e5b, buf);
@@ -2635,7 +2635,7 @@ impl WireFormat for MsgEphemerisGal {
         WireFormat::write(&self.iodc, buf);
         WireFormat::write(&self.source, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGal {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -2837,7 +2837,7 @@ impl WireFormat for MsgEphemerisGalDepA {
             + WireFormat::encoded_len(&self.iode)
             + WireFormat::encoded_len(&self.iodc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.bgd_e1e5a, buf);
         WireFormat::write(&self.bgd_e1e5b, buf);
@@ -2863,7 +2863,7 @@ impl WireFormat for MsgEphemerisGalDepA {
         WireFormat::write(&self.iode, buf);
         WireFormat::write(&self.iodc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGalDepA {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -2987,7 +2987,7 @@ impl WireFormat for MsgEphemerisGlo {
             + WireFormat::encoded_len(&self.fcn)
             + WireFormat::encoded_len(&self.iod)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.gamma, buf);
         WireFormat::write(&self.tau, buf);
@@ -2998,7 +2998,7 @@ impl WireFormat for MsgEphemerisGlo {
         WireFormat::write(&self.fcn, buf);
         WireFormat::write(&self.iod, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGlo {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -3092,7 +3092,7 @@ impl WireFormat for MsgEphemerisGloDepA {
             + WireFormat::encoded_len(&self.vel)
             + WireFormat::encoded_len(&self.acc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.gamma, buf);
         WireFormat::write(&self.tau, buf);
@@ -3100,7 +3100,7 @@ impl WireFormat for MsgEphemerisGloDepA {
         WireFormat::write(&self.vel, buf);
         WireFormat::write(&self.acc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGloDepA {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -3191,7 +3191,7 @@ impl WireFormat for MsgEphemerisGloDepB {
             + WireFormat::encoded_len(&self.vel)
             + WireFormat::encoded_len(&self.acc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.gamma, buf);
         WireFormat::write(&self.tau, buf);
@@ -3199,7 +3199,7 @@ impl WireFormat for MsgEphemerisGloDepB {
         WireFormat::write(&self.vel, buf);
         WireFormat::write(&self.acc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGloDepB {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -3300,7 +3300,7 @@ impl WireFormat for MsgEphemerisGloDepC {
             + WireFormat::encoded_len(&self.acc)
             + WireFormat::encoded_len(&self.fcn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.gamma, buf);
         WireFormat::write(&self.tau, buf);
@@ -3310,7 +3310,7 @@ impl WireFormat for MsgEphemerisGloDepC {
         WireFormat::write(&self.acc, buf);
         WireFormat::write(&self.fcn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGloDepC {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -3416,7 +3416,7 @@ impl WireFormat for MsgEphemerisGloDepD {
             + WireFormat::encoded_len(&self.fcn)
             + WireFormat::encoded_len(&self.iod)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.gamma, buf);
         WireFormat::write(&self.tau, buf);
@@ -3427,7 +3427,7 @@ impl WireFormat for MsgEphemerisGloDepD {
         WireFormat::write(&self.fcn, buf);
         WireFormat::write(&self.iod, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGloDepD {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -3610,7 +3610,7 @@ impl WireFormat for MsgEphemerisGps {
             + WireFormat::encoded_len(&self.iode)
             + WireFormat::encoded_len(&self.iodc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
@@ -3635,7 +3635,7 @@ impl WireFormat for MsgEphemerisGps {
         WireFormat::write(&self.iode, buf);
         WireFormat::write(&self.iodc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGps {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -3832,7 +3832,7 @@ impl WireFormat for MsgEphemerisGpsDepE {
             + WireFormat::encoded_len(&self.iode)
             + WireFormat::encoded_len(&self.iodc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
@@ -3857,7 +3857,7 @@ impl WireFormat for MsgEphemerisGpsDepE {
         WireFormat::write(&self.iode, buf);
         WireFormat::write(&self.iodc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGpsDepE {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -4052,7 +4052,7 @@ impl WireFormat for MsgEphemerisGpsDepF {
             + WireFormat::encoded_len(&self.iode)
             + WireFormat::encoded_len(&self.iodc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
@@ -4077,7 +4077,7 @@ impl WireFormat for MsgEphemerisGpsDepF {
         WireFormat::write(&self.iode, buf);
         WireFormat::write(&self.iodc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisGpsDepF {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -4272,7 +4272,7 @@ impl WireFormat for MsgEphemerisQzss {
             + WireFormat::encoded_len(&self.iode)
             + WireFormat::encoded_len(&self.iodc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.tgd, buf);
         WireFormat::write(&self.c_rs, buf);
@@ -4297,7 +4297,7 @@ impl WireFormat for MsgEphemerisQzss {
         WireFormat::write(&self.iode, buf);
         WireFormat::write(&self.iodc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisQzss {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -4399,7 +4399,7 @@ impl WireFormat for MsgEphemerisSbas {
             + WireFormat::encoded_len(&self.a_gf0)
             + WireFormat::encoded_len(&self.a_gf1)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.pos, buf);
         WireFormat::write(&self.vel, buf);
@@ -4407,7 +4407,7 @@ impl WireFormat for MsgEphemerisSbas {
         WireFormat::write(&self.a_gf0, buf);
         WireFormat::write(&self.a_gf1, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisSbas {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -4492,7 +4492,7 @@ impl WireFormat for MsgEphemerisSbasDepA {
             + WireFormat::encoded_len(&self.a_gf0)
             + WireFormat::encoded_len(&self.a_gf1)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.pos, buf);
         WireFormat::write(&self.vel, buf);
@@ -4500,7 +4500,7 @@ impl WireFormat for MsgEphemerisSbasDepA {
         WireFormat::write(&self.a_gf0, buf);
         WireFormat::write(&self.a_gf1, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisSbasDepA {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -4589,7 +4589,7 @@ impl WireFormat for MsgEphemerisSbasDepB {
             + WireFormat::encoded_len(&self.a_gf0)
             + WireFormat::encoded_len(&self.a_gf1)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.common, buf);
         WireFormat::write(&self.pos, buf);
         WireFormat::write(&self.vel, buf);
@@ -4597,7 +4597,7 @@ impl WireFormat for MsgEphemerisSbasDepB {
         WireFormat::write(&self.a_gf0, buf);
         WireFormat::write(&self.a_gf1, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgEphemerisSbasDepB {
             sender_id: None,
             common: WireFormat::parse_unchecked(buf),
@@ -4682,14 +4682,14 @@ impl WireFormat for MsgGloBiases {
             + WireFormat::encoded_len(&self.l2ca_bias)
             + WireFormat::encoded_len(&self.l2p_bias)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.mask, buf);
         WireFormat::write(&self.l1ca_bias, buf);
         WireFormat::write(&self.l1p_bias, buf);
         WireFormat::write(&self.l2ca_bias, buf);
         WireFormat::write(&self.l2p_bias, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGloBiases {
             sender_id: None,
             mask: WireFormat::parse_unchecked(buf),
@@ -4752,11 +4752,11 @@ impl WireFormat for MsgGnssCapb {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.t_nmct) + WireFormat::encoded_len(&self.gc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t_nmct, buf);
         WireFormat::write(&self.gc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGnssCapb {
             sender_id: None,
             t_nmct: WireFormat::parse_unchecked(buf),
@@ -4838,7 +4838,7 @@ impl WireFormat for MsgGroupDelay {
             + WireFormat::encoded_len(&self.isc_l1ca)
             + WireFormat::encoded_len(&self.isc_l2c)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t_op, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.valid, buf);
@@ -4846,7 +4846,7 @@ impl WireFormat for MsgGroupDelay {
         WireFormat::write(&self.isc_l1ca, buf);
         WireFormat::write(&self.isc_l2c, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGroupDelay {
             sender_id: None,
             t_op: WireFormat::parse_unchecked(buf),
@@ -4932,7 +4932,7 @@ impl WireFormat for MsgGroupDelayDepA {
             + WireFormat::encoded_len(&self.isc_l1ca)
             + WireFormat::encoded_len(&self.isc_l2c)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t_op, buf);
         WireFormat::write(&self.prn, buf);
         WireFormat::write(&self.valid, buf);
@@ -4940,7 +4940,7 @@ impl WireFormat for MsgGroupDelayDepA {
         WireFormat::write(&self.isc_l1ca, buf);
         WireFormat::write(&self.isc_l2c, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGroupDelayDepA {
             sender_id: None,
             t_op: WireFormat::parse_unchecked(buf),
@@ -5026,7 +5026,7 @@ impl WireFormat for MsgGroupDelayDepB {
             + WireFormat::encoded_len(&self.isc_l1ca)
             + WireFormat::encoded_len(&self.isc_l2c)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t_op, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.valid, buf);
@@ -5034,7 +5034,7 @@ impl WireFormat for MsgGroupDelayDepB {
         WireFormat::write(&self.isc_l1ca, buf);
         WireFormat::write(&self.isc_l2c, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGroupDelayDepB {
             sender_id: None,
             t_op: WireFormat::parse_unchecked(buf),
@@ -5131,7 +5131,7 @@ impl WireFormat for MsgIono {
             + WireFormat::encoded_len(&self.b2)
             + WireFormat::encoded_len(&self.b3)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t_nmct, buf);
         WireFormat::write(&self.a0, buf);
         WireFormat::write(&self.a1, buf);
@@ -5142,7 +5142,7 @@ impl WireFormat for MsgIono {
         WireFormat::write(&self.b2, buf);
         WireFormat::write(&self.b3, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgIono {
             sender_id: None,
             t_nmct: WireFormat::parse_unchecked(buf),
@@ -5230,11 +5230,11 @@ impl WireFormat for MsgObs {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgObs {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -5310,11 +5310,11 @@ impl WireFormat for MsgObsDepA {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgObsDepA {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -5393,11 +5393,11 @@ impl WireFormat for MsgObsDepB {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgObsDepB {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -5478,11 +5478,11 @@ impl WireFormat for MsgObsDepC {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgObsDepC {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -5559,11 +5559,11 @@ impl WireFormat for MsgOsr {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgOsr {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -5623,10 +5623,10 @@ impl WireFormat for MsgSvAzEl {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.azel)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.azel, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSvAzEl {
             sender_id: None,
             azel: WireFormat::parse_unchecked(buf),
@@ -5688,11 +5688,11 @@ impl WireFormat for MsgSvConfigurationGpsDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.t_nmct) + WireFormat::encoded_len(&self.l2c_mask)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t_nmct, buf);
         WireFormat::write(&self.l2c_mask, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSvConfigurationGpsDep {
             sender_id: None,
             t_nmct: WireFormat::parse_unchecked(buf),
@@ -5723,11 +5723,11 @@ impl WireFormat for ObservationHeader {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.t) + WireFormat::encoded_len(&self.n_obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t, buf);
         WireFormat::write(&self.n_obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         ObservationHeader {
             t: WireFormat::parse_unchecked(buf),
             n_obs: WireFormat::parse_unchecked(buf),
@@ -5757,11 +5757,11 @@ impl WireFormat for ObservationHeaderDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.t) + WireFormat::encoded_len(&self.n_obs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.t, buf);
         WireFormat::write(&self.n_obs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         ObservationHeaderDep {
             t: WireFormat::parse_unchecked(buf),
             n_obs: WireFormat::parse_unchecked(buf),
@@ -5829,7 +5829,7 @@ impl WireFormat for PackedObsContent {
             + WireFormat::encoded_len(&self.flags)
             + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.p, buf);
         WireFormat::write(&self.l, buf);
         WireFormat::write(&self.d, buf);
@@ -5838,7 +5838,7 @@ impl WireFormat for PackedObsContent {
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         PackedObsContent {
             p: WireFormat::parse_unchecked(buf),
             l: WireFormat::parse_unchecked(buf),
@@ -5890,14 +5890,14 @@ impl WireFormat for PackedObsContentDepA {
             + WireFormat::encoded_len(&self.lock)
             + WireFormat::encoded_len(&self.prn)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.p, buf);
         WireFormat::write(&self.l, buf);
         WireFormat::write(&self.cn0, buf);
         WireFormat::write(&self.lock, buf);
         WireFormat::write(&self.prn, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         PackedObsContentDepA {
             p: WireFormat::parse_unchecked(buf),
             l: WireFormat::parse_unchecked(buf),
@@ -5948,14 +5948,14 @@ impl WireFormat for PackedObsContentDepB {
             + WireFormat::encoded_len(&self.lock)
             + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.p, buf);
         WireFormat::write(&self.l, buf);
         WireFormat::write(&self.cn0, buf);
         WireFormat::write(&self.lock, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         PackedObsContentDepB {
             p: WireFormat::parse_unchecked(buf),
             l: WireFormat::parse_unchecked(buf),
@@ -6007,14 +6007,14 @@ impl WireFormat for PackedObsContentDepC {
             + WireFormat::encoded_len(&self.lock)
             + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.p, buf);
         WireFormat::write(&self.l, buf);
         WireFormat::write(&self.cn0, buf);
         WireFormat::write(&self.lock, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         PackedObsContentDepC {
             p: WireFormat::parse_unchecked(buf),
             l: WireFormat::parse_unchecked(buf),
@@ -6082,7 +6082,7 @@ impl WireFormat for PackedOsrContent {
             + WireFormat::encoded_len(&self.tropo_std)
             + WireFormat::encoded_len(&self.range_std)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.p, buf);
         WireFormat::write(&self.l, buf);
         WireFormat::write(&self.lock, buf);
@@ -6092,7 +6092,7 @@ impl WireFormat for PackedOsrContent {
         WireFormat::write(&self.tropo_std, buf);
         WireFormat::write(&self.range_std, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         PackedOsrContent {
             p: WireFormat::parse_unchecked(buf),
             l: WireFormat::parse_unchecked(buf),
@@ -6133,12 +6133,12 @@ impl WireFormat for SvAzEl {
             + WireFormat::encoded_len(&self.az)
             + WireFormat::encoded_len(&self.el)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.az, buf);
         WireFormat::write(&self.el, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         SvAzEl {
             sid: WireFormat::parse_unchecked(buf),
             az: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/orientation.rs
+++ b/rust/sbp/src/messages/orientation.rs
@@ -103,14 +103,14 @@ impl WireFormat for MsgAngularRate {
             + WireFormat::encoded_len(&self.z)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.x, buf);
         WireFormat::write(&self.y, buf);
         WireFormat::write(&self.z, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgAngularRate {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -200,13 +200,13 @@ impl WireFormat for MsgBaselineHeading {
             + WireFormat::encoded_len(&self.n_sats)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.heading, buf);
         WireFormat::write(&self.n_sats, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgBaselineHeading {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -316,7 +316,7 @@ impl WireFormat for MsgOrientEuler {
             + WireFormat::encoded_len(&self.yaw_accuracy)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.roll, buf);
         WireFormat::write(&self.pitch, buf);
@@ -326,7 +326,7 @@ impl WireFormat for MsgOrientEuler {
         WireFormat::write(&self.yaw_accuracy, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgOrientEuler {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -450,7 +450,7 @@ impl WireFormat for MsgOrientQuat {
             + WireFormat::encoded_len(&self.z_accuracy)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.w, buf);
         WireFormat::write(&self.x, buf);
@@ -462,7 +462,7 @@ impl WireFormat for MsgOrientQuat {
         WireFormat::write(&self.z_accuracy, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgOrientQuat {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/piksi.rs
+++ b/rust/sbp/src/messages/piksi.rs
@@ -55,13 +55,13 @@ impl WireFormat for Latency {
             + WireFormat::encoded_len(&self.lmax)
             + WireFormat::encoded_len(&self.current)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.avg, buf);
         WireFormat::write(&self.lmin, buf);
         WireFormat::write(&self.lmax, buf);
         WireFormat::write(&self.current, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         Latency {
             avg: WireFormat::parse_unchecked(buf),
             lmin: WireFormat::parse_unchecked(buf),
@@ -119,8 +119,8 @@ impl WireFormat for MsgAlmanac {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgAlmanac { sender_id: None }
     }
 }
@@ -187,12 +187,12 @@ impl WireFormat for MsgCellModemStatus {
             + WireFormat::encoded_len(&self.signal_error_rate)
             + WireFormat::encoded_len(&self.reserved)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.signal_strength, buf);
         WireFormat::write(&self.signal_error_rate, buf);
         WireFormat::write(&self.reserved, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgCellModemStatus {
             sender_id: None,
             signal_strength: WireFormat::parse_unchecked(buf),
@@ -258,11 +258,11 @@ impl WireFormat for MsgCommandOutput {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence) + WireFormat::encoded_len(&self.line)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.line, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgCommandOutput {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -327,11 +327,11 @@ impl WireFormat for MsgCommandReq {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence) + WireFormat::encoded_len(&self.command)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.command, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgCommandReq {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -395,11 +395,11 @@ impl WireFormat for MsgCommandResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sequence) + WireFormat::encoded_len(&self.code)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.code, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgCommandResp {
             sender_id: None,
             sequence: WireFormat::parse_unchecked(buf),
@@ -457,8 +457,8 @@ impl WireFormat for MsgCwResults {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgCwResults { sender_id: None }
     }
 }
@@ -512,8 +512,8 @@ impl WireFormat for MsgCwStart {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgCwStart { sender_id: None }
     }
 }
@@ -590,14 +590,14 @@ impl WireFormat for MsgDeviceMonitor {
             + WireFormat::encoded_len(&self.cpu_temperature)
             + WireFormat::encoded_len(&self.fe_temperature)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.dev_vin, buf);
         WireFormat::write(&self.cpu_vint, buf);
         WireFormat::write(&self.cpu_vaux, buf);
         WireFormat::write(&self.cpu_temperature, buf);
         WireFormat::write(&self.fe_temperature, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgDeviceMonitor {
             sender_id: None,
             dev_vin: WireFormat::parse_unchecked(buf),
@@ -669,11 +669,11 @@ impl WireFormat for MsgFrontEndGain {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.rf_gain) + WireFormat::encoded_len(&self.if_gain)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.rf_gain, buf);
         WireFormat::write(&self.if_gain, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgFrontEndGain {
             sender_id: None,
             rf_gain: WireFormat::parse_unchecked(buf),
@@ -734,10 +734,10 @@ impl WireFormat for MsgIarState {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.num_hyps)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.num_hyps, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgIarState {
             sender_id: None,
             num_hyps: WireFormat::parse_unchecked(buf),
@@ -792,8 +792,8 @@ impl WireFormat for MsgInitBaseDep {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgInitBaseDep { sender_id: None }
     }
 }
@@ -853,11 +853,11 @@ impl WireFormat for MsgMaskSatellite {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.mask) + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.mask, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgMaskSatellite {
             sender_id: None,
             mask: WireFormat::parse_unchecked(buf),
@@ -920,11 +920,11 @@ impl WireFormat for MsgMaskSatelliteDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.mask) + WireFormat::encoded_len(&self.sid)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.mask, buf);
         WireFormat::write(&self.sid, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgMaskSatelliteDep {
             sender_id: None,
             mask: WireFormat::parse_unchecked(buf),
@@ -983,10 +983,10 @@ impl WireFormat for MsgNetworkBandwidthUsage {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.interfaces)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.interfaces, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgNetworkBandwidthUsage {
             sender_id: None,
             interfaces: WireFormat::parse_unchecked(buf),
@@ -1042,8 +1042,8 @@ impl WireFormat for MsgNetworkStateReq {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgNetworkStateReq { sender_id: None }
     }
 }
@@ -1134,7 +1134,7 @@ impl WireFormat for MsgNetworkStateResp {
             + WireFormat::encoded_len(&self.interface_name)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.ipv4_address, buf);
         WireFormat::write(&self.ipv4_mask_size, buf);
         WireFormat::write(&self.ipv6_address, buf);
@@ -1144,7 +1144,7 @@ impl WireFormat for MsgNetworkStateResp {
         WireFormat::write(&self.interface_name, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgNetworkStateResp {
             sender_id: None,
             ipv4_address: WireFormat::parse_unchecked(buf),
@@ -1209,10 +1209,10 @@ impl WireFormat for MsgReset {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgReset {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -1267,8 +1267,8 @@ impl WireFormat for MsgResetDep {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgResetDep { sender_id: None }
     }
 }
@@ -1324,10 +1324,10 @@ impl WireFormat for MsgResetFilters {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.filter)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.filter, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgResetFilters {
             sender_id: None,
             filter: WireFormat::parse_unchecked(buf),
@@ -1383,8 +1383,8 @@ impl WireFormat for MsgSetTime {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgSetTime { sender_id: None }
     }
 }
@@ -1469,7 +1469,7 @@ impl WireFormat for MsgSpecan {
             + WireFormat::encoded_len(&self.amplitude_unit)
             + WireFormat::encoded_len(&self.amplitude_value)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.channel_tag, buf);
         WireFormat::write(&self.t, buf);
         WireFormat::write(&self.freq_ref, buf);
@@ -1478,7 +1478,7 @@ impl WireFormat for MsgSpecan {
         WireFormat::write(&self.amplitude_unit, buf);
         WireFormat::write(&self.amplitude_value, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSpecan {
             sender_id: None,
             channel_tag: WireFormat::parse_unchecked(buf),
@@ -1572,7 +1572,7 @@ impl WireFormat for MsgSpecanDep {
             + WireFormat::encoded_len(&self.amplitude_unit)
             + WireFormat::encoded_len(&self.amplitude_value)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.channel_tag, buf);
         WireFormat::write(&self.t, buf);
         WireFormat::write(&self.freq_ref, buf);
@@ -1581,7 +1581,7 @@ impl WireFormat for MsgSpecanDep {
         WireFormat::write(&self.amplitude_unit, buf);
         WireFormat::write(&self.amplitude_value, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSpecanDep {
             sender_id: None,
             channel_tag: WireFormat::parse_unchecked(buf),
@@ -1659,12 +1659,12 @@ impl WireFormat for MsgThreadState {
             + WireFormat::encoded_len(&self.cpu)
             + WireFormat::encoded_len(&self.stack_free)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.name, buf);
         WireFormat::write(&self.cpu, buf);
         WireFormat::write(&self.stack_free, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgThreadState {
             sender_id: None,
             name: WireFormat::parse_unchecked(buf),
@@ -1751,14 +1751,14 @@ impl WireFormat for MsgUartState {
             + WireFormat::encoded_len(&self.latency)
             + WireFormat::encoded_len(&self.obs_period)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.uart_a, buf);
         WireFormat::write(&self.uart_b, buf);
         WireFormat::write(&self.uart_ftdi, buf);
         WireFormat::write(&self.latency, buf);
         WireFormat::write(&self.obs_period, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgUartState {
             sender_id: None,
             uart_a: WireFormat::parse_unchecked(buf),
@@ -1835,13 +1835,13 @@ impl WireFormat for MsgUartStateDepa {
             + WireFormat::encoded_len(&self.uart_ftdi)
             + WireFormat::encoded_len(&self.latency)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.uart_a, buf);
         WireFormat::write(&self.uart_b, buf);
         WireFormat::write(&self.uart_ftdi, buf);
         WireFormat::write(&self.latency, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgUartStateDepa {
             sender_id: None,
             uart_a: WireFormat::parse_unchecked(buf),
@@ -1893,14 +1893,14 @@ impl WireFormat for NetworkUsage {
             + WireFormat::encoded_len(&self.tx_bytes)
             + WireFormat::encoded_len(&self.interface_name)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.duration, buf);
         WireFormat::write(&self.total_bytes, buf);
         WireFormat::write(&self.rx_bytes, buf);
         WireFormat::write(&self.tx_bytes, buf);
         WireFormat::write(&self.interface_name, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         NetworkUsage {
             duration: WireFormat::parse_unchecked(buf),
             total_bytes: WireFormat::parse_unchecked(buf),
@@ -1948,13 +1948,13 @@ impl WireFormat for Period {
             + WireFormat::encoded_len(&self.pmax)
             + WireFormat::encoded_len(&self.current)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.avg, buf);
         WireFormat::write(&self.pmin, buf);
         WireFormat::write(&self.pmax, buf);
         WireFormat::write(&self.current, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         Period {
             avg: WireFormat::parse_unchecked(buf),
             pmin: WireFormat::parse_unchecked(buf),
@@ -2007,7 +2007,7 @@ impl WireFormat for UARTChannel {
             + WireFormat::encoded_len(&self.tx_buffer_level)
             + WireFormat::encoded_len(&self.rx_buffer_level)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tx_throughput, buf);
         WireFormat::write(&self.rx_throughput, buf);
         WireFormat::write(&self.crc_error_count, buf);
@@ -2015,7 +2015,7 @@ impl WireFormat for UARTChannel {
         WireFormat::write(&self.tx_buffer_level, buf);
         WireFormat::write(&self.rx_buffer_level, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         UARTChannel {
             tx_throughput: WireFormat::parse_unchecked(buf),
             rx_throughput: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/sbas.rs
+++ b/rust/sbp/src/messages/sbas.rs
@@ -93,13 +93,13 @@ impl WireFormat for MsgSbasRaw {
             + WireFormat::encoded_len(&self.message_type)
             + WireFormat::encoded_len(&self.data)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.message_type, buf);
         WireFormat::write(&self.data, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSbasRaw {
             sender_id: None,
             sid: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/settings.rs
+++ b/rust/sbp/src/messages/settings.rs
@@ -88,8 +88,8 @@ impl WireFormat for MsgSettingsReadByIndexDone {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgSettingsReadByIndexDone { sender_id: None }
     }
 }
@@ -146,10 +146,10 @@ impl WireFormat for MsgSettingsReadByIndexReq {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.index)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsReadByIndexReq {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -222,11 +222,11 @@ impl WireFormat for MsgSettingsReadByIndexResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.index) + WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsReadByIndexResp {
             sender_id: None,
             index: WireFormat::parse_unchecked(buf),
@@ -293,10 +293,10 @@ impl WireFormat for MsgSettingsReadReq {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsReadReq {
             sender_id: None,
             setting: WireFormat::parse_unchecked(buf),
@@ -360,10 +360,10 @@ impl WireFormat for MsgSettingsReadResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsReadResp {
             sender_id: None,
             setting: WireFormat::parse_unchecked(buf),
@@ -424,10 +424,10 @@ impl WireFormat for MsgSettingsRegister {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsRegister {
             sender_id: None,
             setting: WireFormat::parse_unchecked(buf),
@@ -494,11 +494,11 @@ impl WireFormat for MsgSettingsRegisterResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.status) + WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.status, buf);
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsRegisterResp {
             sender_id: None,
             status: WireFormat::parse_unchecked(buf),
@@ -555,8 +555,8 @@ impl WireFormat for MsgSettingsSave {
     fn encoded_len(&self) -> usize {
         0
     }
-    fn write(&self, _buf: &mut bytes::BytesMut) {}
-    fn parse_unchecked(_buf: &mut bytes::BytesMut) -> Self {
+    fn write<B: BufMut>(&self, _buf: &mut B) {}
+    fn parse_unchecked<B: Buf>(_buf: &mut B) -> Self {
         MsgSettingsSave { sender_id: None }
     }
 }
@@ -618,10 +618,10 @@ impl WireFormat for MsgSettingsWrite {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsWrite {
             sender_id: None,
             setting: WireFormat::parse_unchecked(buf),
@@ -690,11 +690,11 @@ impl WireFormat for MsgSettingsWriteResp {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.status) + WireFormat::encoded_len(&self.setting)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.status, buf);
         WireFormat::write(&self.setting, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSettingsWriteResp {
             sender_id: None,
             status: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/solution_meta.rs
+++ b/rust/sbp/src/messages/solution_meta.rs
@@ -35,10 +35,10 @@ impl WireFormat for GnssInputType {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GnssInputType {
             flags: WireFormat::parse_unchecked(buf),
         }
@@ -64,10 +64,10 @@ impl WireFormat for ImuInputType {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         ImuInputType {
             flags: WireFormat::parse_unchecked(buf),
         }
@@ -179,7 +179,7 @@ impl WireFormat for MsgSolnMeta {
             + WireFormat::encoded_len(&self.age_gnss)
             + WireFormat::encoded_len(&self.sol_in)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.pdop, buf);
         WireFormat::write(&self.hdop, buf);
@@ -188,7 +188,7 @@ impl WireFormat for MsgSolnMeta {
         WireFormat::write(&self.age_gnss, buf);
         WireFormat::write(&self.sol_in, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSolnMeta {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -304,7 +304,7 @@ impl WireFormat for MsgSolnMetaDepA {
             + WireFormat::encoded_len(&self.last_used_gnss_vel_tow)
             + WireFormat::encoded_len(&self.sol_in)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.pdop, buf);
         WireFormat::write(&self.hdop, buf);
         WireFormat::write(&self.vdop, buf);
@@ -315,7 +315,7 @@ impl WireFormat for MsgSolnMetaDepA {
         WireFormat::write(&self.last_used_gnss_vel_tow, buf);
         WireFormat::write(&self.sol_in, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSolnMetaDepA {
             sender_id: None,
             pdop: WireFormat::parse_unchecked(buf),
@@ -350,10 +350,10 @@ impl WireFormat for OdoInputType {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         OdoInputType {
             flags: WireFormat::parse_unchecked(buf),
         }
@@ -387,11 +387,11 @@ impl WireFormat for SolutionInputType {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sensor_type) + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sensor_type, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         SolutionInputType {
             sensor_type: WireFormat::parse_unchecked(buf),
             flags: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -41,11 +41,11 @@ impl WireFormat for CodeBiasesContent {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.code) + WireFormat::encoded_len(&self.value)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.code, buf);
         WireFormat::write(&self.value, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         CodeBiasesContent {
             code: WireFormat::parse_unchecked(buf),
             value: WireFormat::parse_unchecked(buf),
@@ -98,7 +98,7 @@ impl WireFormat for GridDefinitionHeaderDepA {
             + WireFormat::encoded_len(&self.num_msgs)
             + WireFormat::encoded_len(&self.seq_num)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.region_size_inverse, buf);
         WireFormat::write(&self.area_width, buf);
         WireFormat::write(&self.lat_nw_corner_enc, buf);
@@ -106,7 +106,7 @@ impl WireFormat for GridDefinitionHeaderDepA {
         WireFormat::write(&self.num_msgs, buf);
         WireFormat::write(&self.seq_num, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GridDefinitionHeaderDepA {
             region_size_inverse: WireFormat::parse_unchecked(buf),
             area_width: WireFormat::parse_unchecked(buf),
@@ -176,7 +176,7 @@ impl WireFormat for GriddedCorrectionHeader {
             + WireFormat::encoded_len(&self.iod_atmo)
             + WireFormat::encoded_len(&self.tropo_quality_indicator)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tile_set_id, buf);
         WireFormat::write(&self.tile_id, buf);
         WireFormat::write(&self.time, buf);
@@ -186,7 +186,7 @@ impl WireFormat for GriddedCorrectionHeader {
         WireFormat::write(&self.iod_atmo, buf);
         WireFormat::write(&self.tropo_quality_indicator, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GriddedCorrectionHeader {
             tile_set_id: WireFormat::parse_unchecked(buf),
             tile_id: WireFormat::parse_unchecked(buf),
@@ -248,7 +248,7 @@ impl WireFormat for GriddedCorrectionHeaderDepA {
             + WireFormat::encoded_len(&self.iod_atmo)
             + WireFormat::encoded_len(&self.tropo_quality_indicator)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.num_msgs, buf);
         WireFormat::write(&self.seq_num, buf);
@@ -256,7 +256,7 @@ impl WireFormat for GriddedCorrectionHeaderDepA {
         WireFormat::write(&self.iod_atmo, buf);
         WireFormat::write(&self.tropo_quality_indicator, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         GriddedCorrectionHeaderDepA {
             time: WireFormat::parse_unchecked(buf),
             num_msgs: WireFormat::parse_unchecked(buf),
@@ -342,14 +342,14 @@ impl WireFormat for MsgSsrCodeBiases {
             + WireFormat::encoded_len(&self.iod_ssr)
             + WireFormat::encoded_len(&self.biases)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.update_interval, buf);
         WireFormat::write(&self.iod_ssr, buf);
         WireFormat::write(&self.biases, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrCodeBiases {
             sender_id: None,
             time: WireFormat::parse_unchecked(buf),
@@ -428,13 +428,13 @@ impl WireFormat for MsgSsrGriddedCorrection {
             + WireFormat::encoded_len(&self.tropo_delay_correction)
             + WireFormat::encoded_len(&self.stec_residuals)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.tropo_delay_correction, buf);
         WireFormat::write(&self.stec_residuals, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrGriddedCorrection {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -507,13 +507,13 @@ impl WireFormat for MsgSsrGriddedCorrectionDepA {
             + WireFormat::encoded_len(&self.tropo_delay_correction)
             + WireFormat::encoded_len(&self.stec_residuals)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.tropo_delay_correction, buf);
         WireFormat::write(&self.stec_residuals, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrGriddedCorrectionDepA {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -586,13 +586,13 @@ impl WireFormat for MsgSsrGriddedCorrectionNoStdDepA {
             + WireFormat::encoded_len(&self.tropo_delay_correction)
             + WireFormat::encoded_len(&self.stec_residuals)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.index, buf);
         WireFormat::write(&self.tropo_delay_correction, buf);
         WireFormat::write(&self.stec_residuals, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrGriddedCorrectionNoStdDepA {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -657,11 +657,11 @@ impl WireFormat for MsgSsrGridDefinitionDepA {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.rle_list)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.rle_list, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrGridDefinitionDepA {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -789,7 +789,7 @@ impl WireFormat for MsgSsrOrbitClock {
             + WireFormat::encoded_len(&self.c1)
             + WireFormat::encoded_len(&self.c2)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.update_interval, buf);
@@ -805,7 +805,7 @@ impl WireFormat for MsgSsrOrbitClock {
         WireFormat::write(&self.c1, buf);
         WireFormat::write(&self.c2, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrOrbitClock {
             sender_id: None,
             time: WireFormat::parse_unchecked(buf),
@@ -940,7 +940,7 @@ impl WireFormat for MsgSsrOrbitClockDepA {
             + WireFormat::encoded_len(&self.c1)
             + WireFormat::encoded_len(&self.c2)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.update_interval, buf);
@@ -956,7 +956,7 @@ impl WireFormat for MsgSsrOrbitClockDepA {
         WireFormat::write(&self.c1, buf);
         WireFormat::write(&self.c2, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrOrbitClockDepA {
             sender_id: None,
             time: WireFormat::parse_unchecked(buf),
@@ -1073,7 +1073,7 @@ impl WireFormat for MsgSsrPhaseBiases {
             + WireFormat::encoded_len(&self.yaw_rate)
             + WireFormat::encoded_len(&self.biases)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.update_interval, buf);
@@ -1084,7 +1084,7 @@ impl WireFormat for MsgSsrPhaseBiases {
         WireFormat::write(&self.yaw_rate, buf);
         WireFormat::write(&self.biases, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrPhaseBiases {
             sender_id: None,
             time: WireFormat::parse_unchecked(buf),
@@ -1147,10 +1147,10 @@ impl WireFormat for MsgSsrSatelliteApc {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.apc)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.apc, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrSatelliteApc {
             sender_id: None,
             apc: WireFormat::parse_unchecked(buf),
@@ -1217,11 +1217,11 @@ impl WireFormat for MsgSsrStecCorrection {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.stec_sat_list)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.stec_sat_list, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrStecCorrection {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -1281,11 +1281,11 @@ impl WireFormat for MsgSsrStecCorrectionDepA {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.header) + WireFormat::encoded_len(&self.stec_sat_list)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.header, buf);
         WireFormat::write(&self.stec_sat_list, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrStecCorrectionDepA {
             sender_id: None,
             header: WireFormat::parse_unchecked(buf),
@@ -1428,7 +1428,7 @@ impl WireFormat for MsgSsrTileDefinition {
             + WireFormat::encoded_len(&self.cols)
             + WireFormat::encoded_len(&self.bitmask)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tile_set_id, buf);
         WireFormat::write(&self.tile_id, buf);
         WireFormat::write(&self.corner_nw_lat, buf);
@@ -1439,7 +1439,7 @@ impl WireFormat for MsgSsrTileDefinition {
         WireFormat::write(&self.cols, buf);
         WireFormat::write(&self.bitmask, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgSsrTileDefinition {
             sender_id: None,
             tile_set_id: WireFormat::parse_unchecked(buf),
@@ -1497,14 +1497,14 @@ impl WireFormat for PhaseBiasesContent {
             + WireFormat::encoded_len(&self.discontinuity_counter)
             + WireFormat::encoded_len(&self.bias)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.code, buf);
         WireFormat::write(&self.integer_indicator, buf);
         WireFormat::write(&self.widelane_integer_indicator, buf);
         WireFormat::write(&self.discontinuity_counter, buf);
         WireFormat::write(&self.bias, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         PhaseBiasesContent {
             code: WireFormat::parse_unchecked(buf),
             integer_indicator: WireFormat::parse_unchecked(buf),
@@ -1565,7 +1565,7 @@ impl WireFormat for STECHeader {
             + WireFormat::encoded_len(&self.update_interval)
             + WireFormat::encoded_len(&self.iod_atmo)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tile_set_id, buf);
         WireFormat::write(&self.tile_id, buf);
         WireFormat::write(&self.time, buf);
@@ -1574,7 +1574,7 @@ impl WireFormat for STECHeader {
         WireFormat::write(&self.update_interval, buf);
         WireFormat::write(&self.iod_atmo, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         STECHeader {
             tile_set_id: WireFormat::parse_unchecked(buf),
             tile_id: WireFormat::parse_unchecked(buf),
@@ -1627,14 +1627,14 @@ impl WireFormat for STECHeaderDepA {
             + WireFormat::encoded_len(&self.update_interval)
             + WireFormat::encoded_len(&self.iod_atmo)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.num_msgs, buf);
         WireFormat::write(&self.seq_num, buf);
         WireFormat::write(&self.update_interval, buf);
         WireFormat::write(&self.iod_atmo, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         STECHeaderDepA {
             time: WireFormat::parse_unchecked(buf),
             num_msgs: WireFormat::parse_unchecked(buf),
@@ -1673,12 +1673,12 @@ impl WireFormat for STECResidual {
             + WireFormat::encoded_len(&self.residual)
             + WireFormat::encoded_len(&self.stddev)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sv_id, buf);
         WireFormat::write(&self.residual, buf);
         WireFormat::write(&self.stddev, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         STECResidual {
             sv_id: WireFormat::parse_unchecked(buf),
             residual: WireFormat::parse_unchecked(buf),
@@ -1708,11 +1708,11 @@ impl WireFormat for STECResidualNoStd {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.sv_id) + WireFormat::encoded_len(&self.residual)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sv_id, buf);
         WireFormat::write(&self.residual, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         STECResidualNoStd {
             sv_id: WireFormat::parse_unchecked(buf),
             residual: WireFormat::parse_unchecked(buf),
@@ -1748,12 +1748,12 @@ impl WireFormat for STECSatElement {
             + WireFormat::encoded_len(&self.stec_quality_indicator)
             + WireFormat::encoded_len(&self.stec_coeff)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sv_id, buf);
         WireFormat::write(&self.stec_quality_indicator, buf);
         WireFormat::write(&self.stec_coeff, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         STECSatElement {
             sv_id: WireFormat::parse_unchecked(buf),
             stec_quality_indicator: WireFormat::parse_unchecked(buf),
@@ -1803,14 +1803,14 @@ impl WireFormat for SatelliteAPC {
             + WireFormat::encoded_len(&self.pco)
             + WireFormat::encoded_len(&self.pcv)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.sat_info, buf);
         WireFormat::write(&self.svn, buf);
         WireFormat::write(&self.pco, buf);
         WireFormat::write(&self.pcv, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         SatelliteAPC {
             sid: WireFormat::parse_unchecked(buf),
             sat_info: WireFormat::parse_unchecked(buf),
@@ -1849,12 +1849,12 @@ impl WireFormat for TroposphericDelayCorrection {
             + WireFormat::encoded_len(&self.wet)
             + WireFormat::encoded_len(&self.stddev)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.hydro, buf);
         WireFormat::write(&self.wet, buf);
         WireFormat::write(&self.stddev, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TroposphericDelayCorrection {
             hydro: WireFormat::parse_unchecked(buf),
             wet: WireFormat::parse_unchecked(buf),
@@ -1884,11 +1884,11 @@ impl WireFormat for TroposphericDelayCorrectionNoStd {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.hydro) + WireFormat::encoded_len(&self.wet)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.hydro, buf);
         WireFormat::write(&self.wet, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TroposphericDelayCorrectionNoStd {
             hydro: WireFormat::parse_unchecked(buf),
             wet: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/system.rs
+++ b/rust/sbp/src/messages/system.rs
@@ -73,11 +73,11 @@ impl WireFormat for MsgCsacTelemetry {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.id) + WireFormat::encoded_len(&self.telemetry)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.id, buf);
         WireFormat::write(&self.telemetry, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgCsacTelemetry {
             sender_id: None,
             id: WireFormat::parse_unchecked(buf),
@@ -143,11 +143,11 @@ impl WireFormat for MsgCsacTelemetryLabels {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.id) + WireFormat::encoded_len(&self.telemetry_labels)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.id, buf);
         WireFormat::write(&self.telemetry_labels, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgCsacTelemetryLabels {
             sender_id: None,
             id: WireFormat::parse_unchecked(buf),
@@ -223,13 +223,13 @@ impl WireFormat for MsgDgnssStatus {
             + WireFormat::encoded_len(&self.num_signals)
             + WireFormat::encoded_len(&self.source)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.latency, buf);
         WireFormat::write(&self.num_signals, buf);
         WireFormat::write(&self.source, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgDgnssStatus {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -307,13 +307,13 @@ impl WireFormat for MsgGnssTimeOffset {
             + WireFormat::encoded_len(&self.microseconds)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.weeks, buf);
         WireFormat::write(&self.milliseconds, buf);
         WireFormat::write(&self.microseconds, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGnssTimeOffset {
             sender_id: None,
             weeks: WireFormat::parse_unchecked(buf),
@@ -392,13 +392,13 @@ impl WireFormat for MsgGroupMeta {
             + WireFormat::encoded_len(&self.n_group_msgs)
             + WireFormat::encoded_len(&self.group_msgs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.group_id, buf);
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.n_group_msgs, buf);
         WireFormat::write(&self.group_msgs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgGroupMeta {
             sender_id: None,
             group_id: WireFormat::parse_unchecked(buf),
@@ -467,10 +467,10 @@ impl WireFormat for MsgHeartbeat {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgHeartbeat {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -529,10 +529,10 @@ impl WireFormat for MsgInsStatus {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgInsStatus {
             sender_id: None,
             flags: WireFormat::parse_unchecked(buf),
@@ -631,7 +631,7 @@ impl WireFormat for MsgInsUpdates {
             + WireFormat::encoded_len(&self.nhc)
             + WireFormat::encoded_len(&self.zerovel)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.gnsspos, buf);
         WireFormat::write(&self.gnssvel, buf);
@@ -640,7 +640,7 @@ impl WireFormat for MsgInsUpdates {
         WireFormat::write(&self.nhc, buf);
         WireFormat::write(&self.zerovel, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgInsUpdates {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -719,11 +719,11 @@ impl WireFormat for MsgPpsTime {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.time) + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgPpsTime {
             sender_id: None,
             time: WireFormat::parse_unchecked(buf),
@@ -794,12 +794,12 @@ impl WireFormat for MsgStartup {
             + WireFormat::encoded_len(&self.startup_type)
             + WireFormat::encoded_len(&self.reserved)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.cause, buf);
         WireFormat::write(&self.startup_type, buf);
         WireFormat::write(&self.reserved, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgStartup {
             sender_id: None,
             cause: WireFormat::parse_unchecked(buf),
@@ -886,14 +886,14 @@ impl WireFormat for MsgStatusReport {
             + WireFormat::encoded_len(&self.uptime)
             + WireFormat::encoded_len(&self.status)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.reporting_system, buf);
         WireFormat::write(&self.sbp_version, buf);
         WireFormat::write(&self.sequence, buf);
         WireFormat::write(&self.uptime, buf);
         WireFormat::write(&self.status, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgStatusReport {
             sender_id: None,
             reporting_system: WireFormat::parse_unchecked(buf),
@@ -933,12 +933,12 @@ impl WireFormat for SubSystemReport {
             + WireFormat::encoded_len(&self.generic)
             + WireFormat::encoded_len(&self.specific)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.component, buf);
         WireFormat::write(&self.generic, buf);
         WireFormat::write(&self.specific, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         SubSystemReport {
             component: WireFormat::parse_unchecked(buf),
             generic: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/tracking.rs
+++ b/rust/sbp/src/messages/tracking.rs
@@ -70,10 +70,10 @@ impl WireFormat for MsgMeasurementState {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.states)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.states, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgMeasurementState {
             sender_id: None,
             states: WireFormat::parse_unchecked(buf),
@@ -142,12 +142,12 @@ impl WireFormat for MsgTrackingIq {
             + WireFormat::encoded_len(&self.sid)
             + WireFormat::encoded_len(&self.corrs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.channel, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.corrs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingIq {
             sender_id: None,
             channel: WireFormat::parse_unchecked(buf),
@@ -217,12 +217,12 @@ impl WireFormat for MsgTrackingIqDepA {
             + WireFormat::encoded_len(&self.sid)
             + WireFormat::encoded_len(&self.corrs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.channel, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.corrs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingIqDepA {
             sender_id: None,
             channel: WireFormat::parse_unchecked(buf),
@@ -293,12 +293,12 @@ impl WireFormat for MsgTrackingIqDepB {
             + WireFormat::encoded_len(&self.sid)
             + WireFormat::encoded_len(&self.corrs)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.channel, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.corrs, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingIqDepB {
             sender_id: None,
             channel: WireFormat::parse_unchecked(buf),
@@ -360,10 +360,10 @@ impl WireFormat for MsgTrackingState {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.states)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.states, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingState {
             sender_id: None,
             states: WireFormat::parse_unchecked(buf),
@@ -421,10 +421,10 @@ impl WireFormat for MsgTrackingStateDepA {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.states)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.states, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingStateDepA {
             sender_id: None,
             states: WireFormat::parse_unchecked(buf),
@@ -482,10 +482,10 @@ impl WireFormat for MsgTrackingStateDepB {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.states)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.states, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingStateDepB {
             sender_id: None,
             states: WireFormat::parse_unchecked(buf),
@@ -649,7 +649,7 @@ impl WireFormat for MsgTrackingStateDetailedDep {
             + WireFormat::encoded_len(&self.pset_flags)
             + WireFormat::encoded_len(&self.misc_flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.recv_time, buf);
         WireFormat::write(&self.tot, buf);
         WireFormat::write(&self.p, buf);
@@ -672,7 +672,7 @@ impl WireFormat for MsgTrackingStateDetailedDep {
         WireFormat::write(&self.pset_flags, buf);
         WireFormat::write(&self.misc_flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingStateDetailedDep {
             sender_id: None,
             recv_time: WireFormat::parse_unchecked(buf),
@@ -857,7 +857,7 @@ impl WireFormat for MsgTrackingStateDetailedDepA {
             + WireFormat::encoded_len(&self.pset_flags)
             + WireFormat::encoded_len(&self.misc_flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.recv_time, buf);
         WireFormat::write(&self.tot, buf);
         WireFormat::write(&self.p, buf);
@@ -880,7 +880,7 @@ impl WireFormat for MsgTrackingStateDetailedDepA {
         WireFormat::write(&self.pset_flags, buf);
         WireFormat::write(&self.misc_flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgTrackingStateDetailedDepA {
             sender_id: None,
             recv_time: WireFormat::parse_unchecked(buf),
@@ -933,11 +933,11 @@ impl WireFormat for MeasurementState {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.mesid) + WireFormat::encoded_len(&self.cn0)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.mesid, buf);
         WireFormat::write(&self.cn0, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MeasurementState {
             mesid: WireFormat::parse_unchecked(buf),
             cn0: WireFormat::parse_unchecked(buf),
@@ -966,11 +966,11 @@ impl WireFormat for TrackingChannelCorrelation {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.i) + WireFormat::encoded_len(&self.q)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.i, buf);
         WireFormat::write(&self.q, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TrackingChannelCorrelation {
             i: WireFormat::parse_unchecked(buf),
             q: WireFormat::parse_unchecked(buf),
@@ -999,11 +999,11 @@ impl WireFormat for TrackingChannelCorrelationDep {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.i) + WireFormat::encoded_len(&self.q)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.i, buf);
         WireFormat::write(&self.q, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TrackingChannelCorrelationDep {
             i: WireFormat::parse_unchecked(buf),
             q: WireFormat::parse_unchecked(buf),
@@ -1039,12 +1039,12 @@ impl WireFormat for TrackingChannelState {
             + WireFormat::encoded_len(&self.fcn)
             + WireFormat::encoded_len(&self.cn0)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.fcn, buf);
         WireFormat::write(&self.cn0, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TrackingChannelState {
             sid: WireFormat::parse_unchecked(buf),
             fcn: WireFormat::parse_unchecked(buf),
@@ -1080,12 +1080,12 @@ impl WireFormat for TrackingChannelStateDepA {
             + WireFormat::encoded_len(&self.prn)
             + WireFormat::encoded_len(&self.cn0)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.state, buf);
         WireFormat::write(&self.prn, buf);
         WireFormat::write(&self.cn0, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TrackingChannelStateDepA {
             state: WireFormat::parse_unchecked(buf),
             prn: WireFormat::parse_unchecked(buf),
@@ -1121,12 +1121,12 @@ impl WireFormat for TrackingChannelStateDepB {
             + WireFormat::encoded_len(&self.sid)
             + WireFormat::encoded_len(&self.cn0)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.state, buf);
         WireFormat::write(&self.sid, buf);
         WireFormat::write(&self.cn0, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         TrackingChannelStateDepB {
             state: WireFormat::parse_unchecked(buf),
             sid: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/unknown.rs
+++ b/rust/sbp/src/messages/unknown.rs
@@ -1,6 +1,6 @@
 //! Unknown messages.
 
-use bytes::BytesMut;
+use bytes::{Buf, BufMut};
 
 use crate::{wire_format::WireFormat, SbpMessage};
 
@@ -39,11 +39,11 @@ impl WireFormat for Unknown {
         self.payload.encoded_len()
     }
 
-    fn write(&self, buf: &mut BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         self.payload.write(buf)
     }
 
-    fn parse_unchecked(buf: &mut BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         Unknown {
             msg_id: 0,
             sender_id: None,

--- a/rust/sbp/src/messages/user.rs
+++ b/rust/sbp/src/messages/user.rs
@@ -67,10 +67,10 @@ impl WireFormat for MsgUserData {
     fn encoded_len(&self) -> usize {
         WireFormat::encoded_len(&self.contents)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.contents, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgUserData {
             sender_id: None,
             contents: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -95,12 +95,12 @@ impl WireFormat for MsgOdometry {
             + WireFormat::encoded_len(&self.velocity)
             + WireFormat::encoded_len(&self.flags)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.tow, buf);
         WireFormat::write(&self.velocity, buf);
         WireFormat::write(&self.flags, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgOdometry {
             sender_id: None,
             tow: WireFormat::parse_unchecked(buf),
@@ -203,13 +203,13 @@ impl WireFormat for MsgWheeltick {
             + WireFormat::encoded_len(&self.source)
             + WireFormat::encoded_len(&self.ticks)
     }
-    fn write(&self, buf: &mut bytes::BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         WireFormat::write(&self.time, buf);
         WireFormat::write(&self.flags, buf);
         WireFormat::write(&self.source, buf);
         WireFormat::write(&self.ticks, buf);
     }
-    fn parse_unchecked(buf: &mut bytes::BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         MsgWheeltick {
             sender_id: None,
             time: WireFormat::parse_unchecked(buf),

--- a/rust/sbp/src/sbp_string.rs
+++ b/rust/sbp/src/sbp_string.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use bytes::BytesMut;
+use bytes::{Buf, BufMut};
 
 use crate::wire_format::WireFormat;
 
@@ -77,11 +77,11 @@ impl<E, const LEN: usize> WireFormat for SbpString<[u8; LEN], E> {
         LEN
     }
 
-    fn write(&self, buf: &mut BytesMut) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
         self.data.write(buf)
     }
 
-    fn parse_unchecked(buf: &mut BytesMut) -> Self {
+    fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
         let data: [u8; LEN] = WireFormat::parse_unchecked(buf);
         SbpString::new(data)
     }
@@ -96,11 +96,11 @@ macro_rules! forward_payload_vec {
                 self.data.encoded_len()
             }
 
-            fn write(&self, buf: &mut BytesMut) {
+            fn write<B: BufMut>(&self, buf: &mut B) {
                 self.data.write(buf)
             }
 
-            fn parse_unchecked(buf: &mut BytesMut) -> Self {
+            fn parse_unchecked<B: Buf>(buf: &mut B) -> Self {
                 let data: Vec<u8> = WireFormat::parse_unchecked(buf);
                 SbpString::new(data)
             }
@@ -181,6 +181,8 @@ forward_payload_vec!(DoubleNullTerminated, 2);
 
 #[cfg(test)]
 mod tests {
+    use bytes::BytesMut;
+
     use super::*;
 
     #[test]

--- a/rust/sbp/src/time.rs
+++ b/rust/sbp/src/time.rs
@@ -15,7 +15,6 @@ pub enum MessageTime {
 }
 
 impl MessageTime {
-    /*  */
     /// If the `MessageTime` is from a rover return it. Otherwise return None.
     pub fn to_rover(self) -> Option<RoverTime> {
         if let Self::Rover(v) = self {


### PR DESCRIPTION
Re-exposed the functionality to directly parse a message from sender_id + msg_type + payload. Made the parsing generic over `Buf`/`BufMut` so internally we can still use `BytesMut` but people outside the library can use vecs/slices. 

Also adds the readme field to the cargo.toml files so it will show something on crates.io