### PR TITLE
java: Add support for u32 arrays [GV2-74]

### DIFF
--- a/java/src/com/swiftnav/sbp/SBPMessage.java
+++ b/java/src/com/swiftnav/sbp/SBPMessage.java
@@ -189,6 +189,16 @@ public class SBPMessage {
             return ret;
         }
 
+        public long[] getArrayofU32() {
+            return getArrayofU32(buf.remaining() / 4);
+        }
+
+        public long[] getArrayofU32(int n) {
+            long[] ret = new long[n];
+            for (int i = 0; i < n; i++) ret[i] = getU32();
+            return ret;
+        }
+
         public float[] getArrayofFloat() {
             return getArrayofFloat(buf.remaining() / Float.BYTES);
         }
@@ -339,6 +349,15 @@ public class SBPMessage {
         public void putArrayofU16(int[] data, int n) {
             assert (n == data.length);
             putArrayofU16(data);
+        }
+
+        public void putArrayofU32(long[] data) {
+            for (long x : data) buf.putLong(x);
+        }
+
+        public void putArrayofU32(long[] data, int n) {
+            assert (n == data.length);
+            putArrayofU32(data);
         }
 
         public void putArrayofDouble(double[] data) {


### PR DESCRIPTION
# Description

The generated Java code was missing some code to allow for u32 arrays,
which is needed for the upcoming ed25519 signature message.

# API compatibility
No

# JIRA Reference
https://swift-nav.atlassian.net/browse/GV2-74
