### PR TITLE
pass all features to docs.rs build

### DIFF
--- a/generator/sbpg/targets/resources/rust/sbp_cargo.toml
+++ b/generator/sbpg/targets/resources/rust/sbp_cargo.toml
@@ -69,7 +69,6 @@ default-features = false
 [dev-dependencies]
 serialport = "2.1.0"
 
-
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo when building docs for docs.rs
 all-features = true

--- a/generator/sbpg/targets/resources/rust/sbp_cargo.toml
+++ b/generator/sbpg/targets/resources/rust/sbp_cargo.toml
@@ -1,9 +1,9 @@
-#######################################################################
-###                                                                 ###
-### WARNING: This file is generated, please update the template at: ###
-###            generator/sbpg/targets/resources/sbp-cargo.toml      ###
-###                                                                 ###
-#######################################################################
+#########################################################################
+###                                                                   ###
+### WARNING: This file is generated, please update the template at:   ###
+###            generator/sbpg/targets/resources/rust/sbp-cargo.toml   ###
+###                                                                   ###
+#########################################################################
 
 [package]
 name = "sbp"
@@ -68,3 +68,8 @@ default-features = false
 
 [dev-dependencies]
 serialport = "2.1.0"
+
+
+[package.metadata.docs.rs]
+# Whether to pass `--all-features` to Cargo when building docs for docs.rs
+all-features = true

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -69,6 +69,7 @@ default-features = false
 [dev-dependencies]
 serialport = "2.1.0"
 
+
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo when building docs for docs.rs
 all-features = true

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -69,7 +69,6 @@ default-features = false
 [dev-dependencies]
 serialport = "2.1.0"
 
-
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo when building docs for docs.rs
 all-features = true

--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -1,9 +1,9 @@
-#######################################################################
-###                                                                 ###
-### WARNING: This file is generated, please update the template at: ###
-###            generator/sbpg/targets/resources/sbp-cargo.toml      ###
-###                                                                 ###
-#######################################################################
+#########################################################################
+###                                                                   ###
+### WARNING: This file is generated, please update the template at:   ###
+###            generator/sbpg/targets/resources/rust/sbp-cargo.toml   ###
+###                                                                   ###
+#########################################################################
 
 [package]
 name = "sbp"
@@ -68,3 +68,7 @@ default-features = false
 
 [dev-dependencies]
 serialport = "2.1.0"
+
+[package.metadata.docs.rs]
+# Whether to pass `--all-features` to Cargo when building docs for docs.rs
+all-features = true


### PR DESCRIPTION
# Description

@swift-nav/devinfra

This ensures that `--all-features` is passed to cargo doc when building for docs.rs : see description here: https://docs.rs/about/metadata

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

No, purely a cargo doc build change

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference
 
N/A
