### PR TITLE
Fix/improve construct version of sbp2json

### DIFF
--- a/python/tests/sbp/test_sbp2json.py
+++ b/python/tests/sbp/test_sbp2json.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2015-2023 Swift Navigation Inc.
+# Contact: https://support.swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from .utils import PYTHON_ROOT
+import sbp.sbp2json
+import os
+
+TEST_DATA = os.path.join(PYTHON_ROOT, "..", "test_data", "benchmark.sbp")
+
+
+# make sure that we parse exactly 150000 SBP messages from TEST_DATA
+def test_sbp2json():
+    msg_count = 0
+    def counter(args, res):
+        nonlocal msg_count
+        msg_count += 1
+
+    sbp.sbp2json.dump = counter
+
+    # anonymous object to emulate parsed arguments
+    args = type('',(object,),{
+        'file': open(TEST_DATA, "rb"),
+        'include': []
+    })()
+
+    sbp.sbp2json.sbp_main(args)
+
+    assert msg_count == 150000


### PR DESCRIPTION
# Description

1. Account for the possibility that 'buf' contains the first part of a valid message, but more data still needs to be read
2. Improve robustness of the construct version of sbp2json by checking CRCs

This aligns sbp2json with Woodpecker as well as the test cases added in https://github.com/swift-nav/libsbp/pull/1336

# API compatibility

No API change.

## API compatibility plan

N/A