### PR TITLE
Fix rust release.toml and haskell sbp.cabal.

### DIFF
--- a/haskell/sbp.cabal
+++ b/haskell/sbp.cabal
@@ -8,7 +8,7 @@ maintainer:            Swift Navigation <dev@swiftnav.com>
 copyright:             Copyright (C) 2015-2021 Swift Navigation, Inc.
 category:              Network
 build-type:            Simple
-cabal-version:         >= 1.22
+cabal-version:         1.22
 extra-source-files:    README.md
 description:
   Haskell bindings for Swift Navigation Binary Protocol (SBP), a fast,

--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,4 @@
 pre-release-hook = ["./release-hook.sh"]
-disable-tag = true
-disable-push = true
-no-dev-version = true
+tag = false
+push = false
+dev-version = false


### PR DESCRIPTION
# Description

@swift-nav/devinfra
## Rust
There were some breaking changes in cargo-release recently. These changes are needed to use cargo-release on versions beyond 0.19.0, currently it is running at 0.20.0. An alternative approach would be to fix the version we install but this change seems reasonable to me.

Here is where the breaking changes occurred:
https://github.com/crate-ci/cargo-release/releases/tag/v0.19.0

## Haskell
I was unable to publish to hackage without fixing this cabal file. I think the >= format is not valid anymore. Here is the error:
```
Packages relying on Cabal 1.12 or later should specify a specific version of the Cabal spec of the form 'cabal-version: x.y'. Use 'cabal-version: 1.22'.
```
Looks like there was a breaking change in 2.0: https://github.com/haskell/cabal/issues/4899
# Other concerns
* We need to upgrade the rust version in the docker container as the newer version of cargo-release requires 2021 version. There were some strange permission issues trying to upgrade the toolchain in the docker. Is there documentation on how to rebuild and deploy the docker tag somewhere?