### PR TITLE
Fix decoding of truncated messages containing variable length arrays [AP-948]

### DIFF
--- a/c/src/v4/acquisition.c
+++ b/c/src/v4/acquisition.c
@@ -822,6 +822,9 @@ s8 sbp_msg_acq_sv_profile_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_acq_sv_profile_decode_internal(sbp_decode_ctx_t *ctx,
                                             sbp_msg_acq_sv_profile_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_ACQ_SV_PROFILE_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_acq_sv_profile =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ACQ_SV_PROFILE_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {
@@ -904,6 +907,10 @@ s8 sbp_msg_acq_sv_profile_dep_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_acq_sv_profile_dep_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_acq_sv_profile_dep_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_ACQ_SV_PROFILE_DEP_ENCODED_LEN) !=
+      0) {
+    return false;
+  }
   msg->n_acq_sv_profile = (uint8_t)((ctx->buf_len - ctx->offset) /
                                     SBP_ACQ_SV_PROFILE_DEP_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_acq_sv_profile; i++) {

--- a/c/src/v4/file_io.c
+++ b/c/src/v4/file_io.c
@@ -257,6 +257,9 @@ bool sbp_msg_fileio_read_resp_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->sequence)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_contents =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_contents; i++) {
@@ -1007,6 +1010,9 @@ bool sbp_msg_fileio_write_req_decode_internal(sbp_decode_ctx_t *ctx,
   }
   if (!sbp_null_terminated_string_decode(
           &msg->filename, SBP_MSG_FILEIO_WRITE_REQ_FILENAME_MAX, ctx)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
     return false;
   }
   msg->n_data = (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);

--- a/c/src/v4/flash.c
+++ b/c/src/v4/flash.c
@@ -65,6 +65,9 @@ bool sbp_msg_flash_program_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->addr_len)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->addr_len = (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->addr_len; i++) {
     if (!sbp_u8_decode(ctx, &msg->data[i])) {

--- a/c/src/v4/integrity.c
+++ b/c/src/v4/integrity.c
@@ -435,6 +435,9 @@ bool sbp_msg_ssr_flag_satellites_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->n_faulty_sats)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_faulty_sats =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_faulty_sats; i++) {
@@ -564,6 +567,9 @@ bool sbp_msg_ssr_flag_tropo_grid_points_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->n_faulty_points)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U16) != 0) {
+    return false;
+  }
   msg->n_faulty_points =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U16);
   for (uint8_t i = 0; i < msg->n_faulty_points; i++) {
@@ -669,6 +675,9 @@ bool sbp_msg_ssr_flag_iono_grid_points_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->n_faulty_points)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U16) != 0) {
+    return false;
+  }
   msg->n_faulty_points =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U16);
   for (uint8_t i = 0; i < msg->n_faulty_points; i++) {
@@ -772,6 +781,9 @@ bool sbp_msg_ssr_flag_iono_tile_sat_los_decode_internal(
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->n_faulty_los)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_SV_ID_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_faulty_los =
@@ -884,6 +896,9 @@ bool sbp_msg_ssr_flag_iono_grid_point_sat_los_decode_internal(
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->n_faulty_los)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_SV_ID_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_faulty_los =

--- a/c/src/v4/logging.c
+++ b/c/src/v4/logging.c
@@ -208,6 +208,9 @@ bool sbp_msg_fwd_decode_internal(sbp_decode_ctx_t *ctx, sbp_msg_fwd_t *msg) {
   if (!sbp_u8_decode(ctx, &msg->protocol)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_fwd_payload =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_fwd_payload; i++) {

--- a/c/src/v4/observation.c
+++ b/c/src/v4/observation.c
@@ -442,6 +442,10 @@ bool sbp_msg_obs_decode_internal(sbp_decode_ctx_t *ctx, sbp_msg_obs_t *msg) {
   if (!sbp_observation_header_decode_internal(ctx, &msg->header)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_PACKED_OBS_CONTENT_ENCODED_LEN) !=
+      0) {
+    return false;
+  }
   msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) /
                          SBP_PACKED_OBS_CONTENT_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_obs; i++) {
@@ -6486,6 +6490,10 @@ bool sbp_msg_obs_dep_a_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_observation_header_dep_decode_internal(ctx, &msg->header)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_PACKED_OBS_CONTENT_DEP_A_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) /
                          SBP_PACKED_OBS_CONTENT_DEP_A_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_obs; i++) {
@@ -6577,6 +6585,10 @@ bool sbp_msg_obs_dep_b_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_observation_header_dep_decode_internal(ctx, &msg->header)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_PACKED_OBS_CONTENT_DEP_B_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) /
                          SBP_PACKED_OBS_CONTENT_DEP_B_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_obs; i++) {
@@ -6666,6 +6678,10 @@ s8 sbp_msg_obs_dep_c_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 bool sbp_msg_obs_dep_c_decode_internal(sbp_decode_ctx_t *ctx,
                                        sbp_msg_obs_dep_c_t *msg) {
   if (!sbp_observation_header_dep_decode_internal(ctx, &msg->header)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_PACKED_OBS_CONTENT_DEP_C_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) /
@@ -8726,6 +8742,9 @@ s8 sbp_msg_sv_az_el_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_sv_az_el_decode_internal(sbp_decode_ctx_t *ctx,
                                       sbp_msg_sv_az_el_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_SV_AZ_EL_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_azel =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_SV_AZ_EL_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_azel; i++) {
@@ -8807,6 +8826,10 @@ s8 sbp_msg_osr_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_osr_decode_internal(sbp_decode_ctx_t *ctx, sbp_msg_osr_t *msg) {
   if (!sbp_observation_header_decode_internal(ctx, &msg->header)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_PACKED_OSR_CONTENT_ENCODED_LEN) !=
+      0) {
     return false;
   }
   msg->n_obs = (uint8_t)((ctx->buf_len - ctx->offset) /

--- a/c/src/v4/piksi.c
+++ b/c/src/v4/piksi.c
@@ -2323,6 +2323,9 @@ s8 sbp_msg_network_bandwidth_usage_encode(
 
 bool sbp_msg_network_bandwidth_usage_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_network_bandwidth_usage_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_NETWORK_USAGE_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_interfaces =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_NETWORK_USAGE_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_interfaces; i++) {
@@ -2416,6 +2419,9 @@ bool sbp_msg_cell_modem_status_decode_internal(
     return false;
   }
   if (!sbp_float_decode(ctx, &msg->signal_error_rate)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
     return false;
   }
   msg->n_reserved =
@@ -2543,6 +2549,9 @@ bool sbp_msg_specan_dep_decode_internal(sbp_decode_ctx_t *ctx,
     return false;
   }
   if (!sbp_float_decode(ctx, &msg->amplitude_unit)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
     return false;
   }
   msg->n_amplitude_value =
@@ -2689,6 +2698,9 @@ bool sbp_msg_specan_decode_internal(sbp_decode_ctx_t *ctx,
     return false;
   }
   if (!sbp_float_decode(ctx, &msg->amplitude_unit)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
     return false;
   }
   msg->n_amplitude_value =

--- a/c/src/v4/signing.c
+++ b/c/src/v4/signing.c
@@ -261,6 +261,9 @@ bool sbp_msg_ecdsa_certificate_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->flags)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_certificate_bytes =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_certificate_bytes; i++) {
@@ -699,6 +702,9 @@ bool sbp_msg_ecdsa_signature_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_ecdsa_signature_decode_internal(ctx, &msg->signature)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_signed_messages =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_signed_messages; i++) {
@@ -854,6 +860,9 @@ bool sbp_msg_ecdsa_signature_dep_b_decode_internal(
     if (!sbp_u8_decode(ctx, &msg->signature[i])) {
       return false;
     }
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
   }
   msg->n_signed_messages =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
@@ -1014,6 +1023,9 @@ bool sbp_msg_ecdsa_signature_dep_a_decode_internal(
       return false;
     }
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_signed_messages =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_signed_messages; i++) {
@@ -1145,6 +1157,9 @@ bool sbp_msg_ed25519_certificate_dep_decode_internal(
       return false;
     }
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_certificate_bytes =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_certificate_bytes; i++) {
@@ -1261,6 +1276,9 @@ bool sbp_msg_ed25519_signature_dep_a_decode_internal(
     if (!sbp_u8_decode(ctx, &msg->fingerprint[i])) {
       return false;
     }
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U32) != 0) {
+    return false;
   }
   msg->n_signed_messages =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U32);
@@ -1393,6 +1411,9 @@ bool sbp_msg_ed25519_signature_dep_b_decode_internal(
     if (!sbp_u8_decode(ctx, &msg->fingerprint[i])) {
       return false;
     }
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U32) != 0) {
+    return false;
   }
   msg->n_signed_messages =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U32);

--- a/c/src/v4/solution_meta.c
+++ b/c/src/v4/solution_meta.c
@@ -160,6 +160,10 @@ bool sbp_msg_soln_meta_dep_a_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->last_used_gnss_vel_tow)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_SOLUTION_INPUT_TYPE_ENCODED_LEN) !=
+      0) {
+    return false;
+  }
   msg->n_sol_in = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_SOLUTION_INPUT_TYPE_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_sol_in; i++) {
@@ -315,6 +319,10 @@ bool sbp_msg_soln_meta_decode_internal(sbp_decode_ctx_t *ctx,
     return false;
   }
   if (!sbp_u32_decode(ctx, &msg->age_gnss)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_SOLUTION_INPUT_TYPE_ENCODED_LEN) !=
+      0) {
     return false;
   }
   msg->n_sol_in = (uint8_t)((ctx->buf_len - ctx->offset) /

--- a/c/src/v4/ssr.c
+++ b/c/src/v4/ssr.c
@@ -1104,6 +1104,10 @@ bool sbp_msg_ssr_code_biases_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->iod_ssr)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_CODE_BIASES_CONTENT_ENCODED_LEN) !=
+      0) {
+    return false;
+  }
   msg->n_biases = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_CODE_BIASES_CONTENT_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_biases; i++) {
@@ -1254,6 +1258,10 @@ bool sbp_msg_ssr_phase_biases_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_s8_decode(ctx, &msg->yaw_rate)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_PHASE_BIASES_CONTENT_ENCODED_LEN) !=
+      0) {
+    return false;
+  }
   msg->n_biases = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_PHASE_BIASES_CONTENT_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_biases; i++) {
@@ -1380,6 +1388,9 @@ s8 sbp_msg_ssr_stec_correction_dep_encode(
 bool sbp_msg_ssr_stec_correction_dep_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_stec_correction_dep_t *msg) {
   if (!sbp_stec_header_decode_internal(ctx, &msg->header)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_STEC_SAT_ELEMENT_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_stec_sat_list = (uint8_t)((ctx->buf_len - ctx->offset) /
@@ -1601,6 +1612,9 @@ bool sbp_msg_ssr_stec_correction_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->n_sats)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_STEC_SAT_ELEMENT_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_sats = (uint8_t)((ctx->buf_len - ctx->offset) /
                           SBP_STEC_SAT_ELEMENT_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_sats; i++) {
@@ -1726,6 +1740,9 @@ bool sbp_msg_ssr_gridded_correction_decode_internal(
   }
   if (!sbp_tropospheric_delay_correction_decode_internal(
           ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_STEC_RESIDUAL_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_stec_residuals =
@@ -2004,6 +2021,10 @@ bool sbp_msg_ssr_gridded_correction_bounds_decode_internal(
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->n_sats)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_STEC_SAT_ELEMENT_INTEGRITY_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_sats = (uint8_t)((ctx->buf_len - ctx->offset) /
@@ -2805,6 +2826,9 @@ s8 sbp_msg_ssr_satellite_apc_dep_encode(
 
 bool sbp_msg_ssr_satellite_apc_dep_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_satellite_apc_dep_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_SATELLITE_APC_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_apc =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_SATELLITE_APC_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_apc; i++) {
@@ -2910,6 +2934,9 @@ bool sbp_msg_ssr_satellite_apc_decode_internal(
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->iod_ssr)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_SATELLITE_APC_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_apc =
@@ -3568,6 +3595,9 @@ bool sbp_msg_ssr_stec_correction_dep_a_decode_internal(
   if (!sbp_stec_header_dep_a_decode_internal(ctx, &msg->header)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_STEC_SAT_ELEMENT_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_stec_sat_list = (uint8_t)((ctx->buf_len - ctx->offset) /
                                    SBP_STEC_SAT_ELEMENT_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_stec_sat_list; i++) {
@@ -3676,6 +3706,10 @@ bool sbp_msg_ssr_gridded_correction_no_std_dep_a_decode_internal(
   }
   if (!sbp_tropospheric_delay_correction_no_std_decode_internal(
           ctx, &msg->tropo_delay_correction)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_STEC_RESIDUAL_NO_STD_ENCODED_LEN) !=
+      0) {
     return false;
   }
   msg->n_stec_residuals = (uint8_t)((ctx->buf_len - ctx->offset) /
@@ -3800,6 +3834,9 @@ bool sbp_msg_ssr_gridded_correction_dep_a_decode_internal(
           ctx, &msg->tropo_delay_correction)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_STEC_RESIDUAL_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_stec_residuals =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_STEC_RESIDUAL_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_stec_residuals; i++) {
@@ -3903,6 +3940,9 @@ s8 sbp_msg_ssr_grid_definition_dep_a_encode(
 bool sbp_msg_ssr_grid_definition_dep_a_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_ssr_grid_definition_dep_a_t *msg) {
   if (!sbp_grid_definition_header_dep_a_decode_internal(ctx, &msg->header)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
     return false;
   }
   msg->n_rle_list =
@@ -4163,6 +4203,9 @@ bool sbp_msg_ssr_orbit_clock_bounds_decode_internal(
   if (!sbp_u8_decode(ctx, &msg->n_sats)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_ORBIT_CLOCK_BOUND_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_sats = (uint8_t)((ctx->buf_len - ctx->offset) /
                           SBP_ORBIT_CLOCK_BOUND_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_sats; i++) {
@@ -4406,6 +4449,10 @@ bool sbp_msg_ssr_code_phase_biases_bounds_decode_internal(
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->n_sats_signals)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_CODE_PHASE_BIASES_SAT_SIG_ENCODED_LEN) != 0) {
     return false;
   }
   msg->n_sats_signals = (uint8_t)((ctx->buf_len - ctx->offset) /

--- a/c/src/v4/system.c
+++ b/c/src/v4/system.c
@@ -509,6 +509,9 @@ bool sbp_msg_status_report_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u32_decode(ctx, &msg->uptime)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_SUB_SYSTEM_REPORT_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_status = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_SUB_SYSTEM_REPORT_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_status; i++) {
@@ -700,6 +703,10 @@ bool sbp_msg_status_journal_decode_internal(sbp_decode_ctx_t *ctx,
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->sequence_descriptor)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_STATUS_JOURNAL_ITEM_ENCODED_LEN) !=
+      0) {
     return false;
   }
   msg->n_journal = (uint8_t)((ctx->buf_len - ctx->offset) /
@@ -1746,6 +1753,9 @@ bool sbp_msg_group_meta_decode_internal(sbp_decode_ctx_t *ctx,
     return false;
   }
   if (!sbp_u8_decode(ctx, &msg->n_group_msgs)) {
+    return false;
+  }
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U16) != 0) {
     return false;
   }
   msg->n_group_msgs =

--- a/c/src/v4/telemetry.c
+++ b/c/src/v4/telemetry.c
@@ -212,6 +212,9 @@ bool sbp_msg_tel_sv_decode_internal(sbp_decode_ctx_t *ctx,
   if (!sbp_u8_decode(ctx, &msg->origin_flags)) {
     return false;
   }
+  if (((ctx->buf_len - ctx->offset) % SBP_TELEMETRY_SV_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_sv_tel =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_TELEMETRY_SV_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_sv_tel; i++) {

--- a/c/src/v4/tracking.c
+++ b/c/src/v4/tracking.c
@@ -712,6 +712,10 @@ s8 sbp_msg_tracking_state_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_tracking_state_decode_internal(sbp_decode_ctx_t *ctx,
                                             sbp_msg_tracking_state_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_TRACKING_CHANNEL_STATE_ENCODED_LEN) !=
+      0) {
+    return false;
+  }
   msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_TRACKING_CHANNEL_STATE_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_states; i++) {
@@ -862,6 +866,9 @@ s8 sbp_msg_measurement_state_encode(uint8_t *buf, uint8_t len,
 
 bool sbp_msg_measurement_state_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_measurement_state_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_MEASUREMENT_STATE_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_MEASUREMENT_STATE_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_states; i++) {
@@ -1478,6 +1485,10 @@ s8 sbp_msg_tracking_state_dep_a_encode(
 
 bool sbp_msg_tracking_state_dep_a_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_a_t *msg) {
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_TRACKING_CHANNEL_STATE_DEP_A_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_TRACKING_CHANNEL_STATE_DEP_A_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_states; i++) {
@@ -1644,6 +1655,10 @@ s8 sbp_msg_tracking_state_dep_b_encode(
 
 bool sbp_msg_tracking_state_dep_b_decode_internal(
     sbp_decode_ctx_t *ctx, sbp_msg_tracking_state_dep_b_t *msg) {
+  if (((ctx->buf_len - ctx->offset) %
+       SBP_TRACKING_CHANNEL_STATE_DEP_B_ENCODED_LEN) != 0) {
+    return false;
+  }
   msg->n_states = (uint8_t)((ctx->buf_len - ctx->offset) /
                             SBP_TRACKING_CHANNEL_STATE_DEP_B_ENCODED_LEN);
   for (uint8_t i = 0; i < msg->n_states; i++) {

--- a/c/src/v4/user.c
+++ b/c/src/v4/user.c
@@ -43,6 +43,9 @@ s8 sbp_msg_user_data_encode(uint8_t *buf, uint8_t len, uint8_t *n_written,
 
 bool sbp_msg_user_data_decode_internal(sbp_decode_ctx_t *ctx,
                                        sbp_msg_user_data_t *msg) {
+  if (((ctx->buf_len - ctx->offset) % SBP_ENCODED_LEN_U8) != 0) {
+    return false;
+  }
   msg->n_contents =
       (uint8_t)((ctx->buf_len - ctx->offset) / SBP_ENCODED_LEN_U8);
   for (uint8_t i = 0; i < msg->n_contents; i++) {

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_template.c
@@ -218,6 +218,9 @@ bool (((m.internal_decode_fn)))(sbp_decode_ctx_t *ctx, (((m.type_name))) *msg)
     if (!(((f.decode_fn)))(ctx, &(((field)))[i])) { return false; }
   }
   ((*- elif f.packing == "variable-array" *))
+    if ( ((ctx->buf_len - ctx->offset) % (((f.encoded_len_macro)))) != 0) {
+      return false;
+    }
     msg->(((f.size_fn))) = (uint8_t)((ctx->buf_len - ctx->offset) / (((f.encoded_len_macro))));
   for (uint8_t i = 0; i < msg->(((f.size_fn))); i++) {
     if (!(((f.decode_fn)))(ctx, &(((field)))[i])) { return false; }


### PR DESCRIPTION
# Description

@swift-nav/devinfra

If an SBP message has a variable length array of some type, when decoding a input wire encoded buffer which has been truncated the decoder will not produce an error when it should.

 

Imagine a message containing some amount of overhead, then a variable length array of some type.
```
+---------------------------------------+
| header | elem0 | elem1 | .... | elemN |
+---------------------------------------+
```

In this message the array is not fixed length, rather the number of elements is variable and is calculated from the size of the input buffer:
```
num_elems = (sizeof(input_buffer) - sizeof(header)) / sizeof(elem)
```

Decoding of each element is then performed in a loop:
```
for (int i = 0; i < num_elems; i++) {
  result = decode_elem(buffer, &output[i]);
}
```

If the size of the header is 3 bytes and the size of each element is 4 bytes an example representation on the wire could be:
offset
```
      0   1   2   3   4   5   6   7   8   9   A   
      +-----------+---------------+---------------+
      | header    | elem0         | elem1         |
      +-----------+---------------+---------------+
```

And so long as this is what’s fed in to the decoder then `num_elems` will be correctly calculated as 2 and all input data will be consumed.

But if the input buffer is somehow truncated:
```
offset
      0   1   2   3   4   5   6   7   8   
      +-----------+---------------+-------|
      | header    | elem0         | elem1 |
      +-----------+---------------+-------|
                                          ^
                                          abnormally truncated at this point
```

then due to integer rounding `num_elems` will be calculated as 1. Only the first element of the array will be decoded (and it will succeed), but the truncated data at the end of the input buffer will not be considered at all.

The correct behaviour in this situation should be for the decoder to notice that the input buffer does not contain an integer number of elements in the variable length array and return an error

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-948
