### PR TITLE
Run sonar cloud on C/C++ bindings [AP-910]

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,3 +26,40 @@ jobs:
             -Dsonar.exclusions=java/**
             -Dsonar.verbose=true
             -Dsonar.c.file.suffixes=- -Dsonar.cpp.file.suffixes=-
+
+  C:
+    name: C Code Coverage
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install sonar-scanner and build-wrapper
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
+      - name: Setup
+        run: |
+          sudo apt-get install llvm -y
+      - name: Build and Run Tests
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          cmake -S c -B build -DCODE_COVERAGE=ON -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage &&
+          build-wrapper-linux-x86-64 --out-dir ./bw-output cmake --build build -j4 --target ccov-all-export
+      - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_C }}
+        run: sonar-scanner
+            -X
+            -Dsonar.organization=swift-nav
+            -Dsonar.projectName=libsbp-c
+            -Dsonar.projectKey=swift-nav_libsbp_c
+            -Dsonar.verbose=true
+            -Dsonar.login=${{ secrets.SONAR_TOKEN_C }}
+            -Dsonar.cfamily.threads=4
+            -Dsonar.cfamily.llvm-cov.reportPath=./build/ccov/coverage.txt
+            -Dsonar.sources=c/src/,c/include/
+            -Dsonar.tests=c/test/
+            -Dsonar.cfamily.build-wrapper-output=./bw-output 


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Add GA stage to run C/C++ code through sonar cloud

The main sonar cloud stage currently excludes C/C++ code from analysis. Due to the way C/C++ code needs to be processed this stage needs to remain as is.

There is already an extra project in sonar cloud setup up to receive C/C++ but it is currently unused. This PR adds a new stage in GA which runs all the C/C++ unit tests to generate code coverage data, then calls the sonar scanner utility.

Results are posted here as a comment and there is a new status which could be set as a gate on merging PRs (but isn't at the moment)

Code coverage isn't showing up properly on this PR because I accidentally pushed a master analysis to sonar cloud during development of this PR. Since there are no code changes on this PR the diff is 0 and the sonar cloud results are also 0. To test this work I added a new message but didn't create any unit tests. The sonar cloud stage ran properly, detected a couple of code smells and complained about the lack of test coverage. The testing message has since been removed from this branch and is no longer visible.

Results for master can be viewed by going to sonarcloud.io. These results will be the baseline for any future PRs

# API compatibility

Does this change introduce a API compatibility risk?

N/A

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-910
