### PR TITLE
make: add commands to detect staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ SBP_TESTS_SPEC_DIR := $(SWIFTNAV_ROOT)/spec/tests/yaml/
 GENENV ?= py  # the system's default python version
 SBP_GEN_BIN := tox -e $(GENENV) --
 
-SBP_VERSION := $(shell git describe --always --tags)
+SBP_VERSION := $(shell git describe --match 'v*' --always --tags)
 SBP_VERSION_UNPREFIXED := $(shell echo $(SBP_VERSION) | sed 's/^v//')
+SBP_STAGING := $(shell git describe --match 'libsbp-staging*' --always --tags | grep -q '^libsbp-staging' && echo 1 || echo 0)
 
 CHANGELOG_MAX_ISSUES := 100
 
@@ -504,3 +505,7 @@ spec-validator-test:
 	python -m mypy --install scripts/spec_validator.py
 	python -m black --check scripts/spec_validator.py
 	./scripts/validation_test_harness.bash 2>&1 | grep -E 'PASS|FAIL'
+
+version:
+	@echo "SBP version: $(SBP_VERSION)"
+	@echo "SBP is staging: $(SBP_STAGING)"


### PR DESCRIPTION
# Description

Add commands to detect when we're on a staging branch

Example run from a master branch:
```
❯ make version
SBP version: v4.2.0-15-gd85898d1
SBP is staging: 0
```

Example run from a staging branch:
```
❯ make version
SBP version: v4.2.0-24-gafe6fb3d
SBP is staging: 1
```

# Related PRs

https://github.com/swift-nav/libsbp/pull/1130