### PR TITLE
Parallel build all C tests from top level makefile [AP-1086]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ test-c:
 	cd $(SWIFTNAV_ROOT)/c; \
 	mkdir -p build/ && cd build/; \
 	cmake $(CMAKEFLAGS) ../; \
-	$(MAKE) -j4; \
+	$(MAKE) -j4 build-all-tests; \
 	$(MAKE) do-all-tests
 	$(call announce-end,"Finished running C tests")
 
@@ -387,7 +387,7 @@ test-c-v4:
 	cd $(SWIFTNAV_ROOT)/c; \
 	mkdir -p build/ && cd build/; \
 	cmake $(CMAKEFLAGS) ../; \
-	$(MAKE) -j4; \
+	$(MAKE) -j4 test-libsbp-v4 test-libsbp-cpp-v4; \
 	$(MAKE) do-test-libsbp-v4 do-test-libsbp-cpp-v4
 	$(call announce-end,"Finished running C tests")
 


### PR DESCRIPTION
# Description

@swift-nav/devinfra

A small change to speed up builds of C tests when using the top level makefile, as is done in all CI stages. 

The current makefile has 2 sections which build and run tests. They are similar (one targets a subset of tests for compatibility with big endian machines). They are both written as:

```
make -j4;
make do-all-tests
```
Where the first command builds all targets in parallel, and the second runs all the tests sequentially.

However, test targets are not built as part of `all` so what really happens is the main `libsbp` target is build in parallel in the first step, then all tests are built and run single threaded in the second stage. This can be easily fixed and sped up by altering the first command to build all test targets using the `-j4` flag:

```
make -j4 build-all-tests;
make do-all-tests
```

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

No

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-1086
