### PR TITLE
make serde feature depend on serde-big-array

### DIFF
--- a/generator/sbpg/targets/resources/rust/sbp_cargo.toml
+++ b/generator/sbpg/targets/resources/rust/sbp_cargo.toml
@@ -20,7 +20,8 @@ readme = "../../README.md"
 [features]
 default = []
 async = ["futures", "dencode/async"]
-json = ["serde", "serde_json", "serde-big-array", "base64"]
+serde = ["dep:serde", "serde-big-array"]
+json = ["serde", "serde_json", "base64"]
 float_roundtrip = ["serde_json/float_roundtrip"]
 link = ["slotmap"]
 

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -20,7 +20,8 @@ readme = "../../README.md"
 [features]
 default = []
 async = ["futures", "dencode/async"]
-json = ["serde", "serde_json", "serde-big-array", "base64"]
+serde = ["dep:serde", "serde-big-array"]
+json = ["serde", "serde_json", "base64"]
 float_roundtrip = ["serde_json/float_roundtrip"]
 link = ["slotmap"]
 

--- a/test_data/benchmark_main.py
+++ b/test_data/benchmark_main.py
@@ -20,7 +20,7 @@ RATIOS_JSON2SBP = {
 }
 
 RATIOS_JSON2JSON = {
-    "haskell": 2.56,
+    "haskell": 1.71,
 }
 
 FAILED = [False]


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Makes `serde` and `serde-big-array` go together for the `serde` feature, since some users only want to enable `serde` and not the `json` feature.

# API compatibility

_Does this change introduce a API compatibility risk?_

Should not, no messages are changed, but enables just the "serde" feature of the Rust library to be used in isolation from the "json" feature.

## API compatibility plan

_If the above is "Yes", please detail the compatibility (or migration) plan:_

n/a

# References

## Jira
No Jira, but example breakage here: https://github.com/swift-nav/gnss-converters-private/runs/7347817014?check_suite_focus=true

## Related PRs
- https://github.com/swift-nav/gnss-converters-private/pull/1226