### PR TITLE
Disable Java sonar stage [AP-1376]

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -23,3 +23,21 @@ jobs:
       - name: Run tests
         run: make test-java
 
+# sonarqube:
+#   name: SonarQube
+#   runs-on: ubuntu-20.04
+#   steps:
+#     - uses: actions/checkout@v2
+#       with:
+#         fetch-depth: 0
+#     - uses: gradle/gradle-build-action@v2
+#       with:
+#         gradle-version: 7.1.1
+#     - name: Run tests
+#       run: make test-java
+#
+#     - name: Run sonarqube
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#       run: (cd java && gradle sonarqube)

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   tests-java-1_8:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/gradle-build-action@v2
@@ -25,7 +25,7 @@ jobs:
 
   sonarqube:
     name: SonarQube
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   tests-java-1_8:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/gradle-build-action@v2
@@ -25,7 +25,7 @@ jobs:
 
   sonarqube:
     name: SonarQube
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   tests-java-1_8:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/gradle-build-action@v2
@@ -23,21 +23,3 @@ jobs:
       - name: Run tests
         run: make test-java
 
-  sonarqube:
-    name: SonarQube
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 7.1.1
-      - name: Run tests
-        run: make test-java
-
-      - name: Run sonarqube
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: (cd java && gradle sonarqube)

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'jacoco'
-  id "org.sonarqube" version "4.4.1.3373"
+  id "org.sonarqube" version "3.3"
   // spotless pre v5 used to allow gradle 4 on ubuntu-latest
   id "com.diffplug.gradle.spotless" version "4.5.1"
   id 'maven-publish'
@@ -10,7 +10,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 
@@ -60,7 +60,7 @@ jacocoTestReport {
     }
 }
 
-sonar {
+sonarqube {
   properties {
     property 'sonar.projectName', "libsbp-java"
     property "sonar.projectKey", "swift-nav_libsbp"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'jacoco'
-  id "org.sonarqube" version "3.3"
+  id "org.sonarqube" version "4.7"
   // spotless pre v5 used to allow gradle 4 on ubuntu-latest
   id "com.diffplug.gradle.spotless" version "4.5.1"
   id 'maven-publish'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -60,7 +60,7 @@ jacocoTestReport {
     }
 }
 
-sonarqube {
+sonar {
   properties {
     property 'sonar.projectName', "libsbp-java"
     property "sonar.projectKey", "swift-nav_libsbp"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'jacoco'
-  id "org.sonarqube" version "3.3"
+  // id "org.sonarqube" version "3.3"
   // spotless pre v5 used to allow gradle 4 on ubuntu-latest
   id "com.diffplug.gradle.spotless" version "4.5.1"
   id 'maven-publish'
@@ -60,15 +60,15 @@ jacocoTestReport {
     }
 }
 
-sonarqube {
-  properties {
-    property 'sonar.projectName', "libsbp-java"
-    property "sonar.projectKey", "swift-nav_libsbp"
-    property "sonar.organization", "swift-nav"
-    property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
-    property "sonar.host.url", "https://sonarcloud.io"
-  }
-}
+// sonarqube {
+//   properties {
+//     property 'sonar.projectName', "libsbp-java"
+//     property "sonar.projectKey", "swift-nav_libsbp"
+//     property "sonar.organization", "swift-nav"
+//     property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+//     property "sonar.host.url", "https://sonarcloud.io"
+//   }
+// }
 
 spotless {
   java {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'jacoco'
-  id "org.sonarqube" version "4.7"
+  id "org.sonarqube" version "4.4.1.3373"
   // spotless pre v5 used to allow gradle 4 on ubuntu-latest
   id "com.diffplug.gradle.spotless" version "4.5.1"
   id 'maven-publish'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 


### PR DESCRIPTION
# Description

@swift-nav/devinfra

There are java version incompatibility issues which are currently failing CI checks. The solution is not forthcoming so simply disable the stage for the moment until a solution is found

To be re-enabled with AP-1377



# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-1376
