### PR TITLE
ci: auto request additional reviewers (doc review)

### DIFF
--- a/.github/additional_reviewers_config.yaml
+++ b/.github/additional_reviewers_config.yaml
@@ -1,0 +1,10 @@
+files:
+  'docs/sbp.pdf':
+    - swiftnav-adam
+  'spec/yaml/swiftnav/sbp/*.yaml':
+    - swiftnav-adam
+
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - DO NOT REVIEW

--- a/.github/workflows/add_additional_reviewers.yaml
+++ b/.github/workflows/add_additional_reviewers.yaml
@@ -2,7 +2,7 @@ name: Add Additional Reviewers
 
 on:
   pull_request:
-    types: [opened, updated, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   auto-request-review:

--- a/.github/workflows/add_additional_reviewers.yaml
+++ b/.github/workflows/add_additional_reviewers.yaml
@@ -2,7 +2,7 @@ name: Add Additional Reviewers
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, updated, ready_for_review, reopened]
 
 jobs:
   auto-request-review:

--- a/.github/workflows/add_additional_reviewers.yaml
+++ b/.github/workflows/add_additional_reviewers.yaml
@@ -1,0 +1,16 @@
+name: Add Additional Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Add Additional Reviewers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request additional reviews based on supplied rules
+        uses: necojackarc/auto-request-review@v0.10.0
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          config: .github/additional_reviewers_config.yaml

--- a/spec/yaml/swiftnav/sbp/acquisition.yaml
+++ b/spec/yaml/swiftnav/sbp/acquisition.yaml
@@ -247,3 +247,6 @@ definitions:
             fill: AcqSvProfileDep
             desc: SV profiles during acquisition time
 
+
+
+# test change to trigger CI

--- a/spec/yaml/swiftnav/sbp/acquisition.yaml
+++ b/spec/yaml/swiftnav/sbp/acquisition.yaml
@@ -247,6 +247,3 @@ definitions:
             fill: AcqSvProfileDep
             desc: SV profiles during acquisition time
 
-
-
-# test change to trigger CI


### PR DESCRIPTION
# Description

Adds automation to add additional reviewers based on a supplied ruleset.
For this initial setup we're using this to request additional reviewers
if customer facing documentation has changed.

# API compatibility

No issues with API compatibility, adding new repo CI steps.

# JIRA Reference

https://swift-nav.atlassian.net/browse/DEVINFRA-1104
