### PR TITLE
suggested changes to to_value pr

### DIFF
--- a/rust/sbp/src/json/convert.rs
+++ b/rust/sbp/src/json/convert.rs
@@ -29,10 +29,7 @@ impl TryFrom<crate::Sbp> for JsonMap {
     fn try_from(msg: Sbp) -> Result<Self, Self::Error> {
         let mut frame = BytesMut::with_capacity(crate::BUFLEN);
         let mut payload = String::with_capacity(crate::BUFLEN);
-        let output = JsonOutput {
-            common: super::ser::get_common_fields(&mut payload, &mut frame, &msg)?,
-            msg: &msg,
-        };
+        let output = JsonOutput::new_from_sbp(&mut payload, &mut frame, &msg)?;
         let output = serde_json::to_value(output)?;
         let output: serde_json::Map<String, serde_json::Value> = serde_json::from_value(output)?;
         Ok(output)

--- a/rust/sbp/src/json/mod.rs
+++ b/rust/sbp/src/json/mod.rs
@@ -7,6 +7,7 @@ mod ser;
 use std::collections::HashMap;
 use std::io;
 
+use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use serde_json::{ser::Formatter, Value};
 
@@ -18,7 +19,9 @@ pub use de::{iter_json2json_messages, iter_messages, iter_messages_from_fields};
 
 pub use ser::{to_vec, to_writer, Json2JsonEncoder, JsonEncoder};
 
+use crate::SbpMessage;
 pub use convert::JsonMap;
+use ser::get_common_fields;
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -88,6 +91,19 @@ struct JsonOutput<'a, M> {
 
     #[serde(flatten)]
     msg: &'a M,
+}
+
+impl<'a, M: SbpMessage + Serialize> JsonOutput<'a, M> {
+    fn new_from_sbp(
+        payload_buf: &'a mut String,
+        frame_buf: &'a mut BytesMut,
+        msg: &'a M,
+    ) -> Result<Self, JsonError> {
+        Ok(JsonOutput {
+            common: get_common_fields(payload_buf, frame_buf, msg)?,
+            msg,
+        })
+    }
 }
 
 /// Provide Haskell style formatting. Output should be similar to:

--- a/rust/sbp/src/json/ser.rs
+++ b/rust/sbp/src/json/ser.rs
@@ -65,10 +65,7 @@ where
     F: Formatter,
     M: SbpMessage + Serialize,
 {
-    let output = JsonOutput {
-        common: get_common_fields(payload_buf, frame_buf, msg)?,
-        msg,
-    };
+    let output = JsonOutput::new_from_sbp(payload_buf, frame_buf, msg)?;
     let mut ser = Serializer::with_formatter(dst.writer(), formatter);
     output.serialize(&mut ser)?;
     dst.put_slice(b"\n");
@@ -200,10 +197,8 @@ impl<F: Formatter + Clone> Encoder<Json2JsonInput> for Json2JsonEncoderInner<F> 
             BytesMut::from(&payload[..]),
         )?;
         let output = Json2JsonOutput {
-            data: JsonOutput {
-                common: get_common_fields(&mut self.payload_buf, &mut self.frame_buf, &msg)?,
-                msg: &msg,
-            },
+            data: JsonOutput::new_from_sbp(&mut self.payload_buf, &mut self.frame_buf, &msg)?,
+
             other: input.other,
         };
         let mut ser = Serializer::with_formatter(dst.writer(), formatter);


### PR DESCRIPTION
@silverjam this is an example of the change I wanted to see. Whenever JsonOutput is created it should be done by the same function. Therefore if it ever is refactored there will be no drft.