### PR TITLE
bazel add gen_compile_commands target [BUILD-547]

### DIFF
--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -6,7 +6,8 @@ SBP_INCLUDE = glob(["include/**/*.h"])
 SBP_INCLUDE_INTERNAL = glob(["src/**/*.h"])
 
 refresh_compile_commands(
-    name = "refresh_compile_commands",
+    name = "gen_compile_commands",
+    visibility = ["//visibility:public"],
 )
 
 swift_cc_library(

--- a/c/Makefile
+++ b/c/Makefile
@@ -12,3 +12,6 @@ do-code-coverage:
 
 do-generate-coverage-report: do-code-coverage
 	genhtml bazel-out/_coverage/_coverage_report.dat -o coverage
+
+gen-compile-commands:
+	bazel run //c:gen_compile_commands


### PR DESCRIPTION
# Design notes
Renames `refresh_compile_commands` to `gen_compile_commands` for consistency with other repos and adds `gen-compile-commands` make target.

# JIRA
* https://swift-nav.atlassian.net/browse/BUILD-547