### PR TITLE
Finish porting test suite to Bazel [BUILD-311]

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,11 @@ new_local_repository(
     path = "c/third_party/check",
 )
 
+local_repository(
+    name = "my-googletest",
+    path = "c/third_party/googletest",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -47,11 +47,11 @@ cc_library(
         "src/v4/vehicle.c",
     ],
     hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
+    copts = ["-Ic/src/include"],
     includes = [
         "include",
-        "src/include",
-    ],  # FIXME - Don't expose this path publically.
-    visibility = [ "//visibility:public" ],
+    ],
+    visibility = ["//visibility:public"],
 )
 
 SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
@@ -65,9 +65,74 @@ cc_test(
         "test/check_bitfield_macros.c",
         "test/check_suites_legacy.h",
     ] + SBP_LEGACY_C_SOURCES,
+    includes = [
+        "include/libsbp",
+    ],
+    deps = [
+        ":sbp",
+        "@my-check//:check",
+    ],
+)
+
+SBP_V4_C_SOURCES = glob(["test/auto*.c"])
+
+cc_test(
+    name = "sbp-v4-test",
+    srcs = [
+        "test/check_main.c",
+        "test/check_edc.c",
+        "test/check_sbp.c",
+        "test/check_bitfield_macros.c",
+        "test/check_suites.h",
+    ] + SBP_V4_C_SOURCES,
     includes = ["include/libsbp"],
     deps = [
         ":sbp",
         "@my-check//:check",
+    ],
+)
+
+SBP_CPP_V4_C_SOURCES = glob(["test/cpp/auto*.cc"])
+
+cc_test(
+    name = "sbp-cpp-v4-test",
+    srcs = SBP_CPP_V4_C_SOURCES,
+    deps = [
+        ":sbp",
+        "@my-googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "sbp-string-test",
+    srcs = [
+        "test/string/test_double_null_terminated.cc",
+        "test/string/test_multipart.cc",
+        "test/string/test_null_terminated.cc",
+        "test/string/test_unterminated.cc",
+    ],
+    includes = [
+        "src/include",
+    ],
+    deps = [
+        ":sbp",
+        "@my-googletest//:gtest_main",
+    ],
+)
+
+SBP_CPP_LEGACY_SOURCES = glob(["test/legacy/cpp/auto*.cc"])
+
+cc_test(
+    name = "sbp-cpp-legacy-test",
+    srcs = [
+        "test/legacy/cpp/test_sbp_stdio.cc",
+    ] + SBP_CPP_LEGACY_SOURCES,
+    data = [
+        "test/legacy/cpp/sbp_data/gnss_data.sbp",
+    ],
+    env = {"SBP_DATA_PATH": "c/test/legacy/cpp/sbp_data/"},
+    deps = [
+        ":sbp",
+        "@my-googletest//:gtest_main",
     ],
 )

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -130,7 +130,6 @@ cc_test(
     data = [
         "test/legacy/cpp/sbp_data/gnss_data.sbp",
     ],
-    env = {"SBP_DATA_PATH": "c/test/legacy/cpp/sbp_data/"},
     deps = [
         ":sbp",
         "@my-googletest//:gtest_main",

--- a/c/test/legacy/cpp/CMakeLists.txt
+++ b/c/test/legacy/cpp/CMakeLists.txt
@@ -13,4 +13,4 @@ swift_add_test(test-libsbp-cpp-legacy
 swift_set_language_standards(test-libsbp-cpp-legacy)
 swift_set_compile_options(test-libsbp-cpp-legacy ADD -Wno-error=array-bounds)
 
-file(COPY sbp_data/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY sbp_data/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/c/test/legacy/cpp/sbp_data/)

--- a/c/test/legacy/cpp/test_sbp_stdio.cc
+++ b/c/test/legacy/cpp/test_sbp_stdio.cc
@@ -96,19 +96,11 @@ class SbpStdioTest : public ::testing::Test {
 };
 
 TEST_F(SbpStdioTest, ReadsSbpFiles) {
-  if(char* SBP_DATA_PATH = std::getenv("SBP_DATA_PATH")){
-    EXPECT_EQ(num_entries_in_file(strcat(SBP_DATA_PATH, "gnss_data.sbp")), 3);
-  } else {
-    EXPECT_EQ(num_entries_in_file("gnss_data.sbp"), 3);
-  }
+  EXPECT_EQ(num_entries_in_file("c/test/legacy/cpp/sbp_data/gnss_data.sbp"), 3);
 }
 
 TEST_F(SbpStdioTest, WritesToSbpFiles) {
-  if(char* SBP_DATA_PATH = std::getenv("SBP_DATA_PATH")){
-    write_to_file(strcat(SBP_DATA_PATH, "gnss_data.sbp"), "gnss_data_output.sbp");
-  } else {
-    write_to_file("gnss_data.sbp", "gnss_data_output.sbp");
-  }
+  write_to_file("c/test/legacy/cpp/sbp_data/gnss_data.sbp", "gnss_data_output.sbp");
   EXPECT_EQ(num_entries_in_file("gnss_data_output.sbp"), 9);
 }
 

--- a/c/test/legacy/cpp/test_sbp_stdio.cc
+++ b/c/test/legacy/cpp/test_sbp_stdio.cc
@@ -81,7 +81,6 @@ class SbpStdioTest : public ::testing::Test {
     state.set_reader(&reader);
     state.set_writer(&writer);
     MsgObsHandler handler(&state);
-
     while (true) {
       s8 status = state.process();
       if (status < SBP_OK) {
@@ -97,11 +96,19 @@ class SbpStdioTest : public ::testing::Test {
 };
 
 TEST_F(SbpStdioTest, ReadsSbpFiles) {
-  EXPECT_EQ(num_entries_in_file("gnss_data.sbp"), 3);
+  if(char* SBP_DATA_PATH = std::getenv("SBP_DATA_PATH")){
+    EXPECT_EQ(num_entries_in_file(strcat(SBP_DATA_PATH, "gnss_data.sbp")), 3);
+  } else {
+    EXPECT_EQ(num_entries_in_file("gnss_data.sbp"), 3);
+  }
 }
 
 TEST_F(SbpStdioTest, WritesToSbpFiles) {
-  write_to_file("gnss_data.sbp", "gnss_data_output.sbp");
+  if(char* SBP_DATA_PATH = std::getenv("SBP_DATA_PATH")){
+    write_to_file(strcat(SBP_DATA_PATH, "gnss_data.sbp"), "gnss_data_output.sbp");
+  } else {
+    write_to_file("gnss_data.sbp", "gnss_data_output.sbp");
+  }
   EXPECT_EQ(num_entries_in_file("gnss_data_output.sbp"), 9);
 }
 


### PR DESCRIPTION
# Description

@swift-nav/devinfra

This PR adds the following bazel targets:
- sbp-v4-test
- sbp-cpp-v4-test
- sbp-string-test
- sbp-cpp-legacy-test

In the sbp-cpp-legacy-test, `SbpStdioTest.ReadsSbpFiles` and `SbpStdioTest.WritesToSbpFiles` targets have undefined behavior. Assignment of msg to payload in the `MsgObsHandler::handle_sbp_msg` function causes this issue.
It works better with gcc-11 but still, these two testcases shouldn't be run together. In order to run all the test cases:
`CC=gcc-11 CXX=g++-11 bazel test --test_output=all //c:all --test_arg=--gtest_filter=-SbpStdioTest.WritesToSbpFiles`
`CC=gcc-11 CXX=g++-11 bazel test --test_output=all //c:sbp-cpp-legacy-test --test_arg=--gtest_filter=SbpStdioTest.WritesToSbpFiles`
<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-311
