### PR TITLE
rust: check more messages for time validity 

### DIFF
--- a/generator/sbpg/targets/rust.py
+++ b/generator/sbpg/targets/rust.py
@@ -66,11 +66,6 @@ if self.time_source().ok()? == TimeSource::None {
 """
 
 CUSTOM_GPS_TIME_MSGS = {
-    "MSG_GPS_TIME": """
-if !matches!(self.time_source(), Ok(TimeSource::GnssSolution) | Ok(TimeSource::Propagated)) {
-    return None;
-}
-""".strip() + GPS_TIME,
     "MSG_IMU_RAW": """
 const IMU_RAW_TIME_STATUS_MASK: u32 = (1 << 30) | (1 << 31);
 if self.tow & IMU_RAW_TIME_STATUS_MASK != 0 {

--- a/generator/sbpg/targets/rust.py
+++ b/generator/sbpg/targets/rust.py
@@ -60,6 +60,11 @@ let gps_time = match time::GpsTime::new(0, tow_s) {
 BASE_TIME_MSGS = ["MSG_OBS", "MSG_OSR", "MSG_SSR"]
 
 CUSTOM_GPS_TIME_MSGS = {
+    "MSG_GPS_TIME": """
+if !matches!(self.time_source(), Ok(TimeSource::GnssSolution) | Ok(TimeSource::Propagated)) {
+    return None;
+}
+""".strip() + GPS_TIME,
     "MSG_IMU_RAW": """
 const IMU_RAW_TIME_STATUS_MASK: u32 = (1 << 30) | (1 << 31);
 if self.tow & IMU_RAW_TIME_STATUS_MASK != 0 {

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -1888,6 +1888,12 @@ pub mod msg_gps_time {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
+            if !matches!(
+                self.time_source(),
+                Ok(TimeSource::GnssSolution) | Ok(TimeSource::Propagated)
+            ) {
+                return None;
+            }
             let tow_s = (self.tow as f64) / 1000.0;
             #[allow(clippy::useless_conversion)]
             let wn: i16 = match self.wn.try_into() {

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -1888,10 +1888,7 @@ pub mod msg_gps_time {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
-            if !matches!(
-                self.time_source(),
-                Ok(TimeSource::GnssSolution) | Ok(TimeSource::Propagated)
-            ) {
+            if self.time_source().ok()? == TimeSource::None {
                 return None;
             }
             let tow_s = (self.tow as f64) / 1000.0;
@@ -2200,6 +2197,9 @@ pub mod msg_gps_time_gnss {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
+            if self.time_source().ok()? == TimeSource::None {
+                return None;
+            }
             let tow_s = (self.tow as f64) / 1000.0;
             #[allow(clippy::useless_conversion)]
             let wn: i16 = match self.wn.try_into() {
@@ -2469,6 +2469,9 @@ pub mod msg_pose_relative {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
+            if self.time_source().ok()? == TimeSource::None {
+                return None;
+            }
             let tow_s = (self.tow as f64) / 1000.0;
             let gps_time = match time::GpsTime::new(0, tow_s) {
                 Ok(gps_time) => gps_time.tow(),
@@ -7223,6 +7226,9 @@ pub mod msg_utc_time {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
+            if self.time_source().ok()? == TimeSource::None {
+                return None;
+            }
             let tow_s = (self.tow as f64) / 1000.0;
             let gps_time = match time::GpsTime::new(0, tow_s) {
                 Ok(gps_time) => gps_time.tow(),
@@ -7478,6 +7484,9 @@ pub mod msg_utc_time_gnss {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
+            if self.time_source().ok()? == TimeSource::None {
+                return None;
+            }
             let tow_s = (self.tow as f64) / 1000.0;
             let gps_time = match time::GpsTime::new(0, tow_s) {
                 Ok(gps_time) => gps_time.tow(),

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -128,6 +128,9 @@ pub mod msg_odometry {
 
         #[cfg(feature = "swiftnav")]
         fn gps_time(&self) -> Option<std::result::Result<time::MessageTime, time::GpsTimeError>> {
+            if self.time_source().ok()? == TimeSource::None {
+                return None;
+            }
             let tow_s = (self.tow as f64) / 1000.0;
             let gps_time = match time::GpsTime::new(0, tow_s) {
                 Ok(gps_time) => gps_time.tow(),


### PR DESCRIPTION
# Description

Same as https://github.com/swift-nav/libsbp/pull/1375 but accounts for the other 3 time messages and msg_odometry

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
