### PR TITLE
c: bump minimum cmake to 3.13

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(libsbp C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" "${CMAKE_CURRENT_LIST_DIR}/cmake/common")


### PR DESCRIPTION
# Description

Closes #1320 by bumping the minimum cmake to version 3.13.

@swift-nav/devinfra

# API compatibility

_Does this change introduce a API compatibility risk?_

No, just bumping the minimum required version of cmake to match the features we're using.  Specifically `add_link_options` -- see https://cmake.org/cmake/help/latest/command/add_link_options.html.

# JIRA Reference

See issue #1320 