### PR TITLE
bazel: Add CI check for bazel [BUILD-475]

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -133,6 +133,17 @@ jobs:
 
           CMAKEFLAGS: -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-static" -Dgtest_disable_pthreads=ON
 
+  bazel:
+    name: Bazel
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Bazel Build & Test
+        run:
+          bazel test //...
+
 
   windows-2019:
     strategy:

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -75,7 +75,7 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@check//:check",
+        "@check",
     ],
 )
 
@@ -94,7 +94,7 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":sbp",
-        "@check//:check",
+        "@check",
     ],
 )
 


### PR DESCRIPTION
Requires that the bazel build passes before changes can be merged to master.

Build breaking changes in the lower level libraries (libsbp, libswiftnav, gnss-converters, etc...), are rare. We've had bazel support for these libraries for several months now and have only observed 1 or 2 breaking changes during that timespan.

Therefore we think enabling this CI check for merges will be minimally disruptive to development velocity.

# Description

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-475
