### PR TITLE
Add support for arrays > 32 in Rust [GV2-74]

### DIFF
--- a/generator/sbpg/targets/resources/rust/sbp_cargo.toml
+++ b/generator/sbpg/targets/resources/rust/sbp_cargo.toml
@@ -20,7 +20,7 @@ readme = "../../README.md"
 [features]
 default = []
 async = ["futures", "dencode/async"]
-json = ["serde", "serde_json", "base64"]
+json = ["serde", "serde_json", "serde-big-array", "base64"]
 link = ["slotmap"]
 
 [lib]
@@ -46,6 +46,10 @@ optional = true
 
 [dependencies.serde_json]
 version = "1.0"
+optional = true
+
+[dependencies.serde-big-array]
+version = "0.4.1"
 optional = true
 
 [dependencies.base64]

--- a/generator/sbpg/targets/resources/rust/sbp_messages_mod.rs
+++ b/generator/sbpg/targets/resources/rust/sbp_messages_mod.rs
@@ -37,6 +37,9 @@ mod lib {
 
     pub use bytes::{Buf, BufMut};
 
+    #[cfg(feature = "serde")]
+    pub use serde_big_array::BigArray;
+
     macro_rules! get_bit_range {
         ($bitrange:expr, $source_ty:ty, $target_ty:ty, $msb:expr, $lsb:expr) => {{
             let source_bit_len = std::mem::size_of::<$source_ty>() * 8;

--- a/generator/sbpg/targets/resources/rust/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/rust/sbp_messages_template.rs
@@ -53,7 +53,12 @@ pub struct (((m.msg_name))) {
     ((*- if f.desc *))
     /// (((f.desc | commentify(indent=2) )))
     ((*- endif *))
+    ((*- if f.type_id == "array" and "size" in f.options and f.options["size"].value >= 32 *))
+    #[cfg_attr(feature = "serde", serde(with="BigArray", rename(serialize = "(((f.identifier)))")))]
+    ((*- else *))
     #[cfg_attr(feature = "serde", serde(rename(serialize = "(((f.identifier)))")))]
+    ((*- endif *))
+
     pub (((f.field_name))): (((f.type))),
     ((*- endfor *))
 }

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -20,7 +20,7 @@ readme = "../../README.md"
 [features]
 default = []
 async = ["futures", "dencode/async"]
-json = ["serde", "serde_json", "base64"]
+json = ["serde", "serde_json", "serde-big-array", "base64"]
 link = ["slotmap"]
 
 [lib]
@@ -46,6 +46,10 @@ optional = true
 
 [dependencies.serde_json]
 version = "1.0"
+optional = true
+
+[dependencies.serde-big-array]
+version = "0.4.1"
 optional = true
 
 [dependencies.base64]

--- a/rust/sbp/src/messages/mod.rs
+++ b/rust/sbp/src/messages/mod.rs
@@ -270,6 +270,9 @@ mod lib {
 
     pub use bytes::{Buf, BufMut};
 
+    #[cfg(feature = "serde")]
+    pub use serde_big_array::BigArray;
+
     macro_rules! get_bit_range {
         ($bitrange:expr, $source_ty:ty, $target_ty:ty, $msb:expr, $lsb:expr) => {{
             let source_bit_len = std::mem::size_of::<$source_ty>() * 8;


### PR DESCRIPTION
# Description
The upcoming ed25519 signature message requires a fixed array of size 64
which currently breaks the Rust build because Serde does not currently
natively support serializing or deserialzing arrays with sizes larger
than 32.

The `serde-big-array` crates allows us to work around this issue by
using macros defined there for larger arrays.

# API compatibility

No, it only allows bigger arrays to be serialized to JSON.

# JIRA Reference

https://swift-nav.atlassian.net/browse/GV2-74
