### PR TITLE
Remove Bazel submodule [BUILD-394]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "c/third_party/googletest"]
 	path = c/third_party/googletest
 	url = https://github.com/google/googletest.git
-[submodule "bazel"]
-	path = bazel
-	url = https://github.com/swift-nav/swiftnav-bazel.git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,17 +1,12 @@
-workspace(name = "root")
-
-new_local_repository(
-    name = "my-check",
-    build_file = "bazel/check.BUILD",
-    path = "c/third_party/check",
-)
-
-local_repository(
-    name = "my-googletest",
-    path = "c/third_party/googletest",
-)
+workspace(name = "libsbp")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_swiftnav",
+    strip_prefix = "rules_swiftnav-b80ca392ea24a14f8d810380b14495680255903b",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/b80ca392ea24a14f8d810380b14495680255903b.tar.gz",
+)
 
 http_archive(
     name = "rules_foreign_cc",
@@ -35,3 +30,14 @@ http_archive(
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
 
 hedron_compile_commands_setup()
+
+local_repository(
+    name = "googletest",
+    path = "c/third_party/googletest",
+)
+
+new_local_repository(
+    name = "check",
+    build_file = "@rules_swiftnav//third_party:check.BUILD",
+    path = "c/third_party/check",
+)

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:swift_cc_defs.bzl", "UNIT", "swift_cc_library", "swift_cc_test")
+load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_cc_library", "swift_cc_test")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 SBP_INCLUDE = glob(["include/**/*.h"])
@@ -75,7 +75,7 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@my-check//:check",
+        "@check//:check",
     ],
 )
 
@@ -94,7 +94,7 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@my-check//:check",
+        "@check//:check",
     ],
 )
 
@@ -106,7 +106,7 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@my-googletest//:gtest_main",
+        "@googletest//:gtest_main",
     ],
 )
 
@@ -124,7 +124,7 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@my-googletest//:gtest_main",
+        "@googletest//:gtest_main",
     ],
 )
 
@@ -141,6 +141,6 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@my-googletest//:gtest_main",
+        "@googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
# Description

Removes the bazel submodule in favor of fetching the rules repo using `http_archive`. This is more conventional in bazel.

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

No

<!-- Provide a short explanation why or why not -->

Just changing build files.

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-399
