### PR TITLE
rust: pin vergen

### DIFF
--- a/generator/sbpg/targets/resources/rust/sbp2json_cargo.toml
+++ b/generator/sbpg/targets/resources/rust/sbp2json_cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "3.1.15", features = ["derive"] }
 mimalloc = { version = "0.1", default-features = false }
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["git"] }
+vergen = "3"
 
 [dependencies.dencode]
 version = "0.3.0"

--- a/rust/sbp2json/Cargo.toml
+++ b/rust/sbp2json/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "3.1.15", features = ["derive"] }
 mimalloc = { version = "0.1", default-features = false }
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["git"] }
+vergen = "3"
 
 [dependencies.dencode]
 version = "0.3.0"

--- a/rust/sbp2json/build.rs
+++ b/rust/sbp2json/build.rs
@@ -1,5 +1,5 @@
-use vergen::{vergen, Config};
-
 fn main() {
-    vergen(Config::default()).unwrap();
+    use vergen::{generate_cargo_keys, ConstantsFlags};
+    let flags = ConstantsFlags::all();
+    generate_cargo_keys(flags).expect("Unable to generate the cargo keys!");
 }

--- a/rust/sbp2json/src/bin/json2json.rs
+++ b/rust/sbp2json/src/bin/json2json.rs
@@ -13,7 +13,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Convert "compact" SBP JSON data to an "exploded" form
 #[derive(Debug, Parser)]
-#[clap(name = "json2json", verbatim_doc_comment, version = env!("VERGEN_GIT_SEMVER"))]
+#[clap(name = "json2json", verbatim_doc_comment, version = env!("VERGEN_SEMVER_LIGHTWEIGHT"))]
 struct Options {
     /// Path to input file
     input: Option<PathBuf>,

--- a/rust/sbp2json/src/bin/json2sbp.rs
+++ b/rust/sbp2json/src/bin/json2sbp.rs
@@ -12,7 +12,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Convert SBP JSON data to binary SBP.
 #[derive(Debug, Parser)]
-#[clap(name = "json2sbp", verbatim_doc_comment, version = env!("VERGEN_GIT_SEMVER"))]
+#[clap(name = "json2sbp", verbatim_doc_comment, version = env!("VERGEN_SEMVER_LIGHTWEIGHT"))]
 struct Options {
     /// Path to input file
     input: Option<PathBuf>,

--- a/rust/sbp2json/src/bin/sbp2json.rs
+++ b/rust/sbp2json/src/bin/sbp2json.rs
@@ -13,7 +13,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Convert binary SBP data to JSON.
 #[derive(Debug, Parser)]
-#[structopt(name = "sbp2json", verbatim_doc_comment, version = env!("VERGEN_GIT_SEMVER"))]
+#[structopt(name = "sbp2json", verbatim_doc_comment, version = env!("VERGEN_SEMVER_LIGHTWEIGHT"))]
 pub struct Options {
     /// Path to input file
     input: Option<PathBuf>,


### PR DESCRIPTION
# Description

Pin vergen to version 3, which is the last version that doesn't use the enum-iterator crate, this crate pushes the MSRV to a very recent Rust 1.62-- this is a pretty silly/heavy requirement just for a small utility crate. Version 3 of vergen crate gets us the functionality we need and allows people to build with older versions of Rust.

# API compatibility

This doesn't change any APIs but should allow older Rust toolchains to build sbp2json and friends.

# JIRA Reference

n/a
