### PR TITLE
Make integer to enum conversion explicit [SAR-261]

### DIFF
--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -77,9 +77,6 @@ extern "C" {
 /** Get message payload pointer from frame */
 #define SBP_FRAME_MSG_PAYLOAD(frame_ptr) (&((frame_ptr)[SBP_FRAME_OFFSET_MSG]))
 
-/** SBP_MSG_ID to use to register frame callback for ALL messages. */
-#define SBP_MSG_ALL 0
-
 /** SBP callback function prototype definitions. */
 typedef union {
   sbp_msg_callback_t msg;

--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -77,6 +77,9 @@ extern "C" {
 /** Get message payload pointer from frame */
 #define SBP_FRAME_MSG_PAYLOAD(frame_ptr) (&((frame_ptr)[SBP_FRAME_OFFSET_MSG]))
 
+/** SBP_MSG_ID to use to register frame callback for ALL messages. */
+#define SBP_MSG_ALL 0
+
 /** SBP callback function prototype definitions. */
 typedef union {
   sbp_msg_callback_t msg;

--- a/c/include/libsbp/sbp_msg_type.h
+++ b/c/include/libsbp/sbp_msg_type.h
@@ -46,6 +46,9 @@
 extern "C" {
 #endif
 
+/** SBP_MSG_ID to use to register frame callback for ALL messages. */
+#define SBP_MSG_ALL 0
+
 typedef enum {
   SbpMsgAcqResultDepA = SBP_MSG_ACQ_RESULT_DEP_A,
   SbpMsgAcqResultDepB = SBP_MSG_ACQ_RESULT_DEP_B,
@@ -252,6 +255,7 @@ typedef enum {
   SbpMsgVelNedGnss = SBP_MSG_VEL_NED_GNSS,
   SbpMsgVelNed = SBP_MSG_VEL_NED,
   SbpMsgWheeltick = SBP_MSG_WHEELTICK,
+  SbpMsgAll = SBP_MSG_ALL,
 } sbp_msg_type_t;
 
 #ifdef __cplusplus

--- a/c/include/libsbp/sbp_msg_type.h
+++ b/c/include/libsbp/sbp_msg_type.h
@@ -46,9 +46,6 @@
 extern "C" {
 #endif
 
-/** SBP_MSG_ID to use to register frame callback for ALL messages. */
-#define SBP_MSG_ALL 0
-
 typedef enum {
   SbpMsgAcqResultDepA = SBP_MSG_ACQ_RESULT_DEP_A,
   SbpMsgAcqResultDepB = SBP_MSG_ACQ_RESULT_DEP_B,
@@ -255,7 +252,6 @@ typedef enum {
   SbpMsgVelNedGnss = SBP_MSG_VEL_NED_GNSS,
   SbpMsgVelNed = SBP_MSG_VEL_NED,
   SbpMsgWheeltick = SBP_MSG_WHEELTICK,
-  SbpMsgAll = SBP_MSG_ALL,
 } sbp_msg_type_t;
 
 #ifdef __cplusplus

--- a/c/include/libsbp/v4/sbp_msg.h
+++ b/c/include/libsbp/v4/sbp_msg.h
@@ -831,8 +831,6 @@ static inline s8 sbp_message_encode(uint8_t *buf, uint8_t len,
       return sbp_msg_vel_ned_encode(buf, len, n_written, &msg->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_encode(buf, len, n_written, &msg->wheeltick);
-    case SbpMsgAll:
-      break;
     default:
       break;
   }
@@ -1395,8 +1393,6 @@ static inline s8 sbp_message_decode(const uint8_t *buf, uint8_t len,
       return sbp_msg_vel_ned_decode(buf, len, n_read, &msg->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_decode(buf, len, n_read, &msg->wheeltick);
-    case SbpMsgAll:
-      break;
     default:
       break;
   }
@@ -1857,8 +1853,6 @@ static inline size_t sbp_message_encoded_len(sbp_msg_type_t msg_type,
       return sbp_msg_vel_ned_encoded_len(&msg->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_encoded_len(&msg->wheeltick);
-    case SbpMsgAll:
-      break;
     default:
       break;
   }
@@ -2387,8 +2381,6 @@ static inline int sbp_message_cmp(sbp_msg_type_t msg_type, const sbp_msg_t *a,
       return sbp_msg_vel_ned_cmp(&a->vel_ned, &b->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_cmp(&a->wheeltick, &b->wheeltick);
-    case SbpMsgAll:
-      break;
     default:
       break;
   }

--- a/c/include/libsbp/v4/sbp_msg.h
+++ b/c/include/libsbp/v4/sbp_msg.h
@@ -831,6 +831,8 @@ static inline s8 sbp_message_encode(uint8_t *buf, uint8_t len,
       return sbp_msg_vel_ned_encode(buf, len, n_written, &msg->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_encode(buf, len, n_written, &msg->wheeltick);
+    case SbpMsgAll:
+      break;
     default:
       break;
   }
@@ -1393,6 +1395,8 @@ static inline s8 sbp_message_decode(const uint8_t *buf, uint8_t len,
       return sbp_msg_vel_ned_decode(buf, len, n_read, &msg->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_decode(buf, len, n_read, &msg->wheeltick);
+    case SbpMsgAll:
+      break;
     default:
       break;
   }
@@ -1853,6 +1857,8 @@ static inline size_t sbp_message_encoded_len(sbp_msg_type_t msg_type,
       return sbp_msg_vel_ned_encoded_len(&msg->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_encoded_len(&msg->wheeltick);
+    case SbpMsgAll:
+      break;
     default:
       break;
   }
@@ -2381,6 +2387,8 @@ static inline int sbp_message_cmp(sbp_msg_type_t msg_type, const sbp_msg_t *a,
       return sbp_msg_vel_ned_cmp(&a->vel_ned, &b->vel_ned);
     case SbpMsgWheeltick:
       return sbp_msg_wheeltick_cmp(&a->wheeltick, &b->wheeltick);
+    case SbpMsgAll:
+      break;
     default:
       break;
   }

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -670,7 +670,7 @@ s8 sbp_all_message_callback_register(sbp_state_t *s,
                                  sbp_msg_callbacks_node_t *node) {
   sbp_callback_t callback;
   callback.decoded = cb;
-  return sbp_register_callback_generic(s, SBP_MSG_ALL, callback,
+  return sbp_register_callback_generic(s, (sbp_msg_type_t) SBP_MSG_ALL, callback,
                                        SBP_DECODED_CALLBACK, context, node);
 }
 
@@ -738,7 +738,7 @@ s8 sbp_payload_callback_register(sbp_state_t* s, u16 msg_type, sbp_msg_callback_
 {
   sbp_callback_t callback;
   callback.msg = cb;
-  return sbp_register_callback_generic(s, msg_type, callback,
+  return sbp_register_callback_generic(s, (sbp_msg_type_t) msg_type, callback,
                                        SBP_MSG_CALLBACK, context, node);
 }
 
@@ -748,7 +748,7 @@ s8 sbp_frame_callback_register(sbp_state_t* s, u16 msg_type,
 {
   sbp_callback_t callback;
   callback.frame = cb;
-  return sbp_register_callback_generic(s, msg_type, callback,
+  return sbp_register_callback_generic(s, (sbp_msg_type_t) msg_type, callback,
                                        SBP_FRAME_CALLBACK, context, node);
 }
 
@@ -766,7 +766,7 @@ s8 sbp_frame_process(sbp_state_t *s, u16 sender_id, u16 msg_type,
 
 s8 sbp_payload_process(sbp_state_t *s, u16 sender_id, u16 msg_type, u8 msg_len,
                        u8 payload[]) {
-  return process_frame(s, sender_id, msg_type, msg_len, payload,
+  return process_frame(s, sender_id, (sbp_msg_type_t) msg_type, msg_len, payload,
                           0, 0, SBP_CALLBACK_FLAG(SBP_MSG_CALLBACK) | SBP_CALLBACK_FLAG(SBP_DECODED_CALLBACK));
 }
 

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -166,7 +166,7 @@
  *
  * \param s        Pointer to sbp_state
  * \param msg_type Message type on which to fire callback.
- *                 SBP_MSG_ALL will fire for every message, but only
+ *                 SbpMsgAll will fire for every message, but only
  *                 for callbacks of type SBP_FRAME_CALLBACK.
  * \param cb       Pointer to message callback function
  * \param cb_type  sbp_cb_type indicating what kind of cb is in use.
@@ -381,7 +381,7 @@ static s8 process_frame(sbp_state_t *s, u16 sender_id, sbp_msg_type_t msg_type,
   bool unpacked_successfully = false;
   for (node = s->sbp_msg_callbacks_head; node; node = node->next) {
     if ((SBP_CALLBACK_FLAG(node->cb_type) & cb_mask) &&
-        ((node->msg_type == msg_type) || (node->msg_type == SBP_MSG_ALL))) {
+        ((node->msg_type == msg_type) || (node->msg_type == SbpMsgAll))) {
         switch (node->cb_type) {
         case SBP_FRAME_CALLBACK:
         {
@@ -670,7 +670,7 @@ s8 sbp_all_message_callback_register(sbp_state_t *s,
                                  sbp_msg_callbacks_node_t *node) {
   sbp_callback_t callback;
   callback.decoded = cb;
-  return sbp_register_callback_generic(s, (sbp_msg_type_t) SBP_MSG_ALL, callback,
+  return sbp_register_callback_generic(s, SbpMsgAll, callback,
                                        SBP_DECODED_CALLBACK, context, node);
 }
 
@@ -692,7 +692,7 @@ s8 sbp_message_process(sbp_state_t *s, u16 sender_id, sbp_msg_type_t msg_type,
 
   s8 ret = SBP_OK_CALLBACK_UNDEFINED;
   for (node = s->sbp_msg_callbacks_head; node; node = node->next) {
-    if (((node->msg_type == msg_type) || (node->msg_type == SBP_MSG_ALL))) {
+    if (((node->msg_type == msg_type) || (node->msg_type == SbpMsgAll))) {
       switch (node->cb_type) {
         case SBP_FRAME_CALLBACK:
         case SBP_MSG_CALLBACK:

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -166,7 +166,7 @@
  *
  * \param s        Pointer to sbp_state
  * \param msg_type Message type on which to fire callback.
- *                 SbpMsgAll will fire for every message, but only
+ *                 SBP_MSG_ALL will fire for every message, but only
  *                 for callbacks of type SBP_FRAME_CALLBACK.
  * \param cb       Pointer to message callback function
  * \param cb_type  sbp_cb_type indicating what kind of cb is in use.
@@ -381,7 +381,7 @@ static s8 process_frame(sbp_state_t *s, u16 sender_id, sbp_msg_type_t msg_type,
   bool unpacked_successfully = false;
   for (node = s->sbp_msg_callbacks_head; node; node = node->next) {
     if ((SBP_CALLBACK_FLAG(node->cb_type) & cb_mask) &&
-        ((node->msg_type == msg_type) || (node->msg_type == SbpMsgAll))) {
+        ((node->msg_type == msg_type) || (node->msg_type == SBP_MSG_ALL))) {
         switch (node->cb_type) {
         case SBP_FRAME_CALLBACK:
         {
@@ -670,7 +670,7 @@ s8 sbp_all_message_callback_register(sbp_state_t *s,
                                  sbp_msg_callbacks_node_t *node) {
   sbp_callback_t callback;
   callback.decoded = cb;
-  return sbp_register_callback_generic(s, SbpMsgAll, callback,
+  return sbp_register_callback_generic(s, (sbp_msg_type_t) SBP_MSG_ALL, callback,
                                        SBP_DECODED_CALLBACK, context, node);
 }
 
@@ -692,7 +692,7 @@ s8 sbp_message_process(sbp_state_t *s, u16 sender_id, sbp_msg_type_t msg_type,
 
   s8 ret = SBP_OK_CALLBACK_UNDEFINED;
   for (node = s->sbp_msg_callbacks_head; node; node = node->next) {
-    if (((node->msg_type == msg_type) || (node->msg_type == SbpMsgAll))) {
+    if (((node->msg_type == msg_type) || (node->msg_type == SBP_MSG_ALL))) {
       switch (node->cb_type) {
         case SBP_FRAME_CALLBACK:
         case SBP_MSG_CALLBACK:

--- a/generator/sbpg/targets/resources/c/sbp_msg_type_template.h
+++ b/generator/sbpg/targets/resources/c/sbp_msg_type_template.h
@@ -26,10 +26,14 @@
 extern "C" {
 #endif
 
+/** SBP_MSG_ID to use to register frame callback for ALL messages. */
+#define SBP_MSG_ALL 0
+
 typedef enum {
 ((*- for m in real_messages *))
   (((m.v4_msg_type))) = (((m.legacy_msg_type))),
 ((*- endfor *))
+  SbpMsgAll = SBP_MSG_ALL,
 } sbp_msg_type_t;
 
 #ifdef __cplusplus

--- a/generator/sbpg/targets/resources/c/v4/sbp_msg_template.h
+++ b/generator/sbpg/targets/resources/c/v4/sbp_msg_template.h
@@ -60,6 +60,8 @@ static inline s8 sbp_message_encode(uint8_t *buf, uint8_t len, uint8_t *n_writte
     case (((m.v4_msg_type))):
       return (((m.public_encode_fn)))(buf, len, n_written, &msg->(((m.union_member_name))));
 ((*- endfor *))
+    case SbpMsgAll:
+      break;
     default:
       break;
   }
@@ -83,6 +85,8 @@ static inline s8 sbp_message_decode(const uint8_t *buf, uint8_t len, uint8_t *n_
     case (((m.v4_msg_type))):
       return (((m.public_decode_fn)))(buf, len, n_read, &msg->(((m.union_member_name))));
 ((*- endfor *))
+    case SbpMsgAll:
+      break;
     default:
       break;
   }
@@ -101,6 +105,8 @@ static inline size_t sbp_message_encoded_len(sbp_msg_type_t msg_type, const sbp_
     case (((m.v4_msg_type))):
       return (((m.encoded_len_fn)))(&msg->(((m.union_member_name))));
 ((*- endfor *))
+    case SbpMsgAll:
+      break;
     default:
       break;
   }
@@ -122,6 +128,8 @@ static inline int sbp_message_cmp(sbp_msg_type_t msg_type, const sbp_msg_t *a, c
     case (((m.v4_msg_type))):
       return (((m.cmp_fn)))(&a->(((m.union_member_name))), &b->(((m.union_member_name))));
     ((*- endfor *))
+    case SbpMsgAll:
+      break;
     default:
       break;
   }


### PR DESCRIPTION
The signature of the function `sbp_register_callback_generic` defined [here](https://github.com/swift-nav/libsbp/blob/8ec25d0e9dc8b22403a1313e5c4d8ca81fd63b89/c/src/sbp.c#L180-L183) expects an `sbp_msg_type_t` enum as a second parameter. The same happens with the third parameter of `process_frame` defined [here](https://github.com/swift-nav/libsbp/blob/8ec25d0e9dc8b22403a1313e5c4d8ca81fd63b89/c/src/sbp.c#L373-L376).

Without this explicit conversion, the static analyzer thinks there are two different functions with the same name.