### PR TITLE
Suppressed warnings and deprecation notices for Java

### DIFF
--- a/java/src/com/swiftnav/sbp/SBPMessage.java
+++ b/java/src/com/swiftnav/sbp/SBPMessage.java
@@ -92,6 +92,7 @@ public class SBPMessage {
     }
 
     /** There is no exposed access to this class outside of libsbp. */
+    @SuppressWarnings("unchecked")
     public class Parser {
         private ByteBuffer buf;
 
@@ -212,11 +213,11 @@ public class SBPMessage {
             LinkedList<T> l = new LinkedList<T>();
             while (true) {
                 try {
-                    T tmp = t.newInstance();
+                    T tmp = t.getDeclaredConstructor().newInstance();
                     tmp.parse(this);
                     l.add(tmp);
                 } catch (BufferUnderflowException e) {
-                    return (T[]) l.toArray((T[]) Array.newInstance(t, l.size()));
+                    return l.toArray((T[]) Array.newInstance(t, l.size()));
                 } catch (Exception e) {
                     e.printStackTrace();
                     return null;
@@ -228,7 +229,7 @@ public class SBPMessage {
             T[] ret = (T[]) Array.newInstance(t, n);
             for (int i = 0; i < n; i++) {
                 try {
-                    ret[i] = t.newInstance();
+                    ret[i] = t.getDeclaredConstructor().newInstance();
                     ret[i].parse(this);
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/java/src/com/swiftnav/sbp/SBPStruct.java
+++ b/java/src/com/swiftnav/sbp/SBPStruct.java
@@ -20,7 +20,7 @@ public abstract class SBPStruct {
 
     protected abstract void build(SBPMessage.Builder builder);
 
-    protected abstract <T> T parse(SBPMessage.Parser parser) throws SBPBinaryException;
+    protected abstract SBPStruct parse(SBPMessage.Parser parser) throws SBPBinaryException;
 
     protected abstract JSONObject toJSON();
 

--- a/java/src/com/swiftnav/sbp/client/SBPHandler.java
+++ b/java/src/com/swiftnav/sbp/client/SBPHandler.java
@@ -197,7 +197,7 @@ public class SBPHandler implements Iterable<SBPMessage> {
                     if (msg != null) {
                         return msg;
                     }
-                } catch (InterruptedException ignored) { //NOSONAR
+                } catch (InterruptedException ignored) { // NOSONAR
                 }
             }
             // If we get here finished is set to true so there are no more messages available

--- a/java/src/com/swiftnav/sbp/client/SBPHandler.java
+++ b/java/src/com/swiftnav/sbp/client/SBPHandler.java
@@ -116,11 +116,7 @@ public class SBPHandler implements Iterable<SBPMessage> {
     public void removeCallback(SBPCallback cb) {
         synchronized (callbacks) {
             for (List<Reference<SBPCallback>> cblist : callbacks.values()) {
-                for (Reference<SBPCallback> ref : cblist) {
-                    if (ref.get() == cb) {
-                        cblist.remove(ref);
-                    }
-                }
+                cblist.removeIf(ref -> ref.get() == cb);
             }
             strongCallbacks.remove(cb);
         }
@@ -201,9 +197,7 @@ public class SBPHandler implements Iterable<SBPMessage> {
                     if (msg != null) {
                         return msg;
                     }
-                    continue;
-                } catch (InterruptedException e) {
-                    continue;
+                } catch (InterruptedException ignored) {
                 }
             }
             // If we get here finished is set to true so there are no more messages available

--- a/java/src/com/swiftnav/sbp/client/SBPHandler.java
+++ b/java/src/com/swiftnav/sbp/client/SBPHandler.java
@@ -197,7 +197,7 @@ public class SBPHandler implements Iterable<SBPMessage> {
                     if (msg != null) {
                         return msg;
                     }
-                } catch (InterruptedException ignored) {
+                } catch (InterruptedException ignored) { //NOSONAR
                 }
             }
             // If we get here finished is set to true so there are no more messages available


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Adds @SuppressedWarning for unchecked generics and removes SBPStruct#parse return from generic to SBPStruct.

Changes the concurrent for loop removing to maybe prevent ConcurrentModificationException (?) - not sure if needed, also it doesn't look like it was being called anyways

# API compatibility

Does this change introduce a API compatibility risk?

It should not, it only suppresses warnings and narrowing the scope of return type

# JIRA Reference

https://swift-nav.atlassian.net/browse/DEVINFRA-479
