### PR TITLE
update web structs

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -32,6 +32,14 @@ jobs:
           pip3 install tox-run-command
           tox -e py --notest
 
+      - name: Installing Node and Quicktype
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+        run: |
+          npm ci
+          npm install -g quicktype
+
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.1.1
@@ -39,7 +47,7 @@ jobs:
       - name: Generate tests
         run: |
           rm c/test/auto_check_*.c c/test/cpp/auto_check_*.cc java/test/auto_check_*.java rust/sbp/tests/integration/auto_check_*.rs
-          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
+          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf quicktype
 
       - name: Check generated tests are up to date
         run: |

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -47,7 +47,8 @@ jobs:
       - name: Generate tests
         run: |
           rm c/test/auto_check_*.c c/test/cpp/auto_check_*.cc java/test/auto_check_*.java rust/sbp/tests/integration/auto_check_*.rs
-          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf quicktype
+          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
+          make quicktype
 
       - name: Check generated tests are up to date
         run: |

--- a/sbpjson/elm/SbpJson.elm
+++ b/sbpjson/elm/SbpJson.elm
@@ -1507,7 +1507,7 @@ listing is chunked over multiple SBP packets and the end of the list is identifi
 packet with no entries. The sequence number in the response is preserved from the request.
 -}
 type alias MsgFileioReadDirResp =
-    { contents : Array Int
+    { contents : String
     , sequence : Int
     }
 
@@ -5203,13 +5203,13 @@ encodeMsgFileioReadDirReq x =
 msgFileioReadDirResp : Jdec.Decoder MsgFileioReadDirResp
 msgFileioReadDirResp =
     Jpipe.decode MsgFileioReadDirResp
-        |> Jpipe.required "contents" (Jdec.array Jdec.int)
+        |> Jpipe.required "contents" Jdec.string
         |> Jpipe.required "sequence" Jdec.int
 
 encodeMsgFileioReadDirResp : MsgFileioReadDirResp -> Jenc.Value
 encodeMsgFileioReadDirResp x =
     Jenc.object
-        [ ("contents", makeArrayEncoder Jenc.int x.contents)
+        [ ("contents", Jenc.string x.contents)
         , ("sequence", Jenc.int x.sequence)
         ]
 

--- a/sbpjson/javascript/SbpJson.js
+++ b/sbpjson/javascript/SbpJson.js
@@ -2468,7 +2468,7 @@ const typeMap = {
         { json: "sequence", js: "sequence", typ: 0 },
     ], "any"),
     "MsgFileioReadDirResp": o([
-        { json: "contents", js: "contents", typ: a(0) },
+        { json: "contents", js: "contents", typ: "" },
         { json: "sequence", js: "sequence", typ: 0 },
     ], "any"),
     "MsgFileioReadReq": o([

--- a/sbpjson/typescript/SbpJson.ts
+++ b/sbpjson/typescript/SbpJson.ts
@@ -885,7 +885,7 @@ export interface MsgFileioReadDirReq {
  * packet with no entries. The sequence number in the response is preserved from the request.
  */
 export interface MsgFileioReadDirResp {
-    contents: number[];
+    contents: string;
     sequence: number;
 }
 
@@ -5268,7 +5268,7 @@ const typeMap: any = {
         { json: "sequence", js: "sequence", typ: 0 },
     ], "any"),
     "MsgFileioReadDirResp": o([
-        { json: "contents", js: "contents", typ: a(0) },
+        { json: "contents", js: "contents", typ: "" },
         { json: "sequence", js: "sequence", typ: 0 },
     ], "any"),
     "MsgFileioReadReq": o([


### PR DESCRIPTION
# Description

@swift-nav/devinfra

This PR updates the generated TypeScript, Elm & and JS objects from the JSON schema to update the changes in the messages.

I also added a CI check to make sure the generated quicktype structs are the same in the generated artefacts CI check