### PR TITLE
[ESD-2242] Fix integer promotion issues in generated macros

### DIFF
--- a/c/include/libsbp/bootload_macros.h
+++ b/c/include/libsbp/bootload_macros.h
@@ -30,11 +30,12 @@
   (0xff)
 #define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT \
   (8u)
-#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET( \
-    flags)                                                                   \
-  (((flags) >>                                                               \
-    SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
-   SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)
+#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(    \
+    flags)                                                                      \
+  ((u32)(                                                                       \
+      ((flags) >>                                                               \
+       SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
+      SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))
 #define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(           \
     flags, val)                                                                        \
   do {                                                                                 \
@@ -49,11 +50,12 @@
   (0xff)
 #define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT \
   (0u)
-#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET( \
-    flags)                                                                   \
-  (((flags) >>                                                               \
-    SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
-   SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)
+#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(    \
+    flags)                                                                      \
+  ((u32)(                                                                       \
+      ((flags) >>                                                               \
+       SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
+      SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))
 #define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(           \
     flags, val)                                                                        \
   do {                                                                                 \

--- a/c/include/libsbp/bootload_macros.h
+++ b/c/include/libsbp/bootload_macros.h
@@ -35,13 +35,14 @@
   (((flags) >>                                                               \
     SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
    SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)
-#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(        \
-    flags, val)                                                                     \
-  do {                                                                              \
-    ((flags) |=                                                                     \
-     (((val) &                                                                      \
-       (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))      \
-      << (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT))); \
+#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(           \
+    flags, val)                                                                        \
+  do {                                                                                 \
+    (flags) = (u32)(                                                                   \
+        (flags) |                                                                      \
+        (((val) &                                                                      \
+          (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))      \
+         << (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT))); \
   } while (0)
 
 #define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK \
@@ -53,13 +54,14 @@
   (((flags) >>                                                               \
     SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
    SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)
-#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(        \
-    flags, val)                                                                     \
-  do {                                                                              \
-    ((flags) |=                                                                     \
-     (((val) &                                                                      \
-       (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))      \
-      << (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT))); \
+#define SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(           \
+    flags, val)                                                                        \
+  do {                                                                                 \
+    (flags) = (u32)(                                                                   \
+        (flags) |                                                                      \
+        (((val) &                                                                      \
+          (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))      \
+         << (SBP_BOOTLOADER_HANDSHAKE_RESP_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT))); \
   } while (0)
 
 /**

--- a/c/include/libsbp/ext_events_macros.h
+++ b/c/include/libsbp/ext_events_macros.h
@@ -21,9 +21,9 @@
 #define SBP_MSG_EXT_EVENT 0x0101
 #define SBP_EXT_EVENT_TIME_QUALITY_MASK (0x1)
 #define SBP_EXT_EVENT_TIME_QUALITY_SHIFT (1u)
-#define SBP_EXT_EVENT_TIME_QUALITY_GET(flags)      \
-  (((flags) >> SBP_EXT_EVENT_TIME_QUALITY_SHIFT) & \
-   SBP_EXT_EVENT_TIME_QUALITY_MASK)
+#define SBP_EXT_EVENT_TIME_QUALITY_GET(flags)           \
+  ((u8)(((flags) >> SBP_EXT_EVENT_TIME_QUALITY_SHIFT) & \
+        SBP_EXT_EVENT_TIME_QUALITY_MASK))
 #define SBP_EXT_EVENT_TIME_QUALITY_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_EXT_EVENT_TIME_QUALITY_MASK)) \
@@ -34,9 +34,9 @@
 #define SBP_EXT_EVENT_TIME_QUALITY_GOOD (1)
 #define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK (0x1)
 #define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SHIFT (0u)
-#define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_GET(flags)      \
-  (((flags) >> SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SHIFT) & \
-   SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK)
+#define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_GET(flags)           \
+  ((u8)(((flags) >> SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SHIFT) & \
+        SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK))
 #define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SET(flags, val)                        \
   do {                                                                        \
     (flags) = (u8)((flags) | (((val) & (SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK)) \

--- a/c/include/libsbp/ext_events_macros.h
+++ b/c/include/libsbp/ext_events_macros.h
@@ -24,10 +24,10 @@
 #define SBP_EXT_EVENT_TIME_QUALITY_GET(flags)      \
   (((flags) >> SBP_EXT_EVENT_TIME_QUALITY_SHIFT) & \
    SBP_EXT_EVENT_TIME_QUALITY_MASK)
-#define SBP_EXT_EVENT_TIME_QUALITY_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_EXT_EVENT_TIME_QUALITY_MASK)) \
-                 << (SBP_EXT_EVENT_TIME_QUALITY_SHIFT)));    \
+#define SBP_EXT_EVENT_TIME_QUALITY_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_EXT_EVENT_TIME_QUALITY_MASK)) \
+                              << (SBP_EXT_EVENT_TIME_QUALITY_SHIFT)));    \
   } while (0)
 
 #define SBP_EXT_EVENT_TIME_QUALITY_UNKNOWN_DONT_HAVE_NAV_SOLUTION (0)
@@ -37,10 +37,10 @@
 #define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_GET(flags)      \
   (((flags) >> SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SHIFT) & \
    SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK)
-#define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK)) \
-                 << (SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SHIFT)));    \
+#define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SET(flags, val)                        \
+  do {                                                                        \
+    (flags) = (u8)((flags) | (((val) & (SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_MASK)) \
+                              << (SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_SHIFT)));    \
   } while (0)
 
 #define SBP_EXT_EVENT_NEW_LEVEL_OF_PIN_LOW (0)

--- a/c/include/libsbp/flash_macros.h
+++ b/c/include/libsbp/flash_macros.h
@@ -21,9 +21,9 @@
 #define SBP_MSG_FLASH_PROGRAM 0x00E6
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_MASK (0x1)
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SHIFT (0u)
-#define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_GET(flags)      \
-  (((flags) >> SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SHIFT) & \
-   SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_MASK)
+#define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_GET(flags)           \
+  ((u8)(((flags) >> SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SHIFT) & \
+        SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_MASK))
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SET(flags, val)              \
   do {                                                                      \
     (flags) = (u8)((flags) |                                                \
@@ -66,9 +66,9 @@
 #define SBP_MSG_FLASH_DONE 0x00E0
 #define SBP_FLASH_DONE_RESPONSE_CODE_MASK (0x7)
 #define SBP_FLASH_DONE_RESPONSE_CODE_SHIFT (0u)
-#define SBP_FLASH_DONE_RESPONSE_CODE_GET(flags)      \
-  (((flags) >> SBP_FLASH_DONE_RESPONSE_CODE_SHIFT) & \
-   SBP_FLASH_DONE_RESPONSE_CODE_MASK)
+#define SBP_FLASH_DONE_RESPONSE_CODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_FLASH_DONE_RESPONSE_CODE_SHIFT) & \
+        SBP_FLASH_DONE_RESPONSE_CODE_MASK))
 #define SBP_FLASH_DONE_RESPONSE_CODE_SET(flags, val)                        \
   do {                                                                      \
     (flags) = (u8)((flags) | (((val) & (SBP_FLASH_DONE_RESPONSE_CODE_MASK)) \
@@ -90,9 +90,9 @@
 #define SBP_MSG_FLASH_READ_REQ 0x00E7
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_MASK (0x1)
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SHIFT (0u)
-#define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_GET(flags)      \
-  (((flags) >> SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SHIFT) & \
-   SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_MASK)
+#define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_GET(flags)           \
+  ((u8)(((flags) >> SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SHIFT) & \
+        SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_MASK))
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SET(flags, val)              \
   do {                                                                       \
     (flags) = (u8)((flags) |                                                 \
@@ -119,9 +119,9 @@
 #define SBP_MSG_FLASH_READ_RESP 0x00E1
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_MASK (0x1)
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SHIFT (0u)
-#define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_GET(flags)      \
-  (((flags) >> SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SHIFT) & \
-   SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_MASK)
+#define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_GET(flags)           \
+  ((u8)(((flags) >> SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SHIFT) & \
+        SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_MASK))
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -148,9 +148,9 @@
 #define SBP_MSG_FLASH_ERASE 0x00E2
 #define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_MASK (0x1)
 #define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SHIFT (0u)
-#define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_GET(flags)      \
-  (((flags) >> SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SHIFT) & \
-   SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_MASK)
+#define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_GET(flags)           \
+  ((u8)(((flags) >> SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SHIFT) & \
+        SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_MASK))
 #define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \

--- a/c/include/libsbp/flash_macros.h
+++ b/c/include/libsbp/flash_macros.h
@@ -24,10 +24,11 @@
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_GET(flags)      \
   (((flags) >> SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SHIFT) & \
    SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_MASK)
-#define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SET(flags, val)           \
-  do {                                                                   \
-    ((flags) |= (((val) & (SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_MASK)) \
-                 << (SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SHIFT)));    \
+#define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SET(flags, val)              \
+  do {                                                                      \
+    (flags) = (u8)((flags) |                                                \
+                   (((val) & (SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_MASK)) \
+                    << (SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_SHIFT)));    \
   } while (0)
 
 #define SBP_FLASH_PROGRAM_FLASH_TARGET_TO_READ_FLASH_STM (0)
@@ -68,10 +69,10 @@
 #define SBP_FLASH_DONE_RESPONSE_CODE_GET(flags)      \
   (((flags) >> SBP_FLASH_DONE_RESPONSE_CODE_SHIFT) & \
    SBP_FLASH_DONE_RESPONSE_CODE_MASK)
-#define SBP_FLASH_DONE_RESPONSE_CODE_SET(flags, val)           \
-  do {                                                         \
-    ((flags) |= (((val) & (SBP_FLASH_DONE_RESPONSE_CODE_MASK)) \
-                 << (SBP_FLASH_DONE_RESPONSE_CODE_SHIFT)));    \
+#define SBP_FLASH_DONE_RESPONSE_CODE_SET(flags, val)                        \
+  do {                                                                      \
+    (flags) = (u8)((flags) | (((val) & (SBP_FLASH_DONE_RESPONSE_CODE_MASK)) \
+                              << (SBP_FLASH_DONE_RESPONSE_CODE_SHIFT)));    \
   } while (0)
 
 #define SBP_FLASH_DONE_RESPONSE_CODE_FLASH_OK (0)
@@ -92,10 +93,11 @@
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_GET(flags)      \
   (((flags) >> SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SHIFT) & \
    SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_MASK)
-#define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SET(flags, val)           \
-  do {                                                                    \
-    ((flags) |= (((val) & (SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_MASK)) \
-                 << (SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SHIFT)));    \
+#define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SET(flags, val)              \
+  do {                                                                       \
+    (flags) = (u8)((flags) |                                                 \
+                   (((val) & (SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_MASK)) \
+                    << (SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_SHIFT)));    \
   } while (0)
 
 #define SBP_FLASH_READ_REQ_FLASH_TARGET_TO_READ_FLASH_STM (0)
@@ -120,10 +122,11 @@
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_GET(flags)      \
   (((flags) >> SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SHIFT) & \
    SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_MASK)
-#define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_MASK)) \
-                 << (SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SHIFT)));    \
+#define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_MASK)) \
+                    << (SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_SHIFT)));    \
   } while (0)
 
 #define SBP_FLASH_READ_RESP_FLASH_TARGET_TO_READ_FLASH_STM (0)
@@ -148,10 +151,11 @@
 #define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_GET(flags)      \
   (((flags) >> SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SHIFT) & \
    SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_MASK)
-#define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_MASK)) \
-                 << (SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SHIFT)));    \
+#define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_MASK)) \
+                        << (SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_SHIFT)));    \
   } while (0)
 
 #define SBP_FLASH_ERASE_FLASH_TARGET_TO_READ_FLASH_STM (0)

--- a/c/include/libsbp/gnss_macros.h
+++ b/c/include/libsbp/gnss_macros.h
@@ -22,10 +22,10 @@
 #define SBP_GNSSSIGNAL__SHIFT (0u)
 #define SBP_GNSSSIGNAL__GET(flags) \
   (((flags) >> SBP_GNSSSIGNAL__SHIFT) & SBP_GNSSSIGNAL__MASK)
-#define SBP_GNSSSIGNAL__SET(flags, val)                              \
-  do {                                                               \
-    ((flags) |=                                                      \
-     (((val) & (SBP_GNSSSIGNAL__MASK)) << (SBP_GNSSSIGNAL__SHIFT))); \
+#define SBP_GNSSSIGNAL__SET(flags, val)                        \
+  do {                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_GNSSSIGNAL__MASK)) \
+                              << (SBP_GNSSSIGNAL__SHIFT)));    \
   } while (0)
 
 #define SBP_GNSSSIGNAL_GPS_L1CA (0)
@@ -56,10 +56,10 @@
 #define SBP_GNSSSIGNALDEP__SHIFT (0u)
 #define SBP_GNSSSIGNALDEP__GET(flags) \
   (((flags) >> SBP_GNSSSIGNALDEP__SHIFT) & SBP_GNSSSIGNALDEP__MASK)
-#define SBP_GNSSSIGNALDEP__SET(flags, val)                                 \
-  do {                                                                     \
-    ((flags) |=                                                            \
-     (((val) & (SBP_GNSSSIGNALDEP__MASK)) << (SBP_GNSSSIGNALDEP__SHIFT))); \
+#define SBP_GNSSSIGNALDEP__SET(flags, val)                        \
+  do {                                                            \
+    (flags) = (u8)((flags) | (((val) & (SBP_GNSSSIGNALDEP__MASK)) \
+                              << (SBP_GNSSSIGNALDEP__SHIFT)));    \
   } while (0)
 
 #define SBP_GNSSSIGNALDEP_GPS_L1CA (0)

--- a/c/include/libsbp/gnss_macros.h
+++ b/c/include/libsbp/gnss_macros.h
@@ -21,7 +21,7 @@
 #define SBP_GNSSSIGNAL__MASK (0xff)
 #define SBP_GNSSSIGNAL__SHIFT (0u)
 #define SBP_GNSSSIGNAL__GET(flags) \
-  (((flags) >> SBP_GNSSSIGNAL__SHIFT) & SBP_GNSSSIGNAL__MASK)
+  ((u8)(((flags) >> SBP_GNSSSIGNAL__SHIFT) & SBP_GNSSSIGNAL__MASK))
 #define SBP_GNSSSIGNAL__SET(flags, val)                        \
   do {                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_GNSSSIGNAL__MASK)) \
@@ -55,7 +55,7 @@
 #define SBP_GNSSSIGNALDEP__MASK (0xff)
 #define SBP_GNSSSIGNALDEP__SHIFT (0u)
 #define SBP_GNSSSIGNALDEP__GET(flags) \
-  (((flags) >> SBP_GNSSSIGNALDEP__SHIFT) & SBP_GNSSSIGNALDEP__MASK)
+  ((u8)(((flags) >> SBP_GNSSSIGNALDEP__SHIFT) & SBP_GNSSSIGNALDEP__MASK))
 #define SBP_GNSSSIGNALDEP__SET(flags, val)                        \
   do {                                                            \
     (flags) = (u8)((flags) | (((val) & (SBP_GNSSSIGNALDEP__MASK)) \

--- a/c/include/libsbp/imu_macros.h
+++ b/c/include/libsbp/imu_macros.h
@@ -21,8 +21,9 @@
 #define SBP_MSG_IMU_RAW 0x0900
 #define SBP_IMU_RAW_TIME_STATUS_MASK (0x3)
 #define SBP_IMU_RAW_TIME_STATUS_SHIFT (30u)
-#define SBP_IMU_RAW_TIME_STATUS_GET(flags) \
-  (((flags) >> SBP_IMU_RAW_TIME_STATUS_SHIFT) & SBP_IMU_RAW_TIME_STATUS_MASK)
+#define SBP_IMU_RAW_TIME_STATUS_GET(flags)            \
+  ((u32)(((flags) >> SBP_IMU_RAW_TIME_STATUS_SHIFT) & \
+         SBP_IMU_RAW_TIME_STATUS_MASK))
 #define SBP_IMU_RAW_TIME_STATUS_SET(flags, val)                         \
   do {                                                                  \
     (flags) = (u32)((flags) | (((val) & (SBP_IMU_RAW_TIME_STATUS_MASK)) \
@@ -35,9 +36,10 @@
 #define SBP_IMU_RAW_TIME_STATUS_REFERENCE_EPOCH_IS_LAST_PPS (3)
 #define SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_MASK (0x3fffffff)
 #define SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SHIFT (0u)
-#define SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_GET(flags)      \
-  (((flags) >> SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SHIFT) & \
-   SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_MASK)
+#define SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_GET(flags) \
+  ((u32)(((flags) >>                                                      \
+          SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SHIFT) & \
+         SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_MASK))
 #define SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SET(flags, val) \
   do {                                                                         \
     (flags) = (u32)(                                                           \
@@ -57,7 +59,7 @@
 #define SBP_IMU_AUX_IMU_TYPE_MASK (0xff)
 #define SBP_IMU_AUX_IMU_TYPE_SHIFT (0u)
 #define SBP_IMU_AUX_IMU_TYPE_GET(flags) \
-  (((flags) >> SBP_IMU_AUX_IMU_TYPE_SHIFT) & SBP_IMU_AUX_IMU_TYPE_MASK)
+  ((u8)(((flags) >> SBP_IMU_AUX_IMU_TYPE_SHIFT) & SBP_IMU_AUX_IMU_TYPE_MASK))
 #define SBP_IMU_AUX_IMU_TYPE_SET(flags, val)                        \
   do {                                                              \
     (flags) = (u8)((flags) | (((val) & (SBP_IMU_AUX_IMU_TYPE_MASK)) \
@@ -68,9 +70,9 @@
 #define SBP_IMU_AUX_IMU_TYPE_ST_MICROELECTRONICS_ASM330LLH (1)
 #define SBP_IMU_AUX_GYROSCOPE_RANGE_MASK (0xf)
 #define SBP_IMU_AUX_GYROSCOPE_RANGE_SHIFT (4u)
-#define SBP_IMU_AUX_GYROSCOPE_RANGE_GET(flags)      \
-  (((flags) >> SBP_IMU_AUX_GYROSCOPE_RANGE_SHIFT) & \
-   SBP_IMU_AUX_GYROSCOPE_RANGE_MASK)
+#define SBP_IMU_AUX_GYROSCOPE_RANGE_GET(flags)           \
+  ((u8)(((flags) >> SBP_IMU_AUX_GYROSCOPE_RANGE_SHIFT) & \
+        SBP_IMU_AUX_GYROSCOPE_RANGE_MASK))
 #define SBP_IMU_AUX_GYROSCOPE_RANGE_SET(flags, val)                        \
   do {                                                                     \
     (flags) = (u8)((flags) | (((val) & (SBP_IMU_AUX_GYROSCOPE_RANGE_MASK)) \
@@ -89,9 +91,9 @@
 #define SBP_IMU_AUX_GYROSCOPE_RANGE_125_DEG_S (4)
 #define SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK (0xf)
 #define SBP_IMU_AUX_ACCELEROMETER_RANGE_SHIFT (0u)
-#define SBP_IMU_AUX_ACCELEROMETER_RANGE_GET(flags)      \
-  (((flags) >> SBP_IMU_AUX_ACCELEROMETER_RANGE_SHIFT) & \
-   SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK)
+#define SBP_IMU_AUX_ACCELEROMETER_RANGE_GET(flags)           \
+  ((u8)(((flags) >> SBP_IMU_AUX_ACCELEROMETER_RANGE_SHIFT) & \
+        SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK))
 #define SBP_IMU_AUX_ACCELEROMETER_RANGE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK)) \

--- a/c/include/libsbp/imu_macros.h
+++ b/c/include/libsbp/imu_macros.h
@@ -23,10 +23,10 @@
 #define SBP_IMU_RAW_TIME_STATUS_SHIFT (30u)
 #define SBP_IMU_RAW_TIME_STATUS_GET(flags) \
   (((flags) >> SBP_IMU_RAW_TIME_STATUS_SHIFT) & SBP_IMU_RAW_TIME_STATUS_MASK)
-#define SBP_IMU_RAW_TIME_STATUS_SET(flags, val)           \
-  do {                                                    \
-    ((flags) |= (((val) & (SBP_IMU_RAW_TIME_STATUS_MASK)) \
-                 << (SBP_IMU_RAW_TIME_STATUS_SHIFT)));    \
+#define SBP_IMU_RAW_TIME_STATUS_SET(flags, val)                         \
+  do {                                                                  \
+    (flags) = (u32)((flags) | (((val) & (SBP_IMU_RAW_TIME_STATUS_MASK)) \
+                               << (SBP_IMU_RAW_TIME_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_IMU_RAW_TIME_STATUS_REFERENCE_EPOCH_IS_START_OF_CURRENT_GPS_WEEK (0)
@@ -40,9 +40,11 @@
    SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_MASK)
 #define SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SET(flags, val) \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_MASK))  \
-      << (SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SHIFT)));     \
+    (flags) = (u32)(                                                           \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_MASK))       \
+         << (SBP_IMU_RAW_TIME_SINCE_REFERENCE_EPOCH_IN_MILLISECONDS_SHIFT)));  \
   } while (0)
 
 /**
@@ -56,10 +58,10 @@
 #define SBP_IMU_AUX_IMU_TYPE_SHIFT (0u)
 #define SBP_IMU_AUX_IMU_TYPE_GET(flags) \
   (((flags) >> SBP_IMU_AUX_IMU_TYPE_SHIFT) & SBP_IMU_AUX_IMU_TYPE_MASK)
-#define SBP_IMU_AUX_IMU_TYPE_SET(flags, val)                                   \
-  do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_IMU_AUX_IMU_TYPE_MASK)) << (SBP_IMU_AUX_IMU_TYPE_SHIFT))); \
+#define SBP_IMU_AUX_IMU_TYPE_SET(flags, val)                        \
+  do {                                                              \
+    (flags) = (u8)((flags) | (((val) & (SBP_IMU_AUX_IMU_TYPE_MASK)) \
+                              << (SBP_IMU_AUX_IMU_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_IMU_AUX_IMU_TYPE_BOSCH_BMI160 (0)
@@ -69,10 +71,10 @@
 #define SBP_IMU_AUX_GYROSCOPE_RANGE_GET(flags)      \
   (((flags) >> SBP_IMU_AUX_GYROSCOPE_RANGE_SHIFT) & \
    SBP_IMU_AUX_GYROSCOPE_RANGE_MASK)
-#define SBP_IMU_AUX_GYROSCOPE_RANGE_SET(flags, val)           \
-  do {                                                        \
-    ((flags) |= (((val) & (SBP_IMU_AUX_GYROSCOPE_RANGE_MASK)) \
-                 << (SBP_IMU_AUX_GYROSCOPE_RANGE_SHIFT)));    \
+#define SBP_IMU_AUX_GYROSCOPE_RANGE_SET(flags, val)                        \
+  do {                                                                     \
+    (flags) = (u8)((flags) | (((val) & (SBP_IMU_AUX_GYROSCOPE_RANGE_MASK)) \
+                              << (SBP_IMU_AUX_GYROSCOPE_RANGE_SHIFT)));    \
   } while (0)
 
 #define SBP_IMU_AUX_GYROSCOPE_RANGE__2000_DEG__S (0)
@@ -90,10 +92,10 @@
 #define SBP_IMU_AUX_ACCELEROMETER_RANGE_GET(flags)      \
   (((flags) >> SBP_IMU_AUX_ACCELEROMETER_RANGE_SHIFT) & \
    SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK)
-#define SBP_IMU_AUX_ACCELEROMETER_RANGE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK)) \
-                 << (SBP_IMU_AUX_ACCELEROMETER_RANGE_SHIFT)));    \
+#define SBP_IMU_AUX_ACCELEROMETER_RANGE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_IMU_AUX_ACCELEROMETER_RANGE_MASK)) \
+                              << (SBP_IMU_AUX_ACCELEROMETER_RANGE_SHIFT)));    \
   } while (0)
 
 #define SBP_IMU_AUX_ACCELEROMETER_RANGE__2G (0)

--- a/c/include/libsbp/linux_macros.h
+++ b/c/include/libsbp/linux_macros.h
@@ -222,10 +222,11 @@
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_GET(flags)      \
   (((flags) >> SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SHIFT) & \
    SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_MASK)
-#define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_MASK)) \
-                 << (SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SHIFT)));    \
+#define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_MASK)) \
+                        << (SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SYSTEM_TIME_IN_SECONDS (0)
@@ -265,10 +266,11 @@
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_GET(flags)      \
   (((flags) >> SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SHIFT) & \
    SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_MASK)
-#define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_MASK)) \
-                 << (SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SHIFT)));    \
+#define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_MASK)) \
+                        << (SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SYSTEM_TIME_IN_SECONDS (0)
@@ -308,10 +310,11 @@
 #define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_GET(flags)      \
   (((flags) >> SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SHIFT) & \
    SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_MASK)
-#define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_MASK)) \
-                 << (SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SHIFT)));    \
+#define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_MASK)) \
+                        << (SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SYSTEM_TIME_IN_SECONDS (0)

--- a/c/include/libsbp/linux_macros.h
+++ b/c/include/libsbp/linux_macros.h
@@ -219,9 +219,9 @@
 #define SBP_MSG_LINUX_CPU_STATE 0x7F08
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_MASK (0x7)
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SHIFT (0u)
-#define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_GET(flags)      \
-  (((flags) >> SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SHIFT) & \
-   SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_MASK)
+#define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SHIFT) & \
+        SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_MASK))
 #define SBP_LINUX_CPU_STATE_TIMESTAMP_TYPE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -263,9 +263,9 @@
 #define SBP_MSG_LINUX_MEM_STATE 0x7F09
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_MASK (0x7)
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SHIFT (0u)
-#define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_GET(flags)      \
-  (((flags) >> SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SHIFT) & \
-   SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_MASK)
+#define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SHIFT) & \
+        SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_MASK))
 #define SBP_LINUX_MEM_STATE_TIMESTAMP_TYPE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -307,9 +307,9 @@
 #define SBP_MSG_LINUX_SYS_STATE 0x7F0A
 #define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_MASK (0x7)
 #define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SHIFT (0u)
-#define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_GET(flags)      \
-  (((flags) >> SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SHIFT) & \
-   SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_MASK)
+#define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SHIFT) & \
+        SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_MASK))
 #define SBP_LINUX_SYS_STATE_TIMESTAMP_TYPE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \

--- a/c/include/libsbp/logging_macros.h
+++ b/c/include/libsbp/logging_macros.h
@@ -22,7 +22,7 @@
 #define SBP_LOG_LOGGING_LEVEL_MASK (0x7)
 #define SBP_LOG_LOGGING_LEVEL_SHIFT (0u)
 #define SBP_LOG_LOGGING_LEVEL_GET(flags) \
-  (((flags) >> SBP_LOG_LOGGING_LEVEL_SHIFT) & SBP_LOG_LOGGING_LEVEL_MASK)
+  ((u8)(((flags) >> SBP_LOG_LOGGING_LEVEL_SHIFT) & SBP_LOG_LOGGING_LEVEL_MASK))
 #define SBP_LOG_LOGGING_LEVEL_SET(flags, val)                        \
   do {                                                               \
     (flags) = (u8)((flags) | (((val) & (SBP_LOG_LOGGING_LEVEL_MASK)) \

--- a/c/include/libsbp/logging_macros.h
+++ b/c/include/libsbp/logging_macros.h
@@ -23,10 +23,10 @@
 #define SBP_LOG_LOGGING_LEVEL_SHIFT (0u)
 #define SBP_LOG_LOGGING_LEVEL_GET(flags) \
   (((flags) >> SBP_LOG_LOGGING_LEVEL_SHIFT) & SBP_LOG_LOGGING_LEVEL_MASK)
-#define SBP_LOG_LOGGING_LEVEL_SET(flags, val)           \
-  do {                                                  \
-    ((flags) |= (((val) & (SBP_LOG_LOGGING_LEVEL_MASK)) \
-                 << (SBP_LOG_LOGGING_LEVEL_SHIFT)));    \
+#define SBP_LOG_LOGGING_LEVEL_SET(flags, val)                        \
+  do {                                                               \
+    (flags) = (u8)((flags) | (((val) & (SBP_LOG_LOGGING_LEVEL_MASK)) \
+                              << (SBP_LOG_LOGGING_LEVEL_SHIFT)));    \
   } while (0)
 
 #define SBP_LOG_LOGGING_LEVEL_EMERG (0)

--- a/c/include/libsbp/navigation_macros.h
+++ b/c/include/libsbp/navigation_macros.h
@@ -21,8 +21,9 @@
 #define SBP_MSG_GPS_TIME 0x0102
 #define SBP_GPS_TIME_TIME_SOURCE_MASK (0x7)
 #define SBP_GPS_TIME_TIME_SOURCE_SHIFT (0u)
-#define SBP_GPS_TIME_TIME_SOURCE_GET(flags) \
-  (((flags) >> SBP_GPS_TIME_TIME_SOURCE_SHIFT) & SBP_GPS_TIME_TIME_SOURCE_MASK)
+#define SBP_GPS_TIME_TIME_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_GPS_TIME_TIME_SOURCE_SHIFT) & \
+        SBP_GPS_TIME_TIME_SOURCE_MASK))
 #define SBP_GPS_TIME_TIME_SOURCE_SET(flags, val)                        \
   do {                                                                  \
     (flags) = (u8)((flags) | (((val) & (SBP_GPS_TIME_TIME_SOURCE_MASK)) \
@@ -41,9 +42,9 @@
 #define SBP_MSG_GPS_TIME_GNSS 0x0104
 #define SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK (0x7)
 #define SBP_GPS_TIME_GNSS_TIME_SOURCE_SHIFT (0u)
-#define SBP_GPS_TIME_GNSS_TIME_SOURCE_GET(flags)      \
-  (((flags) >> SBP_GPS_TIME_GNSS_TIME_SOURCE_SHIFT) & \
-   SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK)
+#define SBP_GPS_TIME_GNSS_TIME_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_GPS_TIME_GNSS_TIME_SOURCE_SHIFT) & \
+        SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK))
 #define SBP_GPS_TIME_GNSS_TIME_SOURCE_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK)) \
@@ -62,9 +63,9 @@
 #define SBP_MSG_UTC_TIME 0x0103
 #define SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK (0x3)
 #define SBP_UTC_TIME_UTC_OFFSET_SOURCE_SHIFT (3u)
-#define SBP_UTC_TIME_UTC_OFFSET_SOURCE_GET(flags)      \
-  (((flags) >> SBP_UTC_TIME_UTC_OFFSET_SOURCE_SHIFT) & \
-   SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK)
+#define SBP_UTC_TIME_UTC_OFFSET_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_UTC_TIME_UTC_OFFSET_SOURCE_SHIFT) & \
+        SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK))
 #define SBP_UTC_TIME_UTC_OFFSET_SOURCE_SET(flags, val)                        \
   do {                                                                        \
     (flags) = (u8)((flags) | (((val) & (SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK)) \
@@ -76,8 +77,9 @@
 #define SBP_UTC_TIME_UTC_OFFSET_SOURCE_DECODED_THIS_SESSION (2)
 #define SBP_UTC_TIME_TIME_SOURCE_MASK (0x7)
 #define SBP_UTC_TIME_TIME_SOURCE_SHIFT (0u)
-#define SBP_UTC_TIME_TIME_SOURCE_GET(flags) \
-  (((flags) >> SBP_UTC_TIME_TIME_SOURCE_SHIFT) & SBP_UTC_TIME_TIME_SOURCE_MASK)
+#define SBP_UTC_TIME_TIME_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_UTC_TIME_TIME_SOURCE_SHIFT) & \
+        SBP_UTC_TIME_TIME_SOURCE_MASK))
 #define SBP_UTC_TIME_TIME_SOURCE_SET(flags, val)                        \
   do {                                                                  \
     (flags) = (u8)((flags) | (((val) & (SBP_UTC_TIME_TIME_SOURCE_MASK)) \
@@ -96,9 +98,9 @@
 #define SBP_MSG_UTC_TIME_GNSS 0x0105
 #define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_MASK (0x3)
 #define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SHIFT (3u)
-#define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_GET(flags)      \
-  (((flags) >> SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SHIFT) & \
-   SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_MASK)
+#define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SHIFT) & \
+        SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_MASK))
 #define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -111,9 +113,9 @@
 #define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_DECODED_THIS_SESSION (2)
 #define SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK (0x7)
 #define SBP_UTC_TIME_GNSS_TIME_SOURCE_SHIFT (0u)
-#define SBP_UTC_TIME_GNSS_TIME_SOURCE_GET(flags)      \
-  (((flags) >> SBP_UTC_TIME_GNSS_TIME_SOURCE_SHIFT) & \
-   SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK)
+#define SBP_UTC_TIME_GNSS_TIME_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_UTC_TIME_GNSS_TIME_SOURCE_SHIFT) & \
+        SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK))
 #define SBP_UTC_TIME_GNSS_TIME_SOURCE_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK)) \
@@ -132,9 +134,9 @@
 #define SBP_MSG_DOPS 0x0208
 #define SBP_DOPS_RAIM_REPAIR_FLAG_MASK (0x1)
 #define SBP_DOPS_RAIM_REPAIR_FLAG_SHIFT (7u)
-#define SBP_DOPS_RAIM_REPAIR_FLAG_GET(flags)      \
-  (((flags) >> SBP_DOPS_RAIM_REPAIR_FLAG_SHIFT) & \
-   SBP_DOPS_RAIM_REPAIR_FLAG_MASK)
+#define SBP_DOPS_RAIM_REPAIR_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_DOPS_RAIM_REPAIR_FLAG_SHIFT) & \
+        SBP_DOPS_RAIM_REPAIR_FLAG_MASK))
 #define SBP_DOPS_RAIM_REPAIR_FLAG_SET(flags, val)                        \
   do {                                                                   \
     (flags) = (u8)((flags) | (((val) & (SBP_DOPS_RAIM_REPAIR_FLAG_MASK)) \
@@ -144,7 +146,7 @@
 #define SBP_DOPS_FIX_MODE_MASK (0x7)
 #define SBP_DOPS_FIX_MODE_SHIFT (0u)
 #define SBP_DOPS_FIX_MODE_GET(flags) \
-  (((flags) >> SBP_DOPS_FIX_MODE_SHIFT) & SBP_DOPS_FIX_MODE_MASK)
+  ((u8)(((flags) >> SBP_DOPS_FIX_MODE_SHIFT) & SBP_DOPS_FIX_MODE_MASK))
 #define SBP_DOPS_FIX_MODE_SET(flags, val)                        \
   do {                                                           \
     (flags) = (u8)((flags) | (((val) & (SBP_DOPS_FIX_MODE_MASK)) \
@@ -168,7 +170,7 @@
 #define SBP_POS_ECEF_TOW_TYPE_MASK (0x1)
 #define SBP_POS_ECEF_TOW_TYPE_SHIFT (5u)
 #define SBP_POS_ECEF_TOW_TYPE_GET(flags) \
-  (((flags) >> SBP_POS_ECEF_TOW_TYPE_SHIFT) & SBP_POS_ECEF_TOW_TYPE_MASK)
+  ((u8)(((flags) >> SBP_POS_ECEF_TOW_TYPE_SHIFT) & SBP_POS_ECEF_TOW_TYPE_MASK))
 #define SBP_POS_ECEF_TOW_TYPE_SET(flags, val)                        \
   do {                                                               \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_TOW_TYPE_MASK)) \
@@ -179,9 +181,9 @@
 #define SBP_POS_ECEF_TOW_TYPE_OTHER (1)
 #define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_MASK (0x3)
 #define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SHIFT) & \
-   SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_MASK)
+#define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SHIFT) & \
+        SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_MASK))
 #define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                         \
     (flags) =                                                                  \
@@ -194,7 +196,7 @@
 #define SBP_POS_ECEF_FIX_MODE_MASK (0x7)
 #define SBP_POS_ECEF_FIX_MODE_SHIFT (0u)
 #define SBP_POS_ECEF_FIX_MODE_GET(flags) \
-  (((flags) >> SBP_POS_ECEF_FIX_MODE_SHIFT) & SBP_POS_ECEF_FIX_MODE_MASK)
+  ((u8)(((flags) >> SBP_POS_ECEF_FIX_MODE_SHIFT) & SBP_POS_ECEF_FIX_MODE_MASK))
 #define SBP_POS_ECEF_FIX_MODE_SET(flags, val)                        \
   do {                                                               \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_FIX_MODE_MASK)) \
@@ -217,9 +219,9 @@
 #define SBP_MSG_POS_ECEF_COV 0x0214
 #define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                         \
     (flags) =                                                                  \
@@ -231,9 +233,9 @@
 #define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_MASK (0x3)
 #define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SHIFT) & \
-   SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_MASK)
+#define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SHIFT) & \
+        SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_MASK))
 #define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SET(flags, val)              \
   do {                                                                         \
     (flags) = (u8)((flags) |                                                   \
@@ -245,9 +247,9 @@
 #define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_INS_USED (1)
 #define SBP_POS_ECEF_COV_FIX_MODE_MASK (0x7)
 #define SBP_POS_ECEF_COV_FIX_MODE_SHIFT (0u)
-#define SBP_POS_ECEF_COV_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_COV_FIX_MODE_SHIFT) & \
-   SBP_POS_ECEF_COV_FIX_MODE_MASK)
+#define SBP_POS_ECEF_COV_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_COV_FIX_MODE_SHIFT) & \
+        SBP_POS_ECEF_COV_FIX_MODE_MASK))
 #define SBP_POS_ECEF_COV_FIX_MODE_SET(flags, val)                        \
   do {                                                                   \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_COV_FIX_MODE_MASK)) \
@@ -270,9 +272,9 @@
 #define SBP_MSG_POS_LLH 0x020A
 #define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_POS_LLH_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_POS_LLH_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                    \
     (flags) =                                                             \
@@ -284,9 +286,9 @@
 #define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_MASK (0x3)
 #define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SHIFT) & \
-   SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_MASK)
+#define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SHIFT) & \
+        SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_MASK))
 #define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -299,7 +301,7 @@
 #define SBP_POS_LLH_FIX_MODE_MASK (0x7)
 #define SBP_POS_LLH_FIX_MODE_SHIFT (0u)
 #define SBP_POS_LLH_FIX_MODE_GET(flags) \
-  (((flags) >> SBP_POS_LLH_FIX_MODE_SHIFT) & SBP_POS_LLH_FIX_MODE_MASK)
+  ((u8)(((flags) >> SBP_POS_LLH_FIX_MODE_SHIFT) & SBP_POS_LLH_FIX_MODE_MASK))
 #define SBP_POS_LLH_FIX_MODE_SET(flags, val)                        \
   do {                                                              \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_FIX_MODE_MASK)) \
@@ -322,9 +324,9 @@
 #define SBP_MSG_POS_LLH_COV 0x0211
 #define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -336,9 +338,9 @@
 #define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_MASK (0x3)
 #define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SHIFT) & \
-   SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_MASK)
+#define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SHIFT) & \
+        SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_MASK))
 #define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -350,8 +352,9 @@
 #define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_INS_USED (1)
 #define SBP_POS_LLH_COV_FIX_MODE_MASK (0x7)
 #define SBP_POS_LLH_COV_FIX_MODE_SHIFT (0u)
-#define SBP_POS_LLH_COV_FIX_MODE_GET(flags) \
-  (((flags) >> SBP_POS_LLH_COV_FIX_MODE_SHIFT) & SBP_POS_LLH_COV_FIX_MODE_MASK)
+#define SBP_POS_LLH_COV_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_COV_FIX_MODE_SHIFT) & \
+        SBP_POS_LLH_COV_FIX_MODE_MASK))
 #define SBP_POS_LLH_COV_FIX_MODE_SET(flags, val)                        \
   do {                                                                  \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_COV_FIX_MODE_MASK)) \
@@ -380,9 +383,9 @@
 #define SBP_MSG_POS_LLH_ACC 0x0218
 #define SBP_POS_LLH_ACC_GEOID_MODEL_MASK (0x7)
 #define SBP_POS_LLH_ACC_GEOID_MODEL_SHIFT (4u)
-#define SBP_POS_LLH_ACC_GEOID_MODEL_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_ACC_GEOID_MODEL_SHIFT) & \
-   SBP_POS_LLH_ACC_GEOID_MODEL_MASK)
+#define SBP_POS_LLH_ACC_GEOID_MODEL_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_ACC_GEOID_MODEL_SHIFT) & \
+        SBP_POS_LLH_ACC_GEOID_MODEL_MASK))
 #define SBP_POS_LLH_ACC_GEOID_MODEL_SET(flags, val)                        \
   do {                                                                     \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_ACC_GEOID_MODEL_MASK)) \
@@ -394,9 +397,9 @@
 #define SBP_POS_LLH_ACC_GEOID_MODEL_EGM2008 (2)
 #define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_MASK (0xf)
 #define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SHIFT (0u)
-#define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SHIFT) & \
-   SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_MASK)
+#define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SHIFT) & \
+        SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_MASK))
 #define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SET(flags, val)                  \
   do {                                                                    \
     (flags) =                                                             \
@@ -409,9 +412,9 @@
 #define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_9545 (3)
 #define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -423,9 +426,9 @@
 #define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_MASK (0x3)
 #define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SHIFT) & \
-   SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_MASK)
+#define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SHIFT) & \
+        SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_MASK))
 #define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -437,8 +440,9 @@
 #define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_INS_USED (1)
 #define SBP_POS_LLH_ACC_FIX_MODE_MASK (0x7)
 #define SBP_POS_LLH_ACC_FIX_MODE_SHIFT (0u)
-#define SBP_POS_LLH_ACC_FIX_MODE_GET(flags) \
-  (((flags) >> SBP_POS_LLH_ACC_FIX_MODE_SHIFT) & SBP_POS_LLH_ACC_FIX_MODE_MASK)
+#define SBP_POS_LLH_ACC_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_ACC_FIX_MODE_SHIFT) & \
+        SBP_POS_LLH_ACC_FIX_MODE_MASK))
 #define SBP_POS_LLH_ACC_FIX_MODE_SET(flags, val)                        \
   do {                                                                  \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_ACC_FIX_MODE_MASK)) \
@@ -461,9 +465,9 @@
 #define SBP_MSG_BASELINE_ECEF 0x020B
 #define SBP_BASELINE_ECEF_FIX_MODE_MASK (0x7)
 #define SBP_BASELINE_ECEF_FIX_MODE_SHIFT (0u)
-#define SBP_BASELINE_ECEF_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_BASELINE_ECEF_FIX_MODE_SHIFT) & \
-   SBP_BASELINE_ECEF_FIX_MODE_MASK)
+#define SBP_BASELINE_ECEF_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_ECEF_FIX_MODE_SHIFT) & \
+        SBP_BASELINE_ECEF_FIX_MODE_MASK))
 #define SBP_BASELINE_ECEF_FIX_MODE_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_ECEF_FIX_MODE_MASK)) \
@@ -483,9 +487,9 @@
 #define SBP_MSG_BASELINE_NED 0x020C
 #define SBP_BASELINE_NED_FIX_MODE_MASK (0x7)
 #define SBP_BASELINE_NED_FIX_MODE_SHIFT (0u)
-#define SBP_BASELINE_NED_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_BASELINE_NED_FIX_MODE_SHIFT) & \
-   SBP_BASELINE_NED_FIX_MODE_MASK)
+#define SBP_BASELINE_NED_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_NED_FIX_MODE_SHIFT) & \
+        SBP_BASELINE_NED_FIX_MODE_MASK))
 #define SBP_BASELINE_NED_FIX_MODE_SET(flags, val)                        \
   do {                                                                   \
     (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_NED_FIX_MODE_MASK)) \
@@ -505,9 +509,9 @@
 #define SBP_MSG_VEL_ECEF 0x020D
 #define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                     \
     (flags) =                                                              \
@@ -519,9 +523,9 @@
 #define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_VEL_ECEF_INS_NAVIGATION_MODE_MASK (0x3)
 #define SBP_VEL_ECEF_INS_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_VEL_ECEF_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_VEL_ECEF_INS_NAVIGATION_MODE_MASK)
+#define SBP_VEL_ECEF_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_VEL_ECEF_INS_NAVIGATION_MODE_MASK))
 #define SBP_VEL_ECEF_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                    \
     (flags) =                                                             \
@@ -533,9 +537,9 @@
 #define SBP_VEL_ECEF_INS_NAVIGATION_MODE_INS_USED (1)
 #define SBP_VEL_ECEF_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_ECEF_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_ECEF_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_ECEF_VELOCITY_MODE_MASK)
+#define SBP_VEL_ECEF_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_ECEF_VELOCITY_MODE_MASK))
 #define SBP_VEL_ECEF_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_ECEF_VELOCITY_MODE_MASK)) \
@@ -555,9 +559,9 @@
 #define SBP_MSG_VEL_ECEF_COV 0x0215
 #define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                         \
     (flags) =                                                                  \
@@ -569,9 +573,9 @@
 #define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_MASK (0x3)
 #define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_MASK)
+#define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_MASK))
 #define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -583,9 +587,9 @@
 #define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_INS_USED (1)
 #define SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_ECEF_COV_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_ECEF_COV_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_COV_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK)
+#define SBP_VEL_ECEF_COV_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_COV_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK))
 #define SBP_VEL_ECEF_COV_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                        \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK)) \
@@ -605,9 +609,9 @@
 #define SBP_MSG_VEL_NED 0x020E
 #define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_VEL_NED_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_VEL_NED_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                    \
     (flags) =                                                             \
@@ -619,9 +623,9 @@
 #define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_VEL_NED_INS_NAVIGATION_MODE_MASK (0x3)
 #define SBP_VEL_NED_INS_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_VEL_NED_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_VEL_NED_INS_NAVIGATION_MODE_MASK)
+#define SBP_VEL_NED_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_VEL_NED_INS_NAVIGATION_MODE_MASK))
 #define SBP_VEL_NED_INS_NAVIGATION_MODE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_INS_NAVIGATION_MODE_MASK)) \
@@ -632,9 +636,9 @@
 #define SBP_VEL_NED_INS_NAVIGATION_MODE_INS_USED (1)
 #define SBP_VEL_NED_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_NED_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_NED_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_NED_VELOCITY_MODE_MASK)
+#define SBP_VEL_NED_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_NED_VELOCITY_MODE_MASK))
 #define SBP_VEL_NED_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                   \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_VELOCITY_MODE_MASK)) \
@@ -654,9 +658,9 @@
 #define SBP_MSG_VEL_NED_COV 0x0212
 #define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_MASK (0x1)
 #define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SHIFT (5u)
-#define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
-   SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_MASK)
+#define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
+        SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_MASK))
 #define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -668,9 +672,9 @@
 #define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_OTHER (1)
 #define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_MASK (0x3)
 #define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_VEL_NED_COV_INS_NAVIGATION_MODE_MASK)
+#define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_VEL_NED_COV_INS_NAVIGATION_MODE_MASK))
 #define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -682,9 +686,9 @@
 #define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_INS_USED (1)
 #define SBP_VEL_NED_COV_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_NED_COV_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_NED_COV_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_COV_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_NED_COV_VELOCITY_MODE_MASK)
+#define SBP_VEL_NED_COV_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_COV_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_NED_COV_VELOCITY_MODE_MASK))
 #define SBP_VEL_NED_COV_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_COV_VELOCITY_MODE_MASK)) \
@@ -704,9 +708,9 @@
 #define SBP_MSG_POS_ECEF_GNSS 0x0229
 #define SBP_POS_ECEF_GNSS_FIX_MODE_MASK (0x7)
 #define SBP_POS_ECEF_GNSS_FIX_MODE_SHIFT (0u)
-#define SBP_POS_ECEF_GNSS_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_GNSS_FIX_MODE_SHIFT) & \
-   SBP_POS_ECEF_GNSS_FIX_MODE_MASK)
+#define SBP_POS_ECEF_GNSS_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_GNSS_FIX_MODE_SHIFT) & \
+        SBP_POS_ECEF_GNSS_FIX_MODE_MASK))
 #define SBP_POS_ECEF_GNSS_FIX_MODE_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_GNSS_FIX_MODE_MASK)) \
@@ -728,9 +732,9 @@
 #define SBP_MSG_POS_ECEF_COV_GNSS 0x0234
 #define SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK (0x7)
 #define SBP_POS_ECEF_COV_GNSS_FIX_MODE_SHIFT (0u)
-#define SBP_POS_ECEF_COV_GNSS_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_COV_GNSS_FIX_MODE_SHIFT) & \
-   SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK)
+#define SBP_POS_ECEF_COV_GNSS_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_COV_GNSS_FIX_MODE_SHIFT) & \
+        SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK))
 #define SBP_POS_ECEF_COV_GNSS_FIX_MODE_SET(flags, val)                        \
   do {                                                                        \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK)) \
@@ -752,9 +756,9 @@
 #define SBP_MSG_POS_LLH_GNSS 0x022A
 #define SBP_POS_LLH_GNSS_FIX_MODE_MASK (0x7)
 #define SBP_POS_LLH_GNSS_FIX_MODE_SHIFT (0u)
-#define SBP_POS_LLH_GNSS_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_GNSS_FIX_MODE_SHIFT) & \
-   SBP_POS_LLH_GNSS_FIX_MODE_MASK)
+#define SBP_POS_LLH_GNSS_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_GNSS_FIX_MODE_SHIFT) & \
+        SBP_POS_LLH_GNSS_FIX_MODE_MASK))
 #define SBP_POS_LLH_GNSS_FIX_MODE_SET(flags, val)                        \
   do {                                                                   \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_GNSS_FIX_MODE_MASK)) \
@@ -776,9 +780,9 @@
 #define SBP_MSG_POS_LLH_COV_GNSS 0x0231
 #define SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK (0x7)
 #define SBP_POS_LLH_COV_GNSS_FIX_MODE_SHIFT (0u)
-#define SBP_POS_LLH_COV_GNSS_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_COV_GNSS_FIX_MODE_SHIFT) & \
-   SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK)
+#define SBP_POS_LLH_COV_GNSS_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_COV_GNSS_FIX_MODE_SHIFT) & \
+        SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK))
 #define SBP_POS_LLH_COV_GNSS_FIX_MODE_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK)) \
@@ -801,9 +805,9 @@
 #define SBP_MSG_VEL_ECEF_GNSS 0x022D
 #define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK)
+#define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK))
 #define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK)) \
@@ -822,9 +826,9 @@
 #define SBP_MSG_VEL_ECEF_COV_GNSS 0x0235
 #define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_MASK)
+#define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_MASK))
 #define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -844,9 +848,9 @@
 #define SBP_MSG_VEL_NED_GNSS 0x022E
 #define SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_NED_GNSS_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_NED_GNSS_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_GNSS_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK)
+#define SBP_VEL_NED_GNSS_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_GNSS_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK))
 #define SBP_VEL_NED_GNSS_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                        \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK)) \
@@ -865,9 +869,9 @@
 #define SBP_MSG_VEL_NED_COV_GNSS 0x0232
 #define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_MASK)
+#define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_MASK))
 #define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -887,9 +891,9 @@
 #define SBP_MSG_VEL_BODY 0x0213
 #define SBP_VEL_BODY_INS_NAVIGATION_MODE_MASK (0x3)
 #define SBP_VEL_BODY_INS_NAVIGATION_MODE_SHIFT (3u)
-#define SBP_VEL_BODY_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_BODY_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_VEL_BODY_INS_NAVIGATION_MODE_MASK)
+#define SBP_VEL_BODY_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_BODY_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_VEL_BODY_INS_NAVIGATION_MODE_MASK))
 #define SBP_VEL_BODY_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                    \
     (flags) =                                                             \
@@ -901,9 +905,9 @@
 #define SBP_VEL_BODY_INS_NAVIGATION_MODE_INS_USED (1)
 #define SBP_VEL_BODY_VELOCITY_MODE_MASK (0x7)
 #define SBP_VEL_BODY_VELOCITY_MODE_SHIFT (0u)
-#define SBP_VEL_BODY_VELOCITY_MODE_GET(flags)      \
-  (((flags) >> SBP_VEL_BODY_VELOCITY_MODE_SHIFT) & \
-   SBP_VEL_BODY_VELOCITY_MODE_MASK)
+#define SBP_VEL_BODY_VELOCITY_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_VEL_BODY_VELOCITY_MODE_SHIFT) & \
+        SBP_VEL_BODY_VELOCITY_MODE_MASK))
 #define SBP_VEL_BODY_VELOCITY_MODE_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_VEL_BODY_VELOCITY_MODE_MASK)) \
@@ -944,9 +948,9 @@
 #define SBP_MSG_POS_ECEF_DEP_A 0x0200
 #define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK (0x1)
 #define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT (4u)
-#define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
-   SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)
+#define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
+        SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK))
 #define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -958,9 +962,9 @@
 #define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SOLUTION_CAME_FROM_RAIM_REPAIR (1)
 #define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK (0x1)
 #define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT (3u)
-#define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
-   SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
+#define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
+        SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))
 #define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)              \
   do {                                                                         \
     (flags) = (u8)((flags) |                                                   \
@@ -973,9 +977,9 @@
 #define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_AVAILABLE (1)
 #define SBP_POS_ECEF_DEP_A_FIX_MODE_MASK (0x7)
 #define SBP_POS_ECEF_DEP_A_FIX_MODE_SHIFT (0u)
-#define SBP_POS_ECEF_DEP_A_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_ECEF_DEP_A_FIX_MODE_SHIFT) & \
-   SBP_POS_ECEF_DEP_A_FIX_MODE_MASK)
+#define SBP_POS_ECEF_DEP_A_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_ECEF_DEP_A_FIX_MODE_SHIFT) & \
+        SBP_POS_ECEF_DEP_A_FIX_MODE_MASK))
 #define SBP_POS_ECEF_DEP_A_FIX_MODE_SET(flags, val)                        \
   do {                                                                     \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_DEP_A_FIX_MODE_MASK)) \
@@ -994,9 +998,9 @@
 #define SBP_MSG_POS_LLH_DEP_A 0x0201
 #define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_MASK (0x1)
 #define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SHIFT (5u)
-#define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
-   SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_MASK)
+#define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
+        SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_MASK))
 #define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -1008,9 +1012,9 @@
 #define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SOLUTION_CAME_FROM_RAIM_REPAIR (1)
 #define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_MASK (0x1)
 #define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT (4u)
-#define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
-   SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
+#define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
+        SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))
 #define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -1023,9 +1027,9 @@
 #define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_AVAILABLE (1)
 #define SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK (0x1)
 #define SBP_POS_LLH_DEP_A_HEIGHT_MODE_SHIFT (3u)
-#define SBP_POS_LLH_DEP_A_HEIGHT_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_DEP_A_HEIGHT_MODE_SHIFT) & \
-   SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK)
+#define SBP_POS_LLH_DEP_A_HEIGHT_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_DEP_A_HEIGHT_MODE_SHIFT) & \
+        SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK))
 #define SBP_POS_LLH_DEP_A_HEIGHT_MODE_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK)) \
@@ -1036,9 +1040,9 @@
 #define SBP_POS_LLH_DEP_A_HEIGHT_MODE_HEIGHT_ABOVE_MEAN_SEA_LEVEL (1)
 #define SBP_POS_LLH_DEP_A_FIX_MODE_MASK (0x7)
 #define SBP_POS_LLH_DEP_A_FIX_MODE_SHIFT (0u)
-#define SBP_POS_LLH_DEP_A_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_POS_LLH_DEP_A_FIX_MODE_SHIFT) & \
-   SBP_POS_LLH_DEP_A_FIX_MODE_MASK)
+#define SBP_POS_LLH_DEP_A_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_POS_LLH_DEP_A_FIX_MODE_SHIFT) & \
+        SBP_POS_LLH_DEP_A_FIX_MODE_MASK))
 #define SBP_POS_LLH_DEP_A_FIX_MODE_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_DEP_A_FIX_MODE_MASK)) \
@@ -1057,9 +1061,9 @@
 #define SBP_MSG_BASELINE_ECEF_DEP_A 0x0202
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK (0x1)
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT (4u)
-#define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
-  (((flags) >> SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
-   SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)
+#define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
+        SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK))
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -1072,9 +1076,9 @@
   (1)
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK (0x1)
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT (3u)
-#define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
-  (((flags) >> SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
-   SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
+#define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
+        SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)        \
   do {                                                                        \
     (flags) =                                                                 \
@@ -1089,9 +1093,9 @@
   (1)
 #define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_MASK (0x7)
 #define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SHIFT (0u)
-#define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SHIFT) & \
-   SBP_BASELINE_ECEF_DEP_A_FIX_MODE_MASK)
+#define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SHIFT) & \
+        SBP_BASELINE_ECEF_DEP_A_FIX_MODE_MASK))
 #define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SET(flags, val)                  \
   do {                                                                    \
     (flags) =                                                             \
@@ -1110,9 +1114,9 @@
 #define SBP_MSG_BASELINE_NED_DEP_A 0x0203
 #define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_MASK (0x1)
 #define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SHIFT (4u)
-#define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
-  (((flags) >> SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
-   SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_MASK)
+#define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
+        SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_MASK))
 #define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)              \
   do {                                                                       \
     (flags) = (u8)((flags) |                                                 \
@@ -1125,9 +1129,9 @@
   (1)
 #define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_MASK (0x1)
 #define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT (3u)
-#define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
-  (((flags) >> SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
-   SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
+#define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
+        SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))
 #define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)        \
   do {                                                                       \
     (flags) =                                                                \
@@ -1142,9 +1146,9 @@
   (1)
 #define SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK (0x7)
 #define SBP_BASELINE_NED_DEP_A_FIX_MODE_SHIFT (0u)
-#define SBP_BASELINE_NED_DEP_A_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_BASELINE_NED_DEP_A_FIX_MODE_SHIFT) & \
-   SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK)
+#define SBP_BASELINE_NED_DEP_A_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_NED_DEP_A_FIX_MODE_SHIFT) & \
+        SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK))
 #define SBP_BASELINE_NED_DEP_A_FIX_MODE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK)) \
@@ -1176,9 +1180,9 @@
 #define SBP_MSG_BASELINE_HEADING_DEP_A 0x0207
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_MASK (0x1)
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SHIFT (4u)
-#define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
-  (((flags) >> SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
-   SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_MASK)
+#define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
+        SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_MASK))
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)        \
   do {                                                                     \
     (flags) =                                                              \
@@ -1192,9 +1196,9 @@
   (1)
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_MASK (0x1)
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT (3u)
-#define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
-  (((flags) >> SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
-   SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
+#define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
+        SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)   \
   do {                                                                      \
     (flags) = (u8)(                                                         \
@@ -1209,9 +1213,9 @@
   (1)
 #define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_MASK (0x7)
 #define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SHIFT (0u)
-#define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SHIFT) & \
-   SBP_BASELINE_HEADING_DEP_A_FIX_MODE_MASK)
+#define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SHIFT) & \
+        SBP_BASELINE_HEADING_DEP_A_FIX_MODE_MASK))
 #define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -1231,9 +1235,9 @@
 #define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK (0x7)
 #define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT (0u)
 #define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_GET(flags) \
-  (((flags) >>                                                                \
-    SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT) &       \
-   SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK)
+  ((u8)(((flags) >>                                                           \
+         SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT) &  \
+        SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK))
 #define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SET(flags,     \
                                                                        val)       \
   do {                                                                            \
@@ -1261,9 +1265,10 @@
 #define SBP_MSG_PROTECTION_LEVEL 0x0217
 #define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK (0x7)
 #define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT (0u)
-#define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK)
+#define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_GET(flags) \
+  ((u32)(((flags) >>                                                    \
+          SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK))
 #define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SET(flags, val)   \
   do {                                                                         \
     (flags) = (u32)(                                                           \
@@ -1274,9 +1279,9 @@
 
 #define SBP_PROTECTION_LEVEL_FIX_MODE_MASK (0x7)
 #define SBP_PROTECTION_LEVEL_FIX_MODE_SHIFT (15u)
-#define SBP_PROTECTION_LEVEL_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_FIX_MODE_SHIFT) & \
-   SBP_PROTECTION_LEVEL_FIX_MODE_MASK)
+#define SBP_PROTECTION_LEVEL_FIX_MODE_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_FIX_MODE_SHIFT) & \
+         SBP_PROTECTION_LEVEL_FIX_MODE_MASK))
 #define SBP_PROTECTION_LEVEL_FIX_MODE_SET(flags, val)                         \
   do {                                                                        \
     (flags) = (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_FIX_MODE_MASK)) \
@@ -1292,9 +1297,9 @@
 #define SBP_PROTECTION_LEVEL_FIX_MODE_SBAS_POSITION (6)
 #define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_MASK (0x3)
 #define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SHIFT (18u)
-#define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SHIFT) & \
-   SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_MASK)
+#define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SHIFT) & \
+         SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_MASK))
 #define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SET(flags, val)         \
   do {                                                                        \
     (flags) =                                                                 \
@@ -1307,9 +1312,9 @@
 #define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_INS_USED (1)
 #define SBP_PROTECTION_LEVEL_TIME_STATUS_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_TIME_STATUS_SHIFT (20u)
-#define SBP_PROTECTION_LEVEL_TIME_STATUS_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_TIME_STATUS_SHIFT) & \
-   SBP_PROTECTION_LEVEL_TIME_STATUS_MASK)
+#define SBP_PROTECTION_LEVEL_TIME_STATUS_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_TIME_STATUS_SHIFT) & \
+         SBP_PROTECTION_LEVEL_TIME_STATUS_MASK))
 #define SBP_PROTECTION_LEVEL_TIME_STATUS_SET(flags, val)                   \
   do {                                                                     \
     (flags) =                                                              \
@@ -1321,9 +1326,9 @@
 #define SBP_PROTECTION_LEVEL_TIME_STATUS_OTHER (1)
 #define SBP_PROTECTION_LEVEL_VELOCITY_VALID_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_VELOCITY_VALID_SHIFT (21u)
-#define SBP_PROTECTION_LEVEL_VELOCITY_VALID_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_VELOCITY_VALID_SHIFT) & \
-   SBP_PROTECTION_LEVEL_VELOCITY_VALID_MASK)
+#define SBP_PROTECTION_LEVEL_VELOCITY_VALID_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_VELOCITY_VALID_SHIFT) & \
+         SBP_PROTECTION_LEVEL_VELOCITY_VALID_MASK))
 #define SBP_PROTECTION_LEVEL_VELOCITY_VALID_SET(flags, val)                   \
   do {                                                                        \
     (flags) =                                                                 \
@@ -1333,9 +1338,9 @@
 
 #define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SHIFT (22u)
-#define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SHIFT) & \
-   SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK)
+#define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SHIFT) & \
+         SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK))
 #define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SET(flags, val)                   \
   do {                                                                        \
     (flags) =                                                                 \
@@ -1345,9 +1350,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SHIFT (23u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SET(flags, val)                   \
   do {                                                                        \
     (flags) =                                                                 \
@@ -1357,9 +1362,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SHIFT (24u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SET(flags, val)                   \
   do {                                                                        \
     (flags) =                                                                 \
@@ -1369,9 +1374,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SHIFT (25u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -1381,9 +1386,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SHIFT (26u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -1393,9 +1398,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SHIFT (27u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -1405,9 +1410,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SHIFT (28u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -1417,9 +1422,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SHIFT (29u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -1429,9 +1434,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SHIFT (30u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -1441,9 +1446,9 @@
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK (0x1)
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SHIFT (31u)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_GET(flags)      \
-  (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SHIFT) & \
-   SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK)
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_GET(flags)            \
+  ((u32)(((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SHIFT) & \
+         SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK))
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \

--- a/c/include/libsbp/navigation_macros.h
+++ b/c/include/libsbp/navigation_macros.h
@@ -23,10 +23,10 @@
 #define SBP_GPS_TIME_TIME_SOURCE_SHIFT (0u)
 #define SBP_GPS_TIME_TIME_SOURCE_GET(flags) \
   (((flags) >> SBP_GPS_TIME_TIME_SOURCE_SHIFT) & SBP_GPS_TIME_TIME_SOURCE_MASK)
-#define SBP_GPS_TIME_TIME_SOURCE_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_GPS_TIME_TIME_SOURCE_MASK)) \
-                 << (SBP_GPS_TIME_TIME_SOURCE_SHIFT)));    \
+#define SBP_GPS_TIME_TIME_SOURCE_SET(flags, val)                        \
+  do {                                                                  \
+    (flags) = (u8)((flags) | (((val) & (SBP_GPS_TIME_TIME_SOURCE_MASK)) \
+                              << (SBP_GPS_TIME_TIME_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_GPS_TIME_TIME_SOURCE_NONE (0)
@@ -44,10 +44,10 @@
 #define SBP_GPS_TIME_GNSS_TIME_SOURCE_GET(flags)      \
   (((flags) >> SBP_GPS_TIME_GNSS_TIME_SOURCE_SHIFT) & \
    SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK)
-#define SBP_GPS_TIME_GNSS_TIME_SOURCE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK)) \
-                 << (SBP_GPS_TIME_GNSS_TIME_SOURCE_SHIFT)));    \
+#define SBP_GPS_TIME_GNSS_TIME_SOURCE_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_GPS_TIME_GNSS_TIME_SOURCE_MASK)) \
+                              << (SBP_GPS_TIME_GNSS_TIME_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_GPS_TIME_GNSS_TIME_SOURCE_NONE (0)
@@ -65,10 +65,10 @@
 #define SBP_UTC_TIME_UTC_OFFSET_SOURCE_GET(flags)      \
   (((flags) >> SBP_UTC_TIME_UTC_OFFSET_SOURCE_SHIFT) & \
    SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK)
-#define SBP_UTC_TIME_UTC_OFFSET_SOURCE_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK)) \
-                 << (SBP_UTC_TIME_UTC_OFFSET_SOURCE_SHIFT)));    \
+#define SBP_UTC_TIME_UTC_OFFSET_SOURCE_SET(flags, val)                        \
+  do {                                                                        \
+    (flags) = (u8)((flags) | (((val) & (SBP_UTC_TIME_UTC_OFFSET_SOURCE_MASK)) \
+                              << (SBP_UTC_TIME_UTC_OFFSET_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_UTC_TIME_UTC_OFFSET_SOURCE_FACTORY_DEFAULT (0)
@@ -78,10 +78,10 @@
 #define SBP_UTC_TIME_TIME_SOURCE_SHIFT (0u)
 #define SBP_UTC_TIME_TIME_SOURCE_GET(flags) \
   (((flags) >> SBP_UTC_TIME_TIME_SOURCE_SHIFT) & SBP_UTC_TIME_TIME_SOURCE_MASK)
-#define SBP_UTC_TIME_TIME_SOURCE_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_UTC_TIME_TIME_SOURCE_MASK)) \
-                 << (SBP_UTC_TIME_TIME_SOURCE_SHIFT)));    \
+#define SBP_UTC_TIME_TIME_SOURCE_SET(flags, val)                        \
+  do {                                                                  \
+    (flags) = (u8)((flags) | (((val) & (SBP_UTC_TIME_TIME_SOURCE_MASK)) \
+                              << (SBP_UTC_TIME_TIME_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_UTC_TIME_TIME_SOURCE_NONE (0)
@@ -99,10 +99,11 @@
 #define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_GET(flags)      \
   (((flags) >> SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SHIFT) & \
    SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_MASK)
-#define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_MASK)) \
-                 << (SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SHIFT)));    \
+#define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_MASK)) \
+                        << (SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_UTC_TIME_GNSS_UTC_OFFSET_SOURCE_FACTORY_DEFAULT (0)
@@ -113,10 +114,10 @@
 #define SBP_UTC_TIME_GNSS_TIME_SOURCE_GET(flags)      \
   (((flags) >> SBP_UTC_TIME_GNSS_TIME_SOURCE_SHIFT) & \
    SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK)
-#define SBP_UTC_TIME_GNSS_TIME_SOURCE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK)) \
-                 << (SBP_UTC_TIME_GNSS_TIME_SOURCE_SHIFT)));    \
+#define SBP_UTC_TIME_GNSS_TIME_SOURCE_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_UTC_TIME_GNSS_TIME_SOURCE_MASK)) \
+                              << (SBP_UTC_TIME_GNSS_TIME_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_UTC_TIME_GNSS_TIME_SOURCE_NONE (0)
@@ -134,20 +135,20 @@
 #define SBP_DOPS_RAIM_REPAIR_FLAG_GET(flags)      \
   (((flags) >> SBP_DOPS_RAIM_REPAIR_FLAG_SHIFT) & \
    SBP_DOPS_RAIM_REPAIR_FLAG_MASK)
-#define SBP_DOPS_RAIM_REPAIR_FLAG_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_DOPS_RAIM_REPAIR_FLAG_MASK)) \
-                 << (SBP_DOPS_RAIM_REPAIR_FLAG_SHIFT)));    \
+#define SBP_DOPS_RAIM_REPAIR_FLAG_SET(flags, val)                        \
+  do {                                                                   \
+    (flags) = (u8)((flags) | (((val) & (SBP_DOPS_RAIM_REPAIR_FLAG_MASK)) \
+                              << (SBP_DOPS_RAIM_REPAIR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_DOPS_FIX_MODE_MASK (0x7)
 #define SBP_DOPS_FIX_MODE_SHIFT (0u)
 #define SBP_DOPS_FIX_MODE_GET(flags) \
   (((flags) >> SBP_DOPS_FIX_MODE_SHIFT) & SBP_DOPS_FIX_MODE_MASK)
-#define SBP_DOPS_FIX_MODE_SET(flags, val)                                \
-  do {                                                                   \
-    ((flags) |=                                                          \
-     (((val) & (SBP_DOPS_FIX_MODE_MASK)) << (SBP_DOPS_FIX_MODE_SHIFT))); \
+#define SBP_DOPS_FIX_MODE_SET(flags, val)                        \
+  do {                                                           \
+    (flags) = (u8)((flags) | (((val) & (SBP_DOPS_FIX_MODE_MASK)) \
+                              << (SBP_DOPS_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_DOPS_FIX_MODE_INVALID (0)
@@ -168,10 +169,10 @@
 #define SBP_POS_ECEF_TOW_TYPE_SHIFT (5u)
 #define SBP_POS_ECEF_TOW_TYPE_GET(flags) \
   (((flags) >> SBP_POS_ECEF_TOW_TYPE_SHIFT) & SBP_POS_ECEF_TOW_TYPE_MASK)
-#define SBP_POS_ECEF_TOW_TYPE_SET(flags, val)           \
-  do {                                                  \
-    ((flags) |= (((val) & (SBP_POS_ECEF_TOW_TYPE_MASK)) \
-                 << (SBP_POS_ECEF_TOW_TYPE_SHIFT)));    \
+#define SBP_POS_ECEF_TOW_TYPE_SET(flags, val)                        \
+  do {                                                               \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_TOW_TYPE_MASK)) \
+                              << (SBP_POS_ECEF_TOW_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_TOW_TYPE_TIME_OF_MEASUREMENT (0)
@@ -181,10 +182,11 @@
 #define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SHIFT) & \
    SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_MASK)
-#define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                  \
-    ((flags) |= (((val) & (SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_MASK)) \
-                 << (SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u8)((flags) | (((val) & (SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_MASK)) \
+                        << (SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_INERTIAL_NAVIGATION_MODE_NONE (0)
@@ -193,10 +195,10 @@
 #define SBP_POS_ECEF_FIX_MODE_SHIFT (0u)
 #define SBP_POS_ECEF_FIX_MODE_GET(flags) \
   (((flags) >> SBP_POS_ECEF_FIX_MODE_SHIFT) & SBP_POS_ECEF_FIX_MODE_MASK)
-#define SBP_POS_ECEF_FIX_MODE_SET(flags, val)           \
-  do {                                                  \
-    ((flags) |= (((val) & (SBP_POS_ECEF_FIX_MODE_MASK)) \
-                 << (SBP_POS_ECEF_FIX_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_FIX_MODE_SET(flags, val)                        \
+  do {                                                               \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_FIX_MODE_MASK)) \
+                              << (SBP_POS_ECEF_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_FIX_MODE_INVALID (0)
@@ -218,10 +220,11 @@
 #define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                                  \
-    ((flags) |= (((val) & (SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u8)((flags) | (((val) & (SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_COV_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -231,10 +234,11 @@
 #define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SHIFT) & \
    SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_MASK)
-#define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                      \
-    ((flags) |= (((val) & (SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_MASK)) \
-                 << (SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SET(flags, val)              \
+  do {                                                                         \
+    (flags) = (u8)((flags) |                                                   \
+                   (((val) & (SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_MASK)) \
+                    << (SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_COV_INERTIAL_NAVIGATION_MODE_NONE (0)
@@ -244,10 +248,10 @@
 #define SBP_POS_ECEF_COV_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_COV_FIX_MODE_SHIFT) & \
    SBP_POS_ECEF_COV_FIX_MODE_MASK)
-#define SBP_POS_ECEF_COV_FIX_MODE_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_POS_ECEF_COV_FIX_MODE_MASK)) \
-                 << (SBP_POS_ECEF_COV_FIX_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_COV_FIX_MODE_SET(flags, val)                        \
+  do {                                                                   \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_COV_FIX_MODE_MASK)) \
+                              << (SBP_POS_ECEF_COV_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_COV_FIX_MODE_INVALID (0)
@@ -269,10 +273,11 @@
 #define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_POS_LLH_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_POS_LLH_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u8)((flags) | (((val) & (SBP_POS_LLH_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_POS_LLH_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -282,10 +287,11 @@
 #define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SHIFT) & \
    SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_MASK)
-#define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_MASK)) \
-                 << (SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_MASK)) \
+                        << (SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_INERTIAL_NAVIGATION_MODE_NONE (0)
@@ -294,10 +300,10 @@
 #define SBP_POS_LLH_FIX_MODE_SHIFT (0u)
 #define SBP_POS_LLH_FIX_MODE_GET(flags) \
   (((flags) >> SBP_POS_LLH_FIX_MODE_SHIFT) & SBP_POS_LLH_FIX_MODE_MASK)
-#define SBP_POS_LLH_FIX_MODE_SET(flags, val)                                   \
-  do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_POS_LLH_FIX_MODE_MASK)) << (SBP_POS_LLH_FIX_MODE_SHIFT))); \
+#define SBP_POS_LLH_FIX_MODE_SET(flags, val)                        \
+  do {                                                              \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_FIX_MODE_MASK)) \
+                              << (SBP_POS_LLH_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_FIX_MODE_INVALID (0)
@@ -319,10 +325,11 @@
 #define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_COV_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -332,10 +339,11 @@
 #define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SHIFT) & \
    SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_MASK)
-#define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_MASK)) \
-                 << (SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_MASK)) \
+                    << (SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_COV_INERTIAL_NAVIGATION_MODE_NONE (0)
@@ -344,10 +352,10 @@
 #define SBP_POS_LLH_COV_FIX_MODE_SHIFT (0u)
 #define SBP_POS_LLH_COV_FIX_MODE_GET(flags) \
   (((flags) >> SBP_POS_LLH_COV_FIX_MODE_SHIFT) & SBP_POS_LLH_COV_FIX_MODE_MASK)
-#define SBP_POS_LLH_COV_FIX_MODE_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_POS_LLH_COV_FIX_MODE_MASK)) \
-                 << (SBP_POS_LLH_COV_FIX_MODE_SHIFT)));    \
+#define SBP_POS_LLH_COV_FIX_MODE_SET(flags, val)                        \
+  do {                                                                  \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_COV_FIX_MODE_MASK)) \
+                              << (SBP_POS_LLH_COV_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_COV_FIX_MODE_INVALID (0)
@@ -375,10 +383,10 @@
 #define SBP_POS_LLH_ACC_GEOID_MODEL_GET(flags)      \
   (((flags) >> SBP_POS_LLH_ACC_GEOID_MODEL_SHIFT) & \
    SBP_POS_LLH_ACC_GEOID_MODEL_MASK)
-#define SBP_POS_LLH_ACC_GEOID_MODEL_SET(flags, val)           \
-  do {                                                        \
-    ((flags) |= (((val) & (SBP_POS_LLH_ACC_GEOID_MODEL_MASK)) \
-                 << (SBP_POS_LLH_ACC_GEOID_MODEL_SHIFT)));    \
+#define SBP_POS_LLH_ACC_GEOID_MODEL_SET(flags, val)                        \
+  do {                                                                     \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_ACC_GEOID_MODEL_MASK)) \
+                              << (SBP_POS_LLH_ACC_GEOID_MODEL_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_ACC_GEOID_MODEL_NO_MODEL (0)
@@ -389,10 +397,11 @@
 #define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_GET(flags)      \
   (((flags) >> SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SHIFT) & \
    SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_MASK)
-#define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_MASK)) \
-                 << (SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SHIFT)));    \
+#define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SET(flags, val)                  \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u8)((flags) | (((val) & (SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_MASK)) \
+                        << (SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_ACC_CONFIDENCE_LEVEL_3935 (1)
@@ -403,10 +412,11 @@
 #define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_ACC_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -416,10 +426,11 @@
 #define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SHIFT) & \
    SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_MASK)
-#define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_MASK)) \
-                 << (SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_MASK)) \
+                    << (SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_ACC_INERTIAL_NAVIGATION_MODE_NONE (0)
@@ -428,10 +439,10 @@
 #define SBP_POS_LLH_ACC_FIX_MODE_SHIFT (0u)
 #define SBP_POS_LLH_ACC_FIX_MODE_GET(flags) \
   (((flags) >> SBP_POS_LLH_ACC_FIX_MODE_SHIFT) & SBP_POS_LLH_ACC_FIX_MODE_MASK)
-#define SBP_POS_LLH_ACC_FIX_MODE_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_POS_LLH_ACC_FIX_MODE_MASK)) \
-                 << (SBP_POS_LLH_ACC_FIX_MODE_SHIFT)));    \
+#define SBP_POS_LLH_ACC_FIX_MODE_SET(flags, val)                        \
+  do {                                                                  \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_ACC_FIX_MODE_MASK)) \
+                              << (SBP_POS_LLH_ACC_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_ACC_FIX_MODE_INVALID (0)
@@ -453,10 +464,10 @@
 #define SBP_BASELINE_ECEF_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_BASELINE_ECEF_FIX_MODE_SHIFT) & \
    SBP_BASELINE_ECEF_FIX_MODE_MASK)
-#define SBP_BASELINE_ECEF_FIX_MODE_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_BASELINE_ECEF_FIX_MODE_MASK)) \
-                 << (SBP_BASELINE_ECEF_FIX_MODE_SHIFT)));    \
+#define SBP_BASELINE_ECEF_FIX_MODE_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_ECEF_FIX_MODE_MASK)) \
+                              << (SBP_BASELINE_ECEF_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_ECEF_FIX_MODE_INVALID (0)
@@ -475,10 +486,10 @@
 #define SBP_BASELINE_NED_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_BASELINE_NED_FIX_MODE_SHIFT) & \
    SBP_BASELINE_NED_FIX_MODE_MASK)
-#define SBP_BASELINE_NED_FIX_MODE_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_BASELINE_NED_FIX_MODE_MASK)) \
-                 << (SBP_BASELINE_NED_FIX_MODE_SHIFT)));    \
+#define SBP_BASELINE_NED_FIX_MODE_SET(flags, val)                        \
+  do {                                                                   \
+    (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_NED_FIX_MODE_MASK)) \
+                              << (SBP_BASELINE_NED_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_NED_FIX_MODE_INVALID (0)
@@ -497,10 +508,11 @@
 #define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                              \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                     \
+    (flags) =                                                              \
+        (u8)((flags) | (((val) & (SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -510,10 +522,11 @@
 #define SBP_VEL_ECEF_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_VEL_ECEF_INS_NAVIGATION_MODE_MASK)
-#define SBP_VEL_ECEF_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_VEL_ECEF_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_VEL_ECEF_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u8)((flags) | (((val) & (SBP_VEL_ECEF_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_VEL_ECEF_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_INS_NAVIGATION_MODE_NONE (0)
@@ -523,10 +536,10 @@
 #define SBP_VEL_ECEF_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_ECEF_VELOCITY_MODE_MASK)
-#define SBP_VEL_ECEF_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_ECEF_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_ECEF_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_ECEF_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_ECEF_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_VELOCITY_MODE_INVALID (0)
@@ -545,10 +558,11 @@
 #define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                                  \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u8)((flags) | (((val) & (SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_COV_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -558,10 +572,11 @@
 #define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_MASK)
-#define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_COV_INS_NAVIGATION_MODE_NONE (0)
@@ -571,10 +586,10 @@
 #define SBP_VEL_ECEF_COV_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_COV_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK)
-#define SBP_VEL_ECEF_COV_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_ECEF_COV_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_ECEF_COV_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                        \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_ECEF_COV_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_ECEF_COV_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_COV_VELOCITY_MODE_INVALID (0)
@@ -593,10 +608,11 @@
 #define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_VEL_NED_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_VEL_NED_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u8)((flags) | (((val) & (SBP_VEL_NED_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_VEL_NED_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -606,10 +622,10 @@
 #define SBP_VEL_NED_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_NED_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_VEL_NED_INS_NAVIGATION_MODE_MASK)
-#define SBP_VEL_NED_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_VEL_NED_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_VEL_NED_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_VEL_NED_INS_NAVIGATION_MODE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_INS_NAVIGATION_MODE_MASK)) \
+                              << (SBP_VEL_NED_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_INS_NAVIGATION_MODE_NONE (0)
@@ -619,10 +635,10 @@
 #define SBP_VEL_NED_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_NED_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_NED_VELOCITY_MODE_MASK)
-#define SBP_VEL_NED_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_VEL_NED_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_NED_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_NED_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                   \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_NED_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_VELOCITY_MODE_INVALID (0)
@@ -641,10 +657,11 @@
 #define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_GET(flags)      \
   (((flags) >> SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SHIFT) & \
    SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_MASK)
-#define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_MASK)) \
-                 << (SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
+#define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_MASK)) \
+                        << (SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_COV_TYPE_OF_REPORTED_TOW_TIME_OF_MEASUREMENT (0)
@@ -654,10 +671,11 @@
 #define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_VEL_NED_COV_INS_NAVIGATION_MODE_MASK)
-#define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_VEL_NED_COV_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_VEL_NED_COV_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_VEL_NED_COV_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_COV_INS_NAVIGATION_MODE_NONE (0)
@@ -667,10 +685,10 @@
 #define SBP_VEL_NED_COV_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_NED_COV_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_NED_COV_VELOCITY_MODE_MASK)
-#define SBP_VEL_NED_COV_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_VEL_NED_COV_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_NED_COV_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_NED_COV_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_COV_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_NED_COV_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_COV_VELOCITY_MODE_INVALID (0)
@@ -689,10 +707,10 @@
 #define SBP_POS_ECEF_GNSS_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_GNSS_FIX_MODE_SHIFT) & \
    SBP_POS_ECEF_GNSS_FIX_MODE_MASK)
-#define SBP_POS_ECEF_GNSS_FIX_MODE_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_POS_ECEF_GNSS_FIX_MODE_MASK)) \
-                 << (SBP_POS_ECEF_GNSS_FIX_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_GNSS_FIX_MODE_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_GNSS_FIX_MODE_MASK)) \
+                              << (SBP_POS_ECEF_GNSS_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_GNSS_FIX_MODE_INVALID (0)
@@ -713,10 +731,10 @@
 #define SBP_POS_ECEF_COV_GNSS_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_COV_GNSS_FIX_MODE_SHIFT) & \
    SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK)
-#define SBP_POS_ECEF_COV_GNSS_FIX_MODE_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK)) \
-                 << (SBP_POS_ECEF_COV_GNSS_FIX_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_COV_GNSS_FIX_MODE_SET(flags, val)                        \
+  do {                                                                        \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_COV_GNSS_FIX_MODE_MASK)) \
+                              << (SBP_POS_ECEF_COV_GNSS_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_COV_GNSS_FIX_MODE_INVALID (0)
@@ -737,10 +755,10 @@
 #define SBP_POS_LLH_GNSS_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_GNSS_FIX_MODE_SHIFT) & \
    SBP_POS_LLH_GNSS_FIX_MODE_MASK)
-#define SBP_POS_LLH_GNSS_FIX_MODE_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_POS_LLH_GNSS_FIX_MODE_MASK)) \
-                 << (SBP_POS_LLH_GNSS_FIX_MODE_SHIFT)));    \
+#define SBP_POS_LLH_GNSS_FIX_MODE_SET(flags, val)                        \
+  do {                                                                   \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_GNSS_FIX_MODE_MASK)) \
+                              << (SBP_POS_LLH_GNSS_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_GNSS_FIX_MODE_INVALID (0)
@@ -761,10 +779,10 @@
 #define SBP_POS_LLH_COV_GNSS_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_COV_GNSS_FIX_MODE_SHIFT) & \
    SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK)
-#define SBP_POS_LLH_COV_GNSS_FIX_MODE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK)) \
-                 << (SBP_POS_LLH_COV_GNSS_FIX_MODE_SHIFT)));    \
+#define SBP_POS_LLH_COV_GNSS_FIX_MODE_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_COV_GNSS_FIX_MODE_MASK)) \
+                              << (SBP_POS_LLH_COV_GNSS_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_COV_GNSS_FIX_MODE_INVALID (0)
@@ -786,10 +804,10 @@
 #define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK)
-#define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_ECEF_GNSS_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_ECEF_GNSS_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_GNSS_VELOCITY_MODE_INVALID (0)
@@ -807,10 +825,11 @@
 #define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_MASK)
-#define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_MASK)) \
+                        << (SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_ECEF_COV_GNSS_VELOCITY_MODE_INVALID (0)
@@ -828,10 +847,10 @@
 #define SBP_VEL_NED_GNSS_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_NED_GNSS_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK)
-#define SBP_VEL_NED_GNSS_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_NED_GNSS_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_NED_GNSS_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                        \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_NED_GNSS_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_NED_GNSS_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_GNSS_VELOCITY_MODE_INVALID (0)
@@ -849,10 +868,11 @@
 #define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_MASK)
-#define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_MASK)) \
+                        << (SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_NED_COV_GNSS_VELOCITY_MODE_INVALID (0)
@@ -870,10 +890,11 @@
 #define SBP_VEL_BODY_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_BODY_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_VEL_BODY_INS_NAVIGATION_MODE_MASK)
-#define SBP_VEL_BODY_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_VEL_BODY_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_VEL_BODY_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_VEL_BODY_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u8)((flags) | (((val) & (SBP_VEL_BODY_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_VEL_BODY_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_BODY_INS_NAVIGATION_MODE_NONE (0)
@@ -883,10 +904,10 @@
 #define SBP_VEL_BODY_VELOCITY_MODE_GET(flags)      \
   (((flags) >> SBP_VEL_BODY_VELOCITY_MODE_SHIFT) & \
    SBP_VEL_BODY_VELOCITY_MODE_MASK)
-#define SBP_VEL_BODY_VELOCITY_MODE_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_VEL_BODY_VELOCITY_MODE_MASK)) \
-                 << (SBP_VEL_BODY_VELOCITY_MODE_SHIFT)));    \
+#define SBP_VEL_BODY_VELOCITY_MODE_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_VEL_BODY_VELOCITY_MODE_MASK)) \
+                              << (SBP_VEL_BODY_VELOCITY_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_VEL_BODY_VELOCITY_MODE_INVALID (0)
@@ -926,10 +947,11 @@
 #define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
    SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)
-#define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
-                 << (SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
+#define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
+                        << (SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_DEP_A_RAIM_REPAIR_FLAG_NO_REPAIR (0)
@@ -939,10 +961,11 @@
 #define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
    SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
-#define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)           \
-  do {                                                                      \
-    ((flags) |= (((val) & (SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
-                 << (SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
+#define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)              \
+  do {                                                                         \
+    (flags) = (u8)((flags) |                                                   \
+                   (((val) & (SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
+                    << (SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_EXPLICITLY_DISABLED_OR_UNAVAILABLE \
@@ -953,10 +976,10 @@
 #define SBP_POS_ECEF_DEP_A_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_ECEF_DEP_A_FIX_MODE_SHIFT) & \
    SBP_POS_ECEF_DEP_A_FIX_MODE_MASK)
-#define SBP_POS_ECEF_DEP_A_FIX_MODE_SET(flags, val)           \
-  do {                                                        \
-    ((flags) |= (((val) & (SBP_POS_ECEF_DEP_A_FIX_MODE_MASK)) \
-                 << (SBP_POS_ECEF_DEP_A_FIX_MODE_SHIFT)));    \
+#define SBP_POS_ECEF_DEP_A_FIX_MODE_SET(flags, val)                        \
+  do {                                                                     \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_ECEF_DEP_A_FIX_MODE_MASK)) \
+                              << (SBP_POS_ECEF_DEP_A_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_ECEF_DEP_A_FIX_MODE_SINGLE_POINT_POSITIONING (0)
@@ -974,10 +997,11 @@
 #define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
   (((flags) >> SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
    SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_MASK)
-#define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
-                 << (SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
+#define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
+                        << (SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_DEP_A_RAIM_REPAIR_FLAG_NO_REPAIR (0)
@@ -987,10 +1011,11 @@
 #define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
   (((flags) >> SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
    SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
-#define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
-                 << (SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
+#define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
+                    << (SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_EXPLICITLY_DISABLED_OR_UNAVAILABLE \
@@ -1001,10 +1026,10 @@
 #define SBP_POS_LLH_DEP_A_HEIGHT_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_DEP_A_HEIGHT_MODE_SHIFT) & \
    SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK)
-#define SBP_POS_LLH_DEP_A_HEIGHT_MODE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK)) \
-                 << (SBP_POS_LLH_DEP_A_HEIGHT_MODE_SHIFT)));    \
+#define SBP_POS_LLH_DEP_A_HEIGHT_MODE_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_DEP_A_HEIGHT_MODE_MASK)) \
+                              << (SBP_POS_LLH_DEP_A_HEIGHT_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_DEP_A_HEIGHT_MODE_HEIGHT_ABOVE_WGS84_ELLIPSOID (0)
@@ -1014,10 +1039,10 @@
 #define SBP_POS_LLH_DEP_A_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_POS_LLH_DEP_A_FIX_MODE_SHIFT) & \
    SBP_POS_LLH_DEP_A_FIX_MODE_MASK)
-#define SBP_POS_LLH_DEP_A_FIX_MODE_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_POS_LLH_DEP_A_FIX_MODE_MASK)) \
-                 << (SBP_POS_LLH_DEP_A_FIX_MODE_SHIFT)));    \
+#define SBP_POS_LLH_DEP_A_FIX_MODE_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_POS_LLH_DEP_A_FIX_MODE_MASK)) \
+                              << (SBP_POS_LLH_DEP_A_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_POS_LLH_DEP_A_FIX_MODE_SINGLE_POINT_POSITIONING (0)
@@ -1035,10 +1060,11 @@
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
   (((flags) >> SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
    SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)
-#define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
-                 << (SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
+#define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
+                    << (SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_REPAIR_FLAG_NO_REPAIR (0)
@@ -1049,11 +1075,12 @@
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
   (((flags) >> SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
    SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
-#define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val) \
-  do {                                                                 \
-    ((flags) |=                                                        \
-     (((val) & (SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))  \
-      << (SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));     \
+#define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)        \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) |                                                        \
+             (((val) & (SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
+              << (SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_ECEF_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_EXPLICITLY_DISABLED_OR_UNAVAILABLE \
@@ -1065,10 +1092,11 @@
 #define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SHIFT) & \
    SBP_BASELINE_ECEF_DEP_A_FIX_MODE_MASK)
-#define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_BASELINE_ECEF_DEP_A_FIX_MODE_MASK)) \
-                 << (SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SHIFT)));    \
+#define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SET(flags, val)                  \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u8)((flags) | (((val) & (SBP_BASELINE_ECEF_DEP_A_FIX_MODE_MASK)) \
+                        << (SBP_BASELINE_ECEF_DEP_A_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_ECEF_DEP_A_FIX_MODE_FLOAT_RTK (0)
@@ -1085,10 +1113,11 @@
 #define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
   (((flags) >> SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
    SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_MASK)
-#define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)           \
-  do {                                                                    \
-    ((flags) |= (((val) & (SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
-                 << (SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
+#define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)              \
+  do {                                                                       \
+    (flags) = (u8)((flags) |                                                 \
+                   (((val) & (SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
+                    << (SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_NED_DEP_A_RAIM_REPAIR_FLAG_NO_REPAIR (0)
@@ -1099,11 +1128,12 @@
 #define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
   (((flags) >> SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
    SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
-#define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val) \
-  do {                                                                \
-    ((flags) |=                                                       \
-     (((val) & (SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))  \
-      << (SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));     \
+#define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)        \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) |                                                       \
+             (((val) & (SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
+              << (SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_NED_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_EXPLICITLY_DISABLED_OR_UNAVAILABLE \
@@ -1115,10 +1145,10 @@
 #define SBP_BASELINE_NED_DEP_A_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_BASELINE_NED_DEP_A_FIX_MODE_SHIFT) & \
    SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK)
-#define SBP_BASELINE_NED_DEP_A_FIX_MODE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK)) \
-                 << (SBP_BASELINE_NED_DEP_A_FIX_MODE_SHIFT)));    \
+#define SBP_BASELINE_NED_DEP_A_FIX_MODE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_NED_DEP_A_FIX_MODE_MASK)) \
+                              << (SBP_BASELINE_NED_DEP_A_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_NED_DEP_A_FIX_MODE_FLOAT_RTK (0)
@@ -1149,10 +1179,12 @@
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_GET(flags)      \
   (((flags) >> SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SHIFT) & \
    SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_MASK)
-#define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)           \
-  do {                                                                        \
-    ((flags) |= (((val) & (SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
-                 << (SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
+#define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SET(flags, val)        \
+  do {                                                                     \
+    (flags) =                                                              \
+        (u8)((flags) |                                                     \
+             (((val) & (SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_MASK)) \
+              << (SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_REPAIR_FLAG_NO_REPAIR (0)
@@ -1163,11 +1195,12 @@
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_GET(flags)      \
   (((flags) >> SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT) & \
    SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)
-#define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val) \
-  do {                                                                    \
-    ((flags) |=                                                           \
-     (((val) & (SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_MASK))  \
-      << (SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));     \
+#define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SET(flags, val)   \
+  do {                                                                      \
+    (flags) = (u8)(                                                         \
+        (flags) |                                                           \
+        (((val) & (SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_MASK)) \
+         << (SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_HEADING_DEP_A_RAIM_AVAILABILITY_FLAG_RAIM_CHECK_WAS_EXPLICITLY_DISABLED_OR_UNAVAILABLE \
@@ -1179,10 +1212,11 @@
 #define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SHIFT) & \
    SBP_BASELINE_HEADING_DEP_A_FIX_MODE_MASK)
-#define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_BASELINE_HEADING_DEP_A_FIX_MODE_MASK)) \
-                 << (SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SHIFT)));    \
+#define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_BASELINE_HEADING_DEP_A_FIX_MODE_MASK)) \
+                        << (SBP_BASELINE_HEADING_DEP_A_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_HEADING_DEP_A_FIX_MODE_FLOAT_RTK (0)
@@ -1200,13 +1234,14 @@
   (((flags) >>                                                                \
     SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT) &       \
    SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK)
-#define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SET(flags,  \
-                                                                       val)    \
-  do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) &                                                                 \
-       (SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK))      \
-      << (SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT))); \
+#define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SET(flags,     \
+                                                                       val)       \
+  do {                                                                            \
+    (flags) = (u8)(                                                               \
+        (flags) |                                                                 \
+        (((val) &                                                                 \
+          (SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK))      \
+         << (SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT))); \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_DEP_A_TARGET_INTEGRITY_RISK_TIR_LEVEL_SAFE_STATE_PROTECTION_LEVEL_SHALL_NOT_BE_USED_FOR_SAFETY_CRITICAL_APPLICATION \
@@ -1229,11 +1264,12 @@
 #define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT) & \
    SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK)
-#define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SET(flags, val) \
-  do {                                                                       \
-    ((flags) |=                                                              \
-     (((val) & (SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK))  \
-      << (SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT)));     \
+#define SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SET(flags, val)   \
+  do {                                                                         \
+    (flags) = (u32)(                                                           \
+        (flags) |                                                              \
+        (((val) & (SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_MASK)) \
+         << (SBP_PROTECTION_LEVEL_TARGET_INTEGRITY_RISK_TIR_LEVEL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_FIX_MODE_MASK (0x7)
@@ -1241,10 +1277,10 @@
 #define SBP_PROTECTION_LEVEL_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_FIX_MODE_SHIFT) & \
    SBP_PROTECTION_LEVEL_FIX_MODE_MASK)
-#define SBP_PROTECTION_LEVEL_FIX_MODE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_FIX_MODE_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_FIX_MODE_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_FIX_MODE_SET(flags, val)                         \
+  do {                                                                        \
+    (flags) = (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_FIX_MODE_MASK)) \
+                               << (SBP_PROTECTION_LEVEL_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_FIX_MODE_INVALID (0)
@@ -1259,11 +1295,12 @@
 #define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SHIFT) & \
    SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_MASK)
-#define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SET(flags, val) \
-  do {                                                                \
-    ((flags) |=                                                       \
-     (((val) & (SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_MASK))  \
-      << (SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SHIFT)));     \
+#define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SET(flags, val)         \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u32)((flags) |                                                       \
+              (((val) & (SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_MASK)) \
+               << (SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_INERTIAL_NAVIGATION_MODE_NONE (0)
@@ -1273,10 +1310,11 @@
 #define SBP_PROTECTION_LEVEL_TIME_STATUS_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_TIME_STATUS_SHIFT) & \
    SBP_PROTECTION_LEVEL_TIME_STATUS_MASK)
-#define SBP_PROTECTION_LEVEL_TIME_STATUS_SET(flags, val)           \
-  do {                                                             \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_TIME_STATUS_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_TIME_STATUS_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_TIME_STATUS_SET(flags, val)                   \
+  do {                                                                     \
+    (flags) =                                                              \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_TIME_STATUS_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_TIME_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_TIME_STATUS_GNSS_TIME_OF_VALIDITY (0)
@@ -1286,10 +1324,11 @@
 #define SBP_PROTECTION_LEVEL_VELOCITY_VALID_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_VELOCITY_VALID_SHIFT) & \
    SBP_PROTECTION_LEVEL_VELOCITY_VALID_MASK)
-#define SBP_PROTECTION_LEVEL_VELOCITY_VALID_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_VELOCITY_VALID_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_VELOCITY_VALID_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_VELOCITY_VALID_SET(flags, val)                   \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_VELOCITY_VALID_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_VELOCITY_VALID_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK (0x1)
@@ -1297,10 +1336,11 @@
 #define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SHIFT) & \
    SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK)
-#define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SET(flags, val)                   \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_ATTITUDE_VALID_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_ATTITUDE_VALID_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK (0x1)
@@ -1308,10 +1348,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SET(flags, val)                   \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_HPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK (0x1)
@@ -1319,10 +1360,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SET(flags, val)                   \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_VPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK (0x1)
@@ -1330,10 +1372,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_ATPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK (0x1)
@@ -1341,10 +1384,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_CTPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK (0x1)
@@ -1352,10 +1396,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_HVPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK (0x1)
@@ -1363,10 +1408,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_VVPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK (0x1)
@@ -1374,10 +1420,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_HOPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK (0x1)
@@ -1385,10 +1432,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_POPL_SHIFT)));    \
   } while (0)
 
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK (0x1)
@@ -1396,10 +1444,11 @@
 #define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_GET(flags)      \
   (((flags) >> SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SHIFT) & \
    SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK)
-#define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK)) \
-                 << (SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SHIFT)));    \
+#define SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_MASK)) \
+                         << (SBP_PROTECTION_LEVEL_SAFE_STATE_ROPL_SHIFT)));    \
   } while (0)
 
 /**

--- a/c/include/libsbp/ndb_macros.h
+++ b/c/include/libsbp/ndb_macros.h
@@ -23,10 +23,10 @@
 #define SBP_NDB_EVENT_EVENT_TYPE_SHIFT (0u)
 #define SBP_NDB_EVENT_EVENT_TYPE_GET(flags) \
   (((flags) >> SBP_NDB_EVENT_EVENT_TYPE_SHIFT) & SBP_NDB_EVENT_EVENT_TYPE_MASK)
-#define SBP_NDB_EVENT_EVENT_TYPE_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_NDB_EVENT_EVENT_TYPE_MASK)) \
-                 << (SBP_NDB_EVENT_EVENT_TYPE_SHIFT)));    \
+#define SBP_NDB_EVENT_EVENT_TYPE_SET(flags, val)                        \
+  do {                                                                  \
+    (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_EVENT_TYPE_MASK)) \
+                              << (SBP_NDB_EVENT_EVENT_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_NDB_EVENT_EVENT_TYPE_UNKNOWN (0)
@@ -38,10 +38,10 @@
 #define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_GET(flags)      \
   (((flags) >> SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SHIFT) & \
    SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK)
-#define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK)) \
-                 << (SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SHIFT)));    \
+#define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK)) \
+                              << (SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_UNKNOWN (0)
@@ -56,10 +56,10 @@
 #define SBP_NDB_EVENT_EVENT_RESULT_GET(flags)      \
   (((flags) >> SBP_NDB_EVENT_EVENT_RESULT_SHIFT) & \
    SBP_NDB_EVENT_EVENT_RESULT_MASK)
-#define SBP_NDB_EVENT_EVENT_RESULT_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_NDB_EVENT_EVENT_RESULT_MASK)) \
-                 << (SBP_NDB_EVENT_EVENT_RESULT_SHIFT)));    \
+#define SBP_NDB_EVENT_EVENT_RESULT_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_EVENT_RESULT_MASK)) \
+                              << (SBP_NDB_EVENT_EVENT_RESULT_SHIFT)));    \
   } while (0)
 
 #define SBP_NDB_EVENT_EVENT_RESULT_NDB_ERR_NONE (0)
@@ -78,10 +78,10 @@
 #define SBP_NDB_EVENT_DATA_SOURCE_GET(flags)      \
   (((flags) >> SBP_NDB_EVENT_DATA_SOURCE_SHIFT) & \
    SBP_NDB_EVENT_DATA_SOURCE_MASK)
-#define SBP_NDB_EVENT_DATA_SOURCE_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_NDB_EVENT_DATA_SOURCE_MASK)) \
-                 << (SBP_NDB_EVENT_DATA_SOURCE_SHIFT)));    \
+#define SBP_NDB_EVENT_DATA_SOURCE_SET(flags, val)                        \
+  do {                                                                   \
+    (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_DATA_SOURCE_MASK)) \
+                              << (SBP_NDB_EVENT_DATA_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_NDB_EVENT_DATA_SOURCE_NDB_DS_UNDEFINED (0)

--- a/c/include/libsbp/ndb_macros.h
+++ b/c/include/libsbp/ndb_macros.h
@@ -21,8 +21,9 @@
 #define SBP_MSG_NDB_EVENT 0x0400
 #define SBP_NDB_EVENT_EVENT_TYPE_MASK (0x3)
 #define SBP_NDB_EVENT_EVENT_TYPE_SHIFT (0u)
-#define SBP_NDB_EVENT_EVENT_TYPE_GET(flags) \
-  (((flags) >> SBP_NDB_EVENT_EVENT_TYPE_SHIFT) & SBP_NDB_EVENT_EVENT_TYPE_MASK)
+#define SBP_NDB_EVENT_EVENT_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_NDB_EVENT_EVENT_TYPE_SHIFT) & \
+        SBP_NDB_EVENT_EVENT_TYPE_MASK))
 #define SBP_NDB_EVENT_EVENT_TYPE_SET(flags, val)                        \
   do {                                                                  \
     (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_EVENT_TYPE_MASK)) \
@@ -35,9 +36,9 @@
 #define SBP_NDB_EVENT_EVENT_TYPE_ERASE (3)
 #define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK (0x7)
 #define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SHIFT (0u)
-#define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_GET(flags)      \
-  (((flags) >> SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SHIFT) & \
-   SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK)
+#define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SHIFT) & \
+        SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK))
 #define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_EVENT_OBJECT_TYPE_MASK)) \
@@ -53,9 +54,9 @@
 #define SBP_NDB_EVENT_EVENT_OBJECT_TYPE_LGF (6)
 #define SBP_NDB_EVENT_EVENT_RESULT_MASK (0xf)
 #define SBP_NDB_EVENT_EVENT_RESULT_SHIFT (0u)
-#define SBP_NDB_EVENT_EVENT_RESULT_GET(flags)      \
-  (((flags) >> SBP_NDB_EVENT_EVENT_RESULT_SHIFT) & \
-   SBP_NDB_EVENT_EVENT_RESULT_MASK)
+#define SBP_NDB_EVENT_EVENT_RESULT_GET(flags)           \
+  ((u8)(((flags) >> SBP_NDB_EVENT_EVENT_RESULT_SHIFT) & \
+        SBP_NDB_EVENT_EVENT_RESULT_MASK))
 #define SBP_NDB_EVENT_EVENT_RESULT_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_EVENT_RESULT_MASK)) \
@@ -75,9 +76,9 @@
 #define SBP_NDB_EVENT_EVENT_RESULT_NDB_ERR_OLDER_DATA (10)
 #define SBP_NDB_EVENT_DATA_SOURCE_MASK (0x3)
 #define SBP_NDB_EVENT_DATA_SOURCE_SHIFT (0u)
-#define SBP_NDB_EVENT_DATA_SOURCE_GET(flags)      \
-  (((flags) >> SBP_NDB_EVENT_DATA_SOURCE_SHIFT) & \
-   SBP_NDB_EVENT_DATA_SOURCE_MASK)
+#define SBP_NDB_EVENT_DATA_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_NDB_EVENT_DATA_SOURCE_SHIFT) & \
+        SBP_NDB_EVENT_DATA_SOURCE_MASK))
 #define SBP_NDB_EVENT_DATA_SOURCE_SET(flags, val)                        \
   do {                                                                   \
     (flags) = (u8)((flags) | (((val) & (SBP_NDB_EVENT_DATA_SOURCE_MASK)) \

--- a/c/include/libsbp/observation_macros.h
+++ b/c/include/libsbp/observation_macros.h
@@ -32,9 +32,9 @@
 
 #define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_MASK (0x1)
 #define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SHIFT (7u)
-#define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_GET(flags)      \
-  (((flags) >> SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SHIFT) & \
-   SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_MASK)
+#define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SHIFT) & \
+        SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_MASK))
 #define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -47,9 +47,9 @@
   (1)
 #define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_MASK (0x1)
 #define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SHIFT (3u)
-#define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_GET(flags)      \
-  (((flags) >> SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SHIFT) & \
-   SBP_PACKEDOBSCONTENT_DOPPLER_VALID_MASK)
+#define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SHIFT) & \
+        SBP_PACKEDOBSCONTENT_DOPPLER_VALID_MASK))
 #define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -61,9 +61,9 @@
 #define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_VALID_DOPPLER_MEASUREMENT (1)
 #define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_MASK (0x1)
 #define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SHIFT (2u)
-#define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_GET(flags)      \
-  (((flags) >> SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SHIFT) & \
-   SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_MASK)
+#define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SHIFT) & \
+        SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_MASK))
 #define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -77,9 +77,9 @@
   (1)
 #define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_MASK (0x1)
 #define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SHIFT (1u)
-#define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_GET(flags)      \
-  (((flags) >> SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SHIFT) & \
-   SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_MASK)
+#define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SHIFT) & \
+        SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_MASK))
 #define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -93,9 +93,9 @@
   (1)
 #define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_MASK (0x1)
 #define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SHIFT (0u)
-#define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_GET(flags)      \
-  (((flags) >> SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SHIFT) & \
-   SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_MASK)
+#define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SHIFT) & \
+        SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_MASK))
 #define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SET(flags, val)              \
   do {                                                                      \
     (flags) = (u8)((flags) |                                                \
@@ -115,9 +115,9 @@
 
 #define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_MASK (0x1)
 #define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SHIFT (4u)
-#define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_GET(flags)      \
-  (((flags) >> SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SHIFT) & \
-   SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_MASK)
+#define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SHIFT) & \
+        SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_MASK))
 #define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SET(flags, val)        \
   do {                                                                        \
     (flags) =                                                                 \
@@ -132,9 +132,9 @@
   (1)
 #define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_MASK (0x1)
 #define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SHIFT (3u)
-#define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_GET(flags)      \
-  (((flags) >> SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SHIFT) & \
-   SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_MASK)
+#define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SHIFT) & \
+        SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_MASK))
 #define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SET(flags, val)        \
   do {                                                                       \
     (flags) =                                                                \
@@ -148,9 +148,9 @@
   (1)
 #define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_MASK (0x1)
 #define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SHIFT (2u)
-#define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_GET(flags)      \
-  (((flags) >> SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SHIFT) & \
-   SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_MASK)
+#define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SHIFT) & \
+        SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_MASK))
 #define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SET(flags, val)                  \
   do {                                                                         \
     (flags) =                                                                  \
@@ -162,9 +162,9 @@
 #define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_FULL_FIXING_AVAILABLE (1)
 #define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_MASK (0x1)
 #define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SHIFT (1u)
-#define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_GET(flags)      \
-  (((flags) >> SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SHIFT) & \
-   SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_MASK)
+#define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SHIFT) & \
+        SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_MASK))
 #define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -176,9 +176,9 @@
 #define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_PARTIAL_FIXING_AVAILABLE (1)
 #define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_MASK (0x1)
 #define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SHIFT (0u)
-#define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_GET(flags)      \
-  (((flags) >> SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SHIFT) & \
-   SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_MASK)
+#define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_GET(flags)           \
+  ((u8)(((flags) >> SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SHIFT) & \
+        SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_MASK))
 #define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \

--- a/c/include/libsbp/observation_macros.h
+++ b/c/include/libsbp/observation_macros.h
@@ -35,10 +35,11 @@
 #define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_GET(flags)      \
   (((flags) >> SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SHIFT) & \
    SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_MASK)
-#define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_MASK)) \
-                 << (SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SHIFT)));    \
+#define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_MASK)) \
+                        << (SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOBSCONTENT_RAIM_EXCLUSION_NO_EXCLUSION (0)
@@ -49,10 +50,11 @@
 #define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_GET(flags)      \
   (((flags) >> SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SHIFT) & \
    SBP_PACKEDOBSCONTENT_DOPPLER_VALID_MASK)
-#define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_PACKEDOBSCONTENT_DOPPLER_VALID_MASK)) \
-                 << (SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SHIFT)));    \
+#define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_PACKEDOBSCONTENT_DOPPLER_VALID_MASK)) \
+                        << (SBP_PACKEDOBSCONTENT_DOPPLER_VALID_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOBSCONTENT_DOPPLER_VALID_INVALID_DOPPLER_MEASUREMENT (0)
@@ -62,10 +64,11 @@
 #define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_GET(flags)      \
   (((flags) >> SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SHIFT) & \
    SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_MASK)
-#define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_MASK)) \
-                 << (SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SHIFT)));    \
+#define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_MASK)) \
+                    << (SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOBSCONTENT_HALFCYCLE_AMBIGUITY_HALF_CYCLE_PHASE_AMBIGUITY_UNRESOLVED \
@@ -77,10 +80,11 @@
 #define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_GET(flags)      \
   (((flags) >> SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SHIFT) & \
    SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_MASK)
-#define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_MASK)) \
-                 << (SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SHIFT)));    \
+#define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_MASK)) \
+                    << (SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOBSCONTENT_CARRIER_PHASE_VALID_INVALID_CARRIER_PHASE_MEASUREMENT \
@@ -92,10 +96,11 @@
 #define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_GET(flags)      \
   (((flags) >> SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SHIFT) & \
    SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_MASK)
-#define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SET(flags, val)           \
-  do {                                                                   \
-    ((flags) |= (((val) & (SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_MASK)) \
-                 << (SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SHIFT)));    \
+#define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SET(flags, val)              \
+  do {                                                                      \
+    (flags) = (u8)((flags) |                                                \
+                   (((val) & (SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_MASK)) \
+                    << (SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOBSCONTENT_PSEUDORANGE_VALID_INVALID_PSEUDORANGE_MEASUREMENT \
@@ -113,11 +118,12 @@
 #define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_GET(flags)      \
   (((flags) >> SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SHIFT) & \
    SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_MASK)
-#define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SET(flags, val) \
-  do {                                                                 \
-    ((flags) |=                                                        \
-     (((val) & (SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_MASK))  \
-      << (SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SHIFT)));     \
+#define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SET(flags, val)        \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) |                                                        \
+             (((val) & (SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_MASK)) \
+              << (SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOSRCONTENT_INVALID_PHASE_CORRECTIONS_VALID_PHASE_CORRECTIONS \
@@ -129,11 +135,12 @@
 #define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_GET(flags)      \
   (((flags) >> SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SHIFT) & \
    SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_MASK)
-#define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SET(flags, val) \
-  do {                                                                \
-    ((flags) |=                                                       \
-     (((val) & (SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_MASK))  \
-      << (SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SHIFT)));     \
+#define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SET(flags, val)        \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) |                                                       \
+             (((val) & (SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_MASK)) \
+              << (SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOSRCONTENT_INVALID_CODE_CORRECTIONS_VALID_CODE_CORRECTIONS (0)
@@ -144,10 +151,11 @@
 #define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_GET(flags)      \
   (((flags) >> SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SHIFT) & \
    SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_MASK)
-#define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SET(flags, val)           \
-  do {                                                                  \
-    ((flags) |= (((val) & (SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_MASK)) \
-                 << (SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SHIFT)));    \
+#define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SET(flags, val)                  \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u8)((flags) | (((val) & (SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_MASK)) \
+                        << (SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOSRCONTENT_FULL_FIXING_FLAG_FULL_FIXING_UNAVAILABLE (0)
@@ -157,10 +165,11 @@
 #define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_GET(flags)      \
   (((flags) >> SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SHIFT) & \
    SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_MASK)
-#define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_MASK)) \
-                 << (SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SHIFT)));    \
+#define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_MASK)) \
+                    << (SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOSRCONTENT_PARTIAL_FIXING_FLAG_PARTIAL_FIXING_UNAVAILABLE (0)
@@ -170,10 +179,11 @@
 #define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_GET(flags)      \
   (((flags) >> SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SHIFT) & \
    SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_MASK)
-#define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_MASK)) \
-                 << (SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SHIFT)));    \
+#define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_MASK)) \
+                    << (SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_SHIFT)));    \
   } while (0)
 
 #define SBP_PACKEDOSRCONTENT_CORRECTION_VALIDITY_DO_NOT_USE_SIGNAL (0)

--- a/c/include/libsbp/orientation_macros.h
+++ b/c/include/libsbp/orientation_macros.h
@@ -24,10 +24,10 @@
 #define SBP_BASELINE_HEADING_FIX_MODE_GET(flags)      \
   (((flags) >> SBP_BASELINE_HEADING_FIX_MODE_SHIFT) & \
    SBP_BASELINE_HEADING_FIX_MODE_MASK)
-#define SBP_BASELINE_HEADING_FIX_MODE_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_BASELINE_HEADING_FIX_MODE_MASK)) \
-                 << (SBP_BASELINE_HEADING_FIX_MODE_SHIFT)));    \
+#define SBP_BASELINE_HEADING_FIX_MODE_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_HEADING_FIX_MODE_MASK)) \
+                              << (SBP_BASELINE_HEADING_FIX_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_BASELINE_HEADING_FIX_MODE_INVALID (0)
@@ -46,10 +46,11 @@
 #define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_MASK)
-#define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                \
-    ((flags) |= (((val) & (SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) | (((val) & (SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_INVALID (0)
@@ -66,10 +67,11 @@
 #define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_ORIENT_EULER_INS_NAVIGATION_MODE_MASK)
-#define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_ORIENT_EULER_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_ORIENT_EULER_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_INVALID (0)
@@ -86,10 +88,11 @@
 #define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_GET(flags)      \
   (((flags) >> SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SHIFT) & \
    SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_MASK)
-#define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_MASK)) \
-                 << (SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SHIFT)));    \
+#define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_MASK)) \
+                        << (SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_INVALID (0)

--- a/c/include/libsbp/orientation_macros.h
+++ b/c/include/libsbp/orientation_macros.h
@@ -21,9 +21,9 @@
 #define SBP_MSG_BASELINE_HEADING 0x020F
 #define SBP_BASELINE_HEADING_FIX_MODE_MASK (0x7)
 #define SBP_BASELINE_HEADING_FIX_MODE_SHIFT (0u)
-#define SBP_BASELINE_HEADING_FIX_MODE_GET(flags)      \
-  (((flags) >> SBP_BASELINE_HEADING_FIX_MODE_SHIFT) & \
-   SBP_BASELINE_HEADING_FIX_MODE_MASK)
+#define SBP_BASELINE_HEADING_FIX_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_BASELINE_HEADING_FIX_MODE_SHIFT) & \
+        SBP_BASELINE_HEADING_FIX_MODE_MASK))
 #define SBP_BASELINE_HEADING_FIX_MODE_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_BASELINE_HEADING_FIX_MODE_MASK)) \
@@ -43,9 +43,9 @@
 #define SBP_MSG_ORIENT_QUAT 0x0220
 #define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_MASK (0x7)
 #define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SHIFT (0u)
-#define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_MASK)
+#define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_MASK))
 #define SBP_ORIENT_QUAT_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                       \
     (flags) =                                                                \
@@ -64,9 +64,9 @@
 #define SBP_MSG_ORIENT_EULER 0x0221
 #define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_MASK (0x7)
 #define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SHIFT (0u)
-#define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_ORIENT_EULER_INS_NAVIGATION_MODE_MASK)
+#define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_ORIENT_EULER_INS_NAVIGATION_MODE_MASK))
 #define SBP_ORIENT_EULER_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -85,9 +85,9 @@
 #define SBP_MSG_ANGULAR_RATE 0x0222
 #define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_MASK (0x7)
 #define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SHIFT (0u)
-#define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_GET(flags)      \
-  (((flags) >> SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SHIFT) & \
-   SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_MASK)
+#define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SHIFT) & \
+        SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_MASK))
 #define SBP_ANGULAR_RATE_INS_NAVIGATION_MODE_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \

--- a/c/include/libsbp/piksi_macros.h
+++ b/c/include/libsbp/piksi_macros.h
@@ -35,9 +35,9 @@
 #define SBP_MSG_RESET 0x00B6
 #define SBP_RESET_DEFAULT_SETTINGS_MASK (0x1)
 #define SBP_RESET_DEFAULT_SETTINGS_SHIFT (0u)
-#define SBP_RESET_DEFAULT_SETTINGS_GET(flags)      \
-  (((flags) >> SBP_RESET_DEFAULT_SETTINGS_SHIFT) & \
-   SBP_RESET_DEFAULT_SETTINGS_MASK)
+#define SBP_RESET_DEFAULT_SETTINGS_GET(flags)            \
+  ((u32)(((flags) >> SBP_RESET_DEFAULT_SETTINGS_SHIFT) & \
+         SBP_RESET_DEFAULT_SETTINGS_MASK))
 #define SBP_RESET_DEFAULT_SETTINGS_SET(flags, val)                         \
   do {                                                                     \
     (flags) = (u32)((flags) | (((val) & (SBP_RESET_DEFAULT_SETTINGS_MASK)) \
@@ -76,9 +76,9 @@
 #define SBP_MSG_RESET_FILTERS 0x0022
 #define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_MASK (0x3)
 #define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SHIFT (0u)
-#define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_GET(flags)      \
-  (((flags) >> SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SHIFT) & \
-   SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_MASK)
+#define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_GET(flags)           \
+  ((u8)(((flags) >> SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SHIFT) & \
+        SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_MASK))
 #define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SET(flags, val)        \
   do {                                                                      \
     (flags) =                                                               \
@@ -159,9 +159,9 @@
 #define SBP_MSG_MASK_SATELLITE 0x002B
 #define SBP_MASK_SATELLITE_TRACKING_CHANNELS_MASK (0x1)
 #define SBP_MASK_SATELLITE_TRACKING_CHANNELS_SHIFT (1u)
-#define SBP_MASK_SATELLITE_TRACKING_CHANNELS_GET(flags)      \
-  (((flags) >> SBP_MASK_SATELLITE_TRACKING_CHANNELS_SHIFT) & \
-   SBP_MASK_SATELLITE_TRACKING_CHANNELS_MASK)
+#define SBP_MASK_SATELLITE_TRACKING_CHANNELS_GET(flags)           \
+  ((u8)(((flags) >> SBP_MASK_SATELLITE_TRACKING_CHANNELS_SHIFT) & \
+        SBP_MASK_SATELLITE_TRACKING_CHANNELS_MASK))
 #define SBP_MASK_SATELLITE_TRACKING_CHANNELS_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -174,9 +174,9 @@
   (1)
 #define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_MASK (0x1)
 #define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SHIFT (0u)
-#define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_GET(flags)      \
-  (((flags) >> SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SHIFT) & \
-   SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_MASK)
+#define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_GET(flags)           \
+  ((u8)(((flags) >> SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SHIFT) & \
+        SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_MASK))
 #define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SET(flags, val)              \
   do {                                                                      \
     (flags) = (u8)((flags) |                                                \
@@ -196,9 +196,9 @@
 #define SBP_MSG_MASK_SATELLITE_DEP 0x001B
 #define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_MASK (0x1)
 #define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SHIFT (1u)
-#define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_GET(flags)      \
-  (((flags) >> SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SHIFT) & \
-   SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_MASK)
+#define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_GET(flags)           \
+  ((u8)(((flags) >> SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SHIFT) & \
+        SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_MASK))
 #define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SET(flags, val)              \
   do {                                                                        \
     (flags) = (u8)((flags) |                                                  \
@@ -211,9 +211,9 @@
   (1)
 #define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_MASK (0x1)
 #define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SHIFT (0u)
-#define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_GET(flags)      \
-  (((flags) >> SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SHIFT) & \
-   SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_MASK)
+#define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_GET(flags)           \
+  ((u8)(((flags) >> SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SHIFT) & \
+        SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_MASK))
 #define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -325,9 +325,9 @@
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT (15u)
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_GET(flags) \
-  (((flags) >>                                                              \
-    SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT) &       \
-   SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK)
+  ((u32)(((flags) >>                                                        \
+          SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT) & \
+         SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SET(flags,     \
                                                                      val)       \
   do {                                                                          \
@@ -340,11 +340,12 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SHIFT (14u)
-#define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_GET( \
-    flags)                                                                \
-  (((flags) >>                                                            \
-    SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_GET(    \
+    flags)                                                                   \
+  ((u32)(                                                                    \
+      ((flags) >>                                                            \
+       SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SET(           \
     flags, val)                                                                     \
   do {                                                                              \
@@ -357,11 +358,12 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SHIFT (13u)
-#define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_GET( \
-    flags)                                                                \
-  (((flags) >>                                                            \
-    SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_GET(    \
+    flags)                                                                   \
+  ((u32)(                                                                    \
+      ((flags) >>                                                            \
+       SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SET(           \
     flags, val)                                                                     \
   do {                                                                              \
@@ -374,11 +376,12 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SHIFT (12u)
-#define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_GET( \
-    flags)                                                                \
-  (((flags) >>                                                            \
-    SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_GET(    \
+    flags)                                                                   \
+  ((u32)(                                                                    \
+      ((flags) >>                                                            \
+       SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SET(           \
     flags, val)                                                                     \
   do {                                                                              \
@@ -393,11 +396,12 @@
   (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SHIFT \
   (11u)
-#define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_GET( \
-    flags)                                                                   \
-  (((flags) >>                                                               \
-    SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_GET(    \
+    flags)                                                                      \
+  ((u32)(                                                                       \
+      ((flags) >>                                                               \
+       SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SET(           \
     flags, val)                                                                        \
   do {                                                                                 \
@@ -410,11 +414,12 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SHIFT (10u)
-#define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_GET( \
-    flags)                                                                \
-  (((flags) >>                                                            \
-    SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_GET(    \
+    flags)                                                                   \
+  ((u32)(                                                                    \
+      ((flags) >>                                                            \
+       SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SET(           \
     flags, val)                                                                     \
   do {                                                                              \
@@ -429,11 +434,12 @@
   (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SHIFT \
   (9u)
-#define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_GET( \
-    flags)                                                                      \
-  (((flags) >>                                                                  \
-    SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_GET(    \
+    flags)                                                                         \
+  ((u32)(                                                                          \
+      ((flags) >>                                                                  \
+       SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SET(           \
     flags, val)                                                                           \
   do {                                                                                    \
@@ -447,9 +453,9 @@
 #define SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SHIFT (8u)
 #define SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_GET(flags) \
-  (((flags) >>                                                             \
-    SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SHIFT) &       \
-   SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_MASK)
+  ((u32)(((flags) >>                                                       \
+          SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SHIFT) & \
+         SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
@@ -464,11 +470,12 @@
   (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SHIFT \
   (7u)
-#define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_GET( \
-    flags)                                                                    \
-  (((flags) >>                                                                \
-    SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_GET(    \
+    flags)                                                                       \
+  ((u32)(                                                                        \
+      ((flags) >>                                                                \
+       SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SET(           \
     flags, val)                                                                         \
   do {                                                                                  \
@@ -482,9 +489,9 @@
 #define SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SHIFT (6u)
 #define SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_GET(flags) \
-  (((flags) >>                                                             \
-    SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SHIFT) &       \
-   SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_MASK)
+  ((u32)(((flags) >>                                                       \
+          SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SHIFT) & \
+         SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
@@ -497,11 +504,12 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SHIFT (5u)
-#define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_GET( \
-    flags)                                                                \
-  (((flags) >>                                                            \
-    SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_GET(    \
+    flags)                                                                   \
+  ((u32)(                                                                    \
+      ((flags) >>                                                            \
+       SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SET(           \
     flags, val)                                                                     \
   do {                                                                              \
@@ -516,11 +524,12 @@
   (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SHIFT \
   (4u)
-#define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_GET( \
-    flags)                                                                          \
-  (((flags) >>                                                                      \
-    SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_GET(    \
+    flags)                                                                             \
+  ((u32)(                                                                              \
+      ((flags) >>                                                                      \
+       SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SET(           \
     flags, val)                                                                               \
   do {                                                                                        \
@@ -533,9 +542,10 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SHIFT (3u)
-#define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_GET(flags)      \
-  (((flags) >> SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_GET(flags) \
+  ((u32)(((flags) >>                                                      \
+          SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SHIFT) & \
+         SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SET(flags, val) \
   do {                                                                         \
     (flags) = (u32)(                                                           \
@@ -548,9 +558,9 @@
 #define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SHIFT (2u)
 #define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_GET(flags) \
-  (((flags) >>                                                               \
-    SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SHIFT) &       \
-   SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK)
+  ((u32)(((flags) >>                                                         \
+          SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SHIFT) & \
+         SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SET(flags,     \
                                                                       val)       \
   do {                                                                           \
@@ -563,11 +573,12 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SHIFT (1u)
-#define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_GET( \
-    flags)                                                                 \
-  (((flags) >>                                                             \
-    SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_GET(    \
+    flags)                                                                    \
+  ((u32)(                                                                     \
+      ((flags) >>                                                             \
+       SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SHIFT) & \
+      SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SET(           \
     flags, val)                                                                      \
   do {                                                                               \
@@ -580,9 +591,9 @@
 
 #define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK (0x1)
 #define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SHIFT (0u)
-#define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_GET(flags)      \
-  (((flags) >> SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SHIFT) & \
-   SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK)
+#define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_GET(flags)            \
+  ((u32)(((flags) >> SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SHIFT) & \
+         SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK))
 #define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SET(flags, val)         \
   do {                                                                         \
     (flags) =                                                                  \

--- a/c/include/libsbp/piksi_macros.h
+++ b/c/include/libsbp/piksi_macros.h
@@ -38,10 +38,10 @@
 #define SBP_RESET_DEFAULT_SETTINGS_GET(flags)      \
   (((flags) >> SBP_RESET_DEFAULT_SETTINGS_SHIFT) & \
    SBP_RESET_DEFAULT_SETTINGS_MASK)
-#define SBP_RESET_DEFAULT_SETTINGS_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_RESET_DEFAULT_SETTINGS_MASK)) \
-                 << (SBP_RESET_DEFAULT_SETTINGS_SHIFT)));    \
+#define SBP_RESET_DEFAULT_SETTINGS_SET(flags, val)                         \
+  do {                                                                     \
+    (flags) = (u32)((flags) | (((val) & (SBP_RESET_DEFAULT_SETTINGS_MASK)) \
+                               << (SBP_RESET_DEFAULT_SETTINGS_SHIFT)));    \
   } while (0)
 
 #define SBP_RESET_DEFAULT_SETTINGS_PRESERVE_EXISTING_SETTINGS (0)
@@ -79,10 +79,12 @@
 #define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_GET(flags)      \
   (((flags) >> SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SHIFT) & \
    SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_MASK)
-#define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SET(flags, val)           \
-  do {                                                                         \
-    ((flags) |= (((val) & (SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_MASK)) \
-                 << (SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SHIFT)));    \
+#define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SET(flags, val)        \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) |                                                      \
+             (((val) & (SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_MASK)) \
+              << (SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_SHIFT)));    \
   } while (0)
 
 #define SBP_RESET_FILTERS_FILTER_OR_PROCESS_TO_RESET_DGNSS_FILTER (0)
@@ -160,10 +162,11 @@
 #define SBP_MASK_SATELLITE_TRACKING_CHANNELS_GET(flags)      \
   (((flags) >> SBP_MASK_SATELLITE_TRACKING_CHANNELS_SHIFT) & \
    SBP_MASK_SATELLITE_TRACKING_CHANNELS_MASK)
-#define SBP_MASK_SATELLITE_TRACKING_CHANNELS_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_MASK_SATELLITE_TRACKING_CHANNELS_MASK)) \
-                 << (SBP_MASK_SATELLITE_TRACKING_CHANNELS_SHIFT)));    \
+#define SBP_MASK_SATELLITE_TRACKING_CHANNELS_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_MASK_SATELLITE_TRACKING_CHANNELS_MASK)) \
+                        << (SBP_MASK_SATELLITE_TRACKING_CHANNELS_SHIFT)));    \
   } while (0)
 
 #define SBP_MASK_SATELLITE_TRACKING_CHANNELS_ENABLED (0)
@@ -174,10 +177,11 @@
 #define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_GET(flags)      \
   (((flags) >> SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SHIFT) & \
    SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_MASK)
-#define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SET(flags, val)           \
-  do {                                                                   \
-    ((flags) |= (((val) & (SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_MASK)) \
-                 << (SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SHIFT)));    \
+#define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SET(flags, val)              \
+  do {                                                                      \
+    (flags) = (u8)((flags) |                                                \
+                   (((val) & (SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_MASK)) \
+                    << (SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_SHIFT)));    \
   } while (0)
 
 #define SBP_MASK_SATELLITE_ACQUISITION_CHANNEL_ENABLED (0)
@@ -195,10 +199,11 @@
 #define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_GET(flags)      \
   (((flags) >> SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SHIFT) & \
    SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_MASK)
-#define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SET(flags, val)           \
-  do {                                                                     \
-    ((flags) |= (((val) & (SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_MASK)) \
-                 << (SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SHIFT)));    \
+#define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SET(flags, val)              \
+  do {                                                                        \
+    (flags) = (u8)((flags) |                                                  \
+                   (((val) & (SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_MASK)) \
+                    << (SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_SHIFT)));    \
   } while (0)
 
 #define SBP_MASK_SATELLITE_DEP_TRACKING_CHANNELS_ENABLED (0)
@@ -209,10 +214,11 @@
 #define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_GET(flags)      \
   (((flags) >> SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SHIFT) & \
    SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_MASK)
-#define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_MASK)) \
-                 << (SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SHIFT)));    \
+#define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_MASK)) \
+                   << (SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_SHIFT)));    \
   } while (0)
 
 #define SBP_MASK_SATELLITE_DEP_ACQUISITION_CHANNEL_ENABLED (0)
@@ -322,13 +328,14 @@
   (((flags) >>                                                              \
     SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT) &       \
    SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SET(flags,  \
-                                                                     val)    \
-  do {                                                                       \
-    ((flags) |=                                                              \
-     (((val) &                                                               \
-       (SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SET(flags,     \
+                                                                     val)       \
+  do {                                                                          \
+    (flags) = (u32)(                                                            \
+        (flags) |                                                               \
+        (((val) &                                                               \
+          (SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_MULTICAST__SUPPORTS_MULTICAST_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK (0x1)
@@ -338,13 +345,14 @@
   (((flags) >>                                                            \
     SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SET(        \
-    flags, val)                                                                  \
-  do {                                                                           \
-    ((flags) |=                                                                  \
-     (((val) &                                                                   \
-       (SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SET(           \
+    flags, val)                                                                     \
+  do {                                                                              \
+    (flags) = (u32)(                                                                \
+        (flags) |                                                                   \
+        (((val) &                                                                   \
+          (SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_LINK2__PER_LINK_LAYER_DEFINED_BIT_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK (0x1)
@@ -354,13 +362,14 @@
   (((flags) >>                                                            \
     SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SET(        \
-    flags, val)                                                                  \
-  do {                                                                           \
-    ((flags) |=                                                                  \
-     (((val) &                                                                   \
-       (SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SET(           \
+    flags, val)                                                                     \
+  do {                                                                              \
+    (flags) = (u32)(                                                                \
+        (flags) |                                                                   \
+        (((val) &                                                                   \
+          (SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_LINK1__PER_LINK_LAYER_DEFINED_BIT_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK (0x1)
@@ -370,13 +379,14 @@
   (((flags) >>                                                            \
     SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SET(        \
-    flags, val)                                                                  \
-  do {                                                                           \
-    ((flags) |=                                                                  \
-     (((val) &                                                                   \
-       (SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SET(           \
+    flags, val)                                                                     \
+  do {                                                                              \
+    (flags) = (u32)(                                                                \
+        (flags) |                                                                   \
+        (((val) &                                                                   \
+          (SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_LINK0__PER_LINK_LAYER_DEFINED_BIT_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_MASK \
@@ -388,13 +398,14 @@
   (((flags) >>                                                               \
     SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SET(        \
-    flags, val)                                                                     \
-  do {                                                                              \
-    ((flags) |=                                                                     \
-     (((val) &                                                                      \
-       (SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SET(           \
+    flags, val)                                                                        \
+  do {                                                                                 \
+    (flags) = (u32)(                                                                   \
+        (flags) |                                                                      \
+        (((val) &                                                                      \
+          (SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_SIMPLEX__CANT_HEAR_OWN_TRANSMISSIONS_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK (0x1)
@@ -404,13 +415,14 @@
   (((flags) >>                                                            \
     SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SET(        \
-    flags, val)                                                                  \
-  do {                                                                           \
-    ((flags) |=                                                                  \
-     (((val) &                                                                   \
-       (SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SET(           \
+    flags, val)                                                                     \
+  do {                                                                              \
+    (flags) = (u32)(                                                                \
+        (flags) |                                                                   \
+        (((val) &                                                                   \
+          (SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_OACTIVE__TRANSMISSION_IN_PROGRESS_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_MASK \
@@ -422,13 +434,14 @@
   (((flags) >>                                                                  \
     SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SET(        \
-    flags, val)                                                                        \
-  do {                                                                                 \
-    ((flags) |=                                                                        \
-     (((val) &                                                                         \
-       (SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SET(           \
+    flags, val)                                                                           \
+  do {                                                                                    \
+    (flags) = (u32)(                                                                      \
+        (flags) |                                                                         \
+        (((val) &                                                                         \
+          (SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_ALLMULTI__RECEIVE_ALL_MULTICAST_PACKETS_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_MASK (0x1)
@@ -440,9 +453,11 @@
 #define SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_MASK)) \
-      << (SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SHIFT)));    \
+    (flags) = (u32)(                                                           \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_PROMISC__RECEIVE_ALL_PACKETS_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_MASK \
@@ -454,13 +469,14 @@
   (((flags) >>                                                                \
     SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SET(        \
-    flags, val)                                                                      \
-  do {                                                                               \
-    ((flags) |=                                                                      \
-     (((val) &                                                                       \
-       (SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SET(           \
+    flags, val)                                                                         \
+  do {                                                                                  \
+    (flags) = (u32)(                                                                    \
+        (flags) |                                                                       \
+        (((val) &                                                                       \
+          (SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_NOARP__NO_ADDRESS_RESOLUTION_PROTOCOL_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_MASK (0x1)
@@ -472,9 +488,11 @@
 #define SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_MASK)) \
-      << (SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SHIFT)));    \
+    (flags) = (u32)(                                                           \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_RUNNING__RESOURCES_ALLOCATED_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK (0x1)
@@ -484,13 +502,14 @@
   (((flags) >>                                                            \
     SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SET(        \
-    flags, val)                                                                  \
-  do {                                                                           \
-    ((flags) |=                                                                  \
-     (((val) &                                                                   \
-       (SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SET(           \
+    flags, val)                                                                     \
+  do {                                                                              \
+    (flags) = (u32)(                                                                \
+        (flags) |                                                                   \
+        (((val) &                                                                   \
+          (SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_NOTRAILERS__AVOID_USE_OF_TRAILERS_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_MASK \
@@ -502,13 +521,14 @@
   (((flags) >>                                                                      \
     SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SET(        \
-    flags, val)                                                                            \
-  do {                                                                                     \
-    ((flags) |=                                                                            \
-     (((val) &                                                                             \
-       (SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SET(           \
+    flags, val)                                                                               \
+  do {                                                                                        \
+    (flags) = (u32)(                                                                          \
+        (flags) |                                                                             \
+        (((val) &                                                                             \
+          (SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_POINTOPOINT__INTERFACE_IS_POINTTOPOINT_LINK_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK (0x1)
@@ -518,9 +538,11 @@
    SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK)
 #define SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SET(flags, val) \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK))  \
-      << (SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SHIFT)));     \
+    (flags) = (u32)(                                                           \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_MASK))       \
+         << (SBP_NETWORK_STATE_RESP_IFF_LOOPBACK__IS_A_LOOPBACK_NET_SHIFT)));  \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK (0x1)
@@ -529,13 +551,14 @@
   (((flags) >>                                                               \
     SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SHIFT) &       \
    SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SET(flags,  \
-                                                                      val)    \
-  do {                                                                        \
-    ((flags) |=                                                               \
-     (((val) &                                                                \
-       (SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SET(flags,     \
+                                                                      val)       \
+  do {                                                                           \
+    (flags) = (u32)(                                                             \
+        (flags) |                                                                \
+        (((val) &                                                                \
+          (SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_DEBUG__BROADCAST_ADDRESS_VALID_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK (0x1)
@@ -545,13 +568,14 @@
   (((flags) >>                                                             \
     SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SET(        \
-    flags, val)                                                                   \
-  do {                                                                            \
-    ((flags) |=                                                                   \
-     (((val) &                                                                    \
-       (SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK))      \
-      << (SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SHIFT))); \
+#define SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SET(           \
+    flags, val)                                                                      \
+  do {                                                                               \
+    (flags) = (u32)(                                                                 \
+        (flags) |                                                                    \
+        (((val) &                                                                    \
+          (SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_MASK))      \
+         << (SBP_NETWORK_STATE_RESP_IFF_BROADCAST__BROADCAST_ADDRESS_VALID_SHIFT))); \
   } while (0)
 
 #define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK (0x1)
@@ -559,11 +583,12 @@
 #define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_GET(flags)      \
   (((flags) >> SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SHIFT) & \
    SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK)
-#define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SET(flags, val) \
-  do {                                                                 \
-    ((flags) |=                                                        \
-     (((val) & (SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK))  \
-      << (SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SHIFT)));     \
+#define SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SET(flags, val)         \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) |                                                        \
+              (((val) & (SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_MASK)) \
+               << (SBP_NETWORK_STATE_RESP_IFF_UP__INTERFACE_IS_UP_SHIFT)));    \
   } while (0)
 
 /**

--- a/c/include/libsbp/settings_macros.h
+++ b/c/include/libsbp/settings_macros.h
@@ -51,9 +51,9 @@
 #define SBP_MSG_SETTINGS_WRITE_RESP 0x00AF
 #define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_MASK (0x3)
 #define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SHIFT (0u)
-#define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_GET(flags)      \
-  (((flags) >> SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SHIFT) & \
-   SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_MASK)
+#define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SHIFT) & \
+        SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_MASK))
 #define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -208,9 +208,9 @@
 #define SBP_MSG_SETTINGS_REGISTER_RESP 0x01AF
 #define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_MASK (0x3)
 #define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SHIFT (0u)
-#define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_GET(flags)      \
-  (((flags) >> SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SHIFT) & \
-   SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_MASK)
+#define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SHIFT) & \
+        SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_MASK))
 #define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \

--- a/c/include/libsbp/settings_macros.h
+++ b/c/include/libsbp/settings_macros.h
@@ -54,10 +54,11 @@
 #define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_GET(flags)      \
   (((flags) >> SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SHIFT) & \
    SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_MASK)
-#define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_MASK)) \
-                 << (SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SHIFT)));    \
+#define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_MASK)) \
+                        << (SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_SETTINGS_WRITE_RESP_WRITE_STATUS_ACCEPTED_VALUE_UPDATED (0)
@@ -210,10 +211,11 @@
 #define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_GET(flags)      \
   (((flags) >> SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SHIFT) & \
    SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_MASK)
-#define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_MASK)) \
-                 << (SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SHIFT)));    \
+#define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_MASK)) \
+                   << (SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_SETTINGS_REGISTER_RESP_REGISTER_STATUS_ACCEPTED_REQUESTED_DEFAULT_VALUE_RETURNED \

--- a/c/include/libsbp/solution_meta_macros.h
+++ b/c/include/libsbp/solution_meta_macros.h
@@ -20,9 +20,9 @@
 
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_MASK (0x3)
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SHIFT (3u)
-#define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_GET(flags)      \
-  (((flags) >> SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SHIFT) & \
-   SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_MASK)
+#define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_GET(flags)           \
+  ((u8)(((flags) >> SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SHIFT) & \
+        SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_MASK))
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -35,9 +35,9 @@
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_RECEIVED_BUT_NOT_USED (2)
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_MASK (0x7)
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SHIFT (0u)
-#define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_GET(flags)      \
-  (((flags) >> SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SHIFT) & \
-   SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_MASK)
+#define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SHIFT) & \
+        SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_MASK))
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SET(flags, val)                  \
   do {                                                                     \
     (flags) =                                                              \
@@ -61,9 +61,9 @@
 #define SBP_MSG_SOLN_META_DEP_A 0xFF0F
 #define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_MASK (0x7)
 #define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SHIFT (0u)
-#define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_GET(flags)      \
-  (((flags) >> SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SHIFT) & \
-   SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_MASK)
+#define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SHIFT) & \
+        SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_MASK))
 #define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SET(flags, val)                  \
   do {                                                                        \
     (flags) =                                                                 \
@@ -106,9 +106,9 @@
 #define SBP_MSG_SOLN_META 0xFF0E
 #define SBP_SOLN_META_TIME_STATUS_MASK (0x3)
 #define SBP_SOLN_META_TIME_STATUS_SHIFT (30u)
-#define SBP_SOLN_META_TIME_STATUS_GET(flags)      \
-  (((flags) >> SBP_SOLN_META_TIME_STATUS_SHIFT) & \
-   SBP_SOLN_META_TIME_STATUS_MASK)
+#define SBP_SOLN_META_TIME_STATUS_GET(flags)            \
+  ((u32)(((flags) >> SBP_SOLN_META_TIME_STATUS_SHIFT) & \
+         SBP_SOLN_META_TIME_STATUS_MASK))
 #define SBP_SOLN_META_TIME_STATUS_SET(flags, val)                         \
   do {                                                                    \
     (flags) = (u32)((flags) | (((val) & (SBP_SOLN_META_TIME_STATUS_MASK)) \
@@ -121,9 +121,9 @@
   (0x3fffffff)
 #define SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT (0u)
 #define SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_GET(flags) \
-  (((flags) >>                                                                \
-    SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT) &       \
-   SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_MASK)
+  ((u32)(((flags) >>                                                          \
+          SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT) & \
+         SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_MASK))
 #define SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SET(flags,     \
                                                                        val)       \
   do {                                                                            \
@@ -158,9 +158,9 @@
 
 #define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_MASK (0x3)
 #define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SHIFT (0u)
-#define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_GET(flags)      \
-  (((flags) >> SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SHIFT) & \
-   SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_MASK)
+#define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_GET(flags)           \
+  ((u8)(((flags) >> SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SHIFT) & \
+        SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_MASK))
 #define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -180,9 +180,9 @@
 
 #define SBP_IMUINPUTTYPE_TIME_STATUS_MASK (0x3)
 #define SBP_IMUINPUTTYPE_TIME_STATUS_SHIFT (4u)
-#define SBP_IMUINPUTTYPE_TIME_STATUS_GET(flags)      \
-  (((flags) >> SBP_IMUINPUTTYPE_TIME_STATUS_SHIFT) & \
-   SBP_IMUINPUTTYPE_TIME_STATUS_MASK)
+#define SBP_IMUINPUTTYPE_TIME_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_IMUINPUTTYPE_TIME_STATUS_SHIFT) & \
+        SBP_IMUINPUTTYPE_TIME_STATUS_MASK))
 #define SBP_IMUINPUTTYPE_TIME_STATUS_SET(flags, val)                        \
   do {                                                                      \
     (flags) = (u8)((flags) | (((val) & (SBP_IMUINPUTTYPE_TIME_STATUS_MASK)) \
@@ -197,9 +197,9 @@
 #define SBP_IMUINPUTTYPE_TIME_STATUS_REFERENCE_EPOCH_IS_LAST_PPS (3)
 #define SBP_IMUINPUTTYPE_IMU_GRADE_MASK (0x3)
 #define SBP_IMUINPUTTYPE_IMU_GRADE_SHIFT (2u)
-#define SBP_IMUINPUTTYPE_IMU_GRADE_GET(flags)      \
-  (((flags) >> SBP_IMUINPUTTYPE_IMU_GRADE_SHIFT) & \
-   SBP_IMUINPUTTYPE_IMU_GRADE_MASK)
+#define SBP_IMUINPUTTYPE_IMU_GRADE_GET(flags)           \
+  ((u8)(((flags) >> SBP_IMUINPUTTYPE_IMU_GRADE_SHIFT) & \
+        SBP_IMUINPUTTYPE_IMU_GRADE_MASK))
 #define SBP_IMUINPUTTYPE_IMU_GRADE_SET(flags, val)                        \
   do {                                                                    \
     (flags) = (u8)((flags) | (((val) & (SBP_IMUINPUTTYPE_IMU_GRADE_MASK)) \
@@ -212,9 +212,9 @@
 #define SBP_IMUINPUTTYPE_IMU_GRADE_SUPERIOR_GRADE (3)
 #define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_MASK (0x3)
 #define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SHIFT (0u)
-#define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_GET(flags)      \
-  (((flags) >> SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SHIFT) & \
-   SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_MASK)
+#define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_GET(flags)           \
+  ((u8)(((flags) >> SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SHIFT) & \
+        SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_MASK))
 #define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SET(flags, val)                  \
   do {                                                                     \
     (flags) =                                                              \
@@ -233,7 +233,7 @@
 #define SBP_ODOINPUTTYPE_RATE_MASK (0x3)
 #define SBP_ODOINPUTTYPE_RATE_SHIFT (4u)
 #define SBP_ODOINPUTTYPE_RATE_GET(flags) \
-  (((flags) >> SBP_ODOINPUTTYPE_RATE_SHIFT) & SBP_ODOINPUTTYPE_RATE_MASK)
+  ((u8)(((flags) >> SBP_ODOINPUTTYPE_RATE_SHIFT) & SBP_ODOINPUTTYPE_RATE_MASK))
 #define SBP_ODOINPUTTYPE_RATE_SET(flags, val)                        \
   do {                                                               \
     (flags) = (u8)((flags) | (((val) & (SBP_ODOINPUTTYPE_RATE_MASK)) \
@@ -244,9 +244,9 @@
 #define SBP_ODOINPUTTYPE_RATE_TRIGGERED_BY_MINIMUM_DISTANCE_OR_SPEED (1)
 #define SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK (0x3)
 #define SBP_ODOINPUTTYPE_ODOMETER_GRADE_SHIFT (2u)
-#define SBP_ODOINPUTTYPE_ODOMETER_GRADE_GET(flags)      \
-  (((flags) >> SBP_ODOINPUTTYPE_ODOMETER_GRADE_SHIFT) & \
-   SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK)
+#define SBP_ODOINPUTTYPE_ODOMETER_GRADE_GET(flags)           \
+  ((u8)(((flags) >> SBP_ODOINPUTTYPE_ODOMETER_GRADE_SHIFT) & \
+        SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK))
 #define SBP_ODOINPUTTYPE_ODOMETER_GRADE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK)) \
@@ -258,9 +258,9 @@
 #define SBP_ODOINPUTTYPE_ODOMETER_GRADE_SUPERIOR_GRADE (2)
 #define SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK (0x3)
 #define SBP_ODOINPUTTYPE_ODOMETER_CLASS_SHIFT (0u)
-#define SBP_ODOINPUTTYPE_ODOMETER_CLASS_GET(flags)      \
-  (((flags) >> SBP_ODOINPUTTYPE_ODOMETER_CLASS_SHIFT) & \
-   SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK)
+#define SBP_ODOINPUTTYPE_ODOMETER_CLASS_GET(flags)           \
+  ((u8)(((flags) >> SBP_ODOINPUTTYPE_ODOMETER_CLASS_SHIFT) & \
+        SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK))
 #define SBP_ODOINPUTTYPE_ODOMETER_CLASS_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK)) \

--- a/c/include/libsbp/solution_meta_macros.h
+++ b/c/include/libsbp/solution_meta_macros.h
@@ -23,10 +23,11 @@
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_GET(flags)      \
   (((flags) >> SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SHIFT) & \
    SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_MASK)
-#define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_MASK)) \
-                 << (SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SHIFT)));    \
+#define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_MASK)) \
+                        << (SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_SHIFT)));    \
   } while (0)
 
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_USAGE_UNKNOWN (0)
@@ -37,10 +38,11 @@
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_GET(flags)      \
   (((flags) >> SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SHIFT) & \
    SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_MASK)
-#define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SET(flags, val)           \
-  do {                                                              \
-    ((flags) |= (((val) & (SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_MASK)) \
-                 << (SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SHIFT)));    \
+#define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SET(flags, val)                  \
+  do {                                                                     \
+    (flags) =                                                              \
+        (u8)((flags) | (((val) & (SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_MASK)) \
+                        << (SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_SOLUTIONINPUTTYPE_SENSOR_TYPE_INVALID (0)
@@ -62,10 +64,11 @@
 #define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_GET(flags)      \
   (((flags) >> SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SHIFT) & \
    SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_MASK)
-#define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_MASK)) \
-                 << (SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SHIFT)));    \
+#define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SET(flags, val)                  \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) | (((val) & (SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_MASK)) \
+                        << (SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_SOLN_META_DEP_A_ALIGNMENT_STATUS_UNKNOWN_REASON_OR_ALREADY_ALIGNED \
@@ -106,10 +109,10 @@
 #define SBP_SOLN_META_TIME_STATUS_GET(flags)      \
   (((flags) >> SBP_SOLN_META_TIME_STATUS_SHIFT) & \
    SBP_SOLN_META_TIME_STATUS_MASK)
-#define SBP_SOLN_META_TIME_STATUS_SET(flags, val)           \
-  do {                                                      \
-    ((flags) |= (((val) & (SBP_SOLN_META_TIME_STATUS_MASK)) \
-                 << (SBP_SOLN_META_TIME_STATUS_SHIFT)));    \
+#define SBP_SOLN_META_TIME_STATUS_SET(flags, val)                         \
+  do {                                                                    \
+    (flags) = (u32)((flags) | (((val) & (SBP_SOLN_META_TIME_STATUS_MASK)) \
+                               << (SBP_SOLN_META_TIME_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_SOLN_META_TIME_STATUS_AGE_CAN_NOT_BE_USED_TO_RETRIEVE_TOM (0)
@@ -121,13 +124,14 @@
   (((flags) >>                                                                \
     SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT) &       \
    SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_MASK)
-#define SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SET(flags,  \
-                                                                       val)    \
-  do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) &                                                                 \
-       (SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_MASK))      \
-      << (SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT))); \
+#define SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SET(flags,     \
+                                                                       val)       \
+  do {                                                                            \
+    (flags) = (u32)(                                                              \
+        (flags) |                                                                 \
+        (((val) &                                                                 \
+          (SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_MASK))      \
+         << (SBP_SOLN_META_AGE_OF_THE_LAST_RECEIVED_VALID_GNSS_SOLUTION_SHIFT))); \
   } while (0)
 
 /**
@@ -157,10 +161,11 @@
 #define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_GET(flags)      \
   (((flags) >> SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SHIFT) & \
    SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_MASK)
-#define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_MASK)) \
-                 << (SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SHIFT)));    \
+#define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_MASK)) \
+                   << (SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_SHIFT)));    \
   } while (0)
 
 #define SBP_GNSSINPUTTYPE_TYPE_OF_GNSS_MEASUREMENT_GNSS_POSITION (0)
@@ -178,10 +183,10 @@
 #define SBP_IMUINPUTTYPE_TIME_STATUS_GET(flags)      \
   (((flags) >> SBP_IMUINPUTTYPE_TIME_STATUS_SHIFT) & \
    SBP_IMUINPUTTYPE_TIME_STATUS_MASK)
-#define SBP_IMUINPUTTYPE_TIME_STATUS_SET(flags, val)           \
-  do {                                                         \
-    ((flags) |= (((val) & (SBP_IMUINPUTTYPE_TIME_STATUS_MASK)) \
-                 << (SBP_IMUINPUTTYPE_TIME_STATUS_SHIFT)));    \
+#define SBP_IMUINPUTTYPE_TIME_STATUS_SET(flags, val)                        \
+  do {                                                                      \
+    (flags) = (u8)((flags) | (((val) & (SBP_IMUINPUTTYPE_TIME_STATUS_MASK)) \
+                              << (SBP_IMUINPUTTYPE_TIME_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_IMUINPUTTYPE_TIME_STATUS_REFERENCE_EPOCH_IS_START_OF_CURRENT_GPS_WEEK \
@@ -195,10 +200,10 @@
 #define SBP_IMUINPUTTYPE_IMU_GRADE_GET(flags)      \
   (((flags) >> SBP_IMUINPUTTYPE_IMU_GRADE_SHIFT) & \
    SBP_IMUINPUTTYPE_IMU_GRADE_MASK)
-#define SBP_IMUINPUTTYPE_IMU_GRADE_SET(flags, val)           \
-  do {                                                       \
-    ((flags) |= (((val) & (SBP_IMUINPUTTYPE_IMU_GRADE_MASK)) \
-                 << (SBP_IMUINPUTTYPE_IMU_GRADE_SHIFT)));    \
+#define SBP_IMUINPUTTYPE_IMU_GRADE_SET(flags, val)                        \
+  do {                                                                    \
+    (flags) = (u8)((flags) | (((val) & (SBP_IMUINPUTTYPE_IMU_GRADE_MASK)) \
+                              << (SBP_IMUINPUTTYPE_IMU_GRADE_SHIFT)));    \
   } while (0)
 
 #define SBP_IMUINPUTTYPE_IMU_GRADE_CONSUMER_GRADE (0)
@@ -210,10 +215,11 @@
 #define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_GET(flags)      \
   (((flags) >> SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SHIFT) & \
    SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_MASK)
-#define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SET(flags, val)           \
-  do {                                                              \
-    ((flags) |= (((val) & (SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_MASK)) \
-                 << (SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SHIFT)));    \
+#define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SET(flags, val)                  \
+  do {                                                                     \
+    (flags) =                                                              \
+        (u8)((flags) | (((val) & (SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_MASK)) \
+                        << (SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_SHIFT)));    \
   } while (0)
 
 #define SBP_IMUINPUTTYPE_IMU_ARCHITECTURE_6_AXIS_MEMS (0)
@@ -228,10 +234,10 @@
 #define SBP_ODOINPUTTYPE_RATE_SHIFT (4u)
 #define SBP_ODOINPUTTYPE_RATE_GET(flags) \
   (((flags) >> SBP_ODOINPUTTYPE_RATE_SHIFT) & SBP_ODOINPUTTYPE_RATE_MASK)
-#define SBP_ODOINPUTTYPE_RATE_SET(flags, val)           \
-  do {                                                  \
-    ((flags) |= (((val) & (SBP_ODOINPUTTYPE_RATE_MASK)) \
-                 << (SBP_ODOINPUTTYPE_RATE_SHIFT)));    \
+#define SBP_ODOINPUTTYPE_RATE_SET(flags, val)                        \
+  do {                                                               \
+    (flags) = (u8)((flags) | (((val) & (SBP_ODOINPUTTYPE_RATE_MASK)) \
+                              << (SBP_ODOINPUTTYPE_RATE_SHIFT)));    \
   } while (0)
 
 #define SBP_ODOINPUTTYPE_RATE_FIXED_INCOMING_RATE (0)
@@ -241,10 +247,10 @@
 #define SBP_ODOINPUTTYPE_ODOMETER_GRADE_GET(flags)      \
   (((flags) >> SBP_ODOINPUTTYPE_ODOMETER_GRADE_SHIFT) & \
    SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK)
-#define SBP_ODOINPUTTYPE_ODOMETER_GRADE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK)) \
-                 << (SBP_ODOINPUTTYPE_ODOMETER_GRADE_SHIFT)));    \
+#define SBP_ODOINPUTTYPE_ODOMETER_GRADE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_ODOINPUTTYPE_ODOMETER_GRADE_MASK)) \
+                              << (SBP_ODOINPUTTYPE_ODOMETER_GRADE_SHIFT)));    \
   } while (0)
 
 #define SBP_ODOINPUTTYPE_ODOMETER_GRADE_LOW_GRADE (0)
@@ -255,10 +261,10 @@
 #define SBP_ODOINPUTTYPE_ODOMETER_CLASS_GET(flags)      \
   (((flags) >> SBP_ODOINPUTTYPE_ODOMETER_CLASS_SHIFT) & \
    SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK)
-#define SBP_ODOINPUTTYPE_ODOMETER_CLASS_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK)) \
-                 << (SBP_ODOINPUTTYPE_ODOMETER_CLASS_SHIFT)));    \
+#define SBP_ODOINPUTTYPE_ODOMETER_CLASS_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_ODOINPUTTYPE_ODOMETER_CLASS_MASK)) \
+                              << (SBP_ODOINPUTTYPE_ODOMETER_CLASS_SHIFT)));    \
   } while (0)
 
 #define SBP_ODOINPUTTYPE_ODOMETER_CLASS_SINGLE_OR_AVERAGED_TICKS (0)

--- a/c/include/libsbp/ssr_macros.h
+++ b/c/include/libsbp/ssr_macros.h
@@ -189,9 +189,9 @@
 
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_MASK (0x1f)
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_SHIFT (0u)
-#define SBP_SATELLITEAPC_SATELLITE_TYPE_GET(flags)      \
-  (((flags) >> SBP_SATELLITEAPC_SATELLITE_TYPE_SHIFT) & \
-   SBP_SATELLITEAPC_SATELLITE_TYPE_MASK)
+#define SBP_SATELLITEAPC_SATELLITE_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_SATELLITEAPC_SATELLITE_TYPE_SHIFT) & \
+        SBP_SATELLITEAPC_SATELLITE_TYPE_MASK))
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_SET(flags, val)                        \
   do {                                                                         \
     (flags) = (u8)((flags) | (((val) & (SBP_SATELLITEAPC_SATELLITE_TYPE_MASK)) \

--- a/c/include/libsbp/ssr_macros.h
+++ b/c/include/libsbp/ssr_macros.h
@@ -192,10 +192,10 @@
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_GET(flags)      \
   (((flags) >> SBP_SATELLITEAPC_SATELLITE_TYPE_SHIFT) & \
    SBP_SATELLITEAPC_SATELLITE_TYPE_MASK)
-#define SBP_SATELLITEAPC_SATELLITE_TYPE_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_SATELLITEAPC_SATELLITE_TYPE_MASK)) \
-                 << (SBP_SATELLITEAPC_SATELLITE_TYPE_SHIFT)));    \
+#define SBP_SATELLITEAPC_SATELLITE_TYPE_SET(flags, val)                        \
+  do {                                                                         \
+    (flags) = (u8)((flags) | (((val) & (SBP_SATELLITEAPC_SATELLITE_TYPE_MASK)) \
+                              << (SBP_SATELLITEAPC_SATELLITE_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_SATELLITEAPC_SATELLITE_TYPE_UNKNOWN_TYPE (0)

--- a/c/include/libsbp/system_macros.h
+++ b/c/include/libsbp/system_macros.h
@@ -24,10 +24,10 @@
 #define SBP_STARTUP_CAUSE_OF_STARTUP_GET(flags)      \
   (((flags) >> SBP_STARTUP_CAUSE_OF_STARTUP_SHIFT) & \
    SBP_STARTUP_CAUSE_OF_STARTUP_MASK)
-#define SBP_STARTUP_CAUSE_OF_STARTUP_SET(flags, val)           \
-  do {                                                         \
-    ((flags) |= (((val) & (SBP_STARTUP_CAUSE_OF_STARTUP_MASK)) \
-                 << (SBP_STARTUP_CAUSE_OF_STARTUP_SHIFT)));    \
+#define SBP_STARTUP_CAUSE_OF_STARTUP_SET(flags, val)                        \
+  do {                                                                      \
+    (flags) = (u8)((flags) | (((val) & (SBP_STARTUP_CAUSE_OF_STARTUP_MASK)) \
+                              << (SBP_STARTUP_CAUSE_OF_STARTUP_SHIFT)));    \
   } while (0)
 
 #define SBP_STARTUP_CAUSE_OF_STARTUP_POWER_ON (0)
@@ -37,9 +37,10 @@
 #define SBP_STARTUP__SHIFT (0u)
 #define SBP_STARTUP__GET(flags) \
   (((flags) >> SBP_STARTUP__SHIFT) & SBP_STARTUP__MASK)
-#define SBP_STARTUP__SET(flags, val)                                      \
-  do {                                                                    \
-    ((flags) |= (((val) & (SBP_STARTUP__MASK)) << (SBP_STARTUP__SHIFT))); \
+#define SBP_STARTUP__SET(flags, val)                                         \
+  do {                                                                       \
+    (flags) = (u8)((flags) |                                                 \
+                   (((val) & (SBP_STARTUP__MASK)) << (SBP_STARTUP__SHIFT))); \
   } while (0)
 
 #define SBP_STARTUP_COLD_START (0)
@@ -59,10 +60,11 @@
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_GET(flags)      \
   (((flags) >> SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SHIFT) & \
    SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_MASK)
-#define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_MASK)) \
-                 << (SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SHIFT)));    \
+#define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_MASK)) \
+                        << (SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_INVALID (0)
@@ -96,10 +98,11 @@
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_GET(flags)      \
   (((flags) >> SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SHIFT) & \
    SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_MASK)
-#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SET(flags, val)           \
-  do {                                                                   \
-    ((flags) |= (((val) & (SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_MASK)) \
-                 << (SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SHIFT)));    \
+#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SET(flags, val)               \
+  do {                                                                       \
+    (flags) = (u32)((flags) |                                                \
+                    (((val) & (SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_MASK)) \
+                     << (SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_NO_EXTERNAL_ANTENNA_DETECTED (0)
@@ -109,10 +112,11 @@
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_GET(flags)      \
   (((flags) >> SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHIFT) & \
    SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_MASK)
-#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SET(flags, val)           \
-  do {                                                                 \
-    ((flags) |= (((val) & (SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_MASK)) \
-                 << (SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHIFT)));    \
+#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SET(flags, val)                   \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u32)((flags) | (((val) & (SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_MASK)) \
+                         << (SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_NO_SHORT_DETECTED (0)
@@ -122,11 +126,12 @@
 #define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
   (((flags) >> SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
    SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)
-#define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(flags, val) \
-  do {                                                                  \
-    ((flags) |=                                                         \
-     (((val) & (SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))  \
-      << (SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT)));     \
+#define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
+  do {                                                                    \
+    (flags) = (u32)(                                                      \
+        (flags) |                                                         \
+        (((val) & (SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)) \
+         << (SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK (0xff)
@@ -134,11 +139,12 @@
 #define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
   (((flags) >> SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
    SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)
-#define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(flags, val) \
-  do {                                                                  \
-    ((flags) |=                                                         \
-     (((val) & (SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))  \
-      << (SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT)));     \
+#define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
+  do {                                                                    \
+    (flags) = (u32)(                                                      \
+        (flags) |                                                         \
+        (((val) & (SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)) \
+         << (SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK (0x1)
@@ -146,10 +152,10 @@
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_GET(flags)      \
   (((flags) >> SBP_HEARTBEAT_SWIFTNAP_ERROR_SHIFT) & \
    SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK)
-#define SBP_HEARTBEAT_SWIFTNAP_ERROR_SET(flags, val)           \
-  do {                                                         \
-    ((flags) |= (((val) & (SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK)) \
-                 << (SBP_HEARTBEAT_SWIFTNAP_ERROR_SHIFT)));    \
+#define SBP_HEARTBEAT_SWIFTNAP_ERROR_SET(flags, val)                         \
+  do {                                                                       \
+    (flags) = (u32)((flags) | (((val) & (SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK)) \
+                               << (SBP_HEARTBEAT_SWIFTNAP_ERROR_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_SYSTEM_HEALTHY (0)
@@ -158,10 +164,10 @@
 #define SBP_HEARTBEAT_IO_ERROR_SHIFT (1u)
 #define SBP_HEARTBEAT_IO_ERROR_GET(flags) \
   (((flags) >> SBP_HEARTBEAT_IO_ERROR_SHIFT) & SBP_HEARTBEAT_IO_ERROR_MASK)
-#define SBP_HEARTBEAT_IO_ERROR_SET(flags, val)           \
-  do {                                                   \
-    ((flags) |= (((val) & (SBP_HEARTBEAT_IO_ERROR_MASK)) \
-                 << (SBP_HEARTBEAT_IO_ERROR_SHIFT)));    \
+#define SBP_HEARTBEAT_IO_ERROR_SET(flags, val)                         \
+  do {                                                                 \
+    (flags) = (u32)((flags) | (((val) & (SBP_HEARTBEAT_IO_ERROR_MASK)) \
+                               << (SBP_HEARTBEAT_IO_ERROR_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_IO_ERROR_SYSTEM_HEALTHY (0)
@@ -171,10 +177,11 @@
 #define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_GET(flags)      \
   (((flags) >> SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SHIFT) & \
    SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_MASK)
-#define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SET(flags, val)           \
-  do {                                                            \
-    ((flags) |= (((val) & (SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_MASK)) \
-                 << (SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SHIFT)));    \
+#define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SET(flags, val)                   \
+  do {                                                                    \
+    (flags) =                                                             \
+        (u32)((flags) | (((val) & (SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_MASK)) \
+                         << (SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SHIFT)));    \
   } while (0)
 
 #define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SYSTEM_HEALTHY (0)
@@ -190,10 +197,10 @@
 #define SBP_SUBSYSTEMREPORT_SUBSYSTEM_GET(flags)      \
   (((flags) >> SBP_SUBSYSTEMREPORT_SUBSYSTEM_SHIFT) & \
    SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK)
-#define SBP_SUBSYSTEMREPORT_SUBSYSTEM_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK)) \
-                 << (SBP_SUBSYSTEMREPORT_SUBSYSTEM_SHIFT)));    \
+#define SBP_SUBSYSTEMREPORT_SUBSYSTEM_SET(flags, val)                         \
+  do {                                                                        \
+    (flags) = (u16)((flags) | (((val) & (SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK)) \
+                               << (SBP_SUBSYSTEMREPORT_SUBSYSTEM_SHIFT)));    \
   } while (0)
 
 #define SBP_SUBSYSTEMREPORT_SUBSYSTEM_PRIMARY_GNSS_ANTENNA (0)
@@ -208,10 +215,10 @@
 #define SBP_SUBSYSTEMREPORT_GENERIC_GET(flags)      \
   (((flags) >> SBP_SUBSYSTEMREPORT_GENERIC_SHIFT) & \
    SBP_SUBSYSTEMREPORT_GENERIC_MASK)
-#define SBP_SUBSYSTEMREPORT_GENERIC_SET(flags, val)           \
-  do {                                                        \
-    ((flags) |= (((val) & (SBP_SUBSYSTEMREPORT_GENERIC_MASK)) \
-                 << (SBP_SUBSYSTEMREPORT_GENERIC_SHIFT)));    \
+#define SBP_SUBSYSTEMREPORT_GENERIC_SET(flags, val)                        \
+  do {                                                                     \
+    (flags) = (u8)((flags) | (((val) & (SBP_SUBSYSTEMREPORT_GENERIC_MASK)) \
+                              << (SBP_SUBSYSTEMREPORT_GENERIC_SHIFT)));    \
   } while (0)
 
 #define SBP_SUBSYSTEMREPORT_GENERIC_OKNOMINAL (0)
@@ -230,10 +237,10 @@
 #define SBP_STATUS_REPORT_SYSTEM_SHIFT (0u)
 #define SBP_STATUS_REPORT_SYSTEM_GET(flags) \
   (((flags) >> SBP_STATUS_REPORT_SYSTEM_SHIFT) & SBP_STATUS_REPORT_SYSTEM_MASK)
-#define SBP_STATUS_REPORT_SYSTEM_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_STATUS_REPORT_SYSTEM_MASK)) \
-                 << (SBP_STATUS_REPORT_SYSTEM_SHIFT)));    \
+#define SBP_STATUS_REPORT_SYSTEM_SET(flags, val)                         \
+  do {                                                                   \
+    (flags) = (u16)((flags) | (((val) & (SBP_STATUS_REPORT_SYSTEM_MASK)) \
+                               << (SBP_STATUS_REPORT_SYSTEM_SHIFT)));    \
   } while (0)
 
 #define SBP_STATUS_REPORT_SYSTEM_STARLING (0)
@@ -243,11 +250,12 @@
 #define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
   (((flags) >> SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
    SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)
-#define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(flags, val) \
-  do {                                                                      \
-    ((flags) |=                                                             \
-     (((val) & (SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))  \
-      << (SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT)));     \
+#define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
+  do {                                                                        \
+    (flags) = (u16)(                                                          \
+        (flags) |                                                             \
+        (((val) & (SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)) \
+         << (SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT)));    \
   } while (0)
 
 #define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK (0xff)
@@ -255,11 +263,12 @@
 #define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
   (((flags) >> SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
    SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)
-#define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(flags, val) \
-  do {                                                                      \
-    ((flags) |=                                                             \
-     (((val) & (SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))  \
-      << (SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT)));     \
+#define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
+  do {                                                                        \
+    (flags) = (u16)(                                                          \
+        (flags) |                                                             \
+        (((val) & (SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)) \
+         << (SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT)));    \
   } while (0)
 
 /**
@@ -289,10 +298,10 @@
 #define SBP_INS_STATUS_INS_TYPE_SHIFT (29u)
 #define SBP_INS_STATUS_INS_TYPE_GET(flags) \
   (((flags) >> SBP_INS_STATUS_INS_TYPE_SHIFT) & SBP_INS_STATUS_INS_TYPE_MASK)
-#define SBP_INS_STATUS_INS_TYPE_SET(flags, val)           \
-  do {                                                    \
-    ((flags) |= (((val) & (SBP_INS_STATUS_INS_TYPE_MASK)) \
-                 << (SBP_INS_STATUS_INS_TYPE_SHIFT)));    \
+#define SBP_INS_STATUS_INS_TYPE_SET(flags, val)                         \
+  do {                                                                  \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_INS_TYPE_MASK)) \
+                               << (SBP_INS_STATUS_INS_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_INS_TYPE_SMOOTHPOSE_LOOSELY_COUPLED (0)
@@ -302,10 +311,10 @@
 #define SBP_INS_STATUS_MOTION_STATE_GET(flags)      \
   (((flags) >> SBP_INS_STATUS_MOTION_STATE_SHIFT) & \
    SBP_INS_STATUS_MOTION_STATE_MASK)
-#define SBP_INS_STATUS_MOTION_STATE_SET(flags, val)           \
-  do {                                                        \
-    ((flags) |= (((val) & (SBP_INS_STATUS_MOTION_STATE_MASK)) \
-                 << (SBP_INS_STATUS_MOTION_STATE_SHIFT)));    \
+#define SBP_INS_STATUS_MOTION_STATE_SET(flags, val)                         \
+  do {                                                                      \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_MOTION_STATE_MASK)) \
+                               << (SBP_INS_STATUS_MOTION_STATE_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_MOTION_STATE_UNKNOWN_OR_INIT (0)
@@ -317,10 +326,10 @@
 #define SBP_INS_STATUS_ODOMETRY_SYNCH_GET(flags)      \
   (((flags) >> SBP_INS_STATUS_ODOMETRY_SYNCH_SHIFT) & \
    SBP_INS_STATUS_ODOMETRY_SYNCH_MASK)
-#define SBP_INS_STATUS_ODOMETRY_SYNCH_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_INS_STATUS_ODOMETRY_SYNCH_MASK)) \
-                 << (SBP_INS_STATUS_ODOMETRY_SYNCH_SHIFT)));    \
+#define SBP_INS_STATUS_ODOMETRY_SYNCH_SET(flags, val)                         \
+  do {                                                                        \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_ODOMETRY_SYNCH_MASK)) \
+                               << (SBP_INS_STATUS_ODOMETRY_SYNCH_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_ODOMETRY_SYNCH_ODOMETRY_TIMESTAMP_NOMINAL (0)
@@ -330,10 +339,10 @@
 #define SBP_INS_STATUS_ODOMETRY_STATUS_GET(flags)      \
   (((flags) >> SBP_INS_STATUS_ODOMETRY_STATUS_SHIFT) & \
    SBP_INS_STATUS_ODOMETRY_STATUS_MASK)
-#define SBP_INS_STATUS_ODOMETRY_STATUS_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_INS_STATUS_ODOMETRY_STATUS_MASK)) \
-                 << (SBP_INS_STATUS_ODOMETRY_STATUS_SHIFT)));    \
+#define SBP_INS_STATUS_ODOMETRY_STATUS_SET(flags, val)                         \
+  do {                                                                         \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_ODOMETRY_STATUS_MASK)) \
+                               << (SBP_INS_STATUS_ODOMETRY_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_ODOMETRY_STATUS_NO_ODOMETRY (0)
@@ -344,10 +353,10 @@
 #define SBP_INS_STATUS_INS_ERROR_SHIFT (4u)
 #define SBP_INS_STATUS_INS_ERROR_GET(flags) \
   (((flags) >> SBP_INS_STATUS_INS_ERROR_SHIFT) & SBP_INS_STATUS_INS_ERROR_MASK)
-#define SBP_INS_STATUS_INS_ERROR_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_INS_STATUS_INS_ERROR_MASK)) \
-                 << (SBP_INS_STATUS_INS_ERROR_SHIFT)));    \
+#define SBP_INS_STATUS_INS_ERROR_SET(flags, val)                         \
+  do {                                                                   \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_INS_ERROR_MASK)) \
+                               << (SBP_INS_STATUS_INS_ERROR_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_INS_ERROR_IMU_DATA_ERROR (1)
@@ -357,10 +366,10 @@
 #define SBP_INS_STATUS_GNSS_FIX_SHIFT (3u)
 #define SBP_INS_STATUS_GNSS_FIX_GET(flags) \
   (((flags) >> SBP_INS_STATUS_GNSS_FIX_SHIFT) & SBP_INS_STATUS_GNSS_FIX_MASK)
-#define SBP_INS_STATUS_GNSS_FIX_SET(flags, val)           \
-  do {                                                    \
-    ((flags) |= (((val) & (SBP_INS_STATUS_GNSS_FIX_MASK)) \
-                 << (SBP_INS_STATUS_GNSS_FIX_SHIFT)));    \
+#define SBP_INS_STATUS_GNSS_FIX_SET(flags, val)                         \
+  do {                                                                  \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_GNSS_FIX_MASK)) \
+                               << (SBP_INS_STATUS_GNSS_FIX_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_GNSS_FIX_NO_GNSS_FIX_AVAILABLE (0)
@@ -369,10 +378,10 @@
 #define SBP_INS_STATUS_MODE_SHIFT (0u)
 #define SBP_INS_STATUS_MODE_GET(flags) \
   (((flags) >> SBP_INS_STATUS_MODE_SHIFT) & SBP_INS_STATUS_MODE_MASK)
-#define SBP_INS_STATUS_MODE_SET(flags, val)                                  \
-  do {                                                                       \
-    ((flags) |=                                                              \
-     (((val) & (SBP_INS_STATUS_MODE_MASK)) << (SBP_INS_STATUS_MODE_SHIFT))); \
+#define SBP_INS_STATUS_MODE_SET(flags, val)                         \
+  do {                                                              \
+    (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_MODE_MASK)) \
+                               << (SBP_INS_STATUS_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_INS_STATUS_MODE_AWAITING_INITIALIZATION (0)
@@ -446,13 +455,14 @@
   (((flags) >>                                                                            \
     SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                                  \
-  do {                                                                                           \
-    ((flags) |=                                                                                  \
-     (((val) &                                                                                   \
-       (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                     \
+  do {                                                                                              \
+    (flags) = (u8)(                                                                                 \
+        (flags) |                                                                                   \
+        (((val) &                                                                                   \
+          (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -464,13 +474,14 @@
   (((flags) >>                                                                           \
     SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                                 \
-  do {                                                                                          \
-    ((flags) |=                                                                                 \
-     (((val) &                                                                                  \
-       (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                    \
+  do {                                                                                             \
+    (flags) = (u8)(                                                                                \
+        (flags) |                                                                                  \
+        (((val) &                                                                                  \
+          (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -482,13 +493,14 @@
   (((flags) >>                                                                            \
     SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                                  \
-  do {                                                                                           \
-    ((flags) |=                                                                                  \
-     (((val) &                                                                                   \
-       (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                     \
+  do {                                                                                              \
+    (flags) = (u8)(                                                                                 \
+        (flags) |                                                                                   \
+        (((val) &                                                                                   \
+          (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -500,13 +512,14 @@
   (((flags) >>                                                                           \
     SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                                 \
-  do {                                                                                          \
-    ((flags) |=                                                                                 \
-     (((val) &                                                                                  \
-       (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                    \
+  do {                                                                                             \
+    (flags) = (u8)(                                                                                \
+        (flags) |                                                                                  \
+        (((val) &                                                                                  \
+          (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -518,13 +531,14 @@
   (((flags) >>                                                                        \
     SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                              \
-  do {                                                                                       \
-    ((flags) |=                                                                              \
-     (((val) &                                                                               \
-       (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                 \
+  do {                                                                                          \
+    (flags) = (u8)(                                                                             \
+        (flags) |                                                                               \
+        (((val) &                                                                               \
+          (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -536,13 +550,14 @@
   (((flags) >>                                                                       \
     SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                             \
-  do {                                                                                      \
-    ((flags) |=                                                                             \
-     (((val) &                                                                              \
-       (SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                \
+  do {                                                                                         \
+    (flags) = (u8)(                                                                            \
+        (flags) |                                                                              \
+        (((val) &                                                                              \
+          (SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -554,13 +569,14 @@
   (((flags) >>                                                                    \
     SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                          \
-  do {                                                                                   \
-    ((flags) |=                                                                          \
-     (((val) &                                                                           \
-       (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                             \
+  do {                                                                                      \
+    (flags) = (u8)(                                                                         \
+        (flags) |                                                                           \
+        (((val) &                                                                           \
+          (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -572,13 +588,14 @@
   (((flags) >>                                                                   \
     SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                         \
-  do {                                                                                  \
-    ((flags) |=                                                                         \
-     (((val) &                                                                          \
-       (SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                            \
+  do {                                                                                     \
+    (flags) = (u8)(                                                                        \
+        (flags) |                                                                          \
+        (((val) &                                                                          \
+          (SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -590,13 +607,14 @@
   (((flags) >>                                                                  \
     SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                        \
-  do {                                                                                 \
-    ((flags) |=                                                                        \
-     (((val) &                                                                         \
-       (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                           \
+  do {                                                                                    \
+    (flags) = (u8)(                                                                       \
+        (flags) |                                                                         \
+        (((val) &                                                                         \
+          (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -608,13 +626,14 @@
   (((flags) >>                                                                 \
     SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                       \
-  do {                                                                                \
-    ((flags) |=                                                                       \
-     (((val) &                                                                        \
-       (SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                          \
+  do {                                                                                   \
+    (flags) = (u8)(                                                                      \
+        (flags) |                                                                        \
+        (((val) &                                                                        \
+          (SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -626,13 +645,14 @@
   (((flags) >>                                                                            \
     SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                                  \
-  do {                                                                                           \
-    ((flags) |=                                                                                  \
-     (((val) &                                                                                   \
-       (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                     \
+  do {                                                                                              \
+    (flags) = (u8)(                                                                                 \
+        (flags) |                                                                                   \
+        (((val) &                                                                                   \
+          (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK \
@@ -644,13 +664,14 @@
   (((flags) >>                                                                           \
     SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
    SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(        \
-    flags, val)                                                                                 \
-  do {                                                                                          \
-    ((flags) |=                                                                                 \
-     (((val) &                                                                                  \
-       (SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
-      << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
+    flags, val)                                                                                    \
+  do {                                                                                             \
+    (flags) = (u8)(                                                                                \
+        (flags) |                                                                                  \
+        (((val) &                                                                                  \
+          (SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))      \
+         << (SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT))); \
   } while (0)
 
 /**
@@ -672,10 +693,11 @@
 #define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_GET(flags)      \
   (((flags) >> SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SHIFT) & \
    SBP_PPS_TIME_RESERVED_SET_TO_ZERO_MASK)
-#define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SET(flags, val)           \
-  do {                                                              \
-    ((flags) |= (((val) & (SBP_PPS_TIME_RESERVED_SET_TO_ZERO_MASK)) \
-                 << (SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SHIFT)));    \
+#define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SET(flags, val)                  \
+  do {                                                                     \
+    (flags) =                                                              \
+        (u8)((flags) | (((val) & (SBP_PPS_TIME_RESERVED_SET_TO_ZERO_MASK)) \
+                        << (SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SHIFT)));    \
   } while (0)
 
 #define SBP_PPS_TIME_TIME_UNCERTAINTY_MASK (0x3)
@@ -683,10 +705,10 @@
 #define SBP_PPS_TIME_TIME_UNCERTAINTY_GET(flags)      \
   (((flags) >> SBP_PPS_TIME_TIME_UNCERTAINTY_SHIFT) & \
    SBP_PPS_TIME_TIME_UNCERTAINTY_MASK)
-#define SBP_PPS_TIME_TIME_UNCERTAINTY_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_PPS_TIME_TIME_UNCERTAINTY_MASK)) \
-                 << (SBP_PPS_TIME_TIME_UNCERTAINTY_SHIFT)));    \
+#define SBP_PPS_TIME_TIME_UNCERTAINTY_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_PPS_TIME_TIME_UNCERTAINTY_MASK)) \
+                              << (SBP_PPS_TIME_TIME_UNCERTAINTY_SHIFT)));    \
   } while (0)
 
 #define SBP_PPS_TIME_TIME_UNCERTAINTY_UNKNOWN (0)
@@ -709,10 +731,11 @@
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_GET(flags)      \
   (((flags) >> SBP_GROUP_META_SOLUTION_GROUP_TYPE_SHIFT) & \
    SBP_GROUP_META_SOLUTION_GROUP_TYPE_MASK)
-#define SBP_GROUP_META_SOLUTION_GROUP_TYPE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_GROUP_META_SOLUTION_GROUP_TYPE_MASK)) \
-                 << (SBP_GROUP_META_SOLUTION_GROUP_TYPE_SHIFT)));    \
+#define SBP_GROUP_META_SOLUTION_GROUP_TYPE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_GROUP_META_SOLUTION_GROUP_TYPE_MASK)) \
+                        << (SBP_GROUP_META_SOLUTION_GROUP_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_NONE (0)

--- a/c/include/libsbp/system_macros.h
+++ b/c/include/libsbp/system_macros.h
@@ -21,9 +21,9 @@
 #define SBP_MSG_STARTUP 0xFF00
 #define SBP_STARTUP_CAUSE_OF_STARTUP_MASK (0x1ff)
 #define SBP_STARTUP_CAUSE_OF_STARTUP_SHIFT (0u)
-#define SBP_STARTUP_CAUSE_OF_STARTUP_GET(flags)      \
-  (((flags) >> SBP_STARTUP_CAUSE_OF_STARTUP_SHIFT) & \
-   SBP_STARTUP_CAUSE_OF_STARTUP_MASK)
+#define SBP_STARTUP_CAUSE_OF_STARTUP_GET(flags)           \
+  ((u8)(((flags) >> SBP_STARTUP_CAUSE_OF_STARTUP_SHIFT) & \
+        SBP_STARTUP_CAUSE_OF_STARTUP_MASK))
 #define SBP_STARTUP_CAUSE_OF_STARTUP_SET(flags, val)                        \
   do {                                                                      \
     (flags) = (u8)((flags) | (((val) & (SBP_STARTUP_CAUSE_OF_STARTUP_MASK)) \
@@ -36,7 +36,7 @@
 #define SBP_STARTUP__MASK (0x1ff)
 #define SBP_STARTUP__SHIFT (0u)
 #define SBP_STARTUP__GET(flags) \
-  (((flags) >> SBP_STARTUP__SHIFT) & SBP_STARTUP__MASK)
+  ((u8)(((flags) >> SBP_STARTUP__SHIFT) & SBP_STARTUP__MASK))
 #define SBP_STARTUP__SET(flags, val)                                         \
   do {                                                                       \
     (flags) = (u8)((flags) |                                                 \
@@ -57,9 +57,9 @@
 #define SBP_MSG_DGNSS_STATUS 0xFF02
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_MASK (0xf)
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SHIFT (0u)
-#define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_GET(flags)      \
-  (((flags) >> SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SHIFT) & \
-   SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_MASK)
+#define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SHIFT) & \
+        SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_MASK))
 #define SBP_DGNSS_STATUS_DIFFERENTIAL_TYPE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \
@@ -95,9 +95,9 @@
 #define SBP_MSG_HEARTBEAT 0xFFFF
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_MASK (0x1)
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SHIFT (31u)
-#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_GET(flags)      \
-  (((flags) >> SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SHIFT) & \
-   SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_MASK)
+#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SHIFT) & \
+         SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_MASK))
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_SET(flags, val)               \
   do {                                                                       \
     (flags) = (u32)((flags) |                                                \
@@ -109,9 +109,9 @@
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_PRESENT_EXTERNAL_ANTENNA_IS_PRESENT (1)
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_MASK (0x1)
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHIFT (30u)
-#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_GET(flags)      \
-  (((flags) >> SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHIFT) & \
-   SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_MASK)
+#define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHIFT) & \
+         SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_MASK))
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SET(flags, val)                   \
   do {                                                                         \
     (flags) =                                                                  \
@@ -123,9 +123,9 @@
 #define SBP_HEARTBEAT_EXTERNAL_ANTENNA_SHORT_SHORT_DETECTED (1)
 #define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK (0xff)
 #define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT (16u)
-#define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
-  (((flags) >> SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
-   SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)
+#define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
+         SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))
 #define SBP_HEARTBEAT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
   do {                                                                    \
     (flags) = (u32)(                                                      \
@@ -136,9 +136,9 @@
 
 #define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK (0xff)
 #define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT (8u)
-#define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
-  (((flags) >> SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
-   SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)
+#define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
+         SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))
 #define SBP_HEARTBEAT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
   do {                                                                    \
     (flags) = (u32)(                                                      \
@@ -149,9 +149,9 @@
 
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK (0x1)
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_SHIFT (2u)
-#define SBP_HEARTBEAT_SWIFTNAP_ERROR_GET(flags)      \
-  (((flags) >> SBP_HEARTBEAT_SWIFTNAP_ERROR_SHIFT) & \
-   SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK)
+#define SBP_HEARTBEAT_SWIFTNAP_ERROR_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_SWIFTNAP_ERROR_SHIFT) & \
+         SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK))
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_SET(flags, val)                         \
   do {                                                                       \
     (flags) = (u32)((flags) | (((val) & (SBP_HEARTBEAT_SWIFTNAP_ERROR_MASK)) \
@@ -162,8 +162,9 @@
 #define SBP_HEARTBEAT_SWIFTNAP_ERROR_AN_ERROR_HAS_OCCURRED_IN_THE_SWIFTNAP (1)
 #define SBP_HEARTBEAT_IO_ERROR_MASK (0x1)
 #define SBP_HEARTBEAT_IO_ERROR_SHIFT (1u)
-#define SBP_HEARTBEAT_IO_ERROR_GET(flags) \
-  (((flags) >> SBP_HEARTBEAT_IO_ERROR_SHIFT) & SBP_HEARTBEAT_IO_ERROR_MASK)
+#define SBP_HEARTBEAT_IO_ERROR_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_IO_ERROR_SHIFT) & \
+         SBP_HEARTBEAT_IO_ERROR_MASK))
 #define SBP_HEARTBEAT_IO_ERROR_SET(flags, val)                         \
   do {                                                                 \
     (flags) = (u32)((flags) | (((val) & (SBP_HEARTBEAT_IO_ERROR_MASK)) \
@@ -174,9 +175,9 @@
 #define SBP_HEARTBEAT_IO_ERROR_AN_IO_ERROR_HAS_OCCURRED (1)
 #define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_MASK (0x1)
 #define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SHIFT (0u)
-#define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_GET(flags)      \
-  (((flags) >> SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SHIFT) & \
-   SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_MASK)
+#define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_GET(flags)            \
+  ((u32)(((flags) >> SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SHIFT) & \
+         SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_MASK))
 #define SBP_HEARTBEAT_SYSTEM_ERROR_FLAG_SET(flags, val)                   \
   do {                                                                    \
     (flags) =                                                             \
@@ -194,9 +195,9 @@
 
 #define SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK (0xffff)
 #define SBP_SUBSYSTEMREPORT_SUBSYSTEM_SHIFT (0u)
-#define SBP_SUBSYSTEMREPORT_SUBSYSTEM_GET(flags)      \
-  (((flags) >> SBP_SUBSYSTEMREPORT_SUBSYSTEM_SHIFT) & \
-   SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK)
+#define SBP_SUBSYSTEMREPORT_SUBSYSTEM_GET(flags)            \
+  ((u16)(((flags) >> SBP_SUBSYSTEMREPORT_SUBSYSTEM_SHIFT) & \
+         SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK))
 #define SBP_SUBSYSTEMREPORT_SUBSYSTEM_SET(flags, val)                         \
   do {                                                                        \
     (flags) = (u16)((flags) | (((val) & (SBP_SUBSYSTEMREPORT_SUBSYSTEM_MASK)) \
@@ -212,9 +213,9 @@
 #define SBP_SUBSYSTEMREPORT_SUBSYSTEM_SENSOR_FUSION_ENGINE (6)
 #define SBP_SUBSYSTEMREPORT_GENERIC_MASK (0xff)
 #define SBP_SUBSYSTEMREPORT_GENERIC_SHIFT (0u)
-#define SBP_SUBSYSTEMREPORT_GENERIC_GET(flags)      \
-  (((flags) >> SBP_SUBSYSTEMREPORT_GENERIC_SHIFT) & \
-   SBP_SUBSYSTEMREPORT_GENERIC_MASK)
+#define SBP_SUBSYSTEMREPORT_GENERIC_GET(flags)           \
+  ((u8)(((flags) >> SBP_SUBSYSTEMREPORT_GENERIC_SHIFT) & \
+        SBP_SUBSYSTEMREPORT_GENERIC_MASK))
 #define SBP_SUBSYSTEMREPORT_GENERIC_SET(flags, val)                        \
   do {                                                                     \
     (flags) = (u8)((flags) | (((val) & (SBP_SUBSYSTEMREPORT_GENERIC_MASK)) \
@@ -235,8 +236,9 @@
 #define SBP_MSG_STATUS_REPORT 0xFFFE
 #define SBP_STATUS_REPORT_SYSTEM_MASK (0xffff)
 #define SBP_STATUS_REPORT_SYSTEM_SHIFT (0u)
-#define SBP_STATUS_REPORT_SYSTEM_GET(flags) \
-  (((flags) >> SBP_STATUS_REPORT_SYSTEM_SHIFT) & SBP_STATUS_REPORT_SYSTEM_MASK)
+#define SBP_STATUS_REPORT_SYSTEM_GET(flags)            \
+  ((u16)(((flags) >> SBP_STATUS_REPORT_SYSTEM_SHIFT) & \
+         SBP_STATUS_REPORT_SYSTEM_MASK))
 #define SBP_STATUS_REPORT_SYSTEM_SET(flags, val)                         \
   do {                                                                   \
     (flags) = (u16)((flags) | (((val) & (SBP_STATUS_REPORT_SYSTEM_MASK)) \
@@ -247,9 +249,10 @@
 #define SBP_STATUS_REPORT_SYSTEM_PRECISION_GNSS_MODULE (1)
 #define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK (0x1ff)
 #define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT (8u)
-#define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
-  (((flags) >> SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
-   SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK)
+#define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_GET(flags)         \
+  ((u16)(                                                                      \
+      ((flags) >> SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
+      SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_MASK))
 #define SBP_STATUS_REPORT_SBP_MAJOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
   do {                                                                        \
     (flags) = (u16)(                                                          \
@@ -260,9 +263,10 @@
 
 #define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK (0xff)
 #define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT (0u)
-#define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(flags)      \
-  (((flags) >> SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
-   SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK)
+#define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_GET(flags)         \
+  ((u16)(                                                                      \
+      ((flags) >> SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SHIFT) & \
+      SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_MASK))
 #define SBP_STATUS_REPORT_SBP_MINOR_PROTOCOL_VERSION_NUMBER_SET(flags, val)   \
   do {                                                                        \
     (flags) = (u16)(                                                          \
@@ -296,8 +300,9 @@
 #define SBP_MSG_INS_STATUS 0xFF03
 #define SBP_INS_STATUS_INS_TYPE_MASK (0x7)
 #define SBP_INS_STATUS_INS_TYPE_SHIFT (29u)
-#define SBP_INS_STATUS_INS_TYPE_GET(flags) \
-  (((flags) >> SBP_INS_STATUS_INS_TYPE_SHIFT) & SBP_INS_STATUS_INS_TYPE_MASK)
+#define SBP_INS_STATUS_INS_TYPE_GET(flags)            \
+  ((u32)(((flags) >> SBP_INS_STATUS_INS_TYPE_SHIFT) & \
+         SBP_INS_STATUS_INS_TYPE_MASK))
 #define SBP_INS_STATUS_INS_TYPE_SET(flags, val)                         \
   do {                                                                  \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_INS_TYPE_MASK)) \
@@ -308,9 +313,9 @@
 #define SBP_INS_STATUS_INS_TYPE_STARLING (1)
 #define SBP_INS_STATUS_MOTION_STATE_MASK (0x7)
 #define SBP_INS_STATUS_MOTION_STATE_SHIFT (11u)
-#define SBP_INS_STATUS_MOTION_STATE_GET(flags)      \
-  (((flags) >> SBP_INS_STATUS_MOTION_STATE_SHIFT) & \
-   SBP_INS_STATUS_MOTION_STATE_MASK)
+#define SBP_INS_STATUS_MOTION_STATE_GET(flags)            \
+  ((u32)(((flags) >> SBP_INS_STATUS_MOTION_STATE_SHIFT) & \
+         SBP_INS_STATUS_MOTION_STATE_MASK))
 #define SBP_INS_STATUS_MOTION_STATE_SET(flags, val)                         \
   do {                                                                      \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_MOTION_STATE_MASK)) \
@@ -323,9 +328,9 @@
 #define SBP_INS_STATUS_MOTION_STATE_STATIONARY (3)
 #define SBP_INS_STATUS_ODOMETRY_SYNCH_MASK (0x1)
 #define SBP_INS_STATUS_ODOMETRY_SYNCH_SHIFT (10u)
-#define SBP_INS_STATUS_ODOMETRY_SYNCH_GET(flags)      \
-  (((flags) >> SBP_INS_STATUS_ODOMETRY_SYNCH_SHIFT) & \
-   SBP_INS_STATUS_ODOMETRY_SYNCH_MASK)
+#define SBP_INS_STATUS_ODOMETRY_SYNCH_GET(flags)            \
+  ((u32)(((flags) >> SBP_INS_STATUS_ODOMETRY_SYNCH_SHIFT) & \
+         SBP_INS_STATUS_ODOMETRY_SYNCH_MASK))
 #define SBP_INS_STATUS_ODOMETRY_SYNCH_SET(flags, val)                         \
   do {                                                                        \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_ODOMETRY_SYNCH_MASK)) \
@@ -336,9 +341,9 @@
 #define SBP_INS_STATUS_ODOMETRY_SYNCH_ODOMETRY_TIMESTAMP_OUT_OF_BOUNDS (1)
 #define SBP_INS_STATUS_ODOMETRY_STATUS_MASK (0x3)
 #define SBP_INS_STATUS_ODOMETRY_STATUS_SHIFT (8u)
-#define SBP_INS_STATUS_ODOMETRY_STATUS_GET(flags)      \
-  (((flags) >> SBP_INS_STATUS_ODOMETRY_STATUS_SHIFT) & \
-   SBP_INS_STATUS_ODOMETRY_STATUS_MASK)
+#define SBP_INS_STATUS_ODOMETRY_STATUS_GET(flags)            \
+  ((u32)(((flags) >> SBP_INS_STATUS_ODOMETRY_STATUS_SHIFT) & \
+         SBP_INS_STATUS_ODOMETRY_STATUS_MASK))
 #define SBP_INS_STATUS_ODOMETRY_STATUS_SET(flags, val)                         \
   do {                                                                         \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_ODOMETRY_STATUS_MASK)) \
@@ -351,8 +356,9 @@
   (2)
 #define SBP_INS_STATUS_INS_ERROR_MASK (0xf)
 #define SBP_INS_STATUS_INS_ERROR_SHIFT (4u)
-#define SBP_INS_STATUS_INS_ERROR_GET(flags) \
-  (((flags) >> SBP_INS_STATUS_INS_ERROR_SHIFT) & SBP_INS_STATUS_INS_ERROR_MASK)
+#define SBP_INS_STATUS_INS_ERROR_GET(flags)            \
+  ((u32)(((flags) >> SBP_INS_STATUS_INS_ERROR_SHIFT) & \
+         SBP_INS_STATUS_INS_ERROR_MASK))
 #define SBP_INS_STATUS_INS_ERROR_SET(flags, val)                         \
   do {                                                                   \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_INS_ERROR_MASK)) \
@@ -364,8 +370,9 @@
 #define SBP_INS_STATUS_INS_ERROR_IMU_CALIBRATION_DATA_ERROR (3)
 #define SBP_INS_STATUS_GNSS_FIX_MASK (0x1)
 #define SBP_INS_STATUS_GNSS_FIX_SHIFT (3u)
-#define SBP_INS_STATUS_GNSS_FIX_GET(flags) \
-  (((flags) >> SBP_INS_STATUS_GNSS_FIX_SHIFT) & SBP_INS_STATUS_GNSS_FIX_MASK)
+#define SBP_INS_STATUS_GNSS_FIX_GET(flags)            \
+  ((u32)(((flags) >> SBP_INS_STATUS_GNSS_FIX_SHIFT) & \
+         SBP_INS_STATUS_GNSS_FIX_MASK))
 #define SBP_INS_STATUS_GNSS_FIX_SET(flags, val)                         \
   do {                                                                  \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_GNSS_FIX_MASK)) \
@@ -377,7 +384,7 @@
 #define SBP_INS_STATUS_MODE_MASK (0x7)
 #define SBP_INS_STATUS_MODE_SHIFT (0u)
 #define SBP_INS_STATUS_MODE_GET(flags) \
-  (((flags) >> SBP_INS_STATUS_MODE_SHIFT) & SBP_INS_STATUS_MODE_MASK)
+  ((u32)(((flags) >> SBP_INS_STATUS_MODE_SHIFT) & SBP_INS_STATUS_MODE_MASK))
 #define SBP_INS_STATUS_MODE_SET(flags, val)                         \
   do {                                                              \
     (flags) = (u32)((flags) | (((val) & (SBP_INS_STATUS_MODE_MASK)) \
@@ -450,11 +457,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (4u)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                                \
-  (((flags) >>                                                                            \
-    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                                   \
+  ((u8)(                                                                                     \
+      ((flags) >>                                                                            \
+       SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                     \
   do {                                                                                              \
@@ -469,11 +477,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (0u)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                               \
-  (((flags) >>                                                                           \
-    SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                                  \
+  ((u8)(                                                                                    \
+      ((flags) >>                                                                           \
+       SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_POSITION_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                    \
   do {                                                                                             \
@@ -488,11 +497,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (4u)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                                \
-  (((flags) >>                                                                            \
-    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                                   \
+  ((u8)(                                                                                     \
+      ((flags) >>                                                                            \
+       SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                     \
   do {                                                                                              \
@@ -507,11 +517,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (0u)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                               \
-  (((flags) >>                                                                           \
-    SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                                  \
+  ((u8)(                                                                                    \
+      ((flags) >>                                                                           \
+       SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_GNSS_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                    \
   do {                                                                                             \
@@ -526,11 +537,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (4u)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                            \
-  (((flags) >>                                                                        \
-    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                               \
+  ((u8)(                                                                                 \
+      ((flags) >>                                                                        \
+       SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                 \
   do {                                                                                          \
@@ -545,11 +557,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (0u)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                           \
-  (((flags) >>                                                                       \
-    SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                              \
+  ((u8)(                                                                                \
+      ((flags) >>                                                                       \
+       SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_WHEELTICK_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                \
   do {                                                                                         \
@@ -564,11 +577,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (4u)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                        \
-  (((flags) >>                                                                    \
-    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                           \
+  ((u8)(                                                                             \
+      ((flags) >>                                                                    \
+       SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                             \
   do {                                                                                      \
@@ -583,11 +597,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (0u)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                       \
-  (((flags) >>                                                                   \
-    SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                          \
+  ((u8)(                                                                            \
+      ((flags) >>                                                                   \
+       SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_SPEED_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                            \
   do {                                                                                     \
@@ -602,11 +617,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (4u)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                      \
-  (((flags) >>                                                                  \
-    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                         \
+  ((u8)(                                                                           \
+      ((flags) >>                                                                  \
+       SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                           \
   do {                                                                                    \
@@ -621,11 +637,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (0u)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                     \
-  (((flags) >>                                                                 \
-    SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                        \
+  ((u8)(                                                                          \
+      ((flags) >>                                                                 \
+       SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_NHC_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                          \
   do {                                                                                   \
@@ -640,11 +657,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (4u)
-#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                                \
-  (((flags) >>                                                                            \
-    SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                                   \
+  ((u8)(                                                                                     \
+      ((flags) >>                                                                            \
+       SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_ATTEMPTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                     \
   do {                                                                                              \
@@ -659,11 +677,12 @@
   (0xf)
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT \
   (0u)
-#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET( \
-    flags)                                                                               \
-  (((flags) >>                                                                           \
-    SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
-   SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK)
+#define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_GET(    \
+    flags)                                                                                  \
+  ((u8)(                                                                                    \
+      ((flags) >>                                                                           \
+       SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SHIFT) & \
+      SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_MASK))
 #define SBP_INS_UPDATES_NUMBER_OF_REJECTED_ZERO_VELOCITY_UPDATES_SINCE_LAST_MESSAGE_SET(           \
     flags, val)                                                                                    \
   do {                                                                                             \
@@ -690,9 +709,9 @@
 #define SBP_MSG_PPS_TIME 0xFF08
 #define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_MASK (0x3f)
 #define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SHIFT (2u)
-#define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_GET(flags)      \
-  (((flags) >> SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SHIFT) & \
-   SBP_PPS_TIME_RESERVED_SET_TO_ZERO_MASK)
+#define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_GET(flags)           \
+  ((u8)(((flags) >> SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SHIFT) & \
+        SBP_PPS_TIME_RESERVED_SET_TO_ZERO_MASK))
 #define SBP_PPS_TIME_RESERVED_SET_TO_ZERO_SET(flags, val)                  \
   do {                                                                     \
     (flags) =                                                              \
@@ -702,9 +721,9 @@
 
 #define SBP_PPS_TIME_TIME_UNCERTAINTY_MASK (0x3)
 #define SBP_PPS_TIME_TIME_UNCERTAINTY_SHIFT (0u)
-#define SBP_PPS_TIME_TIME_UNCERTAINTY_GET(flags)      \
-  (((flags) >> SBP_PPS_TIME_TIME_UNCERTAINTY_SHIFT) & \
-   SBP_PPS_TIME_TIME_UNCERTAINTY_MASK)
+#define SBP_PPS_TIME_TIME_UNCERTAINTY_GET(flags)           \
+  ((u8)(((flags) >> SBP_PPS_TIME_TIME_UNCERTAINTY_SHIFT) & \
+        SBP_PPS_TIME_TIME_UNCERTAINTY_MASK))
 #define SBP_PPS_TIME_TIME_UNCERTAINTY_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_PPS_TIME_TIME_UNCERTAINTY_MASK)) \
@@ -728,9 +747,9 @@
 #define SBP_MSG_GROUP_META 0xFF0A
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_MASK (0x3)
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_SHIFT (0u)
-#define SBP_GROUP_META_SOLUTION_GROUP_TYPE_GET(flags)      \
-  (((flags) >> SBP_GROUP_META_SOLUTION_GROUP_TYPE_SHIFT) & \
-   SBP_GROUP_META_SOLUTION_GROUP_TYPE_MASK)
+#define SBP_GROUP_META_SOLUTION_GROUP_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_GROUP_META_SOLUTION_GROUP_TYPE_SHIFT) & \
+        SBP_GROUP_META_SOLUTION_GROUP_TYPE_MASK))
 #define SBP_GROUP_META_SOLUTION_GROUP_TYPE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \

--- a/c/include/libsbp/tracking_macros.h
+++ b/c/include/libsbp/tracking_macros.h
@@ -25,13 +25,14 @@
   (((flags) >>                                                              \
     SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SHIFT) &       \
    SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SET(flags,  \
-                                                                     val)    \
-  do {                                                                       \
-    ((flags) |=                                                              \
-     (((val) &                                                               \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SET(flags,     \
+                                                                     val)       \
+  do {                                                                          \
+    (flags) = (u8)(                                                             \
+        (flags) |                                                               \
+        (((val) &                                                               \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_NO_SYNCHRONIZATION \
@@ -49,13 +50,14 @@
   (((flags) >>                                                             \
     SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SET(        \
-    flags, val)                                                                   \
-  do {                                                                            \
-    ((flags) |=                                                                   \
-     (((val) &                                                                    \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SET(           \
+    flags, val)                                                                      \
+  do {                                                                               \
+    (flags) = (u8)(                                                                  \
+        (flags) |                                                                    \
+        (((val) &                                                                    \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_WEEK_NUMBER_IS_NOT_VALID \
@@ -67,10 +69,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SET(flags, val)           \
-  do {                                                                         \
-    ((flags) |= (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_MASK)) \
-                 << (SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SHIFT)));    \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SET(flags, val)        \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) |                                                      \
+             (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_MASK)) \
+              << (SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_TOW_IS_NOT_AVAILABLE (0)
@@ -83,10 +87,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SET(flags, val)           \
-  do {                                                                         \
-    ((flags) |= (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_MASK)) \
-                 << (SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SHIFT)));    \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SET(flags, val)        \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) |                                                      \
+             (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_MASK)) \
+              << (SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_FLL_IS_INACTIVE (0)
@@ -96,10 +102,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SET(flags, val)           \
-  do {                                                                         \
-    ((flags) |= (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_MASK)) \
-                 << (SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SHIFT)));    \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SET(flags, val)        \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) |                                                      \
+             (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_MASK)) \
+              << (SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_PLL_IS_INACTIVE (0)
@@ -111,9 +119,11 @@
    SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_MASK)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SET(flags, val) \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SHIFT)));     \
+    (flags) = (u8)(                                                            \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_MASK))       \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SHIFT)));  \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_NO_LOCKS (0)
@@ -129,13 +139,14 @@
   (((flags) >>                                                             \
     SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SET(        \
-    flags, val)                                                                   \
-  do {                                                                            \
-    ((flags) |=                                                                   \
-     (((val) &                                                                    \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SET(           \
+    flags, val)                                                                      \
+  do {                                                                               \
+    (flags) = (u8)(                                                                  \
+        (flags) |                                                                    \
+        (((val) &                                                                    \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_ALMANAC_IS_NOT_AVAILABLE \
@@ -151,13 +162,14 @@
   (((flags) >>                                                               \
     SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SET(        \
-    flags, val)                                                                     \
-  do {                                                                              \
-    ((flags) |=                                                                     \
-     (((val) &                                                                      \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SET(           \
+    flags, val)                                                                        \
+  do {                                                                                 \
+    (flags) = (u8)(                                                                    \
+        (flags) |                                                                      \
+        (((val) &                                                                      \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_EPHEMERIS_IS_NOT_AVAILABLE \
@@ -169,11 +181,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SET(flags, val) \
-  do {                                                                  \
-    ((flags) |=                                                         \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SHIFT)));     \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SET(flags, val)        \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u8)((flags) |                                                         \
+             (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_MASK)) \
+              << (SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_HEALTH_IS_UNKNOWN (0)
@@ -184,11 +197,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SET(flags, val) \
-  do {                                                                   \
-    ((flags) |=                                                          \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SHIFT)));     \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SET(flags, val)   \
+  do {                                                                     \
+    (flags) = (u8)(                                                        \
+        (flags) |                                                          \
+        (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_MASK)) \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_1_MS_INTEGRATION_TIME \
@@ -208,9 +222,11 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_MASK)) \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SHIFT)));    \
+    (flags) = (u8)(                                                            \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_CLOCK_OFFSET_AND_DRIFT_IS_NOT_VALID \
@@ -224,13 +240,14 @@
   (((flags) >>                                                             \
     SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SET(        \
-    flags, val)                                                                   \
-  do {                                                                            \
-    ((flags) |=                                                                   \
-     (((val) &                                                                    \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SET(           \
+    flags, val)                                                                      \
+  do {                                                                               \
+    (flags) = (u8)(                                                                  \
+        (flags) |                                                                    \
+        (((val) &                                                                    \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_PSEUDORANGE_IS_NOT_VALID \
@@ -246,13 +263,14 @@
   (((flags) >>                                                              \
     SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SET(        \
-    flags, val)                                                                    \
-  do {                                                                             \
-    ((flags) |=                                                                    \
-     (((val) &                                                                     \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SET(           \
+    flags, val)                                                                       \
+  do {                                                                                \
+    (flags) = (u8)(                                                                   \
+        (flags) |                                                                     \
+        (((val) &                                                                     \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_ACCELERATION_IS_NOT_VALID \
@@ -268,13 +286,14 @@
   (((flags) >>                                                                     \
     SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SET(        \
-    flags, val)                                                                           \
-  do {                                                                                    \
-    ((flags) |=                                                                           \
-     (((val) &                                                                            \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SET(           \
+    flags, val)                                                                              \
+  do {                                                                                       \
+    (flags) = (u8)(                                                                          \
+        (flags) |                                                                            \
+        (((val) &                                                                            \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_UNRESOLVED \
@@ -287,13 +306,14 @@
   (((flags) >>                                                               \
     SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SHIFT) &       \
    SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SET(flags,  \
-                                                                      val)    \
-  do {                                                                        \
-    ((flags) |=                                                               \
-     (((val) &                                                                \
-       (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SET(flags,     \
+                                                                      val)       \
+  do {                                                                           \
+    (flags) = (u8)(                                                              \
+        (flags) |                                                                \
+        (((val) &                                                                \
+          (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_RE_ACQUISITION \
@@ -313,9 +333,11 @@
    SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_MASK)
 #define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SET(flags, val) \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SHIFT)));     \
+    (flags) = (u8)(                                                            \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_MASK))       \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SHIFT)));  \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_NO_SYNCHRONIZATION \
@@ -332,13 +354,14 @@
   (((flags) >>                                                                 \
     SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SHIFT) &       \
    SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SET(flags,  \
-                                                                        val)    \
-  do {                                                                          \
-    ((flags) |=                                                                 \
-     (((val) &                                                                  \
-       (SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SET(flags,     \
+                                                                        val)       \
+  do {                                                                             \
+    (flags) = (u8)(                                                                \
+        (flags) |                                                                  \
+        (((val) &                                                                  \
+          (SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_WEEK_NUMBER_IS_NOT_VALID \
@@ -350,10 +373,11 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_MASK)) \
-                 << (SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SHIFT)));    \
+#define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_MASK)) \
+                   << (SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_TOW_IS_NOT_AVAILABLE (0)
@@ -365,10 +389,11 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_MASK)) \
-                 << (SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SHIFT)));    \
+#define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_MASK)) \
+                   << (SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_FLL_IS_INACTIVE (0)
@@ -378,10 +403,11 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_MASK)) \
-                 << (SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SHIFT)));    \
+#define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_MASK)) \
+                   << (SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_PLL_IS_INACTIVE (0)
@@ -391,11 +417,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SET(flags, val) \
-  do {                                                                       \
-    ((flags) |=                                                              \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SHIFT)));     \
+#define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SET(flags, val)   \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) |                                                              \
+        (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_MASK)) \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_NO_LOCKS (0)
@@ -410,13 +437,14 @@
   (((flags) >>                                                                 \
     SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SHIFT) &       \
    SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SET(flags,  \
-                                                                        val)    \
-  do {                                                                          \
-    ((flags) |=                                                                 \
-     (((val) &                                                                  \
-       (SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SET(flags,     \
+                                                                        val)       \
+  do {                                                                             \
+    (flags) = (u8)(                                                                \
+        (flags) |                                                                  \
+        (((val) &                                                                  \
+          (SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_ALMANAC_IS_NOT_AVAILABLE \
@@ -430,13 +458,14 @@
   (((flags) >>                                                             \
     SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SET(        \
-    flags, val)                                                                   \
-  do {                                                                            \
-    ((flags) |=                                                                   \
-     (((val) &                                                                    \
-       (SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SET(           \
+    flags, val)                                                                      \
+  do {                                                                               \
+    (flags) = (u8)(                                                                  \
+        (flags) |                                                                    \
+        (((val) &                                                                    \
+          (SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_EPHEMERIS_IS_NOT_AVAILABLE \
@@ -448,11 +477,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SET(flags, val) \
-  do {                                                                \
-    ((flags) |=                                                       \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SHIFT)));     \
+#define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SET(flags, val)        \
+  do {                                                                       \
+    (flags) =                                                                \
+        (u8)((flags) |                                                       \
+             (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_MASK)) \
+              << (SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_HEALTH_IS_UNKNOWN (0)
@@ -463,11 +493,12 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_GET(flags)      \
   (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SET(flags, val) \
-  do {                                                                 \
-    ((flags) |=                                                        \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SHIFT)));     \
+#define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SET(flags, val)        \
+  do {                                                                        \
+    (flags) =                                                                 \
+        (u8)((flags) |                                                        \
+             (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_MASK)) \
+              << (SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_1_MS_INTEGRATION_TIME (0)
@@ -483,9 +514,11 @@
    SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_MASK)
 #define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SET(flags, val) \
   do {                                                                        \
-    ((flags) |=                                                               \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_MASK))  \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SHIFT)));     \
+    (flags) = (u8)(                                                           \
+        (flags) |                                                             \
+        (((val) &                                                             \
+          (SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_MASK))       \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SHIFT)));  \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_CLOCK_OFFSET_AND_DRIFT_IS_NOT_VALID \
@@ -498,13 +531,14 @@
   (((flags) >>                                                                 \
     SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SHIFT) &       \
    SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SET(flags,  \
-                                                                        val)    \
-  do {                                                                          \
-    ((flags) |=                                                                 \
-     (((val) &                                                                  \
-       (SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SET(flags,     \
+                                                                        val)       \
+  do {                                                                             \
+    (flags) = (u8)(                                                                \
+        (flags) |                                                                  \
+        (((val) &                                                                  \
+          (SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_PSEUDORANGE_IS_NOT_VALID \
@@ -518,13 +552,14 @@
   (((flags) >>                                                            \
     SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SET(        \
-    flags, val)                                                                  \
-  do {                                                                           \
-    ((flags) |=                                                                  \
-     (((val) &                                                                   \
-       (SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SET(           \
+    flags, val)                                                                     \
+  do {                                                                              \
+    (flags) = (u8)(                                                                 \
+        (flags) |                                                                   \
+        (((val) &                                                                   \
+          (SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_ACCELERATION_IS_NOT_VALID \
@@ -540,13 +575,14 @@
   (((flags) >>                                                                   \
     SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT) & \
    SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK)
-#define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SET(        \
-    flags, val)                                                                         \
-  do {                                                                                  \
-    ((flags) |=                                                                         \
-     (((val) &                                                                          \
-       (SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK))      \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT))); \
+#define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SET(           \
+    flags, val)                                                                            \
+  do {                                                                                     \
+    (flags) = (u8)(                                                                        \
+        (flags) |                                                                          \
+        (((val) &                                                                          \
+          (SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_UNRESOLVED \
@@ -562,9 +598,11 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
-    ((flags) |=                                                                \
-     (((val) & (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_MASK)) \
-      << (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SHIFT)));    \
+    (flags) = (u8)(                                                            \
+        (flags) |                                                              \
+        (((val) &                                                              \
+          (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_MASK))      \
+         << (SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SHIFT))); \
   } while (0)
 
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_RE_ACQUISITION \
@@ -694,10 +732,11 @@
 #define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_GET(flags)      \
   (((flags) >> SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SHIFT) & \
    SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_MASK)
-#define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_MASK)) \
-                 << (SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SHIFT)));    \
+#define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_MASK)) \
+                   << (SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_DISABLED (0)
@@ -737,10 +776,11 @@
 #define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_GET(flags)      \
   (((flags) >> SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SHIFT) & \
    SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_MASK)
-#define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SET(flags, val)           \
-  do {                                                                       \
-    ((flags) |= (((val) & (SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_MASK)) \
-                 << (SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SHIFT)));    \
+#define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SET(flags, val)             \
+  do {                                                                         \
+    (flags) = (u8)(                                                            \
+        (flags) | (((val) & (SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_MASK)) \
+                   << (SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SHIFT)));    \
   } while (0)
 
 #define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_DISABLED (0)

--- a/c/include/libsbp/tracking_macros.h
+++ b/c/include/libsbp/tracking_macros.h
@@ -22,9 +22,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SHIFT (0u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_GET(flags) \
-  (((flags) >>                                                              \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_MASK)
+  ((u8)(((flags) >>                                                         \
+         SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_SYNCHRONIZATION_STATUS_SET(flags,     \
                                                                      val)       \
   do {                                                                          \
@@ -45,11 +45,12 @@
   (3)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SHIFT (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_GET( \
-    flags)                                                                 \
-  (((flags) >>                                                             \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_GET(    \
+    flags)                                                                    \
+  ((u8)(                                                                      \
+      ((flags) >>                                                             \
+       SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_WEEK_NUMBER_VALIDITY_STATUS_SET(           \
     flags, val)                                                                      \
   do {                                                                               \
@@ -66,9 +67,9 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TOW_STATUS_SET(flags, val)        \
   do {                                                                      \
     (flags) =                                                               \
@@ -84,9 +85,9 @@
   (2)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SHIFT (4u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_SET(flags, val)        \
   do {                                                                      \
     (flags) =                                                               \
@@ -99,9 +100,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_FLL_STATUS_FLL_IS_ACTIVE (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SHIFT (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_SET(flags, val)        \
   do {                                                                      \
     (flags) =                                                               \
@@ -114,9 +115,10 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PLL_STATUS_PLL_IS_ACTIVE (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_GET(flags) \
+  ((u8)(((flags) >>                                                       \
+         SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_LOOP_STATUS_SET(flags, val) \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -134,11 +136,12 @@
   (3)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SHIFT (4u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_GET( \
-    flags)                                                                 \
-  (((flags) >>                                                             \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_GET(    \
+    flags)                                                                    \
+  ((u8)(                                                                      \
+      ((flags) >>                                                             \
+       SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ALMANAC_AVAILABILITY_STATUS_SET(           \
     flags, val)                                                                      \
   do {                                                                               \
@@ -157,11 +160,12 @@
   (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SHIFT \
   (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_GET( \
-    flags)                                                                   \
-  (((flags) >>                                                               \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_GET(    \
+    flags)                                                                      \
+  ((u8)(                                                                        \
+      ((flags) >>                                                               \
+       SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_EPHEMERIS_AVAILABILITY_STATUS_SET(           \
     flags, val)                                                                        \
   do {                                                                                 \
@@ -178,9 +182,9 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SET(flags, val)        \
   do {                                                                         \
     (flags) =                                                                  \
@@ -194,9 +198,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_HEALTH_STATUS_SIGNAL_IS_HEALTHY (2)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PARAMETER_SETS_SET(flags, val)   \
   do {                                                                     \
     (flags) = (u8)(                                                        \
@@ -216,9 +220,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SHIFT (5u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_GET(flags) \
-  (((flags) >>                                                             \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_MASK)
+  ((u8)(((flags) >>                                                        \
+         SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CLOCK_VALIDITY_STATUS_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
@@ -235,11 +239,12 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SHIFT (4u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_GET( \
-    flags)                                                                 \
-  (((flags) >>                                                             \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_GET(    \
+    flags)                                                                    \
+  ((u8)(                                                                      \
+      ((flags) >>                                                             \
+       SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_PSEUDORANGE_VALIDITY_STATUS_SET(           \
     flags, val)                                                                      \
   do {                                                                               \
@@ -258,11 +263,12 @@
   (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SHIFT \
   (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_GET( \
-    flags)                                                                  \
-  (((flags) >>                                                              \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_GET(    \
+    flags)                                                                     \
+  ((u8)(                                                                       \
+      ((flags) >>                                                              \
+       SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_ACCELERATION_VALIDITY_STATUS_SET(           \
     flags, val)                                                                       \
   do {                                                                                \
@@ -281,11 +287,12 @@
   (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT \
   (2u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_GET( \
-    flags)                                                                         \
-  (((flags) >>                                                                     \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_GET(    \
+    flags)                                                                            \
+  ((u8)(                                                                              \
+      ((flags) >>                                                                     \
+       SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SET(           \
     flags, val)                                                                              \
   do {                                                                                       \
@@ -303,9 +310,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_MASK (0x3)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SHIFT (0u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_GET(flags) \
-  (((flags) >>                                                               \
-    SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_MASK)
+  ((u8)(((flags) >>                                                          \
+         SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_A_TRACKING_CHANNEL_STATUS_SET(flags,     \
                                                                       val)       \
   do {                                                                           \
@@ -328,9 +335,10 @@
 #define SBP_MSG_TRACKING_STATE_DETAILED_DEP 0x0011
 #define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_GET(flags) \
+  ((u8)(((flags) >>                                                       \
+         SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_SYNCHRONIZATION_STATUS_SET(flags, val) \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -351,9 +359,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SHIFT (3u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_GET(flags) \
-  (((flags) >>                                                                 \
-    SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_MASK)
+  ((u8)(((flags) >>                                                            \
+         SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_WEEK_NUMBER_VALIDITY_STATUS_SET(flags,     \
                                                                         val)       \
   do {                                                                             \
@@ -370,9 +378,9 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_TOW_STATUS_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -386,9 +394,9 @@
   (2)
 #define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SHIFT (4u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -400,9 +408,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_FLL_STATUS_FLL_IS_ACTIVE (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SHIFT (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -414,9 +422,10 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_PLL_STATUS_PLL_IS_ACTIVE (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_GET(flags) \
+  ((u8)(((flags) >>                                                     \
+         SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_LOOP_STATUS_SET(flags, val)   \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -434,9 +443,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SHIFT (4u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_GET(flags) \
-  (((flags) >>                                                                 \
-    SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_MASK)
+  ((u8)(((flags) >>                                                            \
+         SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_ALMANAC_AVAILABILITY_STATUS_SET(flags,     \
                                                                         val)       \
   do {                                                                             \
@@ -453,11 +462,12 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SHIFT (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_GET( \
-    flags)                                                                 \
-  (((flags) >>                                                             \
-    SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_GET(    \
+    flags)                                                                    \
+  ((u8)(                                                                      \
+      ((flags) >>                                                             \
+       SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_EPHEMERIS_AVAILABILITY_STATUS_SET(           \
     flags, val)                                                                      \
   do {                                                                               \
@@ -474,9 +484,9 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SET(flags, val)        \
   do {                                                                       \
     (flags) =                                                                \
@@ -490,9 +500,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_HEALTH_STATUS_SIGNAL_IS_HEALTHY (2)
 #define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_MASK (0x7)
 #define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SHIFT (0u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_PARAMETER_SETS_SET(flags, val)        \
   do {                                                                        \
     (flags) =                                                                 \
@@ -509,9 +519,10 @@
   (3)
 #define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SHIFT (5u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_GET(flags)      \
-  (((flags) >> SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_GET(flags) \
+  ((u8)(((flags) >>                                                      \
+         SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_CLOCK_VALIDITY_STATUS_SET(flags, val) \
   do {                                                                        \
     (flags) = (u8)(                                                           \
@@ -528,9 +539,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SHIFT (4u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_GET(flags) \
-  (((flags) >>                                                                 \
-    SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_MASK)
+  ((u8)(((flags) >>                                                            \
+         SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_PSEUDORANGE_VALIDITY_STATUS_SET(flags,     \
                                                                         val)       \
   do {                                                                             \
@@ -547,11 +558,11 @@
   (1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_MASK (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SHIFT (3u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_GET( \
-    flags)                                                                \
-  (((flags) >>                                                            \
-    SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_GET(      \
+    flags)                                                                     \
+  ((u8)(((flags) >>                                                            \
+         SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SHIFT) & \
+        SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_ACCELERATION_VALIDITY_STATUS_SET(           \
     flags, val)                                                                     \
   do {                                                                              \
@@ -570,11 +581,12 @@
   (0x1)
 #define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT \
   (2u)
-#define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_GET( \
-    flags)                                                                       \
-  (((flags) >>                                                                   \
-    SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT) & \
-   SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK)
+#define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_GET(    \
+    flags)                                                                          \
+  ((u8)(                                                                            \
+      ((flags) >>                                                                   \
+       SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SHIFT) & \
+      SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_CARRIER_HALF_CYCLE_AMBIGUITY_STATUS_SET(           \
     flags, val)                                                                            \
   do {                                                                                     \
@@ -592,9 +604,9 @@
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_MASK (0x3)
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SHIFT (0u)
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_GET(flags) \
-  (((flags) >>                                                             \
-    SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SHIFT) &       \
-   SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_MASK)
+  ((u8)(((flags) >>                                                        \
+         SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SHIFT) &  \
+        SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_MASK))
 #define SBP_TRACKING_STATE_DETAILED_DEP_TRACKING_CHANNEL_STATUS_SET(flags,     \
                                                                     val)       \
   do {                                                                         \
@@ -729,9 +741,9 @@
 
 #define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_MASK (0x3)
 #define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SHIFT (0u)
-#define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_GET(flags)      \
-  (((flags) >> SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SHIFT) & \
-   SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_MASK)
+#define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SHIFT) & \
+        SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_MASK))
 #define SBP_TRACKINGCHANNELSTATEDEPA_TRACKING_MODE_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \
@@ -773,9 +785,9 @@
 
 #define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_MASK (0x3)
 #define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SHIFT (0u)
-#define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_GET(flags)      \
-  (((flags) >> SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SHIFT) & \
-   SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_MASK)
+#define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_GET(flags)           \
+  ((u8)(((flags) >> SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SHIFT) & \
+        SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_MASK))
 #define SBP_TRACKINGCHANNELSTATEDEPB_TRACKING_MODE_SET(flags, val)             \
   do {                                                                         \
     (flags) = (u8)(                                                            \

--- a/c/include/libsbp/vehicle_macros.h
+++ b/c/include/libsbp/vehicle_macros.h
@@ -21,9 +21,9 @@
 #define SBP_MSG_ODOMETRY 0x0903
 #define SBP_ODOMETRY_VEHICLE_METADATA_MASK (0x3)
 #define SBP_ODOMETRY_VEHICLE_METADATA_SHIFT (5u)
-#define SBP_ODOMETRY_VEHICLE_METADATA_GET(flags)      \
-  (((flags) >> SBP_ODOMETRY_VEHICLE_METADATA_SHIFT) & \
-   SBP_ODOMETRY_VEHICLE_METADATA_MASK)
+#define SBP_ODOMETRY_VEHICLE_METADATA_GET(flags)           \
+  ((u8)(((flags) >> SBP_ODOMETRY_VEHICLE_METADATA_SHIFT) & \
+        SBP_ODOMETRY_VEHICLE_METADATA_MASK))
 #define SBP_ODOMETRY_VEHICLE_METADATA_SET(flags, val)                        \
   do {                                                                       \
     (flags) = (u8)((flags) | (((val) & (SBP_ODOMETRY_VEHICLE_METADATA_MASK)) \
@@ -36,9 +36,9 @@
 #define SBP_ODOMETRY_VEHICLE_METADATA_PARK (3)
 #define SBP_ODOMETRY_VELOCITY_SOURCE_MASK (0x3)
 #define SBP_ODOMETRY_VELOCITY_SOURCE_SHIFT (3u)
-#define SBP_ODOMETRY_VELOCITY_SOURCE_GET(flags)      \
-  (((flags) >> SBP_ODOMETRY_VELOCITY_SOURCE_SHIFT) & \
-   SBP_ODOMETRY_VELOCITY_SOURCE_MASK)
+#define SBP_ODOMETRY_VELOCITY_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_ODOMETRY_VELOCITY_SOURCE_SHIFT) & \
+        SBP_ODOMETRY_VELOCITY_SOURCE_MASK))
 #define SBP_ODOMETRY_VELOCITY_SOURCE_SET(flags, val)                        \
   do {                                                                      \
     (flags) = (u8)((flags) | (((val) & (SBP_ODOMETRY_VELOCITY_SOURCE_MASK)) \
@@ -51,8 +51,9 @@
 #define SBP_ODOMETRY_VELOCITY_SOURCE_SOURCE_3 (3)
 #define SBP_ODOMETRY_TIME_SOURCE_MASK (0x7)
 #define SBP_ODOMETRY_TIME_SOURCE_SHIFT (0u)
-#define SBP_ODOMETRY_TIME_SOURCE_GET(flags) \
-  (((flags) >> SBP_ODOMETRY_TIME_SOURCE_SHIFT) & SBP_ODOMETRY_TIME_SOURCE_MASK)
+#define SBP_ODOMETRY_TIME_SOURCE_GET(flags)           \
+  ((u8)(((flags) >> SBP_ODOMETRY_TIME_SOURCE_SHIFT) & \
+        SBP_ODOMETRY_TIME_SOURCE_MASK))
 #define SBP_ODOMETRY_TIME_SOURCE_SET(flags, val)                        \
   do {                                                                  \
     (flags) = (u8)((flags) | (((val) & (SBP_ODOMETRY_TIME_SOURCE_MASK)) \
@@ -71,9 +72,9 @@
 #define SBP_MSG_WHEELTICK 0x0904
 #define SBP_WHEELTICK_VEHICLE_METADATA_MASK (0x3)
 #define SBP_WHEELTICK_VEHICLE_METADATA_SHIFT (2u)
-#define SBP_WHEELTICK_VEHICLE_METADATA_GET(flags)      \
-  (((flags) >> SBP_WHEELTICK_VEHICLE_METADATA_SHIFT) & \
-   SBP_WHEELTICK_VEHICLE_METADATA_MASK)
+#define SBP_WHEELTICK_VEHICLE_METADATA_GET(flags)           \
+  ((u8)(((flags) >> SBP_WHEELTICK_VEHICLE_METADATA_SHIFT) & \
+        SBP_WHEELTICK_VEHICLE_METADATA_MASK))
 #define SBP_WHEELTICK_VEHICLE_METADATA_SET(flags, val)                        \
   do {                                                                        \
     (flags) = (u8)((flags) | (((val) & (SBP_WHEELTICK_VEHICLE_METADATA_MASK)) \
@@ -86,9 +87,9 @@
 #define SBP_WHEELTICK_VEHICLE_METADATA_PARK (3)
 #define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MASK (0x3)
 #define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SHIFT (0u)
-#define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_GET(flags)      \
-  (((flags) >> SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SHIFT) & \
-   SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MASK)
+#define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_GET(flags)           \
+  ((u8)(((flags) >> SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SHIFT) & \
+        SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MASK))
 #define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SET(flags, val)                  \
   do {                                                                      \
     (flags) =                                                               \

--- a/c/include/libsbp/vehicle_macros.h
+++ b/c/include/libsbp/vehicle_macros.h
@@ -24,10 +24,10 @@
 #define SBP_ODOMETRY_VEHICLE_METADATA_GET(flags)      \
   (((flags) >> SBP_ODOMETRY_VEHICLE_METADATA_SHIFT) & \
    SBP_ODOMETRY_VEHICLE_METADATA_MASK)
-#define SBP_ODOMETRY_VEHICLE_METADATA_SET(flags, val)           \
-  do {                                                          \
-    ((flags) |= (((val) & (SBP_ODOMETRY_VEHICLE_METADATA_MASK)) \
-                 << (SBP_ODOMETRY_VEHICLE_METADATA_SHIFT)));    \
+#define SBP_ODOMETRY_VEHICLE_METADATA_SET(flags, val)                        \
+  do {                                                                       \
+    (flags) = (u8)((flags) | (((val) & (SBP_ODOMETRY_VEHICLE_METADATA_MASK)) \
+                              << (SBP_ODOMETRY_VEHICLE_METADATA_SHIFT)));    \
   } while (0)
 
 #define SBP_ODOMETRY_VEHICLE_METADATA_UNAVAILABLE (0)
@@ -39,10 +39,10 @@
 #define SBP_ODOMETRY_VELOCITY_SOURCE_GET(flags)      \
   (((flags) >> SBP_ODOMETRY_VELOCITY_SOURCE_SHIFT) & \
    SBP_ODOMETRY_VELOCITY_SOURCE_MASK)
-#define SBP_ODOMETRY_VELOCITY_SOURCE_SET(flags, val)           \
-  do {                                                         \
-    ((flags) |= (((val) & (SBP_ODOMETRY_VELOCITY_SOURCE_MASK)) \
-                 << (SBP_ODOMETRY_VELOCITY_SOURCE_SHIFT)));    \
+#define SBP_ODOMETRY_VELOCITY_SOURCE_SET(flags, val)                        \
+  do {                                                                      \
+    (flags) = (u8)((flags) | (((val) & (SBP_ODOMETRY_VELOCITY_SOURCE_MASK)) \
+                              << (SBP_ODOMETRY_VELOCITY_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_ODOMETRY_VELOCITY_SOURCE_SOURCE_0 (0)
@@ -53,10 +53,10 @@
 #define SBP_ODOMETRY_TIME_SOURCE_SHIFT (0u)
 #define SBP_ODOMETRY_TIME_SOURCE_GET(flags) \
   (((flags) >> SBP_ODOMETRY_TIME_SOURCE_SHIFT) & SBP_ODOMETRY_TIME_SOURCE_MASK)
-#define SBP_ODOMETRY_TIME_SOURCE_SET(flags, val)           \
-  do {                                                     \
-    ((flags) |= (((val) & (SBP_ODOMETRY_TIME_SOURCE_MASK)) \
-                 << (SBP_ODOMETRY_TIME_SOURCE_SHIFT)));    \
+#define SBP_ODOMETRY_TIME_SOURCE_SET(flags, val)                        \
+  do {                                                                  \
+    (flags) = (u8)((flags) | (((val) & (SBP_ODOMETRY_TIME_SOURCE_MASK)) \
+                              << (SBP_ODOMETRY_TIME_SOURCE_SHIFT)));    \
   } while (0)
 
 #define SBP_ODOMETRY_TIME_SOURCE_NONE (0)
@@ -74,10 +74,10 @@
 #define SBP_WHEELTICK_VEHICLE_METADATA_GET(flags)      \
   (((flags) >> SBP_WHEELTICK_VEHICLE_METADATA_SHIFT) & \
    SBP_WHEELTICK_VEHICLE_METADATA_MASK)
-#define SBP_WHEELTICK_VEHICLE_METADATA_SET(flags, val)           \
-  do {                                                           \
-    ((flags) |= (((val) & (SBP_WHEELTICK_VEHICLE_METADATA_MASK)) \
-                 << (SBP_WHEELTICK_VEHICLE_METADATA_SHIFT)));    \
+#define SBP_WHEELTICK_VEHICLE_METADATA_SET(flags, val)                        \
+  do {                                                                        \
+    (flags) = (u8)((flags) | (((val) & (SBP_WHEELTICK_VEHICLE_METADATA_MASK)) \
+                              << (SBP_WHEELTICK_VEHICLE_METADATA_SHIFT)));    \
   } while (0)
 
 #define SBP_WHEELTICK_VEHICLE_METADATA_UNAVAILABLE (0)
@@ -89,10 +89,11 @@
 #define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_GET(flags)      \
   (((flags) >> SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SHIFT) & \
    SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MASK)
-#define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SET(flags, val)           \
-  do {                                                               \
-    ((flags) |= (((val) & (SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MASK)) \
-                 << (SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SHIFT)));    \
+#define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SET(flags, val)                  \
+  do {                                                                      \
+    (flags) =                                                               \
+        (u8)((flags) | (((val) & (SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MASK)) \
+                        << (SBP_WHEELTICK_SYNCHRONIZATION_TYPE_SHIFT)));    \
   } while (0)
 
 #define SBP_WHEELTICK_SYNCHRONIZATION_TYPE_MICROSECONDS_SINCE_LAST_PPS (0)

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -321,9 +321,9 @@ def create_bitfield_macros(field, msg):
             ret_list.append("#define {}_SHIFT ({}u)".format(base_string, start_bit))
             ret_list.append(
                 """#define {}_GET(flags) \\
-                             (((flags) >> {}_SHIFT) \\
-                             & {}_MASK)""".format(
-                    base_string, base_string, base_string
+                             (({})(((flags) >> {}_SHIFT) \\
+                             & {}_MASK))""".format(
+                    base_string, field.basetype, base_string, base_string
                 )
             )
             ret_list.append(

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -328,11 +328,11 @@ def create_bitfield_macros(field, msg):
             )
             ret_list.append(
                 """#define {}_SET(flags, val) \\
-                             do {{((flags) |= \\
+                             do {{(flags) = ({})((flags) | \\
                              (((val) & ({}_MASK)) \\
                              << ({}_SHIFT)));}} while(0)
                              """.format(
-                    base_string, base_string, base_string
+                    base_string, field.basetype, base_string, base_string
                 )
             )
             ret_list.append("")


### PR DESCRIPTION
The generated bitfield macros contains lots of integer promotion when operating on smaller data types. These can cause compiler warnings in consumers of libsbp when compiled with `-Wconversion`