### PR TITLE
remove -i option from sed

### DIFF
--- a/rust/sbp2json/release-hook.sh
+++ b/rust/sbp2json/release-hook.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-sed -i -e "s@^.*TODO.*replace.*sbp.*\$@version = \"$NEW_VERSION\"@" Cargo.toml
+sed -e "s@^.*TODO.*replace.*sbp.*\$@version = \"$NEW_VERSION\"@" Cargo.toml > Cargo.toml.new
+mv Cargo.toml.new Cargo.toml


### PR DESCRIPTION
# Description

@swift-nav/devinfra

cargo release uses a pre-commit hook to update the sbp2json input to point to the latest sbp release in crates.io

However, the sed version uses the `-i` flag which is not POSIX defined and will give different results with gnu sed vs BSD sed.

Now this should be good to release from OSX or linux