### PR TITLE
validator: skip stubbed messages [OTA-150]

### DIFF
--- a/scripts/spec_validator.py
+++ b/scripts/spec_validator.py
@@ -112,6 +112,9 @@ def validate_bitfields(
 
 
 def validate_fields(filename: str, previous_fields: dict, current_fields: dict) -> None:
+    if "stub" in [list(K.keys())[0] for K in previous_fields]:
+        logging.warning("Found stubbed message, skipping validation check...")
+        return
     if len(previous_fields) != len(current_fields):
         raise RuntimeError(
             "Breaking Message Mutation Detected!\n" "Number of fields has changed!\n"


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Tested on a staging branch PR:
```
INFO:root:Processing Definition: 570 (current: MSG_GPS_LEAP_SECOND, previous: MSG_GPS_LEAP_SECOND)
WARNING:root:Found stubbed message, skipping validation check...
INFO:root:Processing Definition: 580 (current: MSG_ITRF, previous: MSG_ITRF)
WARNING:root:Found stubbed message, skipping validation check...
INFO:root:Processing Package: swiftnav.sbp.settings
```

# API compatibility

Does this change introduce a API compatibility risk? -> It introduces a change to the validator to allow stubbed messages to change without failing the PR checks.

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan: stubbed messages are designed to change, so we don't need compatibility.

# JIRA Reference

https://swift-nav.atlassian.net/browse/OTA-150
