### PR TITLE
Replace swiftnav-adam with woodfell for additional reviewers [AP-947]

### DIFF
--- a/.github/additional_reviewers_config.yaml
+++ b/.github/additional_reviewers_config.yaml
@@ -1,8 +1,8 @@
 files:
   'docs/sbp.pdf':
-    - swiftnav-adam
+    - woodfell
   'spec/yaml/swiftnav/sbp/*.yaml':
-    - swiftnav-adam
+    - woodfell
 
 options:
   ignore_draft: true


### PR DESCRIPTION
# Description

@swift-nav/devinfra

`swiftnav-adam` is no longer a valid reviewer in this repository, replace with woodfell for the additional reviewer stage

# API compatibility

Does this change introduce a API compatibility risk?

N/A

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-947
