### PR TITLE
add test to round trip an invalid sbp message

### DIFF
--- a/rust/sbp2json/tests/test_round_trips.rs
+++ b/rust/sbp2json/tests/test_round_trips.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{BufRead, BufReader, Cursor},
+    io::{BufRead, BufReader, Cursor, Write},
 };
 
 #[macro_use]
@@ -13,6 +13,61 @@ use common::{
 
 use crate::common::run_jsonfields2sbp;
 use serde_json::ser::CompactFormatter;
+
+use sbp::json::HaskellishFloatFormatter;
+use serde_json::json;
+
+#[test]
+fn test_invalid_message_round_trip() {
+    // Properly framed data but the payload isn't right given the message type
+    let data: Vec<u8> = vec![0x55, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x65, 0x8D];
+    let mut sbp2json_out: Vec<u8> = Vec::new();
+
+    let mut expected_json = json!({"msg_name": "INVALID", "payload": "VQEBAQEBAWWN"});
+    let expected_json = expected_json.as_object_mut().expect("is a map");
+    let input = Cursor::new(data.clone());
+    let error_handler_opt = converters::ErrorHandlerOptions::CoerceErrorsToInvalidMsg;
+    converters::sbp2json(
+        input,
+        &mut sbp2json_out,
+        HaskellishFloatFormatter {},
+        true,
+        error_handler_opt,
+    )
+    .expect("can run sbp2json");
+
+    let mut out_as_json: serde_json::Value =
+        serde_json::from_str(std::str::from_utf8(&sbp2json_out).expect("is valid utf8"))
+            .expect("is valid JSON");
+
+    for key in &["msg_name".to_string(), "payload".to_string()] {
+        assert!(expected_json.get(key).is_some());
+        assert_eq!(
+            out_as_json.as_object_mut().and_then(|m| m.remove(key)),
+            expected_json.clone().remove(key),
+            "{key} values must be equal"
+        );
+    }
+    assert!(
+        out_as_json
+            .as_object()
+            .map(|m| m.is_empty())
+            .unwrap_or(false),
+        "out object should contain no additional keys"
+    );
+
+    let mut json2sbp_out: Vec<u8> = Vec::new();
+
+    converters::json2sbp(
+        Cursor::new(sbp2json_out),
+        &mut json2sbp_out,
+        true,
+        error_handler_opt,
+    )
+    .expect("can run json2sbp");
+
+    assert_eq!(data, json2sbp_out, "completed round trip");
+}
 
 #[test]
 fn test_stop_on_error() {

--- a/rust/sbp2json/tests/test_round_trips.rs
+++ b/rust/sbp2json/tests/test_round_trips.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{BufRead, BufReader, Cursor, Write},
+    io::{BufRead, BufReader, Cursor},
 };
 
 #[macro_use]


### PR DESCRIPTION
# Description

@swift-nav/devinfra

This adds an integration test (with some unit tests inside of it) which test the round tripping of an invalid message from invalid sbp -> json with msg_name "INVALID" -> invalid sbp. Covers a gap in test coverage from an earlier PR: https://github.com/swift-nav/libsbp/pull/1312 

Please note, there are no non-test code changes here, so it passed as is.