### PR TITLE
ignore dependabot PRs for additional reviewers action

### DIFF
--- a/.github/workflows/add_additional_reviewers.yaml
+++ b/.github/workflows/add_additional_reviewers.yaml
@@ -8,6 +8,7 @@ jobs:
   auto-request-review:
     name: Add Additional Reviewers
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Request additional reviews based on supplied rules
         uses: necojackarc/auto-request-review@v0.10.0

--- a/.github/workflows/add_additional_reviewers.yaml
+++ b/.github/workflows/add_additional_reviewers.yaml
@@ -1,13 +1,14 @@
 name: Add Additional Reviewers
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   auto-request-review:
     name: Add Additional Reviewers
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Request additional reviews based on supplied rules
         uses: necojackarc/auto-request-review@v0.10.0

--- a/.github/workflows/add_additional_reviewers.yaml
+++ b/.github/workflows/add_additional_reviewers.yaml
@@ -1,14 +1,13 @@
 name: Add Additional Reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   auto-request-review:
     name: Add Additional Reviewers
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Request additional reviews based on supplied rules
         uses: necojackarc/auto-request-review@v0.10.0


### PR DESCRIPTION
resolves action failing on dependabot compatibility:
https://github.com/swift-nav/libsbp/pull/1371

can just stop triggering from dependabot PRs.
