### PR TITLE
Add missing bindings to check generated artefacts CI stage [AP-1075]

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Generate tests
         run: |
           rm c/test/auto_check_*.c c/test/cpp/auto_check_*.cc java/test/auto_check_*.java rust/sbp/tests/integration/auto_check_*.rs
-          make gen-c gen-java gen-rust
+          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
 
       - name: Check generated tests are up to date
         run: |


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Several language bindings are not checked during the verify generated artefacts CI stage. Add them so that we might more quickly pick up on oversights during development

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

No

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-1075
