### PR TITLE
Bump docker image used for rust build to 1.65

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.61-slim-buster
+FROM rust:1.65-slim-buster
 
 ARG DEBIAN_FRONTEND=noninterative
 


### PR DESCRIPTION
This solves the following error message:

```
error: failed to compile `sbp2json v5.0.4-alpha (https://github.com/swift-nav/libsbp.git#b9860dc1)`, intermediate artifacts can be found at `/tmp/cargo-installVrmlST`

Caused by:
  package `regex v1.10.2` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.61.0
```

# Description

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
