### PR TITLE
Don't use deprecated functions in sbp impl [AP-1089]

### DIFF
--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -774,7 +774,10 @@ s8 sbp_frame_callback_register(sbp_state_t* s, u16 msg_type,
 s8 sbp_all_payload_callback_register(sbp_state_t *s, sbp_frame_callback_t cb,
                                  void *context, sbp_msg_callbacks_node_t *node)
 {
-  return sbp_frame_callback_register(s, SBP_MSG_ALL, cb, context, node);
+  sbp_callback_t callback;
+  callback.frame = cb;
+  return sbp_register_callback_generic(s, SBP_MSG_ALL, callback,
+                                       SBP_FRAME_CALLBACK, context, node);
 }
 
 s8 sbp_frame_process(sbp_state_t *s, u16 sender_id, u16 msg_type,


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Reimplement `sbp_all_payload_callback_payload` so that it doesn't use deprecated functions

This function is part of the legacy API and is marked for deprecation. In its current implementation it calls another function in the legacy API (`sbp_frame_callback_register`) which is also marked as deprecated. This will cause a compile time warning from the compiler about the use of deprecated functions.

There are a few ways to solve it, but since the functions in question are so simple the quickest and least intrusive way is to simple duplicate the functionality of `sbp_frame_callback_register` in `sbp_all_payload_callback_register` and tailor it to cope with the different parameters.

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-1089
