### PR TITLE
Implement HasTime for Frames [DEVINFRA-516]

### DIFF
--- a/rust/sbp/src/sbp_iter_ext.rs
+++ b/rust/sbp/src/sbp_iter_ext.rs
@@ -119,7 +119,11 @@ where
 mod swiftnav_impl {
     use swiftnav::time::GpsTime;
 
-    use crate::{messages::SbpMessage, time::{GpsTimeError, MessageTime, RoverTime}, Sbp, Frame};
+    use crate::{
+        messages::SbpMessage,
+        time::{GpsTimeError, MessageTime, RoverTime},
+        Frame, Sbp,
+    };
 
     /// See [SbpIterExt::with_rover_time] for more information.
     pub struct RoverTimeIter<I: Iterator> {

--- a/rust/sbp/src/sbp_iter_ext.rs
+++ b/rust/sbp/src/sbp_iter_ext.rs
@@ -119,11 +119,7 @@ where
 mod swiftnav_impl {
     use swiftnav::time::GpsTime;
 
-    use crate::{
-        messages::SbpMessage,
-        time::{GpsTimeError, MessageTime, RoverTime},
-        Sbp,
-    };
+    use crate::{messages::SbpMessage, time::{GpsTimeError, MessageTime, RoverTime}, Sbp, Frame};
 
     /// See [SbpIterExt::with_rover_time] for more information.
     pub struct RoverTimeIter<I: Iterator> {
@@ -202,6 +198,12 @@ mod swiftnav_impl {
                 Ok(m) => m.gps_time(),
                 Err(_) => None,
             }
+        }
+    }
+
+    impl HasTime for Frame {
+        fn time(&self) -> Option<Result<MessageTime, GpsTimeError>> {
+            self.to_sbp().time()
         }
     }
 }


### PR DESCRIPTION
Intended for `with_rover_time`, important to not do redundant `to_sbp` calls after, so this just assumes that we want

`(Frame,  Time)`
since we cant easily convert from sbp -> frame,

or maybe alternatively we can retain frame and sbp.


This is so that we can do 
`Framer::new(...).with_rover_time()` for `(Frame, Time)` tuple
instead of only 
`sbp::iter_messages(...).with_rover_time()` for `(Sbp, Time)` tuple