### PR TITLE
Add bazel build for libsbp c library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,9 @@ gradle.properties
 java/gradlew
 java/gradlew.bat
 java/gradle/wrapper
+
+# Bazel
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-docker

--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,12 @@ java/gradlew
 java/gradlew.bat
 java/gradle/wrapper
 
-# Bazel
-bazel-bin
-bazel-out
-bazel-testlogs
-bazel-docker
+### Added by Hedron's Bazel Compile Commands Extractor: https://github.com/hedronvision/bazel-compile-commands-extractor
+# The external link: Differs on Windows vs macOS/Linux, so we can't check it in. The pattern needs to not have a trailing / because it's a symlink on macOS/Linux.
+/external
+# Bazel output symlinks: Same reasoning as /external. You need the * because people can change the name of the directory your repository is cloned into, changing the bazel-<workspace_name> symlink.
+/bazel-*
+# Compiled output -> don't check in
+/compile_commands.json
+# Directory where clangd puts its indexing work
+/.cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "c/third_party/googletest"]
 	path = c/third_party/googletest
 	url = https://github.com/google/googletest.git
+[submodule "bazel"]
+	path = bazel
+	url = git@github.com:swift-nav/bazel.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/google/googletest.git
 [submodule "bazel"]
 	path = bazel
-	url = git@github.com:swift-nav/bazel.git
+	url = https://github.com/swift-nav/swiftnav-bazel.git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,3 +18,15 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies()
 
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+http_archive(
+    name = "hedron_compile_commands",
+    sha256 = "4b251a482a85de6c5cb0dc34c5671e73190b9ff348e9979fa2c033d81de0f928",
+    strip_prefix = "bazel-compile-commands-extractor-5bb5ff2f32d542a986033102af771aa4206387b9",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/5bb5ff2f32d542a986033102af771aa4206387b9.tar.gz",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,11 @@ new_local_repository(
     path = "c/third_party/check",
 )
 
+local_repository(
+    name = "my-googletest",
+    path = "c/third_party/googletest",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,7 @@
+workspace(name = "root")
+
+new_local_repository(
+    name = "my-check",
+    build_file = "bazel/check.BUILD",
+    path = "c/third_party/check",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,3 +5,16 @@ new_local_repository(
     build_file = "bazel/check.BUILD",
     path = "c/third_party/check",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_foreign_cc",
+    strip_prefix = "rules_foreign_cc-c65e8cfbaa002bcd1ce9c26e9fec63b0b866c94b",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/c65e8cfbaa002bcd1ce9c26e9fec63b0b866c94b.tar.gz",
+)
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,7 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 rules_foreign_cc_dependencies()
 
 # Hedron's Compile Commands Extractor for Bazel
-# https://github.com/hedronvision/bazel-compile-commands-extractor
+# Used to create compile_commands.json file
 http_archive(
     name = "hedron_compile_commands",
     sha256 = "4b251a482a85de6c5cb0dc34c5671e73190b9ff348e9979fa2c033d81de0f928",

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -47,11 +47,11 @@ cc_library(
         "src/v4/vehicle.c",
     ],
     hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
+    copts = ["-Ic/src/include"],
     includes = [
         "include",
-        "src/include",
-    ],  # FIXME - Don't expose this path publically.
-    visibility = [ "//visibility:public" ],
+    ],
+    visibility = ["//visibility:public"],
 )
 
 SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
@@ -65,9 +65,73 @@ cc_test(
         "test/check_bitfield_macros.c",
         "test/check_suites_legacy.h",
     ] + SBP_LEGACY_C_SOURCES,
+    includes = [
+        "include/libsbp",
+    ],
+    deps = [
+        ":sbp",
+        "@my-check//:check",
+    ],
+)
+
+SBP_V4_C_SOURCES = glob(["test/auto*.c"])
+
+cc_test(
+    name = "sbp-v4-test",
+    srcs = [
+        "test/check_main.c",
+        "test/check_edc.c",
+        "test/check_sbp.c",
+        "test/check_bitfield_macros.c",
+        "test/check_suites.h",
+    ] + SBP_V4_C_SOURCES,
     includes = ["include/libsbp"],
     deps = [
         ":sbp",
         "@my-check//:check",
+    ],
+)
+
+SBP_CPP_V4_C_SOURCES = glob(["test/cpp/auto*.cc"])
+
+cc_test(
+    name = "sbp-cpp-v4-test",
+    srcs = SBP_CPP_V4_C_SOURCES,
+    deps = [
+        ":sbp",
+        "@my-googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "sbp-string-test",
+    srcs = [
+        "test/string/test_double_null_terminated.cc",
+        "test/string/test_multipart.cc",
+        "test/string/test_null_terminated.cc",
+        "test/string/test_unterminated.cc",
+    ],
+    includes = [
+        "src/include",
+    ],
+    deps = [
+        ":sbp",
+        "@my-googletest//:gtest_main",
+    ],
+)
+
+SBP_CPP_LEGACY_SOURCES = glob(["test/legacy/cpp/auto*.cc"])
+
+cc_test(
+    name = "sbp-cpp-legacy-test",
+    srcs = [
+        "test/legacy/cpp/test_sbp_stdio.cc",
+    ] + SBP_CPP_LEGACY_SOURCES,
+    data = [
+        "test/legacy/cpp/sbp_data/gnss_data.sbp",
+    ],
+    deps = [
+        ":sbp",
+        "@my-googletest//:gtest_main",
     ],
 )

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 SBP_INCLUDE = glob(["include/**/*.h"])
 
 SBP_INCLUDE_INTERNAL = glob(["src/**/*.h"])
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+)
 
 cc_library(
     name = "sbp",

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 SBP_INCLUDE = glob(["include/**/*.h"])
+
 SBP_INCLUDE_INTERNAL = glob(["src/**/*.h"])
 
 cc_library(
@@ -41,7 +42,10 @@ cc_library(
         "src/v4/vehicle.c",
     ],
     hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
-    includes = ["include", "src/include"], # FIXME - Don't expose this path publically.
+    includes = [
+        "include",
+        "src/include",
+    ],  # FIXME - Don't expose this path publically.
 )
 
 SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
@@ -49,16 +53,15 @@ SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
 cc_test(
     name = "sbp-legacy-test",
     srcs = [
-            "test/check_main_legacy.c",
-            "test/check_edc.c",
-            "test/check_sbp.c",
-            "test/check_bitfield_macros.c",
-            "test/check_suites_legacy.h",
+        "test/check_main_legacy.c",
+        "test/check_edc.c",
+        "test/check_sbp.c",
+        "test/check_bitfield_macros.c",
+        "test/check_suites_legacy.h",
     ] + SBP_LEGACY_C_SOURCES,
     includes = ["include/libsbp"],
     deps = [
-            ":sbp",
-            "@my-check//:check",
+        ":sbp",
+        "@my-check//:check",
     ],
 )
-

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -46,6 +46,7 @@ cc_library(
         "include",
         "src/include",
     ],  # FIXME - Don't expose this path publically.
+    visibility = [ "//visibility:public" ],
 )
 
 SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -3,8 +3,6 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 SBP_INCLUDE = glob(["include/**/*.h"])
 SBP_INCLUDE_INTERNAL = glob(["src/**/*.h"])
 
-print(SBP_INCLUDE_INTERNAL)
-
 cc_library(
     name = "sbp",
     srcs = [
@@ -14,6 +12,7 @@ cc_library(
         "src/v4/string/multipart.c",
         "src/v4/string/null_terminated.c",
         "src/v4/string/double_null_terminated.c",
+        "src/v4/string/unterminated.c",
         # generated files
         "src/v4/acquisition.c",
         "src/v4/bootload.c",
@@ -33,6 +32,7 @@ cc_library(
         "src/v4/piksi.c",
         "src/v4/sbas.c",
         "src/v4/settings.c",
+        "src/v4/signing.c",
         "src/v4/solution_meta.c",
         "src/v4/ssr.c",
         "src/v4/system.c",
@@ -42,5 +42,23 @@ cc_library(
     ],
     hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
     includes = ["include", "src/include"], # FIXME - Don't expose this path publically.
+)
+
+SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
+
+cc_test(
+    name = "sbp-legacy-test",
+    srcs = [
+            "test/check_main_legacy.c",
+            "test/check_edc.c",
+            "test/check_sbp.c",
+            "test/check_bitfield_macros.c",
+            "test/check_suites_legacy.h",
+    ] + SBP_LEGACY_C_SOURCES,
+    includes = ["include/libsbp"],
+    deps = [
+            ":sbp",
+            "@my-check//:check",
+    ],
 )
 

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+SBP_INCLUDE = glob(["include/**/*.h"])
+SBP_INCLUDE_INTERNAL = glob(["src/**/*.h"])
+
+print(SBP_INCLUDE_INTERNAL)
+
+cc_library(
+    name = "sbp",
+    srcs = [
+        "src/edc.c",
+        "src/sbp.c",
+        "src/v4/string/sbp_string.c",
+        "src/v4/string/multipart.c",
+        "src/v4/string/null_terminated.c",
+        "src/v4/string/double_null_terminated.c",
+        # generated files
+        "src/v4/acquisition.c",
+        "src/v4/bootload.c",
+        "src/v4/ext_events.c",
+        "src/v4/file_io.c",
+        "src/v4/flash.c",
+        "src/v4/gnss.c",
+        "src/v4/imu.c",
+        "src/v4/integrity.c",
+        "src/v4/linux.c",
+        "src/v4/logging.c",
+        "src/v4/mag.c",
+        "src/v4/navigation.c",
+        "src/v4/ndb.c",
+        "src/v4/observation.c",
+        "src/v4/orientation.c",
+        "src/v4/piksi.c",
+        "src/v4/sbas.c",
+        "src/v4/settings.c",
+        "src/v4/solution_meta.c",
+        "src/v4/ssr.c",
+        "src/v4/system.c",
+        "src/v4/tracking.c",
+        "src/v4/user.c",
+        "src/v4/vehicle.c",
+    ],
+    hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
+    includes = ["include", "src/include"], # FIXME - Don't expose this path publically.
+)
+

--- a/c/test/legacy/cpp/CMakeLists.txt
+++ b/c/test/legacy/cpp/CMakeLists.txt
@@ -13,4 +13,4 @@ swift_add_test(test-libsbp-cpp-legacy
 swift_set_language_standards(test-libsbp-cpp-legacy)
 swift_set_compile_options(test-libsbp-cpp-legacy ADD -Wno-error=array-bounds)
 
-file(COPY sbp_data/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY sbp_data/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/c/test/legacy/cpp/sbp_data/)

--- a/c/test/legacy/cpp/test_sbp_stdio.cc
+++ b/c/test/legacy/cpp/test_sbp_stdio.cc
@@ -81,7 +81,6 @@ class SbpStdioTest : public ::testing::Test {
     state.set_reader(&reader);
     state.set_writer(&writer);
     MsgObsHandler handler(&state);
-
     while (true) {
       s8 status = state.process();
       if (status < SBP_OK) {
@@ -97,11 +96,11 @@ class SbpStdioTest : public ::testing::Test {
 };
 
 TEST_F(SbpStdioTest, ReadsSbpFiles) {
-  EXPECT_EQ(num_entries_in_file("gnss_data.sbp"), 3);
+  EXPECT_EQ(num_entries_in_file("c/test/legacy/cpp/sbp_data/gnss_data.sbp"), 3);
 }
 
 TEST_F(SbpStdioTest, WritesToSbpFiles) {
-  write_to_file("gnss_data.sbp", "gnss_data_output.sbp");
+  write_to_file("c/test/legacy/cpp/sbp_data/gnss_data.sbp", "gnss_data_output.sbp");
   EXPECT_EQ(num_entries_in_file("gnss_data_output.sbp"), 9);
 }
 

--- a/c/test/legacy/cpp/test_sbp_stdio.cc
+++ b/c/test/legacy/cpp/test_sbp_stdio.cc
@@ -100,7 +100,8 @@ TEST_F(SbpStdioTest, ReadsSbpFiles) {
 }
 
 TEST_F(SbpStdioTest, WritesToSbpFiles) {
-  write_to_file("c/test/legacy/cpp/sbp_data/gnss_data.sbp", "gnss_data_output.sbp");
+  write_to_file("c/test/legacy/cpp/sbp_data/gnss_data.sbp",
+                "gnss_data_output.sbp");
   EXPECT_EQ(num_entries_in_file("gnss_data_output.sbp"), 9);
 }
 


### PR DESCRIPTION
# Description

Adds support for building libsbp c library using bazel. Adds a submodules that contains common helper scritps.

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

No API compatibility risks.
