### PR TITLE
Make the BaseTime inner public

### DIFF
--- a/rust/sbp/src/time.rs
+++ b/rust/sbp/src/time.rs
@@ -89,10 +89,14 @@ impl From<f64> for RoverTime {
 /// Time received via a message from a base station, like
 /// [MsgObs](crate::messages::observation::MsgObs).
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BaseTime(pub GpsTime);
+#[non_exhaustive]
+pub enum BaseTime {
+    /// The [GpsTime] of the message.
+    GpsTime(GpsTime)
+};
 
 impl From<GpsTime> for BaseTime {
     fn from(gps_time: GpsTime) -> Self {
-        BaseTime(gps_time)
+        BaseTime::GpsTime(gps_time)
     }
 }

--- a/rust/sbp/src/time.rs
+++ b/rust/sbp/src/time.rs
@@ -89,7 +89,7 @@ impl From<f64> for RoverTime {
 /// Time received via a message from a base station, like
 /// [MsgObs](crate::messages::observation::MsgObs).
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct BaseTime(GpsTime);
+pub struct BaseTime(pub GpsTime);
 
 impl From<GpsTime> for BaseTime {
     fn from(gps_time: GpsTime) -> Self {

--- a/rust/sbp/src/time.rs
+++ b/rust/sbp/src/time.rs
@@ -89,14 +89,10 @@ impl From<f64> for RoverTime {
 /// Time received via a message from a base station, like
 /// [MsgObs](crate::messages::observation::MsgObs).
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum BaseTime {
-    /// The [GpsTime] of the message.
-    GpsTime(GpsTime)
-};
+pub BaseTime(pub GpsTime);
 
 impl From<GpsTime> for BaseTime {
     fn from(gps_time: GpsTime) -> Self {
-        BaseTime::GpsTime(gps_time)
+        BaseTime(gps_time)
     }
 }


### PR DESCRIPTION
# Description

@swift-nav/devinfra

This PR makes the inner of the BaseTime tuple struct public. This enables users to access the time inside and makes it similar to how RoverTime can be used.

Some minor notes is that the tuple struct here isn't really doing a whole lot anymore so you could envision just removing it and replacing it with `GpsTime` which would be a major breaking change, or you could only allow access to the inner values with an `to_gps_time()` function. However, I think this solution makes the most sense given how `RoverTime` is used and the desire to not add a breaking change for something so simple. 
 
# API compatibility

Does this change introduce a API compatibility risk?

It should not, adding a public item, should be a minor change.
[Minor: adding new public items](https://doc.rust-lang.org/cargo/reference/semver.html#minor-adding-new-public-items)
Adding new, public [items](https://doc.rust-lang.org/reference/items.html) is a minor change.## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

would resolve: https://github.com/swift-nav/libsbp/issues/1331