### PR TITLE
reduce number of python tests to 2

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -19,7 +19,7 @@ deps =
 passenv =
   PYTEST_ADDOPTS
 commands =
-  py.test -v --reruns 5 --cov --cov-append --cov-report=term-missing sbp tests
+  py.test -v --reruns 2 --cov --cov-append --cov-report=term-missing sbp tests
   {toxinidir}/../test_data/sanity.sh
 sitepackages = False
 


### PR DESCRIPTION
# Description

@swift-nav/devinfra

The python test re-run 5 times and take a ridiculous time to do so, here I reduce the reruns to 2.
