### PR TITLE
fixing rust build script

### DIFF
--- a/scripts/ci_build_rust.bash
+++ b/scripts/ci_build_rust.bash
@@ -10,10 +10,10 @@ if [ "$RUNNER_OS" == "macOS" ]; then
     EXECUTABLES=("sbp2json" "json2sbp" "json2json")
     PACKAGE_CMD="zip ../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
 elif [ "$RUNNER_OS" == "Linux" ]; then
-  BUILD_TRIPLET="x86_64-linux-musl"
-  ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"
-  EXECUTABLES=("sbp2json" "json2sbp" "json2json")
-  PACKAGE_CMD="zip ../../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
+    BUILD_TRIPLET="x86_64-linux-musl"
+    ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"
+    EXECUTABLES=("sbp2json" "json2sbp" "json2json")
+    PACKAGE_CMD="zip ../../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
 elif [ "$RUNNER_OS" == "Windows" ]; then
     BUILD_TRIPLET="$(clang -dumpmachine)"
     ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"

--- a/scripts/ci_build_rust.bash
+++ b/scripts/ci_build_rust.bash
@@ -8,7 +8,11 @@ if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "macOS" ]; then
     BUILD_TRIPLET="$(cc -dumpmachine)"
     ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"
     EXECUTABLES=("sbp2json" "json2sbp" "json2json")
-    PACKAGE_CMD="zip ../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
+    if [ "$RUNNER_OS" == "Linux" ]; then
+      PACKAGE_CMD="zip ../../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
+    else
+      PACKAGE_CMD="zip ../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
+    fi
 elif [ "$RUNNER_OS" == "Windows" ]; then
     BUILD_TRIPLET="$(clang -dumpmachine)"
     ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"

--- a/scripts/ci_build_rust.bash
+++ b/scripts/ci_build_rust.bash
@@ -4,15 +4,16 @@ set -ex
 
 VERSION="$(git describe --always --tags --dirty)"
 
-if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "macOS" ]; then
+if [ "$RUNNER_OS" == "macOS" ]; then
     BUILD_TRIPLET="$(cc -dumpmachine)"
     ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"
     EXECUTABLES=("sbp2json" "json2sbp" "json2json")
-    if [ "$RUNNER_OS" == "Linux" ]; then
-      PACKAGE_CMD="zip ../../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
-    else
-      PACKAGE_CMD="zip ../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
-    fi
+    PACKAGE_CMD="zip ../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
+elif [ "$RUNNER_OS" == "Linux" ]; then
+  BUILD_TRIPLET="x86_64-linux-musl"
+  ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"
+  EXECUTABLES=("sbp2json" "json2sbp" "json2json")
+  PACKAGE_CMD="zip ../../../$ARTIFACT_NAME ${EXECUTABLES[*]}"
 elif [ "$RUNNER_OS" == "Windows" ]; then
     BUILD_TRIPLET="$(clang -dumpmachine)"
     ARTIFACT_NAME="sbp_tools-${VERSION}-${BUILD_TRIPLET}.zip"


### PR DESCRIPTION
# Description

right now it doesn't upload the linux build

since linux specifies binary target, directory becomes
`/target/x86_64-unknown-linux-musl/release`
where normally it should be
`/target/release`

and we want to zip it up to end up in the top folder 
`/`
so we will just zip it up with an extra level

this is due to #1161 