### PR TITLE
Bump clang format to 14 [BUILD-267]

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Installing dependencies
         run: |
           sudo apt-get -qq update
-          sudo apt-get install -y tox python3-sphinx clang-format-6.0 enchant
+          sudo apt-get install -y tox python3-sphinx clang-format-12 enchant
           pip3 install tox-run-command
           tox -e py --notest
 


### PR DESCRIPTION
# Description

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-267
