### PR TITLE
Add Message API Change Validation [BUILD-99]

### DIFF
--- a/.github/workflows/test_validate.yaml
+++ b/.github/workflows/test_validate.yaml
@@ -1,0 +1,17 @@
+name: Test Message Validation
+
+on:
+  pull_request:
+    paths:
+      - "scripts/spec_validator.py"
+
+jobs:
+  test_validation:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Run Tests
+        run: |
+          bash ./scripts/validation_test_harness.bash

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,38 @@
+name: Message Validation
+
+on:
+  pull_request:
+    paths:
+      - "spec/**"
+  push:
+    branches:
+      - 'starling-v*-release'
+      - 'v*-release'
+    tags:
+      - 'v*'
+    paths:
+      - "spec/**"
+
+jobs:
+  validation:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Current Spec
+        uses: actions/checkout@v2
+
+      - name: Checkout Previous Spec
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: previous
+
+      - name: Prepare Yaml Comparison
+        run: |
+          mkdir previous-spec
+          mkdir current-spec
+          cp previous/spec/yaml/swiftnav/sbp/*.yaml previous-spec/
+          cp spec/yaml/swiftnav/sbp/*.yaml current-spec/
+
+      - name: Validate Spec
+        run: |
+          bash scripts/validate.bash previous-spec current-spec

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ rust/sbp/Cargo.lock
 rust/sbp/target
 
 python/sbp/_version.py
+
+# Spec Validation
+previous-spec/
+current-spec/

--- a/scripts/spec_validator.py
+++ b/scripts/spec_validator.py
@@ -1,0 +1,180 @@
+import argparse
+import glob
+import logging
+import os
+import sys
+import yaml
+
+
+packages = {}
+
+
+def unpack(dict):
+    return next(iter(dict.items()))
+
+
+def flatten(definitions):
+    # The yaml gets parsed into a list of dictionary objects with 1 entry each.
+    # The entry is a mapping of the definition name to another dictionary object.
+    # This flattens the list of dictionaries into a dictionary of dictionaries.
+    # This is a much more convenient data structure to perform comparisons.
+    d = {}
+    for item in definitions:
+        key, value = unpack(item)
+        d[key] = value
+    return d
+
+
+def is_message(name):
+    return "MSG" in name
+
+
+def parse_packages(root):
+    paths = glob.glob(f"{root}/*.yaml")
+    d = {}
+    for path in paths:
+        with open(path, "r") as file:
+            spec = yaml.safe_load(file)
+            package = unpack(spec)[1]
+            packages[package] = os.path.basename(path)
+            definitions = spec["definitions"]
+            d[package] = flatten(definitions)
+    return d
+
+
+def type_to_digit(type):
+    return int("".join(filter(str.isdigit, type)))
+
+
+def get_upper(bitfield):
+    return int(bitfield.split("-")[1])
+
+
+def check_bitfield_range(type, bitfields):
+    limit = type_to_digit(type)
+    for item in bitfields:
+        bitfield = unpack(item)[0]
+        val = bitfield if isinstance(bitfield, int) else get_upper(bitfield)
+        if not val < limit:
+            raise RuntimeError(
+                f"Invalid Bitfield Range!: Type {type}, Range: {bitfield}"
+            )
+
+
+def check_incoming_packages(packages):
+    logging.info("Checking Bitfield Ranges")
+    for key, value in packages.items():
+        logging.info(f"Processing Package: {key}")
+        for name, definition in value.items():
+            logging.info(f"Processing Definition: {name}")
+            if "fields" in definition:
+                fields = definition["fields"]
+                for item in fields:
+                    name, field = unpack(item)
+                    if "fields" in field:
+                        logging.info(f"Processing Field: {name}")
+                        type = field["type"]
+                        bitfields = field["fields"]
+                        check_bitfield_range(type, bitfields)
+            else:  # skip empty messages
+                continue
+
+
+def check_package_exists(previous, current):
+    if previous not in current:
+        raise RuntimeError(
+            f"Package: {previous} has been renamed or removed"
+        )
+
+
+def validate_bitfields(previous_bitfield, current_bitfield):
+    previous = flatten(previous_bitfield)
+    current = flatten(current_bitfield)
+    for key, value in previous.items():
+        if "desc" in value:  # not all messages have a desc
+            if value["desc"] == "Reserved":
+                continue
+        if key not in current:
+            raise RuntimeError(
+                "Breaking Message Mutation Detected!\n"
+                f"Bitfield {key}, has been modified"
+            )
+
+
+def validate_fields(filename, previous_fields, current_fields):
+    for previous, current in zip(previous_fields, current_fields):
+        previous_key, previous_value = unpack(previous)
+        current_key, current_value = unpack(current)
+        if previous_key != current_key:
+            logging.warning(
+                f" {filename} Name of Field Changed: {previous_key} to {current_key}"
+            )
+        if "fields" in previous_value:
+            logging.info(f"Processing Bitfield: {previous_key}")
+            previous_bitfield = previous_value["fields"]
+            current_bitfield = current_value["fields"]
+            validate_bitfields(previous_bitfield, current_bitfield)
+        previous_type = previous_value["type"]
+        current_type = current_value["type"]
+        if current_type != previous_type:
+            raise RuntimeError(
+                "Breaking Message Mutation Detected!\n"
+                f"Field (previous, current): {previous_key}, {current_key}\n"
+                f"Type (previous, current): {previous_type}, {current_type}"
+            )
+
+
+def validate_id(key, previous, current):
+    if is_message(key):
+        prev_id = previous["id"]
+        curr_id = current["id"]
+        if prev_id != curr_id:
+            raise RuntimeError(
+                "Message ID Change Detected!\n"
+                f"Previous ID: {prev_id}, Current ID: {curr_id}"
+            )
+
+
+def validate_definitions(filename, previous_definitions, current_definitions):
+    for key in previous_definitions.keys():
+        logging.info(f"Processing Definition: {key}")
+        previous = previous_definitions[key]
+        current = current_definitions[key]
+        validate_id(key, previous, current)
+        # bail if message has no fields
+        # assumes adding fields to an empty message is ok.
+        if "fields" not in previous:
+            continue
+        previous_fields = previous["fields"]
+        current_fields = current["fields"]
+        validate_fields(filename, previous_fields, current_fields)
+
+
+def validate(previous, current):
+    previous_packages = parse_packages(previous)
+    current_packages = parse_packages(current)
+    check_incoming_packages(current_packages)
+    for previous_package in previous_packages.keys():
+        logging.info(f"Processing Package: {previous_package}")
+        check_package_exists(previous_package, current_packages)
+        filename = packages[previous_package]
+        previous_def = previous_packages[previous_package]
+        current_def = current_packages[previous_package]
+        validate_definitions(filename, previous_def, current_def)
+
+
+def init():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("previous", help="path to previous yaml specs")
+    parser.add_argument("current", help="path to current yaml specs")
+    return parser.parse_args()
+
+
+def main():
+    args = init()
+    logging.basicConfig(level=logging.INFO)
+    validate(args.previous, args.current)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate.bash
+++ b/scripts/validate.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+python scripts/spec_validator.py $1 $2 2>&1 | tee /tmp/log.txt
+
+ERROR=$(cat /tmp/log.txt | grep RuntimeError)
+
+if [ ! -z "$ERROR" ]; then
+    exit 1
+fi
+
+WARN=$(cat /tmp/log.txt | grep WARNING)
+
+if [ ! -z "$WARN" ]; then
+    FILE=$(echo $WARN | awk '{print $2}')
+    echo "::warning file=spec/yaml/swiftnav/sbp/${FILE}::$WARN"
+fi

--- a/scripts/validation_test_harness.bash
+++ b/scripts/validation_test_harness.bash
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+if ! python scripts/spec_validator.py spec/validation/previous/field_type_changed spec/validation/current/field_type_changed; then
+        echo "Check Field Type Changed: PASS"
+else
+        echo "Check Field Type Changed: FAIL"
+        exit 1
+fi
+
+if ! python scripts/spec_validator.py spec/validation/previous/message_id_changed spec/validation/current/message_id_changed; then
+        echo "Check Message ID Changed: PASS"
+else
+        echo "Check Message ID Changed: FAIL"
+        exit 1
+fi
+
+if ! python scripts/spec_validator.py spec/validation/previous/field_order_changed spec/validation/current/field_order_changed; then
+        echo "Check Field Order Changed: PASS"
+else
+        echo "Check Field Order Changed: FAIL"
+        exit 1
+fi
+
+if python scripts/spec_validator.py spec/validation/previous/field_name_changed spec/validation/current/field_name_changed; then
+        echo "Check Field Name Changed: PASS"
+else
+        echo "Check Field Name Changed: FAIL"
+        exit 1
+fi
+
+if python scripts/spec_validator.py spec/validation/previous/new_field_appended spec/validation/current/new_field_appended; then
+        echo "Check New Field Appended: PASS"
+else
+        echo "Check New Field Appended: FAIL"
+        exit 1
+fi
+
+if python scripts/spec_validator.py spec/validation/previous/new_message_added spec/validation/current/new_message_added; then
+        echo "Check New Message Added: PASS"
+else
+        echo "Check New Message Added: FAIL"
+        exit 1
+fi
+
+if python scripts/spec_validator.py spec/validation/previous/new_package_added spec/validation/current/new_package_added; then
+        echo "Check New Package Added: PASS"
+else
+        echo "Check New Package Added: FAIL"
+        exit 1
+fi
+
+if ! python scripts/spec_validator.py spec/validation/previous/change_bitfield_value spec/validation/current/change_bitfield_value; then
+        echo "Check Bitfield Changed: PASS"
+else
+        echo "Check Bitfield Changed: FAIL"
+        exit 1
+fi
+
+if python scripts/spec_validator.py spec/validation/previous/unreserve_bitfield spec/validation/current/unreserve_bitfield; then
+        echo "Check Modify Reserved Flags: PASS"
+else
+        echo "Check Modify Reserved Flags: FAIL"
+        exit 1
+fi
+
+if ! python scripts/spec_validator.py spec/validation/previous/remove_package spec/validation/current/remove_package; then
+        echo "Check Remove Package: PASS"
+else
+        echo "Check Remove Package: FAIL"
+        exit 1
+fi
+
+if ! python scripts/spec_validator.py spec/validation/previous/invalid_bitfield_range spec/validation/current/invalid_bitfield_range; then
+        echo "Check Invalid Bitfield Range: PASS"
+else
+        echo "Check Invalid Bitfield Range: FAIL"
+        exit 1
+fi

--- a/spec/validation/current/change_bitfield_value/example.yaml
+++ b/spec/validation/current/change_bitfield_value/example.yaml
@@ -1,0 +1,95 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  - types.yaml
+
+definitions:
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 4-7: # MSGBREAK
+                    desc: Reserved
+                - 0-3:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/current/field_name_changed/observation.yaml
+++ b/spec/validation/current/field_name_changed/observation.yaml
@@ -1,0 +1,121 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_EPHEMERIS_GPS_DEP_E:
+    id: 0x0081
+    short_desc: Satellite broadcast ephemeris for GPS
+    replaced_by:
+      - MSG_EPHEMERIS
+    desc: >
+      The ephemeris message returns a set of satellite orbit
+      parameters that is used to calculate GPS satellite position,
+      velocity, and clock offset. Please see the Navstar GPS
+      Space Segment/Navigation user interfaces (ICD-GPS-200, Table
+      20-III) for more details.
+    fields:
+      - uncommon: # MSGBREAK
+          type: EphemerisCommonContentDepA
+          desc: Values common for all ephemeris types
+      - tgd:
+          type: double
+          units: s
+          desc: Group delay differential between L1 and L2
+      - c_rs:
+          type: double
+          units: m
+          desc: Amplitude of the sine harmonic correction term to the orbit radius
+      - c_rc:
+          type: double
+          units: m
+          desc: Amplitude of the cosine harmonic correction term to the orbit radius
+      - c_uc:
+          type: double
+          units: rad
+          desc: Amplitude of the cosine harmonic correction term to the argument of latitude
+      - c_us:
+          type: double
+          units: rad
+          desc: Amplitude of the sine harmonic correction term to the argument of latitude
+      - c_ic:
+          type: double
+          units: rad
+          desc: Amplitude of the cosine harmonic correction term to the angle of inclination
+      - c_is:
+          type: double
+          units: rad
+          desc: Amplitude of the sine harmonic correction term to the angle of inclination
+      - dn:
+          type: double
+          units: rad/s
+          desc: Mean motion difference
+      - m0:
+          type: double
+          units: rad
+          desc: Mean anomaly at reference time
+      - ecc:
+          type: double
+          desc: Eccentricity of satellite orbit
+      - sqrta:
+          type: double
+          units: m^(1/2)
+          desc: Square root of the semi-major axis of orbit
+      - omega0:
+          type: double
+          units: rad
+          desc: Longitude of ascending node of orbit plane at weekly epoch
+      - omegadot:
+          type: double
+          units: rad/s
+          desc: Rate of right ascension
+      - w:
+          type: double
+          units: rad
+          desc: Argument of perigee
+      - inc:
+          type: double
+          units: rad
+          desc: Inclination
+      - inc_dot:
+          type: double
+          units: rad/s
+          desc: Inclination first derivative
+      - af0:
+          type: double
+          units: s
+          desc: Polynomial clock correction coefficient (clock bias)
+      - af1:
+          type: double
+          units: s/s
+          desc: Polynomial clock correction coefficient (clock drift)
+      - af2:
+          type: double
+          units: s/s^2
+          desc: Polynomial clock correction coefficient (rate of clock drift)
+      - toc:
+          type: GPSTimeDep
+          desc: Clock reference
+      - iode:
+          type: u8
+          desc: Issue of ephemeris data
+      - iodc:
+          type: u16
+          desc: Issue of clock data

--- a/spec/validation/current/field_order_changed/observation.yaml
+++ b/spec/validation/current/field_order_changed/observation.yaml
@@ -1,0 +1,49 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - EphemerisCommonContent:
+    short_desc: Common fields for every ephemeris message
+    fields:
+        - sid:
+            type: GnssSignal
+            desc: GNSS signal identifier (16 bit)
+        - toe:
+            type: GPSTimeSec
+            desc: Time of Ephemerides
+        - ura:
+            type: float
+            units: m
+            desc: User Range Accuracy
+        - valid: # MSGBREAK
+            type: u8
+            desc: Status of ephemeris, 1 = valid, 0 = invalid
+        - fit_interval:
+            type: u32
+            units: s
+            desc: Curve fit interval
+        - health_bits:
+            type: u8
+            desc: |
+              Satellite health status.
+              GPS: ICD-GPS-200, chapter 20.3.3.3.1.4
+              SBAS: 0 = valid, non-zero = invalid
+              GLO: 0 = valid, non-zero = invalid

--- a/spec/validation/current/field_type_changed/observation.yaml
+++ b/spec/validation/current/field_type_changed/observation.yaml
@@ -1,0 +1,38 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - Doppler:
+     short_desc: GNSS doppler measurement
+     desc: >
+       Doppler measurement in Hz represented as a 24-bit
+       fixed point number with Q16.8 layout, i.e. 16-bits of whole
+       doppler and 8-bits of fractional doppler. This doppler is defined
+       as positive for approaching satellites.
+     fields:
+         - i:
+             type: u16 # MSGBREAK
+             units: Hz
+             desc: Doppler whole Hz
+         - f:
+             type: u8
+             units: Hz / 256
+             desc: Doppler fractional part

--- a/spec/validation/current/invalid_bitfield_range/example.yaml
+++ b/spec/validation/current/invalid_bitfield_range/example.yaml
@@ -1,0 +1,116 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-8:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/current/message_id_changed/observation.yaml
+++ b/spec/validation/current/message_id_changed/observation.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_BASE_POS_LLH:
+    id: 0x0330 # MSGBREAK
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double 
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height

--- a/spec/validation/current/new_field_appended/observation.yaml
+++ b/spec/validation/current/new_field_appended/observation.yaml
@@ -1,0 +1,55 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_GLO_BIASES:
+    id: 0x0075
+    short_desc: glonass l1/l2 code-phase biases
+    desc: >
+      the glonass l1/l2 code-phase biases allows to perform
+      gps+glonass integer ambiguity resolution for baselines
+      with mixed receiver types (e.g. receiver of different
+      manufacturers).
+    fields:
+        - mask:
+            type: u8
+            units: boolean
+            desc: glonass fdma signals mask
+        - l1ca_bias:
+            type: s16
+            units: m * 0.02
+            desc: glonass l1 c/a code-phase bias
+        - l1p_bias:
+            type: s16
+            units: m * 0.02
+            desc: glonass l1 p code-phase bias
+        - l2ca_bias:
+            type: s16
+            units: m * 0.02
+            desc: glonass l2 c/a code-phase bias
+        - l2p_bias:
+            type: s16
+            units: m * 0.02
+            desc: glonass l2 p code-phase bias
+        - l2bc_bias: # MSGBREAK 
+            type: s16
+            units: m * 0.02
+            desc: foobar

--- a/spec/validation/current/new_message_added/observation.yaml
+++ b/spec/validation/current/new_message_added/observation.yaml
@@ -1,0 +1,67 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_OBS:
+    id: 0x004A
+    short_desc: GPS satellite observations
+    desc: >
+      The GPS observations message reports all the raw pseudorange and
+      carrier phase observations for the satellites being tracked by
+      the device. Carrier phase observation here is represented as a
+      40-bit fixed point number with Q32.8 layout (i.e. 32-bits of
+      whole cycles and 8-bits of fractional cycles). The observations
+      are be interoperable with 3rd party receivers and conform
+      with typical RTCMv3 GNSS observations.
+    fields:
+        - header:
+            type: ObservationHeader
+            desc: Header of a GPS observation message
+        - obs:
+            type: array
+            fill: PackedObsContent
+            map_by: sid
+            desc: >
+              Pseudorange and carrier phase observation for a
+              satellite being tracked.
+
+ - MSG_BASE_POS_LLH: # MSGBREAK
+    id: 0x0044
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double 
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height

--- a/spec/validation/current/new_package_added/navigation.yaml
+++ b/spec/validation/current/new_package_added/navigation.yaml
@@ -1,0 +1,2429 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.navigation
+description: >
+  Geodetic navigation messages reporting GPS time, position, velocity,
+  and baseline position solutions. For position solutions, these
+  messages define several different position solutions: single-point
+  (SPP), RTK, and pseudo-absolute position solutions.
+
+
+  The SPP is the standalone, absolute GPS position solution using only
+  a single receiver. The RTK solution is the differential GPS
+  solution, which can use either a fixed/integer or floating carrier
+  phase ambiguity. The pseudo-absolute position solution uses a
+  user-provided, well-surveyed base station position (if available)
+  and the RTK solution in tandem.
+
+
+  When the inertial navigation mode indicates that the IMU is used,
+  all messages are reported in the vehicle body frame as defined by
+  device settings.  By default, the vehicle body frame is configured to be
+  coincident with the antenna phase center.  When there is no inertial
+  navigation, the solution will be reported at the phase center of the antenna.
+  There is no inertial navigation capability on Piksi Multi or Duro.
+
+
+  The tow field, when valid, is most often the Time of Measurement. When this
+  is the case, the 5th bit of flags is set to the default value of 0.
+  When this is not the case, the tow may be a time of arrival or a local
+  system timestamp, irrespective of the time reference (GPS Week or else),
+  but not a Time of Measurement.
+
+stable: True
+public: True
+include:
+  - types.yaml
+definitions:
+
+ - MSG_GPS_TIME:
+    id: 0x0102
+    short_desc: GPS Time
+    desc: >
+      This message reports the GPS time, representing the time since
+      the GPS epoch began on midnight January 6, 1980 UTC. GPS time
+      counts the weeks and seconds of the week. The weeks begin at the
+      Saturday/Sunday transition. GPS week 0 began at the beginning of
+      the GPS time scale.
+
+
+      Within each week number, the GPS time of the week is between
+      between 0 and 604800 seconds (=60*60*24*7). Note that GPS time
+      does not accumulate leap seconds, and as of now, has a small
+      offset from UTC. In a message stream, this message precedes a
+      set of other navigation messages referenced to the same time
+      (but lacking the ns field) and indicates a more precise time of
+      these messages.
+    fields:
+        - wn:
+            type: u16
+            units: weeks
+            desc: GPS week number
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS time of week rounded to the nearest millisecond
+        - ns_residual:
+            type: s32
+            units: ns
+            desc: >
+              Nanosecond residual of millisecond-rounded TOW (ranges
+              from -500000 to 500000)
+        - flags:
+            type: u8
+            desc: Status flags (reserved)
+            fields:
+                  - 3-7:
+                      desc: Reserved
+                  - 0-2:
+                      desc: Time source
+                      values:
+                          - 0: None (invalid)
+                          - 1: GNSS Solution
+                          - 2: Propagated
+
+ - MSG_GPS_TIME_GNSS:
+    id: 0x0104
+    short_desc: GPS Time
+    desc: >
+      This message reports the GPS time, representing the time since
+      the GPS epoch began on midnight January 6, 1980 UTC. GPS time
+      counts the weeks and seconds of the week. The weeks begin at the
+      Saturday/Sunday transition. GPS week 0 began at the beginning of
+      the GPS time scale.
+
+
+      Within each week number, the GPS time of the week is between
+      between 0 and 604800 seconds (=60*60*24*7). Note that GPS time
+      does not accumulate leap seconds, and as of now, has a small
+      offset from UTC. In a message stream, this message precedes a
+      set of other navigation messages referenced to the same time
+      (but lacking the ns field) and indicates a more precise time of
+      these messages.
+    fields:
+        - wn:
+            type: u16
+            units: weeks
+            desc: GPS week number
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS time of week rounded to the nearest millisecond
+        - ns_residual:
+            type: s32
+            units: ns
+            desc: >
+              Nanosecond residual of millisecond-rounded TOW (ranges
+              from -500000 to 500000)
+        - flags:
+            type: u8
+            desc: Status flags (reserved)
+            fields:
+                  - 3-7:
+                      desc: Reserved
+                  - 0-2:
+                      desc: Time source
+                      values:
+                          - 0: None (invalid)
+                          - 1: GNSS Solution
+                          - 2: Propagated
+
+ - MSG_UTC_TIME:
+    id: 0x0103
+    short_desc: UTC Time
+    desc: >
+      This message reports the Universal Coordinated Time (UTC).  Note the flags
+      which indicate the source of the UTC offset value and source of the time fix.
+    fields:
+        - flags:
+            type: u8
+            desc: Indicates source and time validity
+            fields:
+                - 5-7:
+                    desc: Reserved
+                - 3-4:
+                    desc: UTC offset source
+                    values:
+                        - 0: Factory Default
+                        - 1: Non Volatile Memory
+                        - 2: Decoded this Session
+                - 0-2:
+                    desc: Time source
+                    values:
+                          - 0: None (invalid)
+                          - 1: GNSS Solution
+                          - 2: Propagated
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS time of week rounded to the nearest millisecond
+        - year:
+            type: u16
+            units: year
+            desc: Year
+        - month:
+            type: u8
+            units: months
+            desc: Month (range 1 .. 12)
+        - day:
+            type: u8
+            units: day
+            desc: days in the month (range 1-31)
+        - hours:
+            type: u8
+            units: hours
+            desc: hours of day (range 0-23)
+        - minutes:
+            type: u8
+            units: minutes
+            desc: minutes of hour (range 0-59)
+        - seconds:
+            type: u8
+            units: seconds
+            desc: seconds of minute (range 0-60) rounded down
+        - ns:
+            type: u32
+            units: nanoseconds
+            desc: nanoseconds of second
+                  (range 0-999999999)
+
+ - MSG_UTC_TIME_GNSS:
+    id: 0x0105
+    short_desc: UTC Time
+    desc: >
+      This message reports the Universal Coordinated Time (UTC).  Note the flags
+      which indicate the source of the UTC offset value and source of the time fix.
+    fields:
+        - flags:
+            type: u8
+            desc: Indicates source and time validity
+            fields:
+                - 5-7:
+                    desc: Reserved
+                - 3-4:
+                    desc: UTC offset source
+                    values:
+                        - 0: Factory Default
+                        - 1: Non Volatile Memory
+                        - 2: Decoded this Session
+                - 0-2:
+                    desc: Time source
+                    values:
+                          - 0: None (invalid)
+                          - 1: GNSS Solution
+                          - 2: Propagated
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS time of week rounded to the nearest millisecond
+        - year:
+            type: u16
+            units: year
+            desc: Year
+        - month:
+            type: u8
+            units: months
+            desc: Month (range 1 .. 12)
+        - day:
+            type: u8
+            units: day
+            desc: days in the month (range 1-31)
+        - hours:
+            type: u8
+            units: hours
+            desc: hours of day (range 0-23)
+        - minutes:
+            type: u8
+            units: minutes
+            desc: minutes of hour (range 0-59)
+        - seconds:
+            type: u8
+            units: seconds
+            desc: seconds of minute (range 0-60) rounded down
+        - ns:
+            type: u32
+            units: nanoseconds
+            desc: nanoseconds of second
+                  (range 0-999999999)
+
+ - MSG_DOPS:
+    id: 0x0208
+    short_desc: Dilution of Precision
+    desc: >
+      This dilution of precision (DOP) message describes the effect of
+      navigation satellite geometry on positional measurement
+      precision.  The flags field indicated whether the DOP reported
+      corresponds to differential or SPP solution.
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - gdop:
+            type: u16
+            units: 0.01
+            desc: Geometric Dilution of Precision
+        - pdop:
+            type: u16
+            units: 0.01
+            desc: Position Dilution of Precision
+        - tdop:
+            type: u16
+            units: 0.01
+            desc: Time Dilution of Precision
+        - hdop:
+            type: u16
+            units: 0.01
+            desc: Horizontal Dilution of Precision
+        - vdop:
+            type: u16
+            units: 0.01
+            desc: Vertical Dilution of Precision
+        - flags:
+            type: u8
+            desc: Indicates the position solution with which the DOPS message corresponds
+            fields:
+              - 7:
+                  desc: RAIM repair flag
+              - 3-6:
+                  desc: Reserved
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Undefined
+                      - 6: SBAS Position
+
+ - MSG_POS_ECEF:
+    id: 0x0209
+    short_desc: Single-point position in ECEF
+    desc: >
+      The position solution message reports absolute Earth Centered
+      Earth Fixed (ECEF) coordinates and the status (single point vs
+      pseudo-absolute RTK) of the position solution. If the rover
+      receiver knows the surveyed position of the base station and has
+      an RTK solution, this reports a pseudo-absolute position
+      solution using the base station position and the rover's RTK
+      baseline vector. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - x:
+            type: double
+            units: m
+            desc: ECEF X coordinate
+        - y:
+            type: double
+            units: m
+            desc: ECEF Y coordinate
+        - z:
+            type: double
+            units: m
+            desc: ECEF Z coordinate
+        - accuracy:
+            type: u16
+            units: mm
+            desc: Position estimated standard deviation
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 6-7:
+                  desc: Reserved
+              - 5-5:
+                  desc: TOW type
+                  values:
+                      - 0: Time of Measurement
+                      - 1: Other
+              - 3-4:
+                  desc: Inertial Navigation Mode
+                  values:
+                      - 0: None
+                      - 1: INS used
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+
+ - MSG_POS_ECEF_COV:
+    id: 0x0214
+    short_desc: Single-point position in ECEF
+    desc: >
+      The position solution message reports absolute Earth Centered
+      Earth Fixed (ECEF) coordinates and the status (single point vs
+      pseudo-absolute RTK) of the position solution. The message also
+      reports the upper triangular portion of the 3x3 covariance matrix.
+      If the receiver knows the surveyed position of the base station and has
+      an RTK solution, this reports a pseudo-absolute position
+      solution using the base station position and the rover's RTK
+      baseline vector. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - x:
+            type: double
+            units: m
+            desc: ECEF X coordinate
+        - y:
+            type: double
+            units: m
+            desc: ECEF Y coordinate
+        - z:
+            type: double
+            units: m
+            desc: ECEF Z coordinate
+        - cov_x_x:
+            type: float
+            units: m^2
+            desc: Estimated variance of x
+        - cov_x_y:
+            type: float
+            units: m^2
+            desc: Estimated covariance of x and y
+        - cov_x_z:
+            type: float
+            units: m^2
+            desc: Estimated covariance of x and z
+        - cov_y_y:
+            type: float
+            units: m^2
+            desc: Estimated variance of y
+        - cov_y_z:
+            type: float
+            units: m^2
+            desc: Estimated covariance of y and z
+        - cov_z_z:
+            type: float
+            units: m^2
+            desc: Estimated variance of z
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 6-7:
+                  desc: Reserved
+              - 5-5:
+                  desc: Type of reported TOW
+                  values:
+                      - 0: Time of Measurement
+                      - 1: Other
+              - 3-4:
+                  desc: Inertial Navigation Mode
+                  values:
+                      - 0: None
+                      - 1: INS used
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+
+ - MSG_POS_LLH:
+    id: 0x020A
+    short_desc: Geodetic Position
+    desc: >
+      This position solution message reports the absolute geodetic
+      coordinates and the status (single point vs pseudo-absolute RTK)
+      of the position solution. If the rover receiver knows the
+      surveyed position of the base station and has an RTK solution,
+      this reports a pseudo-absolute position solution using the base
+      station position and the rover's RTK baseline vector. The full
+      GPS time is given by the preceding MSG_GPS_TIME with the
+      matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height above WGS84 ellipsoid
+        - h_accuracy:
+            type: u16
+            units: mm
+            desc: Horizontal position estimated standard deviation
+        - v_accuracy:
+            type: u16
+            units: mm
+            desc: Vertical position estimated standard deviation
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution.
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 6-7:
+                  desc: Reserved
+              - 5-5:
+                  desc: Type of reported TOW
+                  values:
+                      - 0: Time of Measurement
+                      - 1: Other
+              - 3-4:
+                  desc: Inertial Navigation Mode
+                  values:
+                      - 0: None
+                      - 1: INS used
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+
+
+ - MSG_POS_LLH_COV:
+    id: 0x0211
+    short_desc: Geodetic Position
+    desc: >
+      This position solution message reports the absolute geodetic
+      coordinates and the status (single point vs pseudo-absolute RTK)
+      of the position solution as well as the upper triangle of the 3x3
+      covariance matrix.  The position information and Fix Mode flags follow the
+      MSG_POS_LLH message.  Since the covariance matrix is computed in the
+      local-level North, East, Down frame, the covariance terms follow that
+      convention. Thus, covariances are reported against the "downward"
+      measurement and care should be taken with the sign convention.
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height above WGS84 ellipsoid
+        - cov_n_n:
+            type: float
+            units: m^2
+            desc: Estimated variance of northing
+        - cov_n_e:
+            type: float
+            units: m^2
+            desc: Covariance of northing and easting
+        - cov_n_d:
+            type: float
+            units: m^2
+            desc: Covariance of northing and downward measurement
+        - cov_e_e:
+            type: float
+            units: m^2
+            desc: Estimated variance of easting
+        - cov_e_d:
+            type: float
+            units: m^2
+            desc: Covariance of easting and downward measurement
+        - cov_d_d:
+            type: float
+            units: m^2
+            desc: Estimated variance of downward measurement
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution.
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 6-7:
+                  desc: Reserved
+              - 5-5:
+                  desc: Type of reported TOW
+                  values:
+                      - 0: Time of Measurement
+                      - 1: Other
+              - 3-4:
+                  desc: Inertial Navigation Mode
+                  values:
+                      - 0: None
+                      - 1: INS used
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+
+
+ - EstimatedHorizontalErrorEllipse:
+     short_desc: Horizontal estimated error ellipse
+     fields:
+       - semi_major:
+           type: float
+           units: m
+           desc: >
+             The semi major axis of the estimated horizontal error ellipse at
+             the user-configured confidence level; zero implies invalid.
+       - semi_minor:
+           type: float
+           units: m
+           desc: >
+             The semi minor axis of the estimated horizontal error ellipse at
+             the user-configured confidence level; zero implies invalid.
+       - orientation:
+           type: float
+           units: deg
+           desc: >
+             The orientation of the semi major axis of the estimated horizontal
+             error ellipse with respect to North.
+
+
+ - MSG_POS_LLH_ACC:
+    id: 0x0218
+    short_desc: Geodetic Position and Accuracy
+    desc: >
+      This position solution message reports the absolute geodetic coordinates
+      and the status (single point vs pseudo-absolute RTK) of the position
+      solution as well as the estimated horizontal, vertical, cross-track and
+      along-track errors.  The position information and Fix Mode flags  follow
+      the MSG_POS_LLH message. Since the covariance matrix is computed in the
+      local-level North, East, Down frame, the estimated error terms follow that
+      convention.
+
+
+      The estimated errors are reported at a user-configurable confidence level.
+      The user-configured percentile is encoded in the percentile field.
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height above WGS84 ellipsoid
+        - orthometric_height:
+            type: double
+            units: m
+            desc: Height above the geoid (i.e. height above mean sea level). See confidence_and_geoid for geoid model used.
+        - h_accuracy:
+            type: float
+            units: m
+            desc: Estimated horizontal error at the user-configured confidence level; zero implies invalid.
+        - v_accuracy:
+            type: float
+            units: m
+            desc: Estimated vertical error at the user-configured confidence level; zero implies invalid.
+        - ct_accuracy:
+            type: float
+            units: m
+            desc: Estimated cross-track error at the user-configured confidence level; zero implies invalid.
+        - at_accuracy:
+            type: float
+            units: m
+            desc: Estimated along-track error at the user-configured confidence level; zero implies invalid.
+        - h_ellipse:
+            type: EstimatedHorizontalErrorEllipse
+            desc: The estimated horizontal error ellipse at the user-configured confidence level.
+        - confidence_and_geoid:
+            type: u8
+            desc: The lower bits describe the configured confidence level for the estimated position error. The middle bits describe the geoid model used to calculate the orthometric height.
+            fields:
+              - 7-7:
+                  desc: Reserved
+              - 4-6:
+                  desc: Geoid model
+                  values:
+                    - 0: No model
+                    - 1: EGM96
+                    - 2: EGM2008
+              - 0-3:
+                  desc: Confidence level
+                  values:
+                    - 0: reserved
+                    - 1: 39.35%
+                    - 2: 68.27%
+                    - 3: 95.45%
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution.
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 6-7:
+                  desc: Reserved
+              - 5-5:
+                  desc: Type of reported TOW
+                  values:
+                      - 0: Time of Measurement
+                      - 1: Other
+              - 3-4:
+                  desc: Inertial Navigation Mode
+                  values:
+                      - 0: None
+                      - 1: INS used
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+
+ - MSG_BASELINE_ECEF:
+    id: 0x020B
+    short_desc: Baseline Position in ECEF
+    desc: >
+      This message reports the baseline solution in Earth Centered
+      Earth Fixed (ECEF) coordinates. This baseline is the relative
+      vector distance from the base station to the rover receiver. The
+      full GPS time is given by the preceding MSG_GPS_TIME with the
+      matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm
+              desc: Baseline ECEF X coordinate
+          - y:
+              type: s32
+              units: mm
+              desc: Baseline ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm
+              desc: Baseline ECEF Z coordinate
+          - accuracy:
+              type: u16
+              units: mm
+              desc: Position estimated standard deviation
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Invalid
+                        - 1: Reserved
+                        - 2: Differential GNSS (DGNSS)
+                        - 3: Float RTK
+                        - 4: Fixed RTK
+                        - 5: Reserved
+                        - 6: Reserved
+
+ - MSG_BASELINE_NED:
+    id: 0x020C
+    short_desc: Baseline in NED
+    desc: >
+      This message reports the baseline solution in North East Down
+      (NED) coordinates. This baseline is the relative vector distance
+      from the base station to the rover receiver, and NED coordinate
+      system is defined at the local WGS84 tangent plane centered at the
+      base station position.  The full GPS time is given by the
+      preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - h_accuracy:
+              type: u16
+              units: mm
+              desc: Horizontal position estimated standard deviation
+          - v_accuracy:
+              type: u16
+              units: mm
+              desc: Vertical position estimated standard deviation
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Invalid
+                        - 1: Reserved
+                        - 2: Differential GNSS (DGNSS)
+                        - 3: Float RTK
+                        - 4: Fixed RTK
+                        - 5: Reserved
+                        - 6: Reserved
+
+ - MSG_VEL_ECEF:
+    id: 0x020D
+    short_desc: Velocity in ECEF
+    desc: >
+      This message reports the velocity in Earth Centered Earth Fixed
+      (ECEF) coordinates. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF X coordinate
+          - y:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Z coordinate
+          - accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Velocity estimated standard deviation
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 6-7:
+                    desc: Reserved
+                - 5-5:
+                    desc: Type of reported TOW
+                    values:
+                        - 0: Time of Measurement
+                        - 1: Other
+                - 3-4:
+                    desc: INS Navigation Mode
+                    values:
+                        - 0: None
+                        - 1: INS used
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Dead Reckoning
+
+ - MSG_VEL_ECEF_COV:
+    id: 0x0215
+    short_desc: Velocity in ECEF
+    desc: >
+      This message reports the velocity in Earth Centered Earth Fixed
+      (ECEF) coordinates. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF X coordinate
+          - y:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Z coordinate
+          - cov_x_x:
+              type: float
+              units: m^2/s^2
+              desc: Estimated variance of x
+          - cov_x_y:
+              type: float
+              units: m^2/s^2
+              desc: Estimated covariance of x and y
+          - cov_x_z:
+              type: float
+              units: m^2/s^2
+              desc: Estimated covariance of x and z
+          - cov_y_y:
+              type: float
+              units: m^2/s^2
+              desc: Estimated variance of y
+          - cov_y_z:
+              type: float
+              units: m^2/s^2
+              desc: Estimated covariance of y and z
+          - cov_z_z:
+              type: float
+              units: m^2/s^2
+              desc: Estimated variance of z
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 6-7:
+                    desc: Reserved
+                - 5-5:
+                    desc: Type of reported TOW
+                    values:
+                        - 0: Time of Measurement
+                        - 1: Other
+                - 3-4:
+                    desc: INS Navigation Mode
+                    values:
+                        - 0: None
+                        - 1: INS used
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Dead Reckoning
+
+ - MSG_VEL_NED:
+    id: 0x020E
+    short_desc: Velocity in NED
+    desc: >
+      This message reports the velocity in local North East Down (NED)
+      coordinates. The NED coordinate system is defined as the local WGS84
+      tangent plane centered at the current position. The full GPS time is
+      given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm/s
+              desc: Velocity North coordinate
+          - e:
+              type: s32
+              units: mm/s
+              desc: Velocity East coordinate
+          - d:
+              type: s32
+              units: mm/s
+              desc: Velocity Down coordinate
+          - h_accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Horizontal velocity estimated standard deviation
+          - v_accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Vertical velocity estimated standard deviation
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 6-7:
+                    desc: Reserved
+                - 5-5:
+                    desc: Type of reported TOW
+                    values:
+                        - 0: Time of Measurement
+                        - 1: Other
+                - 3-4:
+                    desc: INS Navigation Mode
+                    values:
+                        - 0: None
+                        - 1: INS used
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Dead Reckoning
+
+ - MSG_VEL_NED_COV:
+    id: 0x0212
+    short_desc: Velocity in NED
+    desc: >
+      This message reports the velocity in local North East Down (NED)
+      coordinates. The NED coordinate system is defined as the local WGS84
+      tangent plane centered at the current position. The full GPS time is
+      given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
+      This message is similar to the MSG_VEL_NED, but it includes the upper triangular
+      portion of the 3x3 covariance matrix.
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm/s
+              desc: Velocity North coordinate
+          - e:
+              type: s32
+              units: mm/s
+              desc: Velocity East coordinate
+          - d:
+              type: s32
+              units: mm/s
+              desc: Velocity Down coordinate
+          - cov_n_n:
+              type: float
+              units: m^2
+              desc: Estimated variance of northward measurement
+          - cov_n_e:
+              type: float
+              units: m^2
+              desc: Covariance of northward and eastward measurement
+          - cov_n_d:
+              type: float
+              units: m^2
+              desc: Covariance of northward and downward measurement
+          - cov_e_e:
+              type: float
+              units: m^2
+              desc: Estimated variance of eastward measurement
+          - cov_e_d:
+              type: float
+              units: m^2
+              desc: Covariance of eastward and downward measurement
+          - cov_d_d:
+              type: float
+              units: m^2
+              desc: Estimated variance of downward measurement
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 6-7:
+                    desc: Reserved
+                - 5-5:
+                    desc: Type of reported TOW
+                    values:
+                        - 0: Time of Measurement
+                        - 1: Other
+                - 3-4:
+                    desc: INS Navigation Mode
+                    values:
+                        - 0: None
+                        - 1: INS used
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Dead Reckoning
+
+ - MSG_POS_ECEF_GNSS:
+    id: 0x0229
+    short_desc: GNSS-only Position in ECEF
+    desc: >
+      The position solution message reports absolute Earth Centered
+      Earth Fixed (ECEF) coordinates and the status (single point vs
+      pseudo-absolute RTK) of the position solution. If the rover
+      receiver knows the surveyed position of the base station and has
+      an RTK solution, this reports a pseudo-absolute position
+      solution using the base station position and the rover's RTK
+      baseline vector. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - x:
+            type: double
+            units: m
+            desc: ECEF X coordinate
+        - y:
+            type: double
+            units: m
+            desc: ECEF Y coordinate
+        - z:
+            type: double
+            units: m
+            desc: ECEF Z coordinate
+        - accuracy:
+            type: u16
+            units: mm
+            desc: Position estimated standard deviation
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 3-7:
+                  desc: Reserved
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Reserved
+                      - 6: SBAS Position
+
+ - MSG_POS_ECEF_COV_GNSS:
+    id: 0x0234
+    short_desc: GNSS-only Position in ECEF
+    desc: >
+      The position solution message reports absolute Earth Centered
+      Earth Fixed (ECEF) coordinates and the status (single point vs
+      pseudo-absolute RTK) of the position solution. The message also
+      reports the upper triangular portion of the 3x3 covariance matrix.
+      If the receiver knows the surveyed position of the base station and has
+      an RTK solution, this reports a pseudo-absolute position
+      solution using the base station position and the rover's RTK
+      baseline vector. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - x:
+            type: double
+            units: m
+            desc: ECEF X coordinate
+        - y:
+            type: double
+            units: m
+            desc: ECEF Y coordinate
+        - z:
+            type: double
+            units: m
+            desc: ECEF Z coordinate
+        - cov_x_x:
+            type: float
+            units: m^2
+            desc: Estimated variance of x
+        - cov_x_y:
+            type: float
+            units: m^2
+            desc: Estimated covariance of x and y
+        - cov_x_z:
+            type: float
+            units: m^2
+            desc: Estimated covariance of x and z
+        - cov_y_y:
+            type: float
+            units: m^2
+            desc: Estimated variance of y
+        - cov_y_z:
+            type: float
+            units: m^2
+            desc: Estimated covariance of y and z
+        - cov_z_z:
+            type: float
+            units: m^2
+            desc: Estimated variance of z
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 3-7:
+                  desc: Reserved
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Reserved
+                      - 6: SBAS Position
+
+ - MSG_POS_LLH_GNSS:
+    id: 0x022A
+    short_desc: GNSS-only Geodetic Position
+    desc: >
+      This position solution message reports the absolute geodetic
+      coordinates and the status (single point vs pseudo-absolute RTK)
+      of the position solution. If the rover receiver knows the
+      surveyed position of the base station and has an RTK solution,
+      this reports a pseudo-absolute position solution using the base
+      station position and the rover's RTK baseline vector. The full
+      GPS time is given by the preceding MSG_GPS_TIME with the
+      matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height above WGS84 ellipsoid
+        - h_accuracy:
+            type: u16
+            units: mm
+            desc: Horizontal position estimated standard deviation
+        - v_accuracy:
+            type: u16
+            units: mm
+            desc: Vertical position estimated standard deviation
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution.
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 3-7:
+                  desc: Reserved
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Reserved
+                      - 6: SBAS Position
+
+ - MSG_POS_LLH_COV_GNSS:
+    id: 0x0231
+    short_desc: GNSS-only Geodetic Position
+    desc: >
+      This position solution message reports the absolute geodetic
+      coordinates and the status (single point vs pseudo-absolute RTK)
+      of the position solution as well as the upper triangle of the 3x3
+      covariance matrix.  The position information and Fix Mode flags should
+      follow the MSG_POS_LLH message.  Since the covariance matrix is computed
+      in the local-level North, East, Down frame, the covariance terms follow
+      with that convention. Thus, covariances are reported against the "downward"
+      measurement and care should be taken with the sign convention.
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height above WGS84 ellipsoid
+        - cov_n_n:
+            type: float
+            units: m^2
+            desc: Estimated variance of northing
+        - cov_n_e:
+            type: float
+            units: m^2
+            desc: Covariance of northing and easting
+        - cov_n_d:
+            type: float
+            units: m^2
+            desc: Covariance of northing and downward measurement
+        - cov_e_e:
+            type: float
+            units: m^2
+            desc: Estimated variance of easting
+        - cov_e_d:
+            type: float
+            units: m^2
+            desc: Covariance of easting and downward measurement
+        - cov_d_d:
+            type: float
+            units: m^2
+            desc: Estimated variance of downward measurement
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution.
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 3-7:
+                  desc: Reserved
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+
+ - MSG_VEL_ECEF_GNSS:
+    id: 0x022D
+    short_desc: GNSS-only Velocity in ECEF
+    desc: >
+      This message reports the velocity in Earth Centered Earth Fixed
+      (ECEF) coordinates. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF X coordinate
+          - y:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Z coordinate
+          - accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Velocity estimated standard deviation
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Reserved
+
+ - MSG_VEL_ECEF_COV_GNSS:
+    id: 0x0235
+    short_desc: GNSS-only Velocity in ECEF
+    desc: >
+      This message reports the velocity in Earth Centered Earth Fixed
+      (ECEF) coordinates. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF X coordinate
+          - y:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Z coordinate
+          - cov_x_x:
+              type: float
+              units: m^2/s^2
+              desc: Estimated variance of x
+          - cov_x_y:
+              type: float
+              units: m^2/s^2
+              desc: Estimated covariance of x and y
+          - cov_x_z:
+              type: float
+              units: m^2/s^2
+              desc: Estimated covariance of x and z
+          - cov_y_y:
+              type: float
+              units: m^2/s^2
+              desc: Estimated variance of y
+          - cov_y_z:
+              type: float
+              units: m^2/s^2
+              desc: Estimated covariance of y and z
+          - cov_z_z:
+              type: float
+              units: m^2/s^2
+              desc: Estimated variance of z
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Reserved
+
+ - MSG_VEL_NED_GNSS:
+    id: 0x022E
+    short_desc: GNSS-only Velocity in NED
+    desc: >
+      This message reports the velocity in local North East Down (NED)
+      coordinates. The NED coordinate system is defined as the local WGS84
+      tangent plane centered at the current position. The full GPS time is
+      given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm/s
+              desc: Velocity North coordinate
+          - e:
+              type: s32
+              units: mm/s
+              desc: Velocity East coordinate
+          - d:
+              type: s32
+              units: mm/s
+              desc: Velocity Down coordinate
+          - h_accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Horizontal velocity estimated standard deviation
+          - v_accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Vertical velocity estimated standard deviation
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Reserved
+
+ - MSG_VEL_NED_COV_GNSS:
+    id: 0x0232
+    short_desc: GNSS-only Velocity in NED
+    desc: >
+      This message reports the velocity in local North East Down (NED)
+      coordinates. The NED coordinate system is defined as the local WGS84
+      tangent plane centered at the current position. The full GPS time is
+      given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
+      This message is similar to the MSG_VEL_NED, but it includes the upper triangular
+      portion of the 3x3 covariance matrix.
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm/s
+              desc: Velocity North coordinate
+          - e:
+              type: s32
+              units: mm/s
+              desc: Velocity East coordinate
+          - d:
+              type: s32
+              units: mm/s
+              desc: Velocity Down coordinate
+          - cov_n_n:
+              type: float
+              units: m^2
+              desc: Estimated variance of northward measurement
+          - cov_n_e:
+              type: float
+              units: m^2
+              desc: Covariance of northward and eastward measurement
+          - cov_n_d:
+              type: float
+              units: m^2
+              desc: Covariance of northward and downward measurement
+          - cov_e_e:
+              type: float
+              units: m^2
+              desc: Estimated variance of eastward measurement
+          - cov_e_d:
+              type: float
+              units: m^2
+              desc: Covariance of eastward and downward measurement
+          - cov_d_d:
+              type: float
+              units: m^2
+              desc: Estimated variance of downward measurement
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Reserved
+
+ - MSG_VEL_BODY:
+    id: 0x0213
+    short_desc: Velocity in User Frame
+    desc: >
+      This message reports the velocity in the Vehicle Body Frame. By convention,
+      the x-axis should point out the nose of the vehicle and represent the forward
+      direction, while as the y-axis should point out the right hand side of the vehicle.
+      Since this is a right handed system, z should point out the bottom of the vehicle.
+      The orientation and origin of the Vehicle Body Frame are specified via the device settings.
+      The full GPS time is given by the preceding MSG_GPS_TIME with the
+      matching time-of-week (tow). This message is only produced by inertial versions of Swift
+      products and is not available from Piksi Multi or Duro.
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm/s
+              desc: Velocity in x direction
+          - y:
+              type: s32
+              units: mm/s
+              desc: Velocity in y direction
+          - z:
+              type: s32
+              units: mm/s
+              desc: Velocity in z direction
+          - cov_x_x:
+              type: float
+              units: m^2
+              desc: Estimated variance of x
+          - cov_x_y:
+              type: float
+              units: m^2
+              desc: Covariance of x and y
+          - cov_x_z:
+              type: float
+              units: m^2
+              desc: Covariance of x and z
+          - cov_y_y:
+              type: float
+              units: m^2
+              desc: Estimated variance of y
+          - cov_y_z:
+              type: float
+              units: m^2
+              desc: Covariance of y and z
+          - cov_z_z:
+              type: float
+              units: m^2
+              desc: Estimated variance of z
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 5-7:
+                    desc: Reserved
+                - 3-4:
+                    desc: INS Navigation Mode
+                    values:
+                        - 0: None
+                        - 1: INS used
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Dead Reckoning
+
+ - MSG_VEL_COG:
+    id: 0x021C
+    short_desc: Velocity expressed as course over ground
+    desc: >
+      This message reports the receiver course over ground (COG) and speed over 
+      ground (SOG) based on the horizontal (N-E) components of the NED velocity 
+      vector. It also includes the vertical velocity coordinate.
+      A flag is provided to indicate whether the COG value has been frozen. When 
+      the flag is set to true, the COG field is set to its last valid value until 
+      the system exceeds a minimum velocity threshold. No other fields are 
+      affected by this flag. 
+      The NED coordinate system is defined as the local WGS84 tangent 
+      plane centered at the current position. The full GPS time is given by the 
+      preceding MSG_GPS_TIME with the matching time-of-week (tow).
+      Note: course over ground represents the receiver's direction of travel, 
+      but not necessarily the device heading.
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - cog:
+              type: u32
+              units: microdegrees
+              desc: Course over ground relative to north direction
+          - sog:
+              type: u32
+              units: mm/s
+              desc: >
+                Speed over ground (based on horizontal velocity)
+          - v_up:
+              type: s32
+              units: mm/s
+              desc: Vertical velocity component (positive up)
+          - cog_accuracy:
+              type: u32
+              units: microdegrees
+              desc: >
+                Course over ground estimated standard deviation
+          - sog_accuracy:
+              type: u32
+              units: mm/s
+              desc: >
+                Speed over ground estimated standard deviation
+          - v_up_accuracy:
+              type: u32
+              units: mm/s
+              desc: >
+                Vertical velocity estimated standard deviation
+          - flags:
+              type: u16
+              desc: Status flags
+              fields:
+                - 10-15:
+                    desc: Reserved
+                - 9: 
+                    desc: COG frozen
+                    values:
+                        - 0: Not frozen
+                        - 1: Frozen
+                - 8:
+                    desc: Vertical velocity validity
+                    values:
+                        - 0: Invalid
+                        - 1: Vertical velocity valid
+                - 7:
+                    desc: SOG validity
+                    values:
+                        - 0: Invalid
+                        - 1: SOG valid
+                - 6:
+                    desc: COG validity
+                    values:
+                        - 0: Invalid
+                        - 1: COG valid
+                - 5:
+                    desc: Type of reported TOW
+                    values:
+                        - 0: Time of Measurement
+                        - 1: Other
+                - 3-4:
+                    desc: INS Navigation Mode
+                    values:
+                        - 0: None
+                        - 1: INS used
+                - 0-2:
+                    desc: Velocity mode
+                    values:
+                        - 0: Invalid
+                        - 1: Measured Doppler derived
+                        - 2: Computed Doppler derived
+                        - 3: Dead Reckoning
+
+
+ - MSG_AGE_CORRECTIONS:
+    id: 0x0210
+    short_desc: Age of corrections
+    desc: >
+      This message reports the Age of the corrections used for the current
+      Differential solution.
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - age:
+              type: u16
+              units: deciseconds
+              desc: Age of the corrections (0xFFFF indicates invalid)
+
+
+ - MSG_GPS_TIME_DEP_A:
+    public: false
+    id: 0x0100
+    short_desc: GPS Time (v1.0)
+    desc: >
+      This message reports the GPS time, representing the time since
+      the GPS epoch began on midnight January 6, 1980 UTC. GPS time
+      counts the weeks and seconds of the week. The weeks begin at the
+      Saturday/Sunday transition. GPS week 0 began at the beginning of
+      the GPS time scale.
+
+
+      Within each week number, the GPS time of the week is between
+      between 0 and 604800 seconds (=60*60*24*7). Note that GPS time
+      does not accumulate leap seconds, and as of now, has a small
+      offset from UTC. In a message stream, this message precedes a
+      set of other navigation messages referenced to the same time
+      (but lacking the ns field) and indicates a more precise time of
+      these messages.
+    fields:
+        - wn:
+            type: u16
+            units: weeks
+            desc: GPS week number
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS time of week rounded to the nearest millisecond
+        - ns_residual:
+            type: s32
+            units: ns
+            desc: >
+              Nanosecond residual of millisecond-rounded TOW (ranges
+              from -500000 to 500000)
+        - flags:
+            type: u8
+            desc: Status flags (reserved)
+
+ - MSG_DOPS_DEP_A:
+    id: 0x0206
+    public: false
+    short_desc: Dilution of Precision
+    desc: >
+      This dilution of precision (DOP) message describes the effect of
+      navigation satellite geometry on positional measurement
+      precision.
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - gdop:
+            type: u16
+            units: 0.01
+            desc: Geometric Dilution of Precision
+        - pdop:
+            type: u16
+            units: 0.01
+            desc: Position Dilution of Precision
+        - tdop:
+            type: u16
+            units: 0.01
+            desc: Time Dilution of Precision
+        - hdop:
+            type: u16
+            units: 0.01
+            desc: Horizontal Dilution of Precision
+        - vdop:
+            type: u16
+            units: 0.01
+            desc: Vertical Dilution of Precision
+
+
+ - MSG_POS_ECEF_DEP_A:
+    id: 0x0200
+    public: false
+    short_desc: Single-point position in ECEF
+    desc: >
+      The position solution message reports absolute Earth Centered
+      Earth Fixed (ECEF) coordinates and the status (single point vs
+      pseudo-absolute RTK) of the position solution. If the rover
+      receiver knows the surveyed position of the base station and has
+      an RTK solution, this reports a pseudo-absolute position
+      solution using the base station position and the rover's RTK
+      baseline vector. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - x:
+            type: double
+            units: m
+            desc: ECEF X coordinate
+        - y:
+            type: double
+            units: m
+            desc: ECEF Y coordinate
+        - z:
+            type: double
+            units: m
+            desc: ECEF Z coordinate
+        - accuracy:
+            type: u16
+            units: mm
+            desc: >
+              Position accuracy estimate (not implemented). Defaults
+              to 0.
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 5-7:
+                  desc: Reserved
+              - 4:
+                  desc: RAIM repair flag
+                  values:
+                      - 0: No repair
+                      - 1: Solution came from RAIM repair
+              - 3:
+                  desc: RAIM availability flag
+                  values:
+                      - 0: RAIM check was explicitly disabled or unavailable
+                      - 1: RAIM check was available
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Single Point Positioning (SPP)
+                      - 1: Fixed RTK
+                      - 2: Float RTK
+
+ - MSG_POS_LLH_DEP_A:
+    id: 0x0201
+    public: false
+    short_desc: Geodetic Position
+    desc: >
+      This position solution message reports the absolute geodetic
+      coordinates and the status (single point vs pseudo-absolute RTK)
+      of the position solution. If the rover receiver knows the
+      surveyed position of the base station and has an RTK solution,
+      this reports a pseudo-absolute position solution using the base
+      station position and the rover's RTK baseline vector. The full
+      GPS time is given by the preceding MSG_GPS_TIME with the
+      matching time-of-week (tow).
+    fields:
+        - tow:
+            type: u32
+            units: ms
+            desc: GPS Time of Week
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height
+        - h_accuracy:
+            type: u16
+            units: mm
+            desc: >
+              Horizontal position accuracy estimate (not
+              implemented). Defaults to 0.
+        - v_accuracy:
+            type: u16
+            units: mm
+            desc: >
+              Vertical position accuracy estimate (not
+              implemented). Defaults to 0.
+        - n_sats:
+            type: u8
+            desc: Number of satellites used in solution.
+        - flags:
+            type: u8
+            desc: Status flags
+            fields:
+              - 6-7:
+                  desc: Reserved
+              - 5:
+                  desc: RAIM repair flag
+                  values:
+                      - 0: No repair
+                      - 1: Solution came from RAIM repair
+              - 4:
+                  desc: RAIM availability flag
+                  values:
+                      - 0: RAIM check was explicitly disabled or unavailable
+                      - 1: RAIM check was available
+              - 3:
+                  desc: Height Mode
+                  values:
+                      - 0: Height above WGS84 ellipsoid
+                      - 1: Height above mean sea level
+              - 0-2:
+                  desc: Fix mode
+                  values:
+                      - 0: Single Point Positioning (SPP)
+                      - 1: Fixed RTK
+                      - 2: Float RTK
+
+ - MSG_BASELINE_ECEF_DEP_A:
+    id: 0x0202
+    public: false
+    short_desc: Baseline Position in ECEF
+    desc: >
+      This message reports the baseline solution in Earth Centered
+      Earth Fixed (ECEF) coordinates. This baseline is the relative
+      vector distance from the base station to the rover receiver. The
+      full GPS time is given by the preceding MSG_GPS_TIME with the
+      matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm
+              desc: Baseline ECEF X coordinate
+          - y:
+              type: s32
+              units: mm
+              desc: Baseline ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm
+              desc: Baseline ECEF Z coordinate
+          - accuracy:
+              type: u16
+              units: mm
+              desc: >
+                Position accuracy estimate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 5-7:
+                    desc: Reserved
+                - 4:
+                    desc: RAIM repair flag
+                    values:
+                        - 0: No repair
+                        - 1: Solution came from RAIM repair
+                - 3:
+                    desc: RAIM availability flag
+                    values:
+                        - 0: RAIM check was explicitly disabled or unavailable
+                        - 1: RAIM check was available
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ - MSG_BASELINE_NED_DEP_A:
+    id: 0x0203
+    public: false
+    short_desc: Baseline in NED
+    desc: >
+      This message reports the baseline solution in North East Down
+      (NED) coordinates. This baseline is the relative vector distance
+      from the base station to the rover receiver, and NED coordinate
+      system is defined at the local WGS84 tangent plane centered at the
+      base station position.  The full GPS time is given by the
+      preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - h_accuracy:
+              type: u16
+              units: mm
+              desc: >
+                Horizontal position accuracy estimate (not
+                implemented). Defaults to 0.
+          - v_accuracy:
+              type: u16
+              units: mm
+              desc: >
+                Vertical position accuracy estimate (not
+                implemented). Defaults to 0.
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 5-7:
+                    desc: Reserved
+                - 4:
+                    desc: RAIM repair flag
+                    values:
+                        - 0: No repair
+                        - 1: Solution came from RAIM repair
+                - 3:
+                    desc: RAIM availability flag
+                    values:
+                        - 0: RAIM check was explicitly disabled or unavailable
+                        - 1: RAIM check was available
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ - MSG_VEL_ECEF_DEP_A:
+    id: 0x0204
+    public: false
+    short_desc: Velocity in ECEF
+    desc: >
+      This message reports the velocity in Earth Centered Earth Fixed
+      (ECEF) coordinates. The full GPS time is given by the preceding
+      MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - x:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF X coordinate
+          - y:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Y coordinate
+          - z:
+              type: s32
+              units: mm/s
+              desc: Velocity ECEF Z coordinate
+          - accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Velocity accuracy estimate (not implemented). Defaults
+                to 0.
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags (reserved)
+
+ - MSG_VEL_NED_DEP_A:
+    id: 0x0205
+    short_desc: Velocity in NED
+    public: False
+    desc: >
+      This message reports the velocity in local North East Down (NED)
+      coordinates. The NED coordinate system is defined as the local WGS84
+      tangent plane centered at the current position. The full GPS time is
+      given by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm/s
+              desc: Velocity North coordinate
+          - e:
+              type: s32
+              units: mm/s
+              desc: Velocity East coordinate
+          - d:
+              type: s32
+              units: mm/s
+              desc: Velocity Down coordinate
+          - h_accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Horizontal velocity accuracy estimate (not
+                implemented). Defaults to 0.
+          - v_accuracy:
+              type: u16
+              units: mm/s
+              desc: >
+                Vertical velocity accuracy estimate (not
+                implemented). Defaults to 0.
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags (reserved)
+
+ - MSG_BASELINE_HEADING_DEP_A:
+    public: false
+    id: 0x0207
+    short_desc: Heading relative to True North
+    desc: >
+      This message reports the baseline heading pointing from the base station
+      to the rover relative to True North. The full GPS time is given by the
+      preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - heading:
+              type: u32
+              units: mdeg
+              desc: Heading
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 5-7:
+                    desc: Reserved
+                - 4:
+                    desc: RAIM repair flag
+                    values:
+                        - 0: No repair
+                        - 1: Solution came from RAIM repair
+                - 3:
+                    desc: RAIM availability flag
+                    values:
+                        - 0: RAIM check was explicitly disabled or unavailable
+                        - 1: RAIM check was available
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ - MSG_PROTECTION_LEVEL_DEP_A:
+    public: false
+    id: 0x0216
+    short_desc: Computed Position and Protection Level
+    desc: >
+      This message reports the local vertical and horizontal protection levels
+      associated with a given LLH position solution. The full GPS time is given
+      by the preceding MSG_GPS_TIME with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - vpl:
+              type: u16
+              units: cm
+              desc: Vertical protection level
+          - hpl:
+              type: u16
+              units: cm
+              desc: Horizontal protection level
+          - lat:
+              type: double
+              units: deg
+              desc: Latitude
+          - lon:
+              type: double
+              units: deg
+              desc: Longitude
+          - height:
+              type: double
+              units: m
+              desc: Height
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 0-2:
+                    desc: Target Integrity Risk (TIR) Level
+                    values:
+                        - 0: Safe state, protection level shall not be used for safety-critical application
+                        - 1: TIR Level 1
+                        - 2: TIR Level 2
+                        - 3: TIR Level 3
+                - 3-7:
+                    desc: Reserved
+
+ - MSG_PROTECTION_LEVEL:
+    public: false
+    id: 0x0217
+    short_desc: Computed state and Protection Levels
+    desc: >
+      This message reports the protection levels associated to the given
+      state estimate. The full GPS time is given by the preceding MSG_GPS_TIME
+      with the matching time-of-week (tow).
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - wn:
+              type: s16
+              units: weeks
+              desc: GPS week number
+          - hpl:
+              type: u16
+              units: cm
+              desc: Horizontal protection level
+          - vpl:
+              type: u16
+              units: cm
+              desc: Vertical protection level
+          - atpl:
+              type: u16
+              units: cm
+              desc: Along-track position error protection level
+          - ctpl:
+              type: u16
+              units: cm
+              desc: Cross-track position error protection level
+          - hvpl:
+              type: u16
+              units: mm/s
+              desc: >
+                Protection level for the error vector between estimated and
+                true along/cross track velocity vector
+          - vvpl:
+              type: u16
+              units: mm/s
+              desc: >
+                Protection level for the velocity in vehicle upright direction
+                (different from vertical direction if on a slope)
+          - hopl:
+              type: u16
+              units: mdeg
+              desc: Heading orientation protection level
+          - popl:
+              type: u16
+              units: mdeg
+              desc: Pitch orientation protection level
+          - ropl:
+              type: u16
+              units: mdeg
+              desc: Roll orientation protection level
+          - lat:
+              type: double
+              units: deg
+              desc: Latitude
+          - lon:
+              type: double
+              units: deg
+              desc: Longitude
+          - height:
+              type: double
+              units: m
+              desc: Height
+          - v_x:
+              type: s32
+              units: mm/s
+              desc: Velocity in vehicle x direction
+          - v_y:
+              type: s32
+              units: mm/s
+              desc: Velocity in vehicle y direction
+          - v_z:
+              type: s32
+              units: mm/s
+              desc: Velocity in vehicle z direction
+          - roll:
+              type: s32
+              units: udeg
+              desc: Roll angle
+          - pitch:
+              type: s32
+              units: udeg
+              desc: Pitch angle
+          - heading:
+              type: s32
+              units: udeg
+              desc: Heading angle
+          - flags:
+              type: u32
+              desc: Status flags
+              fields:
+                - 0-2:
+                    desc: Target Integrity Risk (TIR) Level
+                - 3-14:
+                    desc: Reserved
+                - 15-17:
+                    desc: Fix mode
+                    values:
+                      - 0: Invalid
+                      - 1: Single Point Position (SPP)
+                      - 2: Differential GNSS (DGNSS)
+                      - 3: Float RTK
+                      - 4: Fixed RTK
+                      - 5: Dead Reckoning
+                      - 6: SBAS Position
+                - 18-19:
+                    desc: Inertial Navigation Mode
+                    values:
+                      - 0: None
+                      - 1: INS used
+                - 20:
+                    desc: Time status
+                    values:
+                      - 0: GNSS time of validity
+                      - 1: Other
+                - 21:
+                    desc: Velocity valid
+                - 22:
+                    desc: Attitude valid
+                - 23:
+                    desc: Safe state HPL
+                - 24:
+                    desc: Safe state VPL
+                - 25:
+                    desc: Safe state ATPL
+                - 26:
+                    desc: Safe state CTPL
+                - 27:
+                    desc: Safe state HVPL
+                - 28:
+                    desc: Safe state VVPL
+                - 29:
+                    desc: Safe state HOPL
+                - 30:
+                    desc: Safe state POPL
+                - 31:
+                    desc: Safe state ROPL

--- a/spec/validation/current/new_package_added/observation.yaml
+++ b/spec/validation/current/new_package_added/observation.yaml
@@ -1,0 +1,35 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - ObservationHeader:
+    short_desc: Header for observation message
+    desc: Header of a GNSS observation message.
+    fields:
+        - t:
+            type: GPSTime
+            desc: GNSS time of this observation
+        - n_obs:
+            type: u8
+            desc: >
+              Total number of observations. First nibble is the size
+              of the sequence (n), second nibble is the zero-indexed
+              counter (ith packet of n)

--- a/spec/validation/current/remove_package/example.yaml
+++ b/spec/validation/current/remove_package/example.yaml
@@ -1,0 +1,116 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/current/unreserve_bitfield/example.yaml
+++ b/spec/validation/current/unreserve_bitfield/example.yaml
@@ -1,0 +1,121 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 4-7:
+                    desc: Reserved
+                - 3: # MSGBREAK
+                    desc: Foo
+                    values:
+                        - 0: Bar
+                        - 1: Baz
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/previous/change_bitfield_value/example.yaml
+++ b/spec/validation/previous/change_bitfield_value/example.yaml
@@ -1,0 +1,116 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/previous/field_name_changed/observation.yaml
+++ b/spec/validation/previous/field_name_changed/observation.yaml
@@ -1,0 +1,121 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_EPHEMERIS_GPS_DEP_E:
+    id: 0x0081
+    short_desc: Satellite broadcast ephemeris for GPS
+    replaced_by:
+      - MSG_EPHEMERIS
+    desc: >
+      The ephemeris message returns a set of satellite orbit
+      parameters that is used to calculate GPS satellite position,
+      velocity, and clock offset. Please see the Navstar GPS
+      Space Segment/Navigation user interfaces (ICD-GPS-200, Table
+      20-III) for more details.
+    fields:
+      - common:
+          type: EphemerisCommonContentDepA
+          desc: Values common for all ephemeris types
+      - tgd:
+          type: double
+          units: s
+          desc: Group delay differential between L1 and L2
+      - c_rs:
+          type: double
+          units: m
+          desc: Amplitude of the sine harmonic correction term to the orbit radius
+      - c_rc:
+          type: double
+          units: m
+          desc: Amplitude of the cosine harmonic correction term to the orbit radius
+      - c_uc:
+          type: double
+          units: rad
+          desc: Amplitude of the cosine harmonic correction term to the argument of latitude
+      - c_us:
+          type: double
+          units: rad
+          desc: Amplitude of the sine harmonic correction term to the argument of latitude
+      - c_ic:
+          type: double
+          units: rad
+          desc: Amplitude of the cosine harmonic correction term to the angle of inclination
+      - c_is:
+          type: double
+          units: rad
+          desc: Amplitude of the sine harmonic correction term to the angle of inclination
+      - dn:
+          type: double
+          units: rad/s
+          desc: Mean motion difference
+      - m0:
+          type: double
+          units: rad
+          desc: Mean anomaly at reference time
+      - ecc:
+          type: double
+          desc: Eccentricity of satellite orbit
+      - sqrta:
+          type: double
+          units: m^(1/2)
+          desc: Square root of the semi-major axis of orbit
+      - omega0:
+          type: double
+          units: rad
+          desc: Longitude of ascending node of orbit plane at weekly epoch
+      - omegadot:
+          type: double
+          units: rad/s
+          desc: Rate of right ascension
+      - w:
+          type: double
+          units: rad
+          desc: Argument of perigee
+      - inc:
+          type: double
+          units: rad
+          desc: Inclination
+      - inc_dot:
+          type: double
+          units: rad/s
+          desc: Inclination first derivative
+      - af0:
+          type: double
+          units: s
+          desc: Polynomial clock correction coefficient (clock bias)
+      - af1:
+          type: double
+          units: s/s
+          desc: Polynomial clock correction coefficient (clock drift)
+      - af2:
+          type: double
+          units: s/s^2
+          desc: Polynomial clock correction coefficient (rate of clock drift)
+      - toc:
+          type: GPSTimeDep
+          desc: Clock reference
+      - iode:
+          type: u8
+          desc: Issue of ephemeris data
+      - iodc:
+          type: u16
+          desc: Issue of clock data

--- a/spec/validation/previous/field_order_changed/observation.yaml
+++ b/spec/validation/previous/field_order_changed/observation.yaml
@@ -1,0 +1,49 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - EphemerisCommonContent:
+    short_desc: Common fields for every ephemeris message
+    fields:
+        - sid:
+            type: GnssSignal
+            desc: GNSS signal identifier (16 bit)
+        - toe:
+            type: GPSTimeSec
+            desc: Time of Ephemerides
+        - ura:
+            type: float
+            units: m
+            desc: User Range Accuracy
+        - fit_interval:
+            type: u32
+            units: s
+            desc: Curve fit interval
+        - valid:
+            type: u8
+            desc: Status of ephemeris, 1 = valid, 0 = invalid
+        - health_bits:
+            type: u8
+            desc: |
+              Satellite health status.
+              GPS: ICD-GPS-200, chapter 20.3.3.3.1.4
+              SBAS: 0 = valid, non-zero = invalid
+              GLO: 0 = valid, non-zero = invalid

--- a/spec/validation/previous/field_type_changed/observation.yaml
+++ b/spec/validation/previous/field_type_changed/observation.yaml
@@ -1,0 +1,38 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - Doppler:
+     short_desc: GNSS doppler measurement
+     desc: >
+       Doppler measurement in Hz represented as a 24-bit
+       fixed point number with Q16.8 layout, i.e. 16-bits of whole
+       doppler and 8-bits of fractional doppler. This doppler is defined
+       as positive for approaching satellites.
+     fields:
+         - i:
+             type: s16
+             units: Hz
+             desc: Doppler whole Hz
+         - f:
+             type: u8
+             units: Hz / 256
+             desc: Doppler fractional part

--- a/spec/validation/previous/invalid_bitfield_range/example.yaml
+++ b/spec/validation/previous/invalid_bitfield_range/example.yaml
@@ -1,0 +1,116 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/previous/message_id_changed/observation.yaml
+++ b/spec/validation/previous/message_id_changed/observation.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_BASE_POS_LLH:
+    id: 0x0044
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height

--- a/spec/validation/previous/new_field_appended/observation.yaml
+++ b/spec/validation/previous/new_field_appended/observation.yaml
@@ -1,0 +1,51 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_GLO_BIASES:
+    id: 0x0075
+    short_desc: GLONASS L1/L2 Code-Phase biases
+    desc: >
+      The GLONASS L1/L2 Code-Phase biases allows to perform
+      GPS+GLONASS integer ambiguity resolution for baselines
+      with mixed receiver types (e.g. receiver of different
+      manufacturers).
+    fields:
+        - mask:
+            type: u8
+            units: boolean
+            desc: GLONASS FDMA signals mask
+        - l1ca_bias:
+            type: s16
+            units: m * 0.02
+            desc: GLONASS L1 C/A Code-Phase Bias
+        - l1p_bias:
+            type: s16
+            units: m * 0.02
+            desc: GLONASS L1 P Code-Phase Bias
+        - l2ca_bias:
+            type: s16
+            units: m * 0.02
+            desc: GLONASS L2 C/A Code-Phase Bias
+        - l2p_bias:
+            type: s16
+            units: m * 0.02
+            desc: GLONASS L2 P Code-Phase Bias

--- a/spec/validation/previous/new_message_added/observation.yaml
+++ b/spec/validation/previous/new_message_added/observation.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_OBS:
+    id: 0x004A
+    short_desc: GPS satellite observations
+    desc: >
+      The GPS observations message reports all the raw pseudorange and
+      carrier phase observations for the satellites being tracked by
+      the device. Carrier phase observation here is represented as a
+      40-bit fixed point number with Q32.8 layout (i.e. 32-bits of
+      whole cycles and 8-bits of fractional cycles). The observations
+      are be interoperable with 3rd party receivers and conform
+      with typical RTCMv3 GNSS observations.
+    fields:
+        - header:
+            type: ObservationHeader
+            desc: Header of a GPS observation message
+        - obs:
+            type: array
+            fill: PackedObsContent
+            map_by: sid
+            desc: >
+              Pseudorange and carrier phase observation for a
+              satellite being tracked.

--- a/spec/validation/previous/new_package_added/observation.yaml
+++ b/spec/validation/previous/new_package_added/observation.yaml
@@ -1,0 +1,35 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - ObservationHeader:
+    short_desc: Header for observation message
+    desc: Header of a GNSS observation message.
+    fields:
+        - t:
+            type: GPSTime
+            desc: GNSS time of this observation
+        - n_obs:
+            type: u8
+            desc: >
+              Total number of observations. First nibble is the size
+              of the sequence (n), second nibble is the zero-indexed
+              counter (ith packet of n)

--- a/spec/validation/previous/remove_package/example.yaml
+++ b/spec/validation/previous/remove_package/example.yaml
@@ -1,0 +1,116 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.

--- a/spec/validation/previous/remove_package/observation.yaml
+++ b/spec/validation/previous/remove_package/observation.yaml
@@ -1,0 +1,127 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - ObservationHeader:
+    short_desc: Header for observation message
+    desc: Header of a GNSS observation message.
+    fields:
+        - t:
+            type: GPSTime
+            desc: GNSS time of this observation
+        - n_obs:
+            type: u8
+            desc: >
+              Total number of observations. First nibble is the size
+              of the sequence (n), second nibble is the zero-indexed
+              counter (ith packet of n)
+ - Doppler:
+     short_desc: GNSS doppler measurement
+     desc: >
+       Doppler measurement in Hz represented as a 24-bit
+       fixed point number with Q16.8 layout, i.e. 16-bits of whole
+       doppler and 8-bits of fractional doppler. This doppler is defined
+       as positive for approaching satellites.
+     fields:
+         - i:
+             type: s16
+             units: Hz
+             desc: Doppler whole Hz
+         - f:
+             type: u8
+             units: Hz / 256
+             desc: Doppler fractional part
+
+ - PackedObsContent:
+    short_desc: GNSS observations for a particular satellite signal
+    desc: >
+      Pseudorange and carrier phase observation for a satellite being tracked.
+      The observations are interoperable with 3rd party receivers and conform with
+      typical RTCM 3.1 message GPS/GLO observations.
+
+
+      Carrier phase observations are not guaranteed to be aligned to the RINEX 3
+      or RTCM 3.3 MSM reference signal and no 1/4 cycle adjustments are currently
+      performed.
+
+    fields:
+        - P:
+            type: u32
+            units: 2 cm
+            desc: Pseudorange observation
+        - L:
+            type: CarrierPhase
+            units: cycles
+            desc: Carrier phase observation with typical sign convention.
+        - D:
+            type: Doppler
+            units: Hz
+            desc: Doppler observation with typical sign convention.
+        - cn0:
+            type: u8
+            units: dB Hz / 4
+            desc: Carrier-to-Noise density.  Zero implies invalid cn0.
+        - lock:
+            type: u8
+            desc: >
+              Lock timer. This value gives an indication of the time
+              for which a signal has maintained continuous phase lock.
+              Whenever a signal has lost and regained lock, this
+              value is reset to zero. It is encoded according to DF402 from
+              the RTCM 10403.2 Amendment 2 specification.  Valid values range
+              from 0 to 15 and the most significant nibble is reserved for future use.
+        - flags:
+            type: u8
+            desc: >
+              Measurement status flags. A bit field of flags providing the
+              status of this observation.  If this field is 0 it means only the Cn0
+              estimate for the signal is valid.
+            fields:
+              - 7:
+                  desc: RAIM exclusion
+                  values:
+                      - 0: No exclusion
+                      - 1: Measurement was excluded by SPP RAIM, use with care
+              - 4-6:
+                  desc: Reserved
+              - 3:
+                  desc: Doppler valid
+                  values:
+                      - 0: Invalid doppler measurement
+                      - 1: Valid doppler measurement
+              - 2:
+                  desc: Half-cycle ambiguity
+                  values:
+                      - 0: Half cycle phase ambiguity unresolved
+                      - 1: Half cycle phase ambiguity resolved
+              - 1:
+                  desc: Carrier phase valid
+                  values:
+                      - 0: Invalid carrier phase measurement
+                      - 1: Valid carrier phase measurement
+              - 0:
+                  desc: Pseudorange valid
+                  values:
+                      - 0: Invalid pseudorange measurement
+                      - 1: Valid pseudorange measurement and coarse TOW decoded
+        - sid:
+            type: GnssSignal
+            desc: GNSS signal identifier (16 bit)

--- a/spec/validation/previous/unreserve_bitfield/example.yaml
+++ b/spec/validation/previous/unreserve_bitfield/example.yaml
@@ -1,0 +1,116 @@
+# Packages define a logical collection of SBP messages. Packages can
+# in turn include other packages in the directory hierarchy. A package
+# identifier specifies a directory path for the generated code,
+# followed by an optional description used for documentation. By
+# convention, packages marked as "stable" are unlikely to change much
+# in the future, whereas unstable messages may change with future
+# firmware development. Some packages are purely informative and are
+# omitted from code generation using "render_source".
+
+package: example
+description: Geodetic navigation messages and friends.
+render_source: True
+stable: True
+include:
+  # types.yaml defines common primitives used in the spec.
+  - types.yaml
+
+# The definitions in a package can contain both SBP messages and
+# struct definitions.
+
+definitions:
+
+ # A definition contains a series of named keys, many of which are
+ # optional, such as "short_desc", "id", etc. By default, any
+ # definition containing the 'id' field is considered an SBP message;
+ # the 'id' field uniquely identifies the message type of the payload
+ # contents. Defined fields layout the structure of an SBP payload.
+ #
+ # For example, an SBP message with a message type_id 0x0203 is a
+ # MSG_BASELINE_NED instance, with a payload containing 'tow', 'n',
+ # 'e', 'd', etc. data fields consumed by the user.
+
+ - MSG_BASELINE_NED:
+    id: 0x0203
+    short_desc: Baseline in NED
+    desc: |
+        Baseline in local North East Down (NED) coordinates.
+
+    # Each message definition has a series of fields, not unlike a C
+    # struct. Each field has a type, which is either a primitive (e.g.,
+    # u32 for 32-bit unsigned integer) or a more complex, predefined
+    # type. You can optionally include units or a description.
+
+    fields:
+          - tow:
+              type: u32
+              units: ms
+              desc: GPS Time of Week
+          - n:
+              type: s32
+              units: mm
+              desc: Baseline North coordinate
+          - e:
+              type: s32
+              units: mm
+              desc: Baseline East coordinate
+          - d:
+              type: s32
+              units: mm
+              desc: Baseline Down coordinate
+          - n_sats:
+              type: u8
+              desc: Number of satellites used in solution
+
+          # Fields that contain fields themselves denote bitfields.
+
+          - flags:
+              type: u8
+              desc: Status flags
+              fields:
+                - 3-7:
+                    desc: Reserved
+                - 0-2:
+                    desc: Fix mode
+                    values:
+                        - 0: Float RTK
+                        - 1: Fixed RTK
+
+ # Defitions lacking an id are not treated as SBP messages, but are
+ # structured types that can be embedded into SBP definitions. Here,
+ # UARTChannel is a struct composed of primitive types...
+
+ - UARTChannel:
+    desc: State of the UART channel.
+    fields:
+        - tx_throughput:
+            type: float
+            desc: UART transmit throughput.
+        - crc_error_count:
+            type: u16
+            desc: UART CRC error count.
+        - tx_buffer_level:
+            type: u8
+            desc: UART transmit usage percentage.
+
+ # ... that can be used as a field in an actual SBP message...
+
+ - MSG_UART_STATE:
+    id: 0x0018
+    desc: Piksi message about the state of UART0.
+    fields:
+        - uart0:
+            type: UARTChannel
+            desc: State of the UART0 channel.
+
+        # You can also define fixed-size strings and
+        # fixed/variable-size arrays!
+
+        - info:
+            type: string
+            size: 20
+            desc: Info string of length 20 (bytes).
+        - remaining_uart_array:
+            type: array
+            fill: UARTChannel
+            desc: Array of UART channels.


### PR DESCRIPTION
# Description

Adds mechanisms to automatically catch API breaking changes to the `libsbp` message spec.

To that end the following files have been added:
- `scripts/spec_validator.py` - A python script that will compare two sets of package definitions, and raise an error if a breaking change is detected.
- `.github/workflows/validation.yaml` - A workflow that compares the current branches package definitions against master
- `spec/validation/*` - A set of test files for the python script
- `scripts/validation_test_harness.bash` - Runs the python script against the test files
- `.github/workflows/test_validation.yaml` - A workflow that runs the bash test script.

The script currently detects the following changes as breaking (explicitly or implicitly):
- The type of a field is changed (test case 1)
- The ID of a message is changed (test case 2)
- The order of fields are changed (test case 3)
- The order or values of bitfields are changed (test case 8)


The following changes are ok:
- The name of a field changes (test case 4)
- New fields are appended (test case 5)
- New messages are added (test case 6)
- New packages are added (test case 7)

<!-- Changes proposed in this PR -->

# API compatibility

No breaking changes, the message specs are not modified in this commit.

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-99
