### PR TITLE
add parallel tox, remove python 2.7 support [DEVINFRA-771]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ test-c-v4:
 
 test-python:
 	$(call announce-begin,"Running Python tests")
-	cd $(SWIFTNAV_ROOT)/python/ && tox -vv --parallel auto --skip-missing-interpreters
+	cd $(SWIFTNAV_ROOT)/python/ && tox --parallel auto --skip-missing-interpreters
 	$(call announce-end,"Finished running Python tests")
 
 test-javascript:

--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ are both valid. To see a list of all valid targets, run `make help`.
 **Python version notes:**
 1. By default the Python targets `make python` and `make test-python` (as well
    as `make all`) run tests on all Python versions officially supported by *the
-   libsbp Python bindings*, currently **2.7, 3.5-3.9**, skipping any versions
-   not installed. To run tests on just specific Python version(s), specify the
-   `TOXENV` environment variable, e.g., `TOXENV=py27,py35 make python`. Travis
-   runs Python tests on all supported versions.
+   libsbp Python bindings*, currently **3.6-3.9**, skipping any versions not
+   installed. To run tests on just specific Python version(s), specify the
+   `TOXENV` environment variable, e.g., `TOXENV=py36 make python`. Travis runs
+   Python tests on all supported versions.
 2. By default *the code generators* are run on the system's (or virtual env's)
    default Python interpreter. Currently Python versions **2.7, 3.5, and 3.7**
    are officially supported, other versions may or may not work. The generated
@@ -229,7 +229,7 @@ are both valid. To see a list of all valid targets, run `make help`.
    `GENENV` environment variable, e.g., `GENENV=py27 make all` (you must have
    that version of Python installed beforehand).
 3. To run both the generator and the Python tests on specific Python versions,
-   specify both envs, e.g., `GENENV=py37 TOXENV=py27,py37 make python`
+   specify both envs, e.g., `GENENV=py37 TOXENV=py37 make python`
 
 ## SBP Development Procedures
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,7 +24,6 @@ CLASSIFIERS = [
   'Programming Language :: Python',
   'Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator',
   'Topic :: Software Development :: Libraries :: Python Modules',
-  'Programming Language :: Python :: 2.7',
   'Programming Language :: Python :: 3.6',
   'Programming Language :: Python :: 3.7',
   'Programming Language :: Python :: 3.8',

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = py27,py{36,37,38,39,310}-{sbp2json,noextra}-construct{2_9_33,2_9_52,2_10_53,,2_10_67}
+envlist = py{36,37,38,39,310}-{sbp2json,noextra}-construct{2_9_33,2_9_52,2_10_53,,2_10_67}
 minversion = 1.7.2
+install_command=python -m pip install --no-use-pep517 {opts} {packages}
 
 [testenv]
 extras = sbp2json: sbp2json

--- a/scripts/ci_prepare_python.bash
+++ b/scripts/ci_prepare_python.bash
@@ -3,7 +3,12 @@
 set -ex
 
 sudo apt-get -qq update
-sudo apt-get -y install gcc python2.7 python2.7-dev
+
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y ppa:deadsnakes/ppa
+
+sudo apt-get -qq update
+
 sudo apt-get install -y \
     build-essential \
     zlib1g-dev \
@@ -17,13 +22,12 @@ sudo apt-get install -y \
     libexpat-dev \
     libpcap-dev \
     liblzma-dev \
-    libpcre3-dev
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y ppa:deadsnakes/ppa
-sudo apt-get install -y python3.6 python3.6-dev python3.6-distutils \
+    libpcre3-dev \
+    python3.6 python3.6-dev python3.6-distutils \
     python3.7 python3.7-dev python3.7-distutils \
     python3 python3-dev python3-distutils \
     python3.9 python3.9-dev python3.9-distutils \
     python3.10 python3.10-dev python3.10-distutils \
-    tox dpkg-dev
+    tox dpkg-dev wget
+
 pip3 install wheel setuptools


### PR DESCRIPTION
# Description

@swift-nav/devinfra

  - We can introduce tox parallel mode to speed up the test-python target in libsbp, but we’ll need to upgrade the GHA job to use Ubuntu 20.04 to get a tox that’s new enough to run it

  - (Apparently) this exposes some bugs with Python 2.7 support in Ubuntu, this works locally but could not figure out a fix for GHA… so I propose we try to drop support for this again, Python 2 has been obsolete/discontinued for 2 years now.  Removing support for Python 2.7 ~and Python 3.5~ opens the door for us to introduce type annotations to our Python code.

# API compatibility

_Does this change introduce a API compatibility risk?_  Does not introduce compatibility issues in SBP messages or the API but drops support for Python 2.7 ~and Python 3.5~ (which are both obsolete).

## API compatibility plan

_If the above is "Yes", please detail the compatibility (or migration) plan:_ This is a "wait and see" compatibility plan, the last customer we had that was using Python 2 was able to migrate to Python 3 after some prodding, so hopefully we'll OK this time around.

# JIRA Reference

https://swift-nav.atlassian.net/browse/DEVINFRA-771
