### PR TITLE
bazel: use c only macros [BUILD-560]

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-edb32932741b965bde9816fa85c05f2fb3d2699a",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/edb32932741b965bde9816fa85c05f2fb3d2699a.tar.gz"
+    strip_prefix = "rules_swiftnav-26426be6b89a5b9f0489158098599b9fcd973ed4",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/26426be6b89a5b9f0489158098599b9fcd973ed4.tar.gz",
 )
 
 http_archive(

--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_cc_library", "swift_cc_test")
+load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_c_library", "swift_cc_test")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 SBP_INCLUDE = glob(["include/**/*.h"])
@@ -10,7 +10,7 @@ refresh_compile_commands(
     visibility = ["//visibility:public"],
 )
 
-swift_cc_library(
+swift_c_library(
     name = "sbp",
     srcs = [
         "src/edc.c",


### PR DESCRIPTION
# Description

Updates libsbp to use the new `c` only macros in `rules_swiftnav`.

Currently these are just stubs that call the regular `swift_cc` overloads.

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

No

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-560
