### PR TITLE
rust: fix serde feature for standalone compilation

### DIFF
--- a/generator/sbpg/targets/resources/rust/sbp_cargo.toml
+++ b/generator/sbpg/targets/resources/rust/sbp_cargo.toml
@@ -22,7 +22,7 @@ default = []
 async = ["futures", "dencode/async"]
 serde = ["dep:serde", "serde-big-array"]
 json = ["serde", "serde_json", "base64"]
-float_roundtrip = ["serde_json/float_roundtrip"]
+float_roundtrip = ["serde", "serde_json/float_roundtrip"]
 link = ["slotmap"]
 
 [lib]

--- a/generator/sbpg/targets/resources/rust/sbp_messages_mod.rs
+++ b/generator/sbpg/targets/resources/rust/sbp_messages_mod.rs
@@ -123,7 +123,7 @@ pub enum Sbp {
     Unknown( Unknown ),
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 impl<'de> serde::Deserialize<'de> for Sbp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 async = ["futures", "dencode/async"]
 serde = ["dep:serde", "serde-big-array"]
 json = ["serde", "serde_json", "base64"]
-float_roundtrip = ["serde_json/float_roundtrip"]
+float_roundtrip = ["serde", "serde_json/float_roundtrip"]
 link = ["slotmap"]
 
 [lib]

--- a/rust/sbp/src/messages/mod.rs
+++ b/rust/sbp/src/messages/mod.rs
@@ -795,7 +795,7 @@ pub enum Sbp {
     Unknown(Unknown),
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_json")]
 impl<'de> serde::Deserialize<'de> for Sbp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/rust/sbp/src/sbp_string.rs
+++ b/rust/sbp/src/sbp_string.rs
@@ -1,9 +1,8 @@
-use std::convert::TryInto;
 use std::fmt;
-use std::fmt::Formatter;
 use std::marker::PhantomData;
 
 use bytes::{Buf, BufMut};
+#[cfg(feature = "serde")]
 use serde::de::{Error, Visitor};
 
 use crate::wire_format::WireFormat;
@@ -84,7 +83,7 @@ impl<'de, E> serde::Deserialize<'de> for SbpString<Vec<u8>, E> {
         impl<'de, E> Visitor<'de> for SbpStringVisitor<E> {
             type Value = SbpString<Vec<u8>, E>;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("string")
             }
 
@@ -126,12 +125,14 @@ impl<'de, E, const LEN: usize> serde::Deserialize<'de> for SbpString<[u8; LEN], 
     where
         D: serde::Deserializer<'de>,
     {
+        use std::convert::TryInto;
+
         struct SbpStringVisitor<E, const LEN: usize>(PhantomData<SbpString<[u8; LEN], E>>);
 
         impl<'de, E, const LEN: usize> Visitor<'de> for SbpStringVisitor<E, LEN> {
             type Value = SbpString<[u8; LEN], E>;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("string")
             }
 

--- a/scripts/ci_build_rust.bash
+++ b/scripts/ci_build_rust.bash
@@ -24,6 +24,13 @@ else
     exit 1
 fi
 
+cargo build --no-default-features -p sbp
+cargo build --no-default-features -p sbp --features serde
+cargo build --no-default-features -p sbp --features json
+cargo build --no-default-features -p sbp --features async
+cargo build --no-default-features -p sbp --features link
+cargo build --no-default-features -p sbp --features float_roundtrip
+
 if [ "$RUNNER_OS" == "Linux" ]; then
   cargo build --all --release --target=x86_64-unknown-linux-musl
   cd target/x86_64-unknown-linux-musl/release


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Fix standalone compilation of rust library features

# API compatibility

_Does this change introduce a API compatibility risk?_

No, not message changes, no rust API changes

## API compatibility plan

_If the above is "Yes", please detail the compatibility (or migration) plan:_

n/a

# References
 
No Jira, relevant build failure: https://github.com/swift-nav/gnss-converters-private/runs/7350183326?check_suite_focus=true