### PR TITLE
rust: ability to convert to common serde map structure

### DIFF
--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -6,6 +6,21 @@ use crate::Sbp;
 
 use super::{JsonError, JsonOutput};
 
+/// A JSON map holding all the fields and metadata of the
+/// SBP message.  This is format used by the output of the
+/// `sbp2json` tool, for example:
+///
+/// {
+///   "crc": 49084,
+///   "length": 52,
+///   "msg_type": 1025,
+///   "msg_name": "MSG_LOG",
+///   "payload": "BHNicCBuZXcgY2xpZW50IGNvbm5lY3Rpb24gOjpmZmZmOjE5Mi4xNjguMC4xMDo2MTQ1MA==",
+///   "preamble": 85,
+///   "sender": 4096,
+///   "level": 4,
+///   "text": "sbp new client connection ::ffff:192.168.0.10:61450"
+/// }
 pub type JsonMap = serde_json::Map<String, serde_json::Value>;
 
 impl<'a> TryFrom<crate::Sbp> for JsonMap

--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -6,7 +6,9 @@ use crate::Sbp;
 
 use super::{JsonError, JsonOutput};
 
-impl<'a> TryFrom<crate::Sbp> for serde_json::Map<String, serde_json::Value>
+pub type JsonMap = serde_json::Map<String, serde_json::Value>;
+
+impl<'a> TryFrom<crate::Sbp> for JsonMap
 {
     type Error = JsonError;
 

--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -23,8 +23,7 @@ use super::{JsonError, JsonOutput};
 /// }
 pub type JsonMap = serde_json::Map<String, serde_json::Value>;
 
-impl<'a> TryFrom<crate::Sbp> for JsonMap
-{
+impl<'a> TryFrom<crate::Sbp> for JsonMap {
     type Error = JsonError;
 
     fn try_from(msg: Sbp) -> Result<Self, Self::Error> {

--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -29,10 +29,7 @@ impl TryFrom<crate::Sbp> for JsonMap {
     fn try_from(msg: Sbp) -> Result<Self, Self::Error> {
         let mut frame = BytesMut::with_capacity(crate::BUFLEN);
         let mut payload = String::with_capacity(crate::BUFLEN);
-        let output = JsonOutput {
-            common: super::ser::get_common_fields(&mut payload, &mut frame, &msg)?,
-            msg: &msg,
-        };
+        let output = JsonOutput::new_from_sbp(&mut payload, &mut frame, &msg)?;
         let output = serde_json::to_value(output)?;
         let output: serde_json::Map<String, serde_json::Value> = serde_json::from_value(output)?;
         Ok(output)

--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -23,7 +23,7 @@ use super::{JsonError, JsonOutput};
 /// }
 pub type JsonMap = serde_json::Map<String, serde_json::Value>;
 
-impl<'a> TryFrom<crate::Sbp> for JsonMap {
+impl TryFrom<crate::Sbp> for JsonMap {
     type Error = JsonError;
 
     fn try_from(msg: Sbp) -> Result<Self, Self::Error> {

--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -1,0 +1,24 @@
+use std::convert::TryFrom;
+
+use bytes::BytesMut;
+
+use crate::Sbp;
+
+use super::{JsonError, JsonOutput};
+
+impl<'a> TryFrom<crate::Sbp> for serde_json::Map<String, serde_json::Value>
+{
+    type Error = JsonError;
+
+    fn try_from(msg: Sbp) -> Result<Self, Self::Error> {
+        let mut frame = BytesMut::with_capacity(crate::BUFLEN);
+        let mut payload = String::with_capacity(crate::BUFLEN);
+        let output = JsonOutput {
+            common: super::ser::get_common_fields(&mut payload, &mut frame, &msg)?,
+            msg: &msg,
+        };
+        let output = serde_json::to_value(output)?;
+        let output: serde_json::Map<String, serde_json::Value> = serde_json::from_value(output)?;
+        Ok(output)
+    }
+}

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -2,6 +2,7 @@
 
 mod de;
 mod ser;
+mod convert;
 
 use std::collections::HashMap;
 use std::io;
@@ -15,7 +16,7 @@ pub use serde_json::ser::CompactFormatter;
 pub use de::stream_messages;
 pub use de::{iter_json2json_messages, iter_messages, iter_messages_from_fields};
 
-pub use ser::{to_value, to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
+pub use ser::{to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -15,7 +15,7 @@ pub use serde_json::ser::CompactFormatter;
 pub use de::stream_messages;
 pub use de::{iter_json2json_messages, iter_messages, iter_messages_from_fields};
 
-pub use ser::{to_vec, to_value, to_writer, Json2JsonEncoder, JsonEncoder};
+pub use ser::{to_value, to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -7,6 +7,7 @@ mod ser;
 use std::collections::HashMap;
 use std::io;
 
+use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use serde_json::{ser::Formatter, Value};
 
@@ -18,7 +19,9 @@ pub use de::{iter_json2json_messages, iter_messages, iter_messages_from_fields};
 
 pub use ser::{to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
 
+use crate::SbpMessage;
 pub use convert::JsonMap;
+use ser::get_common_fields;
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -88,6 +91,19 @@ struct JsonOutput<'a, M> {
 
     #[serde(flatten)]
     msg: &'a M,
+}
+
+impl<'a, M: SbpMessage + Serialize> JsonOutput<'a, M> {
+    fn new_from_sbp(
+        payload_buf: &'a mut String,
+        frame_buf: &'a mut BytesMut,
+        msg: &'a M,
+    ) -> Result<Self, JsonError> {
+        Ok(JsonOutput {
+            common: get_common_fields(payload_buf, frame_buf, msg)?,
+            msg,
+        })
+    }
 }
 
 /// Provide Haskell style formatting. Output should be similar to:

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -18,6 +18,8 @@ pub use de::{iter_json2json_messages, iter_messages, iter_messages_from_fields};
 
 pub use ser::{to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
 
+pub use convert::JsonMap;
+
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum JsonInput {

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -15,7 +15,7 @@ pub use serde_json::ser::CompactFormatter;
 pub use de::stream_messages;
 pub use de::{iter_json2json_messages, iter_messages, iter_messages_from_fields};
 
-pub use ser::{to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
+pub use ser::{to_vec, to_value, to_writer, Json2JsonEncoder, JsonEncoder};
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -1,8 +1,8 @@
 //! Encode/decode SBP messages as JSON.
 
+mod convert;
 mod de;
 mod ser;
-mod convert;
 
 use std::collections::HashMap;
 use std::io;

--- a/rust/sbp/src/json/ser.rs
+++ b/rust/sbp/src/json/ser.rs
@@ -74,6 +74,22 @@ where
     Ok(())
 }
 
+/// Serialize the given message as a JSON byte vector.
+pub fn to_value<M>(msg: &M) -> Result<serde_json::Value, JsonError>
+where
+    M: SbpMessage + Serialize + WireFormat + Clone,
+{
+    let mut frame = BytesMut::with_capacity(BUFLEN);
+    let mut payload = String::with_capacity(BUFLEN);
+
+    let output = JsonOutput {
+        common: get_common_fields(&mut payload, &mut frame, msg)?,
+        msg,
+    };
+
+    serde_json::to_value(output).map_err(|e| e.into())
+}
+
 /// Writes [Sbp] messages as JSON into a writer.
 #[derive(Debug)]
 pub struct JsonEncoder<W, F>(FramedWrite<W, JsonEncoderInner<F>>);

--- a/rust/sbp/src/json/ser.rs
+++ b/rust/sbp/src/json/ser.rs
@@ -6,7 +6,10 @@ use serde::Serialize;
 use serde_json::{ser::Formatter, Serializer};
 
 use crate::{
-    json::{CommonJson, HaskellishFloatFormatter, Json2JsonInput, Json2JsonOutput, JsonError, JsonOutput},
+    json::{
+        CommonJson, HaskellishFloatFormatter, Json2JsonInput, Json2JsonOutput, JsonError,
+        JsonOutput,
+    },
     messages::Sbp,
     SbpMessage, BUFLEN, CRC_LEN, HEADER_LEN, PREAMBLE,
 };
@@ -210,7 +213,7 @@ impl<F: Formatter + Clone> Encoder<Json2JsonInput> for Json2JsonEncoderInner<F> 
     }
 }
 
-pub (in super) fn get_common_fields<'a, M: SbpMessage>(
+pub(super) fn get_common_fields<'a, M: SbpMessage>(
     payload_buf: &'a mut String,
     frame_buf: &'a mut BytesMut,
     msg: &M,

--- a/rust/sbp/src/json/ser.rs
+++ b/rust/sbp/src/json/ser.rs
@@ -77,7 +77,7 @@ where
 /// Serialize the given message as a JSON byte vector.
 pub fn to_value<M>(msg: &M) -> Result<serde_json::Value, JsonError>
 where
-    M: SbpMessage + Serialize + WireFormat + Clone,
+    M: SbpMessage + Serialize,
 {
     let mut frame = BytesMut::with_capacity(BUFLEN);
     let mut payload = String::with_capacity(BUFLEN);

--- a/rust/sbp/src/json/ser.rs
+++ b/rust/sbp/src/json/ser.rs
@@ -65,10 +65,7 @@ where
     F: Formatter,
     M: SbpMessage + Serialize,
 {
-    let output = JsonOutput {
-        common: get_common_fields(payload_buf, frame_buf, msg)?,
-        msg,
-    };
+    let output = JsonOutput::new_from_sbp(payload_buf, frame_buf, msg)?;
     let mut ser = Serializer::with_formatter(dst.writer(), formatter);
     output.serialize(&mut ser)?;
     dst.put_slice(b"\n");
@@ -200,10 +197,8 @@ impl<F: Formatter + Clone> Encoder<Json2JsonInput> for Json2JsonEncoderInner<F> 
             BytesMut::from(&payload[..]),
         )?;
         let output = Json2JsonOutput {
-            data: JsonOutput {
-                common: get_common_fields(&mut self.payload_buf, &mut self.frame_buf, &msg)?,
-                msg: &msg,
-            },
+            data: JsonOutput::new_from_sbp(&mut self.payload_buf, &mut self.frame_buf, &msg)?,
+
             other: input.other,
         };
         let mut ser = Serializer::with_formatter(dst.writer(), formatter);

--- a/test_data/benchmark_main.py
+++ b/test_data/benchmark_main.py
@@ -11,10 +11,10 @@ SLUSH_PERCENTAGE = 0.25
 
 # How much faster Rust should be than other implementations
 RATIOS_SBP2JSON = {
-    "haskell": 2.12,
-    "python": 17,
-    "kaitai_python": 3.7,
-    "kaitai_perl": 18,
+    "haskell"       : 3.01,
+    "python"        : 23.38,
+    "kaitai_python" : 5.00,
+    "kaitai_perl"   : 18,
 }
 
 RATIOS_JSON2SBP = {


### PR DESCRIPTION
# Description

Adds new API function to return a serde_json::Value type that corresponds to what we get when running sbp2json -- this enables functionality that requires access to a JSON like object (with all the associated message data) without requiring that we parse JSON.

See here for an example usage: https://github.com/swift-nav/sbp-filter/pull/122

# API compatibility

No API compatibility issues since we're just adding a new function.

# JIRA Reference

https://swift-nav.atlassian.net/browse/DIP-2