### PR TITLE
Fix bazel build: stack-protector

### DIFF
--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -54,6 +54,7 @@ swift_cc_library(
     includes = [
         "include",
     ],
+    nocopts = ["-Wstack-protector"],
     visibility = ["//visibility:public"],
 )
 
@@ -61,7 +62,6 @@ SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
 
 swift_cc_test(
     name = "sbp-legacy-test",
-    type = UNIT,
     srcs = [
         "test/check_main_legacy.c",
         "test/check_edc.c",
@@ -72,6 +72,7 @@ swift_cc_test(
     includes = [
         "include/libsbp",
     ],
+    type = UNIT,
     deps = [
         ":sbp",
         "@my-check//:check",
@@ -82,7 +83,6 @@ SBP_V4_C_SOURCES = glob(["test/auto*.c"])
 
 swift_cc_test(
     name = "sbp-v4-test",
-    type = UNIT,
     srcs = [
         "test/check_main.c",
         "test/check_edc.c",
@@ -91,6 +91,7 @@ swift_cc_test(
         "test/check_suites.h",
     ] + SBP_V4_C_SOURCES,
     includes = ["include/libsbp"],
+    type = UNIT,
     deps = [
         ":sbp",
         "@my-check//:check",
@@ -101,8 +102,8 @@ SBP_CPP_V4_C_SOURCES = glob(["test/cpp/auto*.cc"])
 
 swift_cc_test(
     name = "sbp-cpp-v4-test",
-    type = UNIT,
     srcs = SBP_CPP_V4_C_SOURCES,
+    type = UNIT,
     deps = [
         ":sbp",
         "@my-googletest//:gtest_main",
@@ -111,7 +112,6 @@ swift_cc_test(
 
 swift_cc_test(
     name = "sbp-string-test",
-    type = UNIT,
     srcs = [
         "test/string/test_double_null_terminated.cc",
         "test/string/test_multipart.cc",
@@ -121,6 +121,7 @@ swift_cc_test(
     includes = [
         "src/include",
     ],
+    type = UNIT,
     deps = [
         ":sbp",
         "@my-googletest//:gtest_main",
@@ -131,13 +132,13 @@ SBP_CPP_LEGACY_SOURCES = glob(["test/legacy/cpp/auto*.cc"])
 
 swift_cc_test(
     name = "sbp-cpp-legacy-test",
-    type = UNIT,
     srcs = [
         "test/legacy/cpp/test_sbp_stdio.cc",
     ] + SBP_CPP_LEGACY_SOURCES,
     data = [
         "test/legacy/cpp/sbp_data/gnss_data.sbp",
     ],
+    type = UNIT,
     deps = [
         ":sbp",
         "@my-googletest//:gtest_main",


### PR DESCRIPTION
# Description

@swift-nav/devinfra
[The error in gnss-converters](https://jenkins.ci.swift-nav.com/blue/organizations/jenkins/swift-nav%2Fgnss-converters-private/detail/master/478/pipeline/25):
```
external/libsbp/c/src/sbp.c: In function 'send_payload':
external/libsbp/c/src/sbp.c:580:11: error: stack protector not protecting function: all local arrays are less than 8 bytes long [-Werror=stack-protector]
  580 | static s8 send_payload(sbp_state_t *s, sbp_msg_type_t msg_type, u16 sender_id, u8 len, u8 *payload,
      |           ^~~~~~~~~~~~
cc1: all warnings being treated as errors
```
It is caused by the `-fstack-protector` flag, which Bazel c++ rules add by default. In the Bazel submodule update, we enabled `-Werror`, causing the libsbp build to fail.
I removed the `-Wstack-protector` flag from libsbp.

Tested here:
https://github.com/swift-nav/gnss-converters-private/pull/1366
https://jenkins.ci.swift-nav.com/blue/organizations/jenkins/swift-nav%2Fgnss-converters-private/detail/PR-1366/1/pipeline/25

# API compatibility

Does this change introduce a API compatibility risk?

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference
