### PR TITLE
bazel: Export sbp headers [BUILD-650]

### DIFF
--- a/c/BUILD.bazel
+++ b/c/BUILD.bazel
@@ -60,6 +60,12 @@ swift_c_library(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "sbp_headers",
+    srcs = SBP_INCLUDE,
+    visibility = ["//visibility:public"],
+)
+
 SBP_LEGACY_C_SOURCES = glob(["test/legacy/auto*.c"])
 
 swift_cc_test(


### PR DESCRIPTION
# Description

The sbp headers are needed to create release in starling:
https://github.com/swift-nav/starling/pull/7806

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BUILD-650
