### PR TITLE
ci: drop python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,6 @@ RUN \
       imagemagick \
       enchant \
       clang-format-6.0 \
-      python3.6 python3.6-dev python3.6-distutils \
       python3.7 python3.7-dev python3.7-distutils \
       python3 python3-dev python3-distutils \
       python3.9 python3.9-dev python3.9-distutils \

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ are both valid. To see a list of all valid targets, run `make help`.
    as `make all`) run tests on all Python versions officially supported by *the
    libsbp Python bindings*, currently **3.6-3.9**, skipping any versions not
    installed. To run tests on just specific Python version(s), specify the
-   `TOXENV` environment variable, e.g., `TOXENV=py36 make python`. Travis runs
+   `TOXENV` environment variable, e.g., `TOXENV=py37 make python`. Travis runs
    Python tests on all supported versions.
 2. By default *the code generators* are run on the system's (or virtual env's)
    default Python interpreter. Currently Python versions **2.7, 3.5, and 3.7**

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py{36,37,38,39,310}-{sbp2json,noextra}-construct{2_9_52,}
+envlist = clean,py{37,38,39,310}-{sbp2json,noextra}-construct{2_9_52,}
 minversion = 1.7.2
 
 [testenv:clean]
@@ -10,7 +10,7 @@ commands = coverage erase
 [testenv]
 extras = sbp2json: sbp2json
 depends =
-  py{36,37,38,39,310}-{sbp2json,noextra}-construct{2_9_52,}: clean
+  py{37,38,39,310}-{sbp2json,noextra}-construct{2_9_52,}: clean
 deps =
   construct_2_9_52: construct==2.9.52
   -r{toxinidir}/setup_requirements.txt

--- a/scripts/ci_prepare_python.bash
+++ b/scripts/ci_prepare_python.bash
@@ -23,7 +23,6 @@ sudo apt-get install -y \
     libpcap-dev \
     liblzma-dev \
     libpcre3-dev \
-    python3.6 python3.6-dev python3.6-distutils \
     python3.7 python3.7-dev python3.7-distutils \
     python3 python3-dev python3-distutils \
     python3.9 python3.9-dev python3.9-distutils \


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Fixes remaining CI breakage (python 3.6 has been removed from dead snakes).

# API compatibility

n/a

# JIRA Reference

n/a, fixes observed CI breakage