### PR TITLE
Fix Include Paths in Bazel Build

### DIFF
--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -47,10 +47,10 @@ cc_library(
         "src/v4/vehicle.c",
     ],
     hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
-    copts = ["-Ic/src/include"],
     includes = [
         "include",
-    ],
+        "src/include",
+    ], # exposing src/include for now to fix upstream builds.
     visibility = ["//visibility:public"],
 )
 

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -47,10 +47,13 @@ cc_library(
         "src/v4/vehicle.c",
     ],
     hdrs = SBP_INCLUDE + SBP_INCLUDE_INTERNAL,
+    copts = [
+        "-Ic/src/include",
+        "-Iexternal/libsbp/c/src/include",
+    ],
     includes = [
         "include",
-        "src/include",
-    ], # exposing src/include for now to fix upstream builds.
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
# Description

Adds the include path for when this project is added as an external project in
another workspace.

It is copied into the bazel sandbox at `external/<name>/` which doesn't
match `-Ic/src/include`.

I think this is the better option that making the private include path public (copts are not propagated to dependants), but ideally this sort of a workaround wouldn't be
needed.

Have a ticket open to explore alternatives: [jira](https://swift-nav.atlassian.net/browse/BUILD-328)

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

No api risks.
