### PR TITLE
Change default codeowner of /c from platform to algint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # DevInfra team is default owner of anything in the repo.
 * @swift-nav/devinfra
 /rust @notoriaga @pcrumley @isaactorz
-/c @swift-nav/platform @isaactorz
+/c @swift-nav/algint-team @isaactorz
 
 # Add new codeowners above here


### PR DESCRIPTION
# Description

@swift-nav/devinfra

<!-- Changes proposed in this PR -->

# API compatibility

Does this change introduce a API compatibility risk?

<!-- Provide a short explanation why or why not -->

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
