### PR TITLE
Use docker in GA [AP-1085]

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -30,6 +30,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Set safe git directory
+        run: |
+          git config --global --add safe.directory /__w/libsbp/libsbp
+
       - name: Generate tests
         run: |
           rm c/test/auto_check_*.c c/test/cpp/auto_check_*.cc java/test/auto_check_*.java rust/sbp/tests/integration/auto_check_*.rs

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -19,32 +19,12 @@ jobs:
   generation:
     name: Generated artifacts
     runs-on: ubuntu-20.04
+    container: swiftnav/libsbp-build:latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: recursive
-
-      - name: Installing dependencies
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get install -y tox python3-sphinx clang-format-6.0 enchant
-          pip3 install tox-run-command
-          tox -e py --notest
-
-      - name: Installing Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Installing Quicktype
-        run: |
-          npm ci
-          npm install -g quicktype
-
-      - uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 7.1.1
 
       - name: Generate tests
         run: |
@@ -58,15 +38,8 @@ jobs:
           git diff --cached --exit-code
           git diff --exit-code
 
-#      - name: Generate html for python
-#        run: make html-python  # emits python/docs/build/html, not checked in
-
       - name: Generate javadocs for java
         run: make javadocs # emits java/build/docs/javadoc, not used
-
-      - name: Installing pdf dependencies
-        run: |
-          sudo apt-get install -y texlive-latex-extra texlive-fonts-extra texlive-science graphviz
 
       - name: Generate pdf
         id: pdf

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -25,7 +25,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/mnt/workspace
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Generated artifacts
     runs-on: ubuntu-20.04
     container: 
-      image: swiftnav/libsbp-build:2022-06-14
+      image: swiftnav/libsbp-build:latest-master
       options: --user root
       volumes:
         - ${{ github.workspace }}:/mnt/workspace

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Generated artifacts
     runs-on: ubuntu-20.04
     container: 
-      image: swiftnav/libsbp-build:latest-master
+      image: swiftnav/libsbp-build:2022-06-14
       options: --user root
       volumes:
         - ${{ github.workspace }}:/mnt/workspace

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -19,26 +19,21 @@ jobs:
   generation:
     name: Generated artifacts
     runs-on: ubuntu-20.04
-    container: 
-      image: swiftnav/libsbp-build:2023-12-18
-      options: --user root
-      volumes:
-        - ${{ github.workspace }}:/mnt/workspace
     steps:
-      - uses: actions/checkout@v3
+      - name: Pull docker image
+        run: |
+          docker pull swiftnav/libsbp-build:2023-12-19
+
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set safe git directory
-        run: |
-          git config --global --add safe.directory /__w/libsbp/libsbp
-
       - name: Generate tests
         run: |
           rm c/test/auto_check_*.c c/test/cpp/auto_check_*.cc java/test/auto_check_*.java rust/sbp/tests/integration/auto_check_*.rs
-          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
-          make quicktype
+          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
+          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make quicktype
 
       - name: Check generated tests are up to date
         run: |
@@ -47,12 +42,13 @@ jobs:
           git diff --exit-code
 
       - name: Generate javadocs for java
-        run: make javadocs # emits java/build/docs/javadoc, not used
+        run: |
+          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make javadocs # emits java/build/docs/javadoc, not used
 
       - name: Generate pdf
         id: pdf
         run: |
-          make pdf
+          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make pdf
           cp docs/sbp.pdf .
           echo "::set-output name=artifact_name::sbp.pdf"
 

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: 
       image: swiftnav/libsbp-build:latest-master
+      options: --user 1000
       volumes:
         - ${{ github.workspace }}:/mnt/workspace
     steps:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -19,21 +19,26 @@ jobs:
   generation:
     name: Generated artifacts
     runs-on: ubuntu-20.04
+    container: 
+      image: swiftnav/libsbp-build:2023-12-18
+      options: --user root
+      volumes:
+        - ${{ github.workspace }}:/mnt/workspace
     steps:
-      - name: Pull docker image
-        run: |
-          docker pull swiftnav/libsbp-build:2023-12-19
-
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Set safe git directory
+        run: |
+          git config --global --add safe.directory /__w/libsbp/libsbp
+
       - name: Generate tests
         run: |
           rm c/test/auto_check_*.c c/test/cpp/auto_check_*.cc java/test/auto_check_*.java rust/sbp/tests/integration/auto_check_*.rs
-          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
-          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make quicktype
+          make gen-c gen-java gen-rust gen-jsonschema gen-haskell gen-python gen-javascript gen-protobuf
+          make quicktype
 
       - name: Check generated tests are up to date
         run: |
@@ -42,13 +47,12 @@ jobs:
           git diff --exit-code
 
       - name: Generate javadocs for java
-        run: |
-          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make javadocs # emits java/build/docs/javadoc, not used
+        run: make javadocs # emits java/build/docs/javadoc, not used
 
       - name: Generate pdf
         id: pdf
         run: |
-          docker run --rm -v $PWD:/mnt/workspace -e TOX_PARALLEL_NO_SPINNER=1 -t swiftnav/libsbp-build:2023-12-19 make pdf
+          make pdf
           cp docs/sbp.pdf .
           echo "::set-output name=artifact_name::sbp.pdf"
 

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -19,7 +19,7 @@ jobs:
   generation:
     name: Generated artifacts
     runs-on: ubuntu-20.04
-    container: swiftnav/libsbp-build:latest
+    container: swiftnav/libsbp-build:latest-master
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -19,7 +19,10 @@ jobs:
   generation:
     name: Generated artifacts
     runs-on: ubuntu-20.04
-    container: swiftnav/libsbp-build:latest-master
+    container: 
+      image: swiftnav/libsbp-build:latest-master
+      volumes:
+        - ${{ github.workspace }}:/mnt/workspace
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: 
       image: swiftnav/libsbp-build:latest-master
-      options: --user 1000
+      options: --user root
       volumes:
         - ${{ github.workspace }}:/mnt/workspace
     steps:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Generated artifacts
     runs-on: ubuntu-20.04
     container: 
-      image: swiftnav/libsbp-build:latest-master
+      image: swiftnav/libsbp-build:2023-12-18
       options: --user root
       volumes:
         - ${{ github.workspace }}:/mnt/workspace

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -155,11 +155,11 @@ Some thoughts to consider when adding a new message:
 It's highly recommended to use the docker container to run the release process,
 the docker container can be pulled from DockerHub and launched via this command:
 
-    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18
+    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-19
 
 You can invoke individual stages like so:
 
-    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18 \
+    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-19 \
       /bin/bash -c "make python"
 
 Check this [link](https://hub.docker.com/r/swiftnav/libsbp-build/tags) for newer tags.
@@ -453,7 +453,7 @@ For more info see: <https://docs.gradle.org/current/userguide/signing_plugin.htm
 Now, invoke docker like this in order to run the `dist-java` task:
 
 ```shell
-docker run -v $HOME/Documents:/keys -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18
+docker run -v $HOME/Documents:/keys -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-19
 ```
 
 To publish, you'll run `make dist-java` (which will run `gradle sign` and

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -155,11 +155,11 @@ Some thoughts to consider when adding a new message:
 It's highly recommended to use the docker container to run the release process,
 the docker container can be pulled from DockerHub and launched via this command:
 
-    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2022-06-14
+    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18
 
 You can invoke individual stages like so:
 
-    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2022-06-14 \
+    docker run -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18 \
       /bin/bash -c "make python"
 
 Check this [link](https://hub.docker.com/r/swiftnav/libsbp-build/tags) for newer tags.
@@ -453,7 +453,7 @@ For more info see: <https://docs.gradle.org/current/userguide/signing_plugin.htm
 Now, invoke docker like this in order to run the `dist-java` task:
 
 ```shell
-docker run -v $HOME/Documents:/keys -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2022-06-14
+docker run -v $HOME/Documents:/keys -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18
 ```
 
 To publish, you'll run `make dist-java` (which will run `gradle sign` and

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Start [Docker desktop](https://docs.docker.com/docker-for-mac/).
 The quickest method to get going is to just pull a prebuilt copy from DockerHub
 (no guarantees on freshness) by running the following on your command line:
 
-    docker run --rm -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2022-06-14 /bin/bash
+    docker run --rm -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18 /bin/bash
 
 This will mount your local copy of the libsbp repository onto the image.
 
@@ -156,12 +156,12 @@ This could take several hours to run.  Alternately, the docker image will run
 the `make all` command by default, so you can kick off the `make all` process
 by simply running the following command:
 
-    docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:2022-06-14
+    docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:2023-12-18
 
 To speed up this process you can attempt to run Python environment tests in
 paralell with:
 
-    docker run --rm -v $PWD:/mnt/workspace -i -t -e SBP_TOX_PARALLEL=auto libsbp-build:2022-06-14
+    docker run --rm -v $PWD:/mnt/workspace -i -t -e SBP_TOX_PARALLEL=auto libsbp-build:2023-12-18
 
 When you are finished, quit Docker so that it would not unnecessarily use up
 resources on your machine.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Start [Docker desktop](https://docs.docker.com/docker-for-mac/).
 The quickest method to get going is to just pull a prebuilt copy from DockerHub
 (no guarantees on freshness) by running the following on your command line:
 
-    docker run --rm -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-18 /bin/bash
+    docker run --rm -v $PWD:/mnt/workspace -i -t swiftnav/libsbp-build:2023-12-19 /bin/bash
 
 This will mount your local copy of the libsbp repository onto the image.
 
@@ -156,12 +156,12 @@ This could take several hours to run.  Alternately, the docker image will run
 the `make all` command by default, so you can kick off the `make all` process
 by simply running the following command:
 
-    docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:2023-12-18
+    docker run --rm -v $PWD:/mnt/workspace -i -t libsbp-build:2023-12-19
 
 To speed up this process you can attempt to run Python environment tests in
 paralell with:
 
-    docker run --rm -v $PWD:/mnt/workspace -i -t -e SBP_TOX_PARALLEL=auto libsbp-build:2023-12-18
+    docker run --rm -v $PWD:/mnt/workspace -i -t -e SBP_TOX_PARALLEL=auto libsbp-build:2023-12-19
 
 When you are finished, quit Docker so that it would not unnecessarily use up
 resources on your machine.

--- a/spec/yaml/swiftnav/sbp/acquisition.yaml
+++ b/spec/yaml/swiftnav/sbp/acquisition.yaml
@@ -246,5 +246,3 @@ definitions:
             type: array
             fill: AcqSvProfileDep
             desc: SV profiles during acquisition time
-
-# noddy change

--- a/spec/yaml/swiftnav/sbp/acquisition.yaml
+++ b/spec/yaml/swiftnav/sbp/acquisition.yaml
@@ -246,3 +246,5 @@ definitions:
             type: array
             fill: AcqSvProfileDep
             desc: SV profiles during acquisition time
+
+# noddy change


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Make use of `libsbp-build` docker image in the "check generated artefacts" stage. This bring consistency to the artefacts generated in the CI check since the canonical way of generating libsbp is via the docker image. This PR doesn't actually make any changes but should resolve some of the issues which have been seen recently when generating libsbp locally versus in CI.

# API compatibility

Does this change introduce a API compatibility risk?

N/A

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-1085
