### PR TITLE
windows-2016 is deprecated, move to windows-2022

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -63,7 +63,7 @@ jobs:
         os:
           - ubuntu-18.04
           - macos-10.15
-          - windows-2016
+          - windows-2022
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Some builds are failing because of a "brownout" where they have disabled the service prior to it being fully disabled https://github.com/swift-nav/libsbp/actions/runs/2062186044.

See: https://github.com/actions/virtual-environments/issues/5238

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

N/A
