### PR TITLE
Increase SLUSH_PERCENTAGE to 45%

### DIFF
--- a/test_data/benchmark_main.py
+++ b/test_data/benchmark_main.py
@@ -7,7 +7,8 @@ import json
 import subprocess
 
 # If the ratio is off from expected by more than this percentage
-SLUSH_PERCENTAGE = 0.25
+# fail the benchmark
+SLUSH_PERCENTAGE = 0.45
 
 # How much faster Rust should be than other implementations
 RATIOS_SBP2JSON = {


### PR DESCRIPTION
The actual variation of benchmarks is closer to 45% than 25%. This PR would just increase the tolerance we have for variation in our benchmarks when doing checks against the `main`.

An alternative approach would be to diagnose what is causing this variability and work to decrease it, but [I really like slop!](https://www.amazon.com/Really-Like-Slop-Elephant-Piggie/dp/1484722620)

# Description

@swift-nav/devinfra

Increase slop to 45%

# API compatibility

Does this change introduce a API compatibility risk?

No, it's only risk would be allowing perf degradations. 

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

No

# JIRA Reference

None, came from getting an errant warning about my PR failing.

