### PR TITLE
Deprecate SSR gridded correction message

### DIFF
--- a/c/include/libsbp/cpp/message_traits.h
+++ b/c/include/libsbp/cpp/message_traits.h
@@ -6074,6 +6074,43 @@ struct MessageTraits<sbp_msg_ssr_gridded_correction_dep_a_t> {
 };
 
 template <>
+struct MessageTraits<sbp_msg_ssr_gridded_correction_dep_t> {
+  static constexpr sbp_msg_type_t id = SbpMsgSsrGriddedCorrectionDep;
+  static const sbp_msg_ssr_gridded_correction_dep_t &get(const sbp_msg_t &msg) {
+    return msg.ssr_gridded_correction_dep;
+  }
+  static sbp_msg_ssr_gridded_correction_dep_t &get(sbp_msg_t &msg) {
+    return msg.ssr_gridded_correction_dep;
+  }
+  static void to_sbp_msg(const sbp_msg_ssr_gridded_correction_dep_t &msg,
+                         sbp_msg_t *sbp_msg) {
+    sbp_msg->ssr_gridded_correction_dep = msg;
+  }
+  static sbp_msg_t to_sbp_msg(const sbp_msg_ssr_gridded_correction_dep_t &msg) {
+    sbp_msg_t sbp_msg;
+    sbp_msg.ssr_gridded_correction_dep = msg;
+    return sbp_msg;
+  }
+  static s8 send(sbp_state_t *state, u16 sender_id,
+                 const sbp_msg_ssr_gridded_correction_dep_t &msg,
+                 sbp_write_fn_t write) {
+    return sbp_msg_ssr_gridded_correction_dep_send(state, sender_id, &msg,
+                                                   write);
+  }
+  static s8 encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
+                   const sbp_msg_ssr_gridded_correction_dep_t &msg) {
+    return sbp_msg_ssr_gridded_correction_dep_encode(buf, len, n_written, &msg);
+  }
+  static s8 decode(const uint8_t *buf, uint8_t len, uint8_t *n_read,
+                   sbp_msg_ssr_gridded_correction_dep_t *msg) {
+    return sbp_msg_ssr_gridded_correction_dep_decode(buf, len, n_read, msg);
+  }
+  static size_t encoded_len(const sbp_msg_ssr_gridded_correction_dep_t &msg) {
+    return sbp_msg_ssr_gridded_correction_dep_encoded_len(&msg);
+  }
+};
+
+template <>
 struct MessageTraits<sbp_msg_ssr_gridded_correction_no_std_dep_a_t> {
   static constexpr sbp_msg_type_t id = SbpMsgSsrGriddedCorrectionNoStdDepA;
   static const sbp_msg_ssr_gridded_correction_no_std_dep_a_t &get(

--- a/c/include/libsbp/legacy/cpp/message_traits.h
+++ b/c/include/libsbp/legacy/cpp/message_traits.h
@@ -1029,7 +1029,7 @@ struct MessageTraits<msg_ssr_stec_correction_dep_t> {
 
 
 template<>
-struct MessageTraits<msg_ssr_gridded_correction_t> {
+struct MessageTraits<msg_ssr_gridded_correction_dep_t> {
   static constexpr u16 id = 1532;
 };
 
@@ -1043,6 +1043,12 @@ struct MessageTraits<msg_ssr_stec_correction_t> {
 template<>
 struct MessageTraits<msg_ssr_gridded_correction_bounds_t> {
   static constexpr u16 id = 1534;
+};
+
+
+template<>
+struct MessageTraits<msg_ssr_gridded_correction_t> {
+  static constexpr u16 id = 1535;
 };
 
 

--- a/c/include/libsbp/legacy/ssr.h
+++ b/c/include/libsbp/legacy/ssr.h
@@ -291,9 +291,8 @@ typedef struct SBP_ATTR_PACKED {
 
 /** Gridded troposphere and STEC correction residuals
  *
- * STEC residuals are per space vehicle, troposphere is not.
- *
- * It is typically equivalent to the QZSS CLAS Sub Type 9 messages.
+ * STEC residuals are per space vehicle, troposphere is not. It is typically
+ * equivalent to the QZSS CLAS Sub Type 9 messages.
  */
 
 typedef struct SBP_ATTR_PACKED {
@@ -311,6 +310,28 @@ typedef struct SBP_ATTR_PACKED {
   stec_residual_t stec_residuals[0]; /**< STEC residuals for each
                                           satellite (mean, stddev). */
 } msg_ssr_gridded_correction_t;
+
+/** Gridded troposphere and STEC correction residuals
+ *
+ * STEC residuals are per space vehicle, troposphere is not. It is typically
+ * equivalent to the QZSS CLAS Sub Type 9 messages.
+ */
+
+typedef struct SBP_ATTR_PACKED {
+  gridded_correction_header_t header; /**< Header of a
+                                           gridded
+                                           correction
+                                           message */
+  u16 index;                          /**< Index of the grid point. */
+  tropospheric_delay_correction_t tropo_delay_correction; /**< Wet and
+                                                               hydrostatic
+                                                               vertical
+                                                               delays
+                                                               (mean,
+                                                               stddev). */
+  stec_residual_t stec_residuals[0]; /**< STEC residuals for each
+                                          satellite (mean, stddev). */
+} msg_ssr_gridded_correction_dep_t;
 
 /** None
  *

--- a/c/include/libsbp/sbp_msg_type.h
+++ b/c/include/libsbp/sbp_msg_type.h
@@ -223,6 +223,7 @@ typedef enum {
   SbpMsgSsrGridDefinitionDepA = SBP_MSG_SSR_GRID_DEFINITION_DEP_A,
   SbpMsgSsrGriddedCorrectionBounds = SBP_MSG_SSR_GRIDDED_CORRECTION_BOUNDS,
   SbpMsgSsrGriddedCorrectionDepA = SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_A,
+  SbpMsgSsrGriddedCorrectionDep = SBP_MSG_SSR_GRIDDED_CORRECTION_DEP,
   SbpMsgSsrGriddedCorrectionNoStdDepA =
       SBP_MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A,
   SbpMsgSsrGriddedCorrection = SBP_MSG_SSR_GRIDDED_CORRECTION,

--- a/c/include/libsbp/ssr_macros.h
+++ b/c/include/libsbp/ssr_macros.h
@@ -186,7 +186,7 @@
  */
 #define SBP_MSG_SSR_STEC_CORRECTION_ENCODED_OVERHEAD 16u
 
-#define SBP_MSG_SSR_GRIDDED_CORRECTION 0x05FC
+#define SBP_MSG_SSR_GRIDDED_CORRECTION 0x05FF
 /**
  * The maximum number of items that can be stored in
  * sbp_msg_ssr_gridded_correction_t::stec_residuals (V4 API) or
@@ -209,6 +209,30 @@
  * structure and its variable length component(s)
  */
 #define SBP_MSG_SSR_GRIDDED_CORRECTION_ENCODED_OVERHEAD 23u
+
+#define SBP_MSG_SSR_GRIDDED_CORRECTION_DEP 0x05FC
+/**
+ * The maximum number of items that can be stored in
+ * sbp_msg_ssr_gridded_correction_dep_t::stec_residuals (V4 API) or
+ * msg_ssr_gridded_correction_dep_t::stec_residuals (legacy API) before the
+ * maximum SBP message size is exceeded
+ */
+#define SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_STEC_RESIDUALS_MAX 46u
+
+/**
+ * Encoded length of sbp_msg_ssr_gridded_correction_dep_t (V4 API) and
+ * msg_ssr_gridded_correction_dep_t (legacy API)
+ *
+ * This type is not fixed size and an instance of this message may be longer
+ * than the value indicated by this symbol. Users of the V4 API should call
+ * #sbp_msg_ssr_gridded_correction_dep_encoded_len to determine the actual size
+ * of an instance of this message. Users of the legacy API are required to track
+ * the encoded message length when interacting with the legacy type.
+ *
+ * See the documentation for libsbp for more details regarding the message
+ * structure and its variable length component(s)
+ */
+#define SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_ENCODED_OVERHEAD 23u
 
 /**
  * Encoded length of sbp_stec_sat_element_integrity_t (V4 API) and

--- a/c/include/libsbp/v4/sbp_msg.h
+++ b/c/include/libsbp/v4/sbp_msg.h
@@ -229,6 +229,7 @@ typedef union {
   sbp_msg_ssr_grid_definition_dep_a_t ssr_grid_definition_dep_a;
   sbp_msg_ssr_gridded_correction_bounds_t ssr_gridded_correction_bounds;
   sbp_msg_ssr_gridded_correction_dep_a_t ssr_gridded_correction_dep_a;
+  sbp_msg_ssr_gridded_correction_dep_t ssr_gridded_correction_dep;
   sbp_msg_ssr_gridded_correction_no_std_dep_a_t
       ssr_gridded_correction_no_std_dep_a;
   sbp_msg_ssr_gridded_correction_t ssr_gridded_correction;
@@ -764,6 +765,9 @@ static inline s8 sbp_message_encode(uint8_t *buf, uint8_t len,
     case SbpMsgSsrGriddedCorrectionDepA:
       return sbp_msg_ssr_gridded_correction_dep_a_encode(
           buf, len, n_written, &msg->ssr_gridded_correction_dep_a);
+    case SbpMsgSsrGriddedCorrectionDep:
+      return sbp_msg_ssr_gridded_correction_dep_encode(
+          buf, len, n_written, &msg->ssr_gridded_correction_dep);
     case SbpMsgSsrGriddedCorrectionNoStdDepA:
       return sbp_msg_ssr_gridded_correction_no_std_dep_a_encode(
           buf, len, n_written, &msg->ssr_gridded_correction_no_std_dep_a);
@@ -1382,6 +1386,9 @@ static inline s8 sbp_message_decode(const uint8_t *buf, uint8_t len,
     case SbpMsgSsrGriddedCorrectionDepA:
       return sbp_msg_ssr_gridded_correction_dep_a_decode(
           buf, len, n_read, &msg->ssr_gridded_correction_dep_a);
+    case SbpMsgSsrGriddedCorrectionDep:
+      return sbp_msg_ssr_gridded_correction_dep_decode(
+          buf, len, n_read, &msg->ssr_gridded_correction_dep);
     case SbpMsgSsrGriddedCorrectionNoStdDepA:
       return sbp_msg_ssr_gridded_correction_no_std_dep_a_decode(
           buf, len, n_read, &msg->ssr_gridded_correction_no_std_dep_a);
@@ -1909,6 +1916,9 @@ static inline size_t sbp_message_encoded_len(sbp_msg_type_t msg_type,
     case SbpMsgSsrGriddedCorrectionDepA:
       return sbp_msg_ssr_gridded_correction_dep_a_encoded_len(
           &msg->ssr_gridded_correction_dep_a);
+    case SbpMsgSsrGriddedCorrectionDep:
+      return sbp_msg_ssr_gridded_correction_dep_encoded_len(
+          &msg->ssr_gridded_correction_dep);
     case SbpMsgSsrGriddedCorrectionNoStdDepA:
       return sbp_msg_ssr_gridded_correction_no_std_dep_a_encoded_len(
           &msg->ssr_gridded_correction_no_std_dep_a);
@@ -2476,6 +2486,9 @@ static inline int sbp_message_cmp(sbp_msg_type_t msg_type, const sbp_msg_t *a,
     case SbpMsgSsrGriddedCorrectionDepA:
       return sbp_msg_ssr_gridded_correction_dep_a_cmp(
           &a->ssr_gridded_correction_dep_a, &b->ssr_gridded_correction_dep_a);
+    case SbpMsgSsrGriddedCorrectionDep:
+      return sbp_msg_ssr_gridded_correction_dep_cmp(
+          &a->ssr_gridded_correction_dep, &b->ssr_gridded_correction_dep);
     case SbpMsgSsrGriddedCorrectionNoStdDepA:
       return sbp_msg_ssr_gridded_correction_no_std_dep_a_cmp(
           &a->ssr_gridded_correction_no_std_dep_a,

--- a/c/include/libsbp/v4/ssr.h
+++ b/c/include/libsbp/v4/ssr.h
@@ -27,6 +27,7 @@
 #include <libsbp/v4/ssr/MSG_SSR_CODE_PHASE_BIASES_BOUNDS.h>
 #include <libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION.h>
 #include <libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_BOUNDS.h>
+#include <libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP.h>
 #include <libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h>
 #include <libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h>
 #include <libsbp/v4/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h>

--- a/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP.h
+++ b/c/include/libsbp/v4/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP.h
@@ -15,8 +15,8 @@
  * with generate.py. Please do not hand edit!
  *****************************************************************************/
 
-#ifndef LIBSBP_V4_SSR_MSG_SSR_GRIDDED_CORRECTION_H
-#define LIBSBP_V4_SSR_MSG_SSR_GRIDDED_CORRECTION_H
+#ifndef LIBSBP_V4_SSR_MSG_SSR_GRIDDED_CORRECTION_DEP_H
+#define LIBSBP_V4_SSR_MSG_SSR_GRIDDED_CORRECTION_DEP_H
 
 #include <math.h>
 #include <stdarg.h>
@@ -38,7 +38,7 @@ extern "C" {
 
 /******************************************************************************
  *
- * SBP_MSG_SSR_GRIDDED_CORRECTION
+ * SBP_MSG_SSR_GRIDDED_CORRECTION_DEP
  *
  *****************************************************************************/
 /** Gridded troposphere and STEC correction residuals
@@ -66,7 +66,7 @@ typedef struct {
    * STEC residuals for each satellite (mean, stddev).
    */
   sbp_stec_residual_t
-      stec_residuals[SBP_MSG_SSR_GRIDDED_CORRECTION_STEC_RESIDUALS_MAX];
+      stec_residuals[SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_STEC_RESIDUALS_MAX];
   /**
    * Number of elements in stec_residuals
    *
@@ -78,22 +78,23 @@ typedef struct {
    * this field is undefined
    */
   u8 n_stec_residuals;
-} sbp_msg_ssr_gridded_correction_t;
+} sbp_msg_ssr_gridded_correction_dep_t;
 
 /**
- * Get encoded size of an instance of sbp_msg_ssr_gridded_correction_t
+ * Get encoded size of an instance of sbp_msg_ssr_gridded_correction_dep_t
  *
- * @param msg sbp_msg_ssr_gridded_correction_t instance
+ * @param msg sbp_msg_ssr_gridded_correction_dep_t instance
  * @return Length of on-wire representation
  */
-static inline size_t sbp_msg_ssr_gridded_correction_encoded_len(
-    const sbp_msg_ssr_gridded_correction_t *msg) {
-  return SBP_MSG_SSR_GRIDDED_CORRECTION_ENCODED_OVERHEAD +
+static inline size_t sbp_msg_ssr_gridded_correction_dep_encoded_len(
+    const sbp_msg_ssr_gridded_correction_dep_t *msg) {
+  return SBP_MSG_SSR_GRIDDED_CORRECTION_DEP_ENCODED_OVERHEAD +
          (msg->n_stec_residuals * SBP_STEC_RESIDUAL_ENCODED_LEN);
 }
 
 /**
- * Encode an instance of sbp_msg_ssr_gridded_correction_t to wire representation
+ * Encode an instance of sbp_msg_ssr_gridded_correction_dep_t to wire
+ * representation
  *
  * This function encodes the given instance in to the user provided buffer. The
  * buffer provided to this function must be large enough to store the encoded
@@ -108,23 +109,24 @@ static inline size_t sbp_msg_ssr_gridded_correction_encoded_len(
  * @param len Length of \p buf
  * @param n_written If not null, on success will be set to the number of bytes
  * written to \p buf
- * @param msg Instance of sbp_msg_ssr_gridded_correction_t to encode
+ * @param msg Instance of sbp_msg_ssr_gridded_correction_dep_t to encode
  * @return SBP_OK on success, or other libsbp error code
  */
-SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_encode(
+SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_dep_encode(
     uint8_t *buf, uint8_t len, uint8_t *n_written,
-    const sbp_msg_ssr_gridded_correction_t *msg);
+    const sbp_msg_ssr_gridded_correction_dep_t *msg);
 
 /**
- * Decode an instance of sbp_msg_ssr_gridded_correction_t from wire
+ * Decode an instance of sbp_msg_ssr_gridded_correction_dep_t from wire
  * representation
  *
  * This function decodes the wire representation of a
- * sbp_msg_ssr_gridded_correction_t message to the given instance. The caller
- * must specify the length of the buffer in the \p len parameter. If non-null
- * the number of bytes read from the buffer will be returned in \p n_read.
+ * sbp_msg_ssr_gridded_correction_dep_t message to the given instance. The
+ * caller must specify the length of the buffer in the \p len parameter. If
+ * non-null the number of bytes read from the buffer will be returned in \p
+ * n_read.
  *
- * @param buf Wire representation of the sbp_msg_ssr_gridded_correction_t
+ * @param buf Wire representation of the sbp_msg_ssr_gridded_correction_dep_t
  * instance
  * @param len Length of \p buf
  * @param n_read If not null, on success will be set to the number of bytes read
@@ -132,15 +134,15 @@ SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_encode(
  * @param msg Destination
  * @return SBP_OK on success, or other libsbp error code
  */
-SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_decode(
+SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_dep_decode(
     const uint8_t *buf, uint8_t len, uint8_t *n_read,
-    sbp_msg_ssr_gridded_correction_t *msg);
+    sbp_msg_ssr_gridded_correction_dep_t *msg);
 /**
- * Send an instance of sbp_msg_ssr_gridded_correction_t with the given write
+ * Send an instance of sbp_msg_ssr_gridded_correction_dep_t with the given write
  * function
  *
  * An equivalent of #sbp_message_send which operates specifically on
- * sbp_msg_ssr_gridded_correction_t
+ * sbp_msg_ssr_gridded_correction_dep_t
  *
  * The given message will be encoded to wire representation and passed in to the
  * given write function callback. The write callback will be called several
@@ -152,12 +154,12 @@ SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_decode(
  * @param write Write function
  * @return SBP_OK on success, or other libsbp error code
  */
-SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_send(
-    sbp_state_t *s, u16 sender_id, const sbp_msg_ssr_gridded_correction_t *msg,
-    sbp_write_fn_t write);
+SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_dep_send(
+    sbp_state_t *s, u16 sender_id,
+    const sbp_msg_ssr_gridded_correction_dep_t *msg, sbp_write_fn_t write);
 
 /**
- * Compare two instances of sbp_msg_ssr_gridded_correction_t
+ * Compare two instances of sbp_msg_ssr_gridded_correction_dep_t
  *
  * The two instances will be compared and a value returned consistent with the
  * return codes of comparison functions from the C standard library
@@ -167,47 +169,47 @@ SBP_EXPORT s8 sbp_msg_ssr_gridded_correction_send(
  * b A value greater than 0 will be returned if \p b is considered to be greater
  * than \p b
  *
- * @param a sbp_msg_ssr_gridded_correction_t instance
- * @param b sbp_msg_ssr_gridded_correction_t instance
+ * @param a sbp_msg_ssr_gridded_correction_dep_t instance
+ * @param b sbp_msg_ssr_gridded_correction_dep_t instance
  * @return 0, <0, >0
  */
-SBP_EXPORT int sbp_msg_ssr_gridded_correction_cmp(
-    const sbp_msg_ssr_gridded_correction_t *a,
-    const sbp_msg_ssr_gridded_correction_t *b);
+SBP_EXPORT int sbp_msg_ssr_gridded_correction_dep_cmp(
+    const sbp_msg_ssr_gridded_correction_dep_t *a,
+    const sbp_msg_ssr_gridded_correction_dep_t *b);
 
 #ifdef __cplusplus
 }
 
-static inline bool operator==(const sbp_msg_ssr_gridded_correction_t &lhs,
-                              const sbp_msg_ssr_gridded_correction_t &rhs) {
-  return sbp_msg_ssr_gridded_correction_cmp(&lhs, &rhs) == 0;
+static inline bool operator==(const sbp_msg_ssr_gridded_correction_dep_t &lhs,
+                              const sbp_msg_ssr_gridded_correction_dep_t &rhs) {
+  return sbp_msg_ssr_gridded_correction_dep_cmp(&lhs, &rhs) == 0;
 }
 
-static inline bool operator!=(const sbp_msg_ssr_gridded_correction_t &lhs,
-                              const sbp_msg_ssr_gridded_correction_t &rhs) {
-  return sbp_msg_ssr_gridded_correction_cmp(&lhs, &rhs) != 0;
+static inline bool operator!=(const sbp_msg_ssr_gridded_correction_dep_t &lhs,
+                              const sbp_msg_ssr_gridded_correction_dep_t &rhs) {
+  return sbp_msg_ssr_gridded_correction_dep_cmp(&lhs, &rhs) != 0;
 }
 
-static inline bool operator<(const sbp_msg_ssr_gridded_correction_t &lhs,
-                             const sbp_msg_ssr_gridded_correction_t &rhs) {
-  return sbp_msg_ssr_gridded_correction_cmp(&lhs, &rhs) < 0;
+static inline bool operator<(const sbp_msg_ssr_gridded_correction_dep_t &lhs,
+                             const sbp_msg_ssr_gridded_correction_dep_t &rhs) {
+  return sbp_msg_ssr_gridded_correction_dep_cmp(&lhs, &rhs) < 0;
 }
 
-static inline bool operator<=(const sbp_msg_ssr_gridded_correction_t &lhs,
-                              const sbp_msg_ssr_gridded_correction_t &rhs) {
-  return sbp_msg_ssr_gridded_correction_cmp(&lhs, &rhs) <= 0;
+static inline bool operator<=(const sbp_msg_ssr_gridded_correction_dep_t &lhs,
+                              const sbp_msg_ssr_gridded_correction_dep_t &rhs) {
+  return sbp_msg_ssr_gridded_correction_dep_cmp(&lhs, &rhs) <= 0;
 }
 
-static inline bool operator>(const sbp_msg_ssr_gridded_correction_t &lhs,
-                             const sbp_msg_ssr_gridded_correction_t &rhs) {
-  return sbp_msg_ssr_gridded_correction_cmp(&lhs, &rhs) > 0;
+static inline bool operator>(const sbp_msg_ssr_gridded_correction_dep_t &lhs,
+                             const sbp_msg_ssr_gridded_correction_dep_t &rhs) {
+  return sbp_msg_ssr_gridded_correction_dep_cmp(&lhs, &rhs) > 0;
 }
 
-static inline bool operator>=(const sbp_msg_ssr_gridded_correction_t &lhs,
-                              const sbp_msg_ssr_gridded_correction_t &rhs) {
-  return sbp_msg_ssr_gridded_correction_cmp(&lhs, &rhs) >= 0;
+static inline bool operator>=(const sbp_msg_ssr_gridded_correction_dep_t &lhs,
+                              const sbp_msg_ssr_gridded_correction_dep_t &rhs) {
+  return sbp_msg_ssr_gridded_correction_dep_cmp(&lhs, &rhs) >= 0;
 }
 
 #endif  // ifdef __cplusplus
 
-#endif /* LIBSBP_V4_SSR_MSG_SSR_GRIDDED_CORRECTION_H */
+#endif /* LIBSBP_V4_SSR_MSG_SSR_GRIDDED_CORRECTION_DEP_H */

--- a/c/src/include/libsbp/internal/v4/ssr.h
+++ b/c/src/include/libsbp/internal/v4/ssr.h
@@ -356,6 +356,26 @@ bool sbp_msg_ssr_gridded_correction_decode_internal(
  * @param msg SBP type instance
  * @return true on success, false otherwise
  */
+bool sbp_msg_ssr_gridded_correction_dep_encode_internal(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_t *msg);
+
+/**
+ * Internal function to decode an SBP type from a buffer
+ *
+ * @param ctx Decode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
+bool sbp_msg_ssr_gridded_correction_dep_decode_internal(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_t *msg);
+
+/**
+ * Internal function to encode an SBP type to a buffer
+ *
+ * @param ctx Encode context
+ * @param msg SBP type instance
+ * @return true on success, false otherwise
+ */
 bool sbp_stec_sat_element_integrity_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_stec_sat_element_integrity_t *msg);
 

--- a/c/src/v4/ssr.c
+++ b/c/src/v4/ssr.c
@@ -1799,6 +1799,125 @@ int sbp_msg_ssr_gridded_correction_cmp(
   return ret;
 }
 
+bool sbp_msg_ssr_gridded_correction_dep_encode_internal(
+    sbp_encode_ctx_t *ctx, const sbp_msg_ssr_gridded_correction_dep_t *msg) {
+  if (!sbp_gridded_correction_header_encode_internal(ctx, &msg->header)) {
+    return false;
+  }
+  if (!sbp_u16_encode(ctx, &msg->index)) {
+    return false;
+  }
+  if (!sbp_tropospheric_delay_correction_encode_internal(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  for (size_t i = 0; i < msg->n_stec_residuals; i++) {
+    if (!sbp_stec_residual_encode_internal(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+s8 sbp_msg_ssr_gridded_correction_dep_encode(
+    uint8_t *buf, uint8_t len, uint8_t *n_written,
+    const sbp_msg_ssr_gridded_correction_dep_t *msg) {
+  sbp_encode_ctx_t ctx;
+  ctx.buf = buf;
+  ctx.buf_len = len;
+  ctx.offset = 0;
+  if (!sbp_msg_ssr_gridded_correction_dep_encode_internal(&ctx, msg)) {
+    return SBP_ENCODE_ERROR;
+  }
+  if (n_written != NULL) {
+    *n_written = (uint8_t)ctx.offset;
+  }
+  return SBP_OK;
+}
+
+bool sbp_msg_ssr_gridded_correction_dep_decode_internal(
+    sbp_decode_ctx_t *ctx, sbp_msg_ssr_gridded_correction_dep_t *msg) {
+  if (!sbp_gridded_correction_header_decode_internal(ctx, &msg->header)) {
+    return false;
+  }
+  if (!sbp_u16_decode(ctx, &msg->index)) {
+    return false;
+  }
+  if (!sbp_tropospheric_delay_correction_decode_internal(
+          ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  msg->n_stec_residuals =
+      (uint8_t)((ctx->buf_len - ctx->offset) / SBP_STEC_RESIDUAL_ENCODED_LEN);
+  for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
+    if (!sbp_stec_residual_decode_internal(ctx, &msg->stec_residuals[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+s8 sbp_msg_ssr_gridded_correction_dep_decode(
+    const uint8_t *buf, uint8_t len, uint8_t *n_read,
+    sbp_msg_ssr_gridded_correction_dep_t *msg) {
+  sbp_decode_ctx_t ctx;
+  ctx.buf = buf;
+  ctx.buf_len = len;
+  ctx.offset = 0;
+  if (!sbp_msg_ssr_gridded_correction_dep_decode_internal(&ctx, msg)) {
+    return SBP_DECODE_ERROR;
+  }
+  if (n_read != NULL) {
+    *n_read = (uint8_t)ctx.offset;
+  }
+  return SBP_OK;
+}
+
+s8 sbp_msg_ssr_gridded_correction_dep_send(
+    sbp_state_t *s, u16 sender_id,
+    const sbp_msg_ssr_gridded_correction_dep_t *msg, sbp_write_fn_t write) {
+  uint8_t payload[SBP_MAX_PAYLOAD_LEN];
+  uint8_t payload_len;
+  s8 ret = sbp_msg_ssr_gridded_correction_dep_encode(payload, sizeof(payload),
+                                                     &payload_len, msg);
+  if (ret != SBP_OK) {
+    return ret;
+  }
+  return sbp_payload_send(s, SBP_MSG_SSR_GRIDDED_CORRECTION_DEP, sender_id,
+                          payload_len, payload, write);
+}
+
+int sbp_msg_ssr_gridded_correction_dep_cmp(
+    const sbp_msg_ssr_gridded_correction_dep_t *a,
+    const sbp_msg_ssr_gridded_correction_dep_t *b) {
+  int ret = 0;
+
+  ret = sbp_gridded_correction_header_cmp(&a->header, &b->header);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_u16_cmp(&a->index, &b->index);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_tropospheric_delay_correction_cmp(&a->tropo_delay_correction,
+                                              &b->tropo_delay_correction);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = sbp_u8_cmp(&a->n_stec_residuals, &b->n_stec_residuals);
+  for (uint8_t i = 0; ret == 0 && i < a->n_stec_residuals; i++) {
+    ret = sbp_stec_residual_cmp(&a->stec_residuals[i], &b->stec_residuals[i]);
+  }
+  if (ret != 0) {
+    return ret;
+  }
+  return ret;
+}
+
 bool sbp_stec_sat_element_integrity_encode_internal(
     sbp_encode_ctx_t *ctx, const sbp_stec_sat_element_integrity_t *msg) {
   if (!sbp_stec_residual_encode_internal(ctx, &msg->stec_residual)) {

--- a/spec/yaml/swiftnav/sbp/ssr.yaml
+++ b/spec/yaml/swiftnav/sbp/ssr.yaml
@@ -434,12 +434,31 @@ definitions:
            desc: Array of STEC polynomial coefficients for each space vehicle.
 
  - MSG_SSR_GRIDDED_CORRECTION:
+    id: 0x05FF
+    short_desc: Gridded troposphere and STEC correction residuals
+    desc: >
+      STEC residuals are per space vehicle, troposphere is not.
+      It is typically equivalent to the QZSS CLAS Sub Type 9 messages.
+    fields:
+        - header:
+            type: GriddedCorrectionHeader
+            desc: Header of a gridded correction message
+        - index:
+            type: u16
+            desc: Index of the grid point.
+        - tropo_delay_correction:
+            type: TroposphericDelayCorrection
+            desc: Wet and hydrostatic vertical delays (mean, stddev).
+        - stec_residuals:
+            type: array
+            fill: STECResidual
+            desc: STEC residuals for each satellite (mean, stddev).
+
+ - MSG_SSR_GRIDDED_CORRECTION_DEP:
     id: 0x05FC
     short_desc: Gridded troposphere and STEC correction residuals
     desc: >
       STEC residuals are per space vehicle, troposphere is not.
-
-
       It is typically equivalent to the QZSS CLAS Sub Type 9 messages.
     fields:
         - header:


### PR DESCRIPTION
# Description

Add a deprecated SSR gridded correction message so that there are not deprecated and non-deprecated SSR messages composing the SSR atmospheric message.

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

This removes a API compatibility risk with using a non-deprecated message amongst deprecated messages.

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
