### PR TITLE
validator: allow message deprecation

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Check generated tests are up to date
         run: |
           git add c/test/ rust/sbp/tests/
-          git diff --cached --name-only --exit-code
-          git diff --name-only --exit-code
+          git diff --cached --exit-code
+          git diff --exit-code
 
       - name: Generate html
         run: make html-python  # emits python/docs/build/html, not checked in

--- a/.github/workflows/test_validate.yaml
+++ b/.github/workflows/test_validate.yaml
@@ -3,6 +3,7 @@ name: Test Message Validation
 on:
   pull_request:
     paths:
+      - "spec/validation/**"
       - "scripts/spec_validator.py"
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,7 @@ java-examples:
 	$(call announce-end,"Finished building fat jar")
 
 spec-validator-fmt:
-	black scripts/spec_validator.py
+	python -m black scripts/spec_validator.py
 
 spec-validator-test:
 	python -m pylint --disable=C0116,W1203 scripts/spec_validator.py

--- a/Makefile
+++ b/Makefile
@@ -495,3 +495,12 @@ java-examples:
 	$(call announce-begin,"Building java example fat jar")
 	cd $(SWIFTNAV_ROOT)/java/example && gradle clean fatjar
 	$(call announce-end,"Finished building fat jar")
+
+spec-validator-fmt:
+	black scripts/spec_validator.py
+
+spec-validator-test:
+	python -m pylint --disable=C0116,W1203 scripts/spec_validator.py
+	python -m mypy --install scripts/spec_validator.py
+	python -m black --check scripts/spec_validator.py
+	./scripts/validation_test_harness.bash 2>&1 | grep -E 'PASS|FAIL'

--- a/scripts/spec_validator.py
+++ b/scripts/spec_validator.py
@@ -14,7 +14,7 @@ import yaml
 
 
 PACKAGES = {}
-DEP_MESSAGE_PATTERN = re.compile("^.*(_DEP)|(_DEP_[A-Z])$")
+DEP_MESSAGE_PATTERN = re.compile("^.*(_DEP|_DEP_[A-Z])$")
 
 
 def unpack(value: dict):

--- a/scripts/validation_test_harness.bash
+++ b/scripts/validation_test_harness.bash
@@ -14,6 +14,13 @@ else
         exit 1
 fi
 
+if ! python scripts/spec_validator.py spec/validation/previous/message_id_changed_dep_fail spec/validation/current/message_id_changed_dep_fail; then
+        echo "Check Message ID (Dep) Changed: PASS"
+else
+        echo "Check Message ID (Dep) Changed: FAIL"
+        exit 1
+fi
+
 if python scripts/spec_validator.py spec/validation/previous/message_id_changed_dep spec/validation/current/message_id_changed_dep; then
         echo "Check Message ID (Dep) Changed: PASS"
 else
@@ -35,7 +42,7 @@ else
         exit 1
 fi
 
-if python scripts/spec_validator.py spec/validation/previous/new_field_appended spec/validation/current/new_field_appended; then
+if ! python scripts/spec_validator.py spec/validation/previous/new_field_appended spec/validation/current/new_field_appended; then
         echo "Check New Field Appended: PASS"
 else
         echo "Check New Field Appended: FAIL"

--- a/scripts/validation_test_harness.bash
+++ b/scripts/validation_test_harness.bash
@@ -14,6 +14,13 @@ else
         exit 1
 fi
 
+if python scripts/spec_validator.py spec/validation/previous/message_id_changed_dep spec/validation/current/message_id_changed_dep; then
+        echo "Check Message ID (Dep) Changed: PASS"
+else
+        echo "Check Message ID (Dep) Changed: FAIL"
+        exit 1
+fi
+
 if ! python scripts/spec_validator.py spec/validation/previous/field_order_changed spec/validation/current/field_order_changed; then
         echo "Check Field Order Changed: PASS"
 else

--- a/spec/validation/current/message_id_changed_dep/observation.yaml
+++ b/spec/validation/current/message_id_changed_dep/observation.yaml
@@ -1,0 +1,71 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_BASE_POS_LLH:
+    id: 0x0045
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double 
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height
+        - height_acc:
+            type: float
+            units: m
+
+
+ - MSG_BASE_POS_LLH_DEP:
+    id: 0x0044
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height

--- a/spec/validation/current/message_id_changed_dep/ssr.yaml
+++ b/spec/validation/current/message_id_changed_dep/ssr.yaml
@@ -1,0 +1,66 @@
+# Copyright (C) 2018-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.ssr
+description: Precise State Space Representation (SSR) corrections format
+stable: False
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+ - MSG_SSR_STEC_CORRECTION_DEP:
+    id: 0x05FB
+    short_desc: STEC correction polynomial coefficients
+    desc: >
+      The Slant Total Electron Content per space vehicle, given as polynomial
+      approximation for a given tile. This should be combined with the
+      MSG_SSR_GRIDDED_CORRECTION message to get the state space representation
+      of the atmospheric delay.
+
+
+      It is typically equivalent to the QZSS CLAS Sub Type 8 messages.
+    replaced_by:
+      - MSG_SSR_STEC_CORRECTION
+    fields:
+        - header:
+            type: STECHeader
+            desc: Header of a STEC polynomial coefficient message.
+        - stec_sat_list:
+            type: array
+            fill: STECSatElement
+            desc: Array of STEC polynomial coefficients for each space vehicle.
+
+ - MSG_SSR_STEC_CORRECTION:
+     id: 0x05FD
+     short_desc: STEC correction polynomial coefficients
+     public: False
+     fields:
+       - header:
+           type: BoundsHeader
+           desc: Header of a STEC correction with bounds message.
+       - ssr_iod_atmo:
+           type: u8
+           desc: IOD of the SSR atmospheric correction
+       - tile_set_id:
+           type: u16
+           desc: Tile set ID
+       - tile_id:
+           type: u16
+           desc: Tile ID
+       - n_sats:
+           type: u8
+           desc: Number of satellites.
+       - stec_sat_list:
+           type: array
+           fill: STECSatElement
+           size_fn: n_sats
+           desc: Array of STEC polynomial coefficients for each space vehicle.
+

--- a/spec/validation/current/message_id_changed_dep_fail/observation.yaml
+++ b/spec/validation/current/message_id_changed_dep_fail/observation.yaml
@@ -1,0 +1,73 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_BASE_POS_LLH:
+    id: 0x0045
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double 
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height
+        - height_acc:
+            type: float
+            units: m
+
+
+ - MSG_BASE_POS_LLH_DEP:
+    id: 0x0044
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        # Should cause failure, field removed from existing message
+        #   (and id the same, but name changed)
+#        - height:
+#            type: double
+#            units: m
+#            desc: Height

--- a/spec/validation/previous/message_id_changed_dep/observation.yaml
+++ b/spec/validation/previous/message_id_changed_dep/observation.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_BASE_POS_LLH:
+    id: 0x0044
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height

--- a/spec/validation/previous/message_id_changed_dep/ssr.yaml
+++ b/spec/validation/previous/message_id_changed_dep/ssr.yaml
@@ -1,0 +1,38 @@
+# Copyright (C) 2018-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.ssr
+description: Precise State Space Representation (SSR) corrections format
+stable: False
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+ - MSG_SSR_STEC_CORRECTION:
+    id: 0x05FB
+    short_desc: STEC correction polynomial coefficients
+    desc: >
+      The Slant Total Electron Content per space vehicle, given as polynomial
+      approximation for a given tile. This should be combined with the
+      MSG_SSR_GRIDDED_CORRECTION message to get the state space representation
+      of the atmospheric delay.
+
+
+      It is typically equivalent to the QZSS CLAS Sub Type 8 messages.
+    fields:
+        - header:
+            type: STECHeader
+            desc: Header of a STEC polynomial coefficient message.
+        - stec_sat_list:
+            type: array
+            fill: STECSatElement
+            desc: Array of STEC polynomial coefficients for each space vehicle.
+

--- a/spec/validation/previous/message_id_changed_dep_fail/observation.yaml
+++ b/spec/validation/previous/message_id_changed_dep_fail/observation.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) 2015-2021 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package: swiftnav.sbp.observation
+description: Satellite observation messages from the device.
+             The SBP sender ID of 0 indicates remote observations
+             from a GNSS base station, correction network, or Skylark,
+             Swift's cloud GNSS correction product.
+stable: True
+public: True
+include:
+  - types.yaml
+  - gnss.yaml
+definitions:
+
+ - MSG_BASE_POS_LLH:
+    id: 0x0044
+    short_desc: Base station position
+    desc: >
+      The base station position message is the position reported by
+      the base station itself. It is used for pseudo-absolute RTK
+      positioning, and is required to be a high-accuracy surveyed
+      location of the base station. Any error here will result in an
+      error in the pseudo-absolute position output.
+    fields:
+        - lat:
+            type: double
+            units: deg
+            desc: Latitude
+        - lon:
+            type: double
+            units: deg
+            desc: Longitude
+        - height:
+            type: double
+            units: m
+            desc: Height


### PR DESCRIPTION
# Description

@swift-nav/devinfra

See below.

# API compatibility

*Does this change introduce a API compatibility risk?*

No, this message allows existing messages to be renamed with the `_DEP` or `_DEP_A` syntax so that they can be deprecated.

# JIRA Reference

n/a -- see https://github.com/swift-nav/libsbp/pull/1131 (cc @fpezzinosn)